### PR TITLE
[ci] Check for clippy and rustfmt issues in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,29 @@
-name: Build and Test
+name: brimstone
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
-    name: "Build and Test"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Test
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run tests
         run: cargo test


### PR DESCRIPTION
Ensure that we do not merge changes that introduce clippy or formatting issues by running clippy and rustfmt in CI. These jobs will run both on PRs and on merging to master.

Note this also implies a process change for this repo. All further changes should first go through a PR and only be merged to master if all CI jobs are passing.