### PR TITLE
[deps] Update to latest test262

### DIFF
--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -2,8 +2,8 @@
   // Tests which are always ignored
   "always": {
     "tests": [
-      // Using more recent version of Unicode that test262 - fixed in newer test262
-      "built-ins/RegExp/unicode_full_case_folding.js",
+      // BUG: RegExp matcher loops on this test case
+      "built-ins/RegExp/nullable-quantifier.js",
       // ECMA-402 Internationalization API is not implemented
       "intl402/*",
       // Incorrect tests due to changed base/property evaluation order
@@ -49,10 +49,7 @@
       // The errors returned from a derived constructor's [[Construct]] if the constructor's 
       // return value is invalid or uninitialized must be in the callee's realm.
       "built-ins/Function/internals/Construct/derived-this-uninitialized-realm.js",
-      // Does not evaluate ToPropertyKey in LHS of member assignment before evaluating the RHS
-      "language/expressions/assignment/S11.13.1_A7_T3.js",
       // Does not evaluate ToPropertyKey in key of object destructuring before evaluating the RHS
-      "language/expressions/assignment/destructuring/iterator-destructuring-property-reference-target-evaluation-order.js",
       "language/expressions/assignment/destructuring/keyed-destructuring-property-reference-target-evaluation-order.js",
       // Does not evaluate LHS of assignment to reference before evaluating the RHS, when RHS can modify reference
       "language/expressions/assignment/S11.13.1_A5_T1.js",
@@ -105,23 +102,32 @@
       // Non-standard extension
       "caller",
       // Stage < 4 proposals
-      "array-grouping",
-      "arraybuffer-transfer",
       "decorators",
+      "explicit-resource-management",
       "import-assertions",
       "iterator-helpers",
       "json-modules",
       "json-parse-with-source",
       "legacy-regexp",
-      "regexp-duplicate-named-groups",
-      "resizable-arraybuffer",
+      "promise-try",
+      "regexp-modifiers",
+      "uint8array-base64",
       "Array.fromAsync",
       "FinalizationRegistry.prototype.cleanupSome",
+      "Float16Array",
       "Intl.DurationFormat",
       "Intl.Locale-info",
       "Intl.NumberFormat-v3",
+      "Math.sumPrecise",
+      "RegExp.escape",
       "Temporal",
-      "ShadowRealm"
+      "ShadowRealm",
+      // Unimplemented Stage 4 proposals
+      "array-grouping",
+      "arraybuffer-transfer",
+      "regexp-duplicate-named-groups",
+      "resizable-arraybuffer",
+      "set-methods"
     ]
   },
   // Slow tests which are ignored in normal runs but can be run with the --all flag

--- a/tests/test262/install_test262.sh
+++ b/tests/test262/install_test262.sh
@@ -6,7 +6,8 @@ CURRENT_DIR=$(cd "$(dirname "$0")" && pwd)
 TEST262_REPO_DIR="$CURRENT_DIR/test262"
 
 # Pinned commit hash of test262 repo that we test off of
-TEST262_COMMIT_SHA="0c87a86b58391b40aa7623b919603d87d4b77a4d"
+# Last updated on 2024-08-27
+TEST262_COMMIT_SHA="b69e9d5e722291dcb6ada5582c71887133626c63"
 
 # Clone the test262 repo if it is not already present
 if [ ! -d "$TEST262_REPO_DIR" ]; then


### PR DESCRIPTION
Upgrade to the latest test262 commit: [b69e9d5e722291dcb6ada5582c71887133626c63](https://github.com/tc39/test262/commit/b69e9d5e722291dcb6ada5582c71887133626c63).

Also perform some initial cleanup from this upgrade. A few ignores can be removed due to the tests now passing or being deleted.

Audit failed tests and add ignores for all unimplemented proposals. Finally mark ignored proposals that have reached stage 4.