### PR TITLE
[deps] Replace once_cell with stabilized std version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ indexmap = "2.1.0"
 match_u32 = { path = "src/js/parser/match_u32" }
 num-bigint = "0.4.3"
 num-traits = "0.2.16"
-once_cell = "1.18.0"
 rand = "0.8.5"
 ryu-js = "0.2.2"
 wrap_ordinary_object = { path = "src/js/runtime/wrap_ordinary_object" }

--- a/src/js/common/icu.rs
+++ b/src/js/common/icu.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use icu_casemap::CaseMapper;
 use icu_collator::{Collator, CollatorOptions};
 use icu_locid::{locale, Locale};
@@ -11,7 +13,6 @@ use icu_properties::{
 };
 use icu_provider::DataLocale;
 use icu_provider_adapters::fallback::LocaleFallbackProvider;
-use once_cell::sync::Lazy;
 
 use super::icu_data::BakedDataProvider;
 
@@ -227,11 +228,11 @@ pub struct Normalizers {
     pub nfkd: DecomposingNormalizer,
 }
 
-pub static ICU: Lazy<ICU> = Lazy::new(|| {
+pub static ICU: LazyLock<ICU> = LazyLock::new(|| {
     // General category sets
     macro_rules! general_category_static {
         ($static_name:ident, $category_name:ident) => {
-            static $static_name: Lazy<CodePointSetData> = Lazy::new(|| {
+            static $static_name: LazyLock<CodePointSetData> = LazyLock::new(|| {
                 sets::load_for_general_category_group(
                     &BakedDataProvider,
                     GeneralCategoryGroup::$category_name,
@@ -283,8 +284,8 @@ pub static ICU: Lazy<ICU> = Lazy::new(|| {
     // Binary property sets
     macro_rules! binary_property_static {
         ($static_name:ident, $load_fn:ident) => {
-            static $static_name: Lazy<CodePointSetData> =
-                Lazy::new(|| sets::$load_fn(&BakedDataProvider).unwrap());
+            static $static_name: LazyLock<CodePointSetData> =
+                LazyLock::new(|| sets::$load_fn(&BakedDataProvider).unwrap());
         };
     }
 
@@ -340,10 +341,10 @@ pub static ICU: Lazy<ICU> = Lazy::new(|| {
     binary_property_static!(XID_START_SET, load_xid_start);
 
     // Scripts
-    static SCRIPT_CLASSIFIER: Lazy<ScriptWithExtensions> =
-        Lazy::new(|| script::load_script_with_extensions_unstable(&BakedDataProvider).unwrap());
-    static SCRIPT_NAMES: Lazy<PropertyValueNameToEnumMapper<Script>> =
-        Lazy::new(|| Script::get_name_to_enum_mapper(&BakedDataProvider).unwrap());
+    static SCRIPT_CLASSIFIER: LazyLock<ScriptWithExtensions> =
+        LazyLock::new(|| script::load_script_with_extensions_unstable(&BakedDataProvider).unwrap());
+    static SCRIPT_NAMES: LazyLock<PropertyValueNameToEnumMapper<Script>> =
+        LazyLock::new(|| Script::get_name_to_enum_mapper(&BakedDataProvider).unwrap());
 
     let locale_provider = LocaleFallbackProvider::try_new_unstable(BakedDataProvider).unwrap();
 

--- a/tests/test262/Cargo.lock
+++ b/tests/test262/Cargo.lock
@@ -48,7 +48,6 @@ dependencies = [
  "match_u32",
  "num-bigint",
  "num-traits",
- "once_cell",
  "rand",
  "ryu-js",
  "wrap_ordinary_object",


### PR DESCRIPTION
The `once_cell` crate has been fully stabilized as of [Rust 1.80](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html#lazycell-and-lazylock) so we can switch our use of `once_cell::sync::Lazy` to `std::sync::LazyLock` and drop the `once_cell` dependency.