### PR TITLE
[runtime] Global load/store checks lex names before var names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,6 @@ dependencies = [
  "match_u32",
  "num-bigint",
  "num-traits",
- "once_cell",
  "rand",
  "ryu-js",
  "wrap_ordinary_object",


### PR DESCRIPTION
## Summary

Global lexical bindings can overwrite non-configurable global var bindings as per the spec. We represent this as the lexical binding being in a new global scope as usual, while the var bindings remain in the shared global object.

However during global load/store we were looking up the name in the global object before looking it up in the shared lexical bindings map. Instead we should look up names in the shared lexical bindings map first so that the lexical binding is treated as overwriting the var binding.

## Fixes:
- https://github.com/tc39/test262/blob/d62fa93c8f9ce5e687c0bbaa5d2b59670ab2ff60/test/language/global-code/script-decl-lex-var-declared-via-eval.js