### PR TITLE
[runtime] Fix GC safety bug when inserting into SetObjects

### DIFF
--- a/src/js/runtime/intrinsics/set_object.rs
+++ b/src/js/runtime/intrinsics/set_object.rs
@@ -10,7 +10,7 @@ use crate::{
         object_value::ObjectValue,
         ordinary_object::{object_create, object_create_from_constructor},
         value::ValueCollectionKey,
-        Context, EvalResult, Handle, HeapPtr,
+        Context, EvalResult, Handle, HeapPtr, Value,
     },
     maybe, set_uninit,
 };
@@ -70,10 +70,10 @@ impl Handle<SetObject> {
         SetObjectSetField(*self)
     }
 
-    pub fn insert(&self, cx: Context, item: ValueCollectionKey) -> bool {
+    pub fn insert(&self, cx: Context, item: Handle<Value>) -> bool {
         self.set_data_field()
             .maybe_grow_for_insertion(cx)
-            .insert_without_growing(item)
+            .insert_without_growing(ValueCollectionKey::from(item))
     }
 }
 

--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -96,7 +96,7 @@ impl SetPrototype {
         let value = get_argument(cx, arguments, 0);
         let value = canonicalize_keyed_collection_key(cx, value);
 
-        set.insert(cx, ValueCollectionKey::from(value));
+        set.insert(cx, value);
 
         this_value.into()
     }
@@ -311,7 +311,7 @@ impl SetPrototype {
                 ));
 
                 if in_other.is_true() {
-                    new_set.insert(cx, item);
+                    new_set.insert(cx, item_handle);
                 }
             }
         } else {
@@ -322,9 +322,12 @@ impl SetPrototype {
                 other_set_record.set_object.into(),
                 other_set_record.keys_method,
                 &mut |cx, key| {
-                    let key = ValueCollectionKey::from(canonicalize_keyed_collection_key(cx, key));
+                    let key = canonicalize_keyed_collection_key(cx, key);
 
-                    if this_set.set_data_ptr().contains(&key) {
+                    if this_set
+                        .set_data_ptr()
+                        .contains(&ValueCollectionKey::from(key))
+                    {
                         new_set.insert(cx, key);
                     }
 
@@ -533,11 +536,12 @@ impl SetPrototype {
             other_set_record.set_object.into(),
             other_set_record.keys_method,
             &mut |cx, key| {
-                let key = ValueCollectionKey::from(canonicalize_keyed_collection_key(cx, key));
+                let key = canonicalize_keyed_collection_key(cx, key);
+                let collection_key = ValueCollectionKey::from(key);
 
-                if this_set.set_data_ptr().contains(&key) {
+                if this_set.set_data_ptr().contains(&collection_key) {
                     // Both sets contain the key so remove it from the new set
-                    new_set.set_data_ptr().remove(&key);
+                    new_set.set_data_ptr().remove(&collection_key);
                 } else {
                     // Key is in the other set but not in this set so add it to the new set
                     new_set.insert(cx, key);
@@ -577,7 +581,7 @@ impl SetPrototype {
             other_set_record.keys_method,
             &mut |cx, key| {
                 let key = canonicalize_keyed_collection_key(cx, key);
-                new_set.insert(cx, ValueCollectionKey::from(key));
+                new_set.insert(cx, key);
 
                 None
             }


### PR DESCRIPTION
## Summary

Fixes a GC safety bug in the `insert` method for `SetObject`. The `ValueCollectionKey` parameter holds a raw `Value`, which could be invalidated by the call to `maybe_grow_for_insertion`. The solution is deferring the dereference in `ValueCollectionKey::from` until after the call to `maybe_grow_for_insert`.

## Tests

- Fixes some test262 tests which hit this case in GC stress test mode