### PR TITLE
[runtime] Fix GC safety bug in Set.prototype.difference

### DIFF
--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -177,7 +177,9 @@ impl SetPrototype {
                 ));
 
                 if in_other.is_true() {
-                    new_set.set_data_ptr().remove(&item);
+                    new_set
+                        .set_data_ptr()
+                        .remove(&ValueCollectionKey::from(item_handle));
                 }
             }
         } else {


### PR DESCRIPTION
## Summary

Fixes a GC safety bug in `Set.prototype.difference`. The variable `item` is a `ValueCollectionKey` which holds a raw `Value`, which could be invalidated by the call to `call_object`. 

## Tests

- Fixes some test262 tests which hit this case in GC stress test mode