### PR TITLE
[runtime] MapObject and SetObject iterators handle resizing the underlying collection

### DIFF
--- a/src/js/runtime/collections/index_set.rs
+++ b/src/js/runtime/collections/index_set.rs
@@ -121,6 +121,19 @@ impl<T: Eq + Hash + Clone> HeapObject for HeapPtr<BsIndexSet<T>> {
 
     /// Visit pointers intrinsic to all IndexSets. Do not visit entries as they could be of any type.
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast_mut::<BsIndexMap<T, ()>>().visit_pointers(visitor)
+        self.cast_mut::<BsIndexMap<T, ()>>()
+            .visit_pointers_impl(visitor, |_, _| ())
+    }
+}
+
+impl<T: Eq + Hash + Clone> HeapPtr<BsIndexSet<T>> {
+    #[inline]
+    pub fn visit_pointers_impl<H: HeapVisitor>(
+        &mut self,
+        visitor: &mut H,
+        mut entries_visitor: impl FnMut(&mut Self, &mut H),
+    ) {
+        self.cast_mut::<BsIndexMap<T, ()>>()
+            .visit_pointers_impl(visitor, |map, visitor| entries_visitor(&mut map.cast(), visitor))
     }
 }

--- a/src/js/runtime/intrinsics/map_constructor.rs
+++ b/src/js/runtime/intrinsics/map_constructor.rs
@@ -3,7 +3,6 @@ use crate::{
         abstract_operations::{call_object, construct, group_by, GroupByKeyCoercion},
         array_object::create_array_from_list,
         builtin_function::BuiltinFunction,
-        collections::BsIndexMapField,
         completion::EvalResult,
         error::type_error,
         function::get_argument,
@@ -13,7 +12,7 @@ use crate::{
         property_key::PropertyKey,
         realm::Realm,
         type_utilities::is_callable,
-        value::{Value, ValueCollectionKey},
+        value::Value,
         Context, Handle,
     },
     maybe, must,
@@ -100,10 +99,7 @@ impl MapConstructor {
         for group in groups {
             let items: Handle<Value> = create_array_from_list(cx, &group.items).into();
 
-            map.cast::<MapObject>()
-                .map_data_field()
-                .maybe_grow_for_insertion(cx)
-                .insert_without_growing(ValueCollectionKey::from(group.key), items.get());
+            map.cast::<MapObject>().insert(cx, group.key, items);
         }
 
         map.into()

--- a/src/js/runtime/intrinsics/map_iterator.rs
+++ b/src/js/runtime/intrinsics/map_iterator.rs
@@ -111,6 +111,15 @@ impl MapIteratorPrototype {
             return create_iter_result_object(cx, cx.undefined(), true).into();
         }
 
+        // Follow tombstone objects, fixing up iterator as needed. This may be a chain of tombstone
+        // objects and we need to fix up the iterator at each step.
+        while map_iterator.map.is_tombstone() {
+            map_iterator.map = ValueMap::fix_iterator_for_resized_map(
+                map_iterator.map,
+                &mut map_iterator.next_entry_index,
+            );
+        }
+
         // Perform a single iteration, mutating iterator object
         let mut iter = map_iterator.get_iter();
         let iter_result = iter.next();

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -2,7 +2,6 @@ use crate::{
     js::runtime::{
         abstract_operations::call_object,
         builtin_function::BuiltinFunction,
-        collections::BsIndexMapField,
         completion::EvalResult,
         error::type_error,
         function::get_argument,
@@ -230,9 +229,7 @@ impl MapPrototype {
             key = Value::number(0.0).to_handle(cx);
         }
 
-        map.map_data_field()
-            .maybe_grow_for_insertion(cx)
-            .insert_without_growing(ValueCollectionKey::from(key), value.get());
+        map.insert(cx, key, value);
 
         this_value.into()
     }

--- a/src/js/runtime/intrinsics/set_iterator.rs
+++ b/src/js/runtime/intrinsics/set_iterator.rs
@@ -107,6 +107,15 @@ impl SetIteratorPrototype {
             return create_iter_result_object(cx, cx.undefined(), true).into();
         }
 
+        // Follow tombstone objects, fixing up iterator as needed. This may be a chain of tombstone
+        // objects and we need to fix up the iterator at each step.
+        while set_iterator.set.is_tombstone() {
+            set_iterator.set = BsIndexMap::fix_iterator_for_resized_map(
+                set_iterator.set,
+                &mut set_iterator.next_entry_index,
+            );
+        }
+
         // Perform a single iteration, mutating iterator object
         let mut iter = set_iterator.get_iter();
         let iter_result = iter.next();

--- a/src/js/runtime/intrinsics/weak_map_object.rs
+++ b/src/js/runtime/intrinsics/weak_map_object.rs
@@ -9,7 +9,7 @@ use crate::{
         object_descriptor::ObjectKind,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
-        value::ValueCollectionKey,
+        value::{ValueCollectionKey, ValueCollectionKeyHandle},
         Context, Handle, HeapPtr, Value,
     },
     maybe, set_uninit,
@@ -66,6 +66,14 @@ impl WeakMapObject {
 impl Handle<WeakMapObject> {
     pub fn weak_map_data_field(&self) -> WeakMapObjectMapField {
         WeakMapObjectMapField(*self)
+    }
+
+    pub fn insert(&self, cx: Context, key: Handle<Value>, value: Handle<Value>) -> bool {
+        let key_handle = ValueCollectionKeyHandle::new(key);
+
+        self.weak_map_data_field()
+            .maybe_grow_for_insertion(cx)
+            .insert_without_growing(key_handle.get(), value.get())
     }
 }
 

--- a/src/js/runtime/intrinsics/weak_map_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_map_prototype.rs
@@ -1,5 +1,5 @@
 use crate::js::runtime::{
-    collections::BsHashMapField, completion::EvalResult, error::type_error, function::get_argument,
+    completion::EvalResult, error::type_error, function::get_argument,
     intrinsics::weak_ref_constructor::can_be_held_weakly, object_value::ObjectValue,
     property::Property, realm::Realm, value::ValueCollectionKey, Context, Handle, Value,
 };
@@ -122,10 +122,7 @@ impl WeakMapPrototype {
             return type_error(cx, "WeakMap keys must be objects or symbols");
         }
 
-        weak_map_object
-            .weak_map_data_field()
-            .maybe_grow_for_insertion(cx)
-            .insert_without_growing(ValueCollectionKey::from(key), value.get());
+        weak_map_object.insert(cx, key, value);
 
         this_value.into()
     }

--- a/src/js/runtime/intrinsics/weak_set_object.rs
+++ b/src/js/runtime/intrinsics/weak_set_object.rs
@@ -9,8 +9,8 @@ use crate::{
         object_descriptor::ObjectKind,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
-        value::ValueCollectionKey,
-        Context, Handle, HeapPtr,
+        value::{ValueCollectionKey, ValueCollectionKeyHandle},
+        Context, Handle, HeapPtr, Value,
     },
     maybe, set_uninit,
 };
@@ -66,6 +66,14 @@ impl WeakSetObject {
 impl Handle<WeakSetObject> {
     pub fn weak_set_data_field(&self) -> WeakSetObjectSetField {
         WeakSetObjectSetField(*self)
+    }
+
+    pub fn insert(&self, cx: Context, item: Handle<Value>) -> bool {
+        let item_handle = ValueCollectionKeyHandle::new(item);
+
+        self.weak_set_data_field()
+            .maybe_grow_for_insertion(cx)
+            .insert_without_growing(item_handle.get())
     }
 }
 

--- a/src/js/runtime/intrinsics/weak_set_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_set_prototype.rs
@@ -1,5 +1,5 @@
 use crate::js::runtime::{
-    collections::BsHashSetField, completion::EvalResult, error::type_error, function::get_argument,
+    completion::EvalResult, error::type_error, function::get_argument,
     intrinsics::weak_ref_constructor::can_be_held_weakly, object_value::ObjectValue,
     property::Property, realm::Realm, value::ValueCollectionKey, Context, Handle, Value,
 };
@@ -48,10 +48,7 @@ impl WeakSetPrototype {
             return type_error(cx, "WeakSet only holds objects and symbols");
         }
 
-        weak_set_object
-            .weak_set_data_field()
-            .maybe_grow_for_insertion(cx)
-            .insert_without_growing(ValueCollectionKey::from(value));
+        weak_set_object.insert(cx, value);
 
         this_value.into()
     }

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -773,11 +773,11 @@ impl NamedPropertiesMapField {
     }
 
     pub fn visit_pointers(map: &mut HeapPtr<NamedPropertiesMap>, visitor: &mut impl HeapVisitor) {
-        map.visit_pointers(visitor);
-
-        for (property_key, property) in map.iter_mut_gc_unsafe() {
-            visitor.visit_property_key(property_key);
-            property.visit_pointers(visitor);
-        }
+        map.visit_pointers_impl(visitor, |map, visitor| {
+            for (property_key, property) in map.iter_mut_gc_unsafe() {
+                visitor.visit_property_key(property_key);
+                property.visit_pointers(visitor);
+            }
+        });
     }
 }

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -857,3 +857,22 @@ impl hash::Hash for ValueCollectionKey {
         self.0.as_raw_bits().hash(state);
     }
 }
+
+#[derive(Clone, Copy)]
+pub struct ValueCollectionKeyHandle(Handle<Value>);
+
+impl ValueCollectionKeyHandle {
+    /// Identical to ValueCollectionKey::from but stores a handle instead.
+    pub fn new(value: Handle<Value>) -> Self {
+        if value.is_string() {
+            let flat_string = value.as_string().flatten();
+            return ValueCollectionKeyHandle(flat_string.as_string().into());
+        }
+
+        ValueCollectionKeyHandle(value)
+    }
+
+    pub fn get(&self) -> ValueCollectionKey {
+        ValueCollectionKey(self.0.get())
+    }
+}


### PR DESCRIPTION
## Summary

MapObject and SetObject iterators maintain a direct reference to the underlying BsIndexMap. However the map or set can be resized while iterating, which creates a different BsIndexMap with a copy of the collection's contents. But the iterator still has a reference to the old underlying BsIndexMap.

To handle resizing we must rewrite the old BsIndexMap in place to contain the information needed to update the iterator to point to the new BsIndexMap. This old BsIndexMap is called a tombstone which we set a flag to indicate.

The tombstone needs to contain the pointer to the new BsIndexMap, which is stored at the first entry of the indices array. We also need information to update the iterator's old next entry index. We can update this by counting the number of occupied entries in the old map up to that index. Note that we only need the occupied flag, so tombstones do not hold strong references to their entries.

Also fixes a GC safety bug when inserting into BsIndexMap and BsIndexSet with ValueCollectionKeys.