### PR TITLE
[regexp] Implement duplicate named capture groups proposal

### DIFF
--- a/src/js/parser/regexp.rs
+++ b/src/js/parser/regexp.rs
@@ -7,6 +7,7 @@ use super::ast::P;
 pub struct RegExp {
     pub disjunction: Disjunction,
     pub flags: RegExpFlags,
+    pub has_duplicate_named_capture_groups: bool,
     // All capture groups with their names if one was provided
     pub capture_groups: Vec<Option<String>>,
 }

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -129,7 +129,6 @@
       "ShadowRealm",
       // Unimplemented Stage 4 proposals
       "arraybuffer-transfer",
-      "regexp-duplicate-named-groups",
       "resizable-arraybuffer"
     ]
   },


### PR DESCRIPTION
## Summary

Implements the duplicate named capture groups proposal as specified in https://github.com/tc39/proposal-duplicate-named-capturing-groups.

## Tests
- Passes all non-annexB test262 duplicate named capture groups tests, the regexp-duplicate-named-groups feature is no longer ignored

