### PR TITLE
[runtime] Fix GC safety bugs in typed arrays

### DIFF
--- a/src/js/runtime/intrinsics/typed_array.rs
+++ b/src/js/runtime/intrinsics/typed_array.rs
@@ -31,7 +31,7 @@ use crate::{
         value::{BigIntValue, Value},
         Context, Handle, HeapPtr,
     },
-    maybe, must, set_uninit,
+    maybe, set_uninit,
 };
 
 use super::{
@@ -72,10 +72,6 @@ pub trait TypedArray {
 
     fn element_size(&self) -> usize;
 
-    fn read_element_ptr(&self, cx: Context, ptr: *const u8) -> Handle<Value>;
-
-    fn write_element_ptr(&self, cx: Context, ptr: *mut u8, value: Handle<Value>);
-
     fn read_element_value(
         &self,
         cx: Context,
@@ -83,7 +79,17 @@ pub trait TypedArray {
         byte_index: usize,
     ) -> Handle<Value>;
 
-    /// Write the value at a particular index. Do not check that the index is in bounds.
+    /// Write the value at a particular byte index. Only valid to use on a value that will not
+    /// invoke user code when converted to an array element (such as values read directly from
+    /// another array).
+    fn write_element_value(
+        &mut self,
+        cx: Context,
+        byte_index: usize,
+        value: Handle<Value>,
+    ) -> EvalResult<()>;
+
+    /// Write the value at a particular array index. Do not check that the index is in bounds.
     fn write_element_value_unchecked(
         &mut self,
         cx: Context,

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -221,7 +221,8 @@
       "built-ins/encodeURI/S15.1.3.3_A1.3_T1.js",
       "built-ins/encodeURI/S15.1.3.3_A2.2_T1.js",
       "built-ins/encodeURIComponent/S15.1.3.4_A1.3_T1.js",
-      "built-ins/encodeURIComponent/S15.1.3.4_A2.2_T1.js"
+      "built-ins/encodeURIComponent/S15.1.3.4_A2.2_T1.js",
+      "staging/ArrayBuffer/resizable/set-with-resizable-source.js"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Fixes two instances of the same class of GC safety bug in typed arrays. When copying values from a typed array to another of a different type, we were holding a raw pointer over an allocation. This was occurring in the typed array constructor as well as TypedArray.prototype.set.

## Tests

- Now passes test262 tests with GC stress test mode enabled (`cargo run --release --features gc_stress_test`)