### PR TITLE
[runtime] Fix typed array [[DefineOwnProperty]] and [[Set]] bug caused be shrinking ArrayBuffer

### DIFF
--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -333,20 +333,26 @@ macro_rules! create_typed_array_constructor {
                         //
                         // The only additional case we need to check is if the ArrayBuffer was
                         // detached by the call to `$to_element`.
-                        if array_buffer_ptr.is_fixed_length() && self.array_length().is_some() {
+                        let index = if array_buffer_ptr.is_fixed_length()
+                            && self.array_length().is_some()
+                        {
                             if array_buffer_ptr.is_detached() {
                                 return true.into();
                             }
+
+                            index.unwrap()
                         } else {
                             // Slow path - all bets are off and we must redo all bounds checks.
-                            let index_result =
+                            let new_index =
                                 canonical_numeric_index_string(cx, key, self.as_typed_array());
-                            if !matches!(index_result, Some(Some(_))) {
+                            if !matches!(new_index, Some(Some(_))) {
                                 return true.into();
                             }
-                        }
 
-                        let byte_index = index.unwrap() * element_size!() + self.byte_offset;
+                            new_index.unwrap().unwrap()
+                        };
+
+                        let byte_index = index * element_size!() + self.byte_offset;
 
                         $typed_array::write_element(array_buffer_ptr, byte_index, element_value);
 
@@ -411,20 +417,26 @@ macro_rules! create_typed_array_constructor {
                         //
                         // The only additional case we need to check is if the ArrayBuffer was
                         // detached by the call to `$to_element`.
-                        if array_buffer_ptr.is_fixed_length() && self.array_length().is_some() {
+                        let index = if array_buffer_ptr.is_fixed_length()
+                            && self.array_length().is_some()
+                        {
                             if array_buffer_ptr.is_detached() || index.is_none() {
                                 return true.into();
                             }
+
+                            index.unwrap()
                         } else {
                             // Slow path - all bets are off and we must redo all bounds checks.
-                            let index_result =
+                            let new_index =
                                 canonical_numeric_index_string(cx, key, self.as_typed_array());
-                            if !matches!(index_result, Some(Some(_))) {
+                            if !matches!(new_index, Some(Some(_))) {
                                 return true.into();
                             }
-                        }
 
-                        let byte_index = index.unwrap() * element_size!() + self.byte_offset;
+                            new_index.unwrap().unwrap()
+                        };
+
+                        let byte_index = index * element_size!() + self.byte_offset;
 
                         $typed_array::write_element(array_buffer_ptr, byte_index, element_value);
 


### PR DESCRIPTION
## Summary

Fixes a bug in typed array [[DefineOwnProperty]] and [[Set]]. Converting the input value into the typed array's expected type can invoke user code, which may resize the underlying ArrayBuffer. If the index is initially out of bounds but user code is invoked to shrink it so that the index is in range, we should use the new index. Previously we crashed on this case.

## Tests

- [built-ins/TypedArray/of/resized-with-out-of-bounds-and-in-bounds-indices.js](https://github.com/tc39/test262/blob/98c7e9114e7eb663f895953c3750c6b270660a51/test/built-ins/TypedArray/of/resized-with-out-of-bounds-and-in-bounds-indices.js)
- [built-ins/TypedArrayConstructors/internals/Set/resized-out-of-bounds-to-in-bounds-index.js](https://github.com/tc39/test262/blob/98c7e9114e7eb663f895953c3750c6b270660a51/test/built-ins/TypedArrayConstructors/internals/Set/resized-out-of-bounds-to-in-bounds-index.js)