### PR TITLE
[runtime] Fix ArrayIterator.prototype.next when called on a resized TypedArray

### DIFF
--- a/src/js/runtime/intrinsics/array_iterator.rs
+++ b/src/js/runtime/intrinsics/array_iterator.rs
@@ -130,6 +130,11 @@ impl ArrayIteratorPrototype {
         let mut array_iterator = maybe!(ArrayIterator::cast_from_value(cx, this_value));
         let array = array_iterator.array();
 
+        // Early return if iterator is already done, before potential failure during `get_length`
+        if array_iterator.is_done {
+            return create_iter_result_object(cx, cx.undefined(), true).into();
+        }
+
         // Dispatches based on whether this is array or typed array
         let length = maybe!((array_iterator.get_length)(cx, array));
 


### PR DESCRIPTION
## Summary

Fixes a bug in `ArrayIterator.prototype.next` when called on a resized TypedArray. This exposed that iterators that have already completed could throw an error on `next` during the call to `get_length`, e.g. if the TypedArray has been resized making the current index out of bounds. The solution is to immediately return from `ArrayIterator.prototype.next` if the iterator is done before potentially invoking any user code.

## Tests

- [built-ins/TypedArray/prototype/values/make-out-of-bounds-after-exhausted.js](https://github.com/tc39/test262/blob/98c7e9114e7eb663f895953c3750c6b270660a51/test/built-ins/TypedArray/prototype/values/make-out-of-bounds-after-exhausted.js)