### PR TITLE
[runtime] Typed array CanonicalNumericIndexString returns an enum

### DIFF
--- a/src/js/runtime/intrinsics/typed_array.rs
+++ b/src/js/runtime/intrinsics/typed_array.rs
@@ -37,7 +37,7 @@ use crate::{
 use super::{
     array_buffer_constructor::{clone_array_buffer, ArrayBufferObject},
     intrinsics::Intrinsic,
-    typed_array_constructor::canonical_numeric_index_string,
+    typed_array_constructor::{canonical_numeric_index_string, CanonicalIndexType},
     typed_array_prototype::{
         is_typed_array_out_of_bounds, make_typed_array_with_buffer_witness_record,
         typed_array_length,


### PR DESCRIPTION
## Summary

Refactor `CanonicalNumericIndexString` for typed arrays to return an enum with more clearly named values instead of a nested option.