### PR TITLE
[regexp] Always emit progress instructions in optional quantifier iterations that are not guaranteed to consume

### DIFF
--- a/src/js/runtime/regexp/compiler.rs
+++ b/src/js/runtime/regexp/compiler.rs
@@ -630,7 +630,7 @@ impl CompiledRegExpBuilder {
             // Each repitition must consume at least one character, so we know this quantifier will
             // fail to match.
             self.emit_fail_instruction();
-        } else {
+        } else if quantifier.min != 0 {
             // Jump to a new loop block for the minimum repititions
             let loop_block_id = self.new_block();
             let loop_end_block_id = self.new_block();

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -2,8 +2,6 @@
   // Tests which are always ignored
   "always": {
     "tests": [
-      // BUG: RegExp matcher loops on this test case
-      "built-ins/RegExp/nullable-quantifier.js",
       // ECMA-402 Internationalization API is not implemented
       "intl402/*",
       // Incorrect tests due to changed base/property evaluation order


### PR DESCRIPTION
## Summary

Fixes bugs concerning the progress instruction in quantifiers. The progress instruction is used in optional iterations of quantifiers that are not guaranteed to consume any characters. This ensures that forward progress is made (avoiding infinite epsilon loops), and also makes it so that optional quantifier iterations do not match if they match the empty string.

Previously we were only emitting the progress instruction for quantifiers with an uncapped max. We should also be emitting progress instructions for quantifiers with fixed maximums.

Additionally we were checking progress on the back edge of the loop (and were branching beforehand), which means the quantifier iteration could match the empty string. Instead we should always be checking progress right after the loop, but before the branch to either the beginning of loop or end.

## Tests

- Fixes [built-ins/RegExp/nullable-quantifier.js](https://github.com/tc39/test262/blob/867ca540d6cc991a82b41a3b7f9ccb9e93efe803/test/built-ins/RegExp/nullable-quantifier.js)