### PR TITLE
[test] Refactor ignored tests into known failures, non-standard tests, and unimplemented features

### DIFF
--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -1,9 +1,7 @@
 {
-  // Tests which are always ignored
-  "always": {
+  // Tests that are known to fail but should count against test262 progress.
+  "known_failures": {
     "tests": [
-      // ECMA-402 Internationalization API is not implemented
-      "intl402/*",
       // Incorrect tests due to changed base/property evaluation order
       // https://github.com/tc39/test262/issues/3407
       "language/expressions/assignment/target-member-computed-reference-null.js",
@@ -101,21 +99,55 @@
     ],
     "features": [
       // Always skip tail-call-optimization tests as they cause stack overflow
-      "tail-call-optimization",
-      // Non-standard extension
+      "tail-call-optimization"
+    ]
+  },
+  // Tests for unimplemented features. Counts against test262 progress.
+  "unimplemented": {
+    "features": [
+      // Features requiring modules to be implemented
+      "import.meta",
+      "top-level-await",
+      "dynamic-import",
+      // Other unimplemented features
+      "regexp-v-flag",
+      "SharedArrayBuffer",
+      "Atomics"
+    ]
+  },
+  // Tests for features that are not part of the standard. These tests are always ignored, and do
+  // not count against test262 progress.
+  //
+  // This includes tests for:
+  // - Stage < 4 proposals
+  // - Annex B (Additional ECMAScript Features for Web Browsers)
+  // - Non-standard extensions to the language
+  // - Standards other than ECMA-262
+  "non_standard": {
+    "tests": [
+      // Annex B
+      "annexB/*",
+      // The ECMA-402 Internationalization API is not part of ECMA-262
+      "intl402/*"
+    ],
+    "features": [
+      // Non-standard extensions
       "caller",
       // Stage < 4 proposals
       "decorators",
       "explicit-resource-management",
       "import-assertions",
+      "import-attributes",
       "iterator-helpers",
       "json-modules",
       "json-parse-with-source",
       "legacy-regexp",
       "promise-try",
       "regexp-modifiers",
+      "source-phase-imports",
       "uint8array-base64",
       "Array.fromAsync",
+      "Atomics.pause",
       "FinalizationRegistry.prototype.cleanupSome",
       "Float16Array",
       "Intl.DurationFormat",

--- a/tests/test262/src/main.rs
+++ b/tests/test262/src/main.rs
@@ -9,7 +9,7 @@ use brimstone_test262::{
 #[derive(Parser)]
 #[command(about)]
 struct Args {
-    /// Run all tests, including slow tests
+    /// Run all tests, including non-standard and slow tests
     #[arg(long, default_value_t = false)]
     all: bool,
 
@@ -25,13 +25,9 @@ struct Args {
     #[arg(long, default_value_t = String::from("ignored_tests.jsonc"))]
     ignored_path: String,
 
-    /// Ignore module tests
+    /// Ignore tests for unimplemented features
     #[arg(long, default_value_t = false)]
-    ignore_module: bool,
-
-    /// Ignore Annex B tests
-    #[arg(long, default_value_t = false)]
-    ignore_annex_b: bool,
+    ignore_unimplemented: bool,
 
     /// Reindex the test262 test suite
     #[arg(long, default_value_t = false)]
@@ -80,12 +76,7 @@ fn main_impl() -> GenericResult {
     }
 
     let index = TestIndex::load_from_file(index_path)?;
-    let ignored = IgnoredIndex::load_from_file(
-        ignored_path,
-        args.all,
-        args.ignore_module,
-        args.ignore_annex_b,
-    )?;
+    let ignored = IgnoredIndex::load_from_file(ignored_path, args.all, args.ignore_unimplemented)?;
 
     let mut runner = TestRunner::new(index, ignored, args.threads, args.filter, args.feature);
     let results = runner.run(args.verbose);


### PR DESCRIPTION
## Summary

Refactor the ignored tests in the ignored test index to fall into one of three categories:
- Known failures, which count against test262 progress
- Unimplemented features which count against test262 progress
- Non-standard features, including Annex B, non-stage-4 proposals, and ECMA-402 tests. These do not count against test262 progress

This also lets us remove the `--ignore-annex-b` and `--ignore-module` options. Non-standard tests are now ignored by default (unless run with the `--all` option). Unimplemented features can be ignored with the new `--ignore-unimplemented` option.

## Tests

- `cargo run` now returns 38281 successes and 1599 failures
- `cargo run -- --ignore-unimplemented` now returns 37962 successes and 24 failures
