### PR TITLE
[test] Report test262 progress in harness

### DIFF
--- a/tests/test262/README.md
+++ b/tests/test262/README.md
@@ -1,4 +1,4 @@
-# brimstone-test26
+# brimstone-test262
 
 Brimstone test runner for the official test262 test suite.
 
@@ -6,7 +6,7 @@ Brimstone test runner for the official test262 test suite.
 
 The test runner requires the https://github.com/tc39/test262 repo. For consistency the test runner uses the test262 repo pinned to a specific commit. The current commit hash is:
 
-`Dec 2 2022: 3d939ef566456d6a5609bcba48643b14177a77fe`.
+`2024-08-27: b69e9d5e722291dcb6ada5582c71887133626c63`.
 
 Install the test262 repo at the pinned commit by running the following script:
 
@@ -18,7 +18,7 @@ Install the test262 repo at the pinned commit by running the following script:
 
 The test runner is run with `cargo run` in this directory. Run `cargo run -- --help` to see the full set of options for the test runner.
 
-Before running any tests, the test runner must first create an index of the test262 tests for fast consumption later on. This only needs to be run once:
+Before running any tests, the test runner must first create an index of the test262 tests for fast consumption later on. This only needs to be run after you pull in a new version of the test272 repo.:
 
 ```
 cargo run -- --reindex
@@ -32,7 +32,19 @@ cargo run
 
 # Run only the tests that match a filter string
 cargo run -- language/expressions
-
-# Run only the tests that match a feature
-cargo run -- --feature computed-property-names
 ```
+
+Other important options include:
+- `--report-test262-progress` report the overall progress against the test262 suite, properly categorizing ignored tests
+- `--ignore-unimplemented` ignore tests for features that are not yet implemented
+- `-t, --threads` specify the number of threads to use for running tests, defaults to 8
+
+# Ignored Tests
+
+The file `ignored_tests.jsonc` contains sets of test which should be ignored by the test runner. These sets of tests are specified by regexp patterns and by feature.
+
+- `known_failures`, which count against test262 progress
+- `unimplemented` features, which count against test262 progress
+- `non_standard` tests, which do not count against test262 progress
+- `slow` tests which are skipped by default
+- `gc_stress_test`, which are slow tests that are skipped by default in GC stress test mode

--- a/tests/test262/install_test262.sh
+++ b/tests/test262/install_test262.sh
@@ -5,7 +5,7 @@ set -e
 CURRENT_DIR=$(cd "$(dirname "$0")" && pwd)
 TEST262_REPO_DIR="$CURRENT_DIR/test262"
 
-# Pinned commit hash of test262 repo that we test off of
+# Pinned commit hash of test262 repo that we test off of. Be sure to also update README.md.
 # Last updated on 2024-08-27
 TEST262_COMMIT_SHA="b69e9d5e722291dcb6ada5582c71887133626c63"
 


### PR DESCRIPTION
## Summary

Adds the `--report-test262-progress` option to the test harness which makes the test harness report exact progress against the test262 test suite. This means that all ignored known failures and ignored unimplemented features should count as failures instead of skips.

This includes a refactor to bundle the matched tests regex, features, and ignore_module into a `Matcher` struct, so we can reuse this matching logic between ignored tests which count as skips and ignored tests which count as failures. We also introduce builders for the ignored index.

Now running `cargo run -- --report-test262-progress` reports that we have 94% test262 compliance!

```
> cargo run -- --report-test262-progress
Test262 progress: 94.00%
37962/40385 tests passed
```

## Tests

Tests runs not reporting test262 progress are unaffected.