### PR TITLE
[parser] Early errors for ModuleExportNames in import and export specifiers

### DIFF
--- a/src/js/common/unicode.rs
+++ b/src/js/common/unicode.rs
@@ -35,6 +35,16 @@ pub fn is_surrogate_code_point(code_point: CodePoint) -> bool {
 }
 
 #[inline]
+pub fn is_high_surrogate_code_point(code_point: CodePoint) -> bool {
+    code_point >= HIGH_SURROGATE_START as u32 && code_point <= HIGH_SURROGATE_END as u32
+}
+
+#[inline]
+pub fn is_low_surrogate_code_point(code_point: CodePoint) -> bool {
+    code_point >= LOW_SURROGATE_START as u32 && code_point <= LOW_SURROGATE_END as u32
+}
+
+#[inline]
 pub fn is_high_surrogate_code_unit(code_unit: CodeUnit) -> bool {
     (HIGH_SURROGATE_START..=HIGH_SURROGATE_END).contains(&code_unit)
 }

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -1473,11 +1473,6 @@ pub struct ExportAllDeclaration {
 }
 
 pub enum ModuleName {
-    Id(ModuleNameIdentifier),
+    Id(Identifier),
     String(StringLiteral),
-}
-
-pub struct ModuleNameIdentifier {
-    pub loc: Loc,
-    pub name: String,
 }

--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -82,6 +82,7 @@ pub enum ParseError {
     AwaitInStaticInitializer,
     AwaitInParameters,
     YieldInParameters,
+    ModuleNameNotWellFormed,
     // RegExpr parsing errors
     UnexpectedRegExpToken,
     InvalidRegExpFlag,
@@ -352,6 +353,9 @@ impl fmt::Display for ParseError {
             }
             ParseError::YieldInParameters => {
                 write!(f, "Yield expression not allowed in function parameters")
+            }
+            ParseError::ModuleNameNotWellFormed => {
+                write!(f, "Module name is not well formed")
             }
             ParseError::UnexpectedRegExpToken => {
                 write!(f, "Unexpected token")

--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -83,6 +83,7 @@ pub enum ParseError {
     AwaitInParameters,
     YieldInParameters,
     ModuleNameNotWellFormed,
+    ModuleNameIsReservedWord,
     // RegExpr parsing errors
     UnexpectedRegExpToken,
     InvalidRegExpFlag,
@@ -356,6 +357,9 @@ impl fmt::Display for ParseError {
             }
             ParseError::ModuleNameNotWellFormed => {
                 write!(f, "Module name is not well formed")
+            }
+            ParseError::ModuleNameIsReservedWord => {
+                write!(f, "Module name is a reserved word")
             }
             ParseError::UnexpectedRegExpToken => {
                 write!(f, "Unexpected token")


### PR DESCRIPTION
## Summary

Early errors on two conditions for ModuleExportNames, which may appear in both import and export specifiers.

- ModuleExportNames must be well formed strings, meaning there cannot be any lone surrogates
- ModuleExportNames in export specifiers cannot be a reserved word
