### PR TITLE
[runtime] Implement basic module loading

### DIFF
--- a/src/js/common/error.rs
+++ b/src/js/common/error.rs
@@ -1,0 +1,4 @@
+pub fn print_error_message_and_exit(message: &str) {
+    eprintln!("{}", message);
+    std::process::exit(1);
+}

--- a/src/js/common/mod.rs
+++ b/src/js/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod icu;
 mod icu_data;
 pub mod macros;

--- a/src/js/common/options.rs
+++ b/src/js/common/options.rs
@@ -19,7 +19,7 @@ pub struct Args {
     pub print_regexp_bytecode: bool,
 
     /// Parse as module instead of script
-    #[arg(long, default_value_t = false)]
+    #[arg(short, long, default_value_t = false)]
     pub module: bool,
 
     /// Expose global gc methods
@@ -36,6 +36,8 @@ pub struct Args {
 
 /// Options passed throughout the program.
 pub struct Options {
+    /// Print each AST to the console
+    pub print_ast: bool,
     /// Print the bytecode to the console
     pub print_bytecode: bool,
     /// Print the bytecode for all RegExps to the console
@@ -48,6 +50,7 @@ impl Options {
     /// Create a new options struct from the command line arguments.
     pub fn new_from_args(args: &Args) -> Self {
         Self {
+            print_ast: args.print_ast,
             print_bytecode: args.print_bytecode,
             print_regexp_bytecode: args.print_regexp_bytecode,
             dump_buffer: None,
@@ -66,6 +69,7 @@ impl Default for Options {
     /// Create a new options struct with default values.
     fn default() -> Self {
         Self {
+            print_ast: false,
             print_bytecode: false,
             print_regexp_bytecode: false,
             dump_buffer: None,

--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -1520,10 +1520,8 @@ impl Analyzer<'_> {
     }
 }
 
-pub fn analyze(
-    parse_result: &mut ParseProgramResult,
-    source: Rc<Source>,
-) -> Result<(), LocalizedParseErrors> {
+pub fn analyze(parse_result: &mut ParseProgramResult) -> Result<(), LocalizedParseErrors> {
+    let source = parse_result.program.source.clone();
     let mut analyzer = Analyzer::new(source, &mut parse_result.scope_tree);
     analyzer.visit_program(&mut parse_result.program);
 

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -1321,8 +1321,8 @@ impl<'a> Printer<'a> {
 }
 
 // Prints JSON in ESTree format
-pub fn print_program(program: &Program, source: &Source) -> String {
-    let mut printer = Printer::new(source);
+pub fn print_program(program: &Program) -> String {
+    let mut printer = Printer::new(&program.source);
     printer.print_program(program);
     printer.finish()
 }

--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -43,6 +43,7 @@ macro_rules! builtin_names {
 builtin_names!(
     (empty_string, ""),
     (negative_zero, "-0"),
+    (default_name, "*default*"),
     (__define_getter__, "__defineGetter__"),
     (__define_setter__, "__defineSetter__"),
     (__lookup_getter__, "__lookupGetter__"),

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -65,7 +65,7 @@ use crate::{
 use super::{
     constant_table::ConstantTable,
     function::{BytecodeFunction, Closure},
-    generator::BytecodeProgram,
+    generator::BytecodeScript,
     instruction::{
         extra_wide_prefix_index_to_opcode_index, wide_prefix_index_to_opcode_index, AddInstruction,
         AsyncIteratorCloseFinishInstruction, AsyncIteratorCloseStartInstruction, AwaitInstruction,
@@ -209,14 +209,14 @@ impl VM {
         vm
     }
 
-    /// Execute an entire bytecode program, first instantiating the global declarations then
+    /// Execute an entire bytecode script, first instantiating the global declarations then
     /// running the script function.
-    pub fn execute_program(
+    pub fn execute_script(
         &mut self,
-        bytecode_program: BytecodeProgram,
+        bytecode_script: BytecodeScript,
     ) -> Result<Handle<Value>, Handle<Value>> {
-        let mut realm = bytecode_program.script_function.realm();
-        let global_names = bytecode_program.global_names;
+        let mut realm = bytecode_script.script_function.realm();
+        let global_names = bytecode_script.global_names;
 
         // Call the GlobalDeclarationInstantiation function in the rust runtime
         let init_closure = realm
@@ -242,7 +242,7 @@ impl VM {
 
         // Create program closure and execute in VM
         let program_closure =
-            Closure::new_in_realm(self.cx(), bytecode_program.script_function, global_scope, realm);
+            Closure::new_in_realm(self.cx(), bytecode_script.script_function, global_scope, realm);
 
         self.execute(program_closure, &[])
     }

--- a/src/js/runtime/error.rs
+++ b/src/js/runtime/error.rs
@@ -1,11 +1,20 @@
+use crate::js::common::error::print_error_message_and_exit;
+
 use super::{
+    builtin_function::BuiltinFunction,
     completion::EvalResult,
-    intrinsics::native_error::{RangeError, ReferenceError, SyntaxError, TypeError, URIError},
+    function::get_argument,
+    intrinsics::{
+        native_error::{RangeError, ReferenceError, SyntaxError, TypeError, URIError},
+        promise_prototype::perform_promise_then,
+    },
+    object_value::ObjectValue,
+    promise_object::PromiseObject,
     string_value::{FlatString, StringValue},
-    Context, Handle, HeapPtr, Value,
+    to_console_string, Context, Handle, HeapPtr, Value,
 };
 
-fn syntax_error_value(cx: Context, message: &str) -> Handle<Value> {
+pub fn syntax_error_value(cx: Context, message: &str) -> Handle<Value> {
     SyntaxError::new_with_message(cx, message.to_owned()).into()
 }
 
@@ -55,4 +64,65 @@ pub fn err_assign_constant<T>(cx: Context, name: HeapPtr<FlatString>) -> EvalRes
 
 pub fn err_cannot_set_property<T>(cx: Context, name: impl std::fmt::Display) -> EvalResult<T> {
     type_error(cx, &format!("can't set property {}", name))
+}
+
+pub fn print_eval_error_and_exit(cx: Context, error: Handle<Value>) {
+    let error_string = to_console_string(cx, error);
+    print_error_message_and_exit(&error_string);
+}
+
+/// Prints the error passed as the first argument then exits the process.
+pub fn print_eval_error_and_exit_runtime(
+    cx: Context,
+    _: Handle<Value>,
+    arguments: &[Handle<Value>],
+    _: Option<Handle<ObjectValue>>,
+) -> EvalResult<Handle<Value>> {
+    let error = get_argument(cx, arguments, 0);
+    print_eval_error_and_exit(cx, error);
+
+    cx.undefined().into()
+}
+
+/// Panics with a message referencing the error passed as the first argument.
+pub fn panic_runtime(
+    cx: Context,
+    _: Handle<Value>,
+    arguments: &[Handle<Value>],
+    _: Option<Handle<ObjectValue>>,
+) -> EvalResult<Handle<Value>> {
+    let error = get_argument(cx, arguments, 0);
+    let error_string = to_console_string(cx, error);
+
+    panic!("{}", error_string);
+}
+
+/// Print an error to the console and exit if the provided promise rejects.
+pub fn print_error_and_exit_if_rejects(cx: Context, promise: Handle<PromiseObject>) {
+    let on_reject = BuiltinFunction::create(
+        cx,
+        print_eval_error_and_exit_runtime,
+        1,
+        cx.names.empty_string(),
+        cx.current_realm(),
+        None,
+        None,
+    );
+
+    perform_promise_then(cx, promise, cx.undefined(), on_reject.into(), None);
+}
+
+/// Panic if the provided promise rejects.
+pub fn panic_if_rejects(cx: Context, promise: Handle<PromiseObject>) {
+    let on_reject = BuiltinFunction::create(
+        cx,
+        panic_runtime,
+        1,
+        cx.names.empty_string(),
+        cx.current_realm(),
+        None,
+        None,
+    );
+
+    perform_promise_then(cx, promise, cx.undefined(), on_reject.into(), None);
 }

--- a/src/js/runtime/eval/eval.rs
+++ b/src/js/runtime/eval/eval.rs
@@ -66,11 +66,10 @@ pub fn perform_eval(
         flags.contains(EvalFlags::IN_STATIC_INITIALIZER),
         flags.contains(EvalFlags::IN_CLASS_FIELD_INITIALIZER),
     );
+
+    // Return the first syntax error
     if let Err(errors) = analyze_result {
-        // TODO: Return an aggregate error with all syntax errors
-        // Choose an arbitrary syntax error to return
-        let error = &errors.errors[0];
-        return syntax_error(cx, &error.to_string());
+        return syntax_error(cx, &errors.errors[0].to_string());
     }
 
     // Sloppy direct evals must perform EvalDeclarationInstantiation as var scoped bindings will

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -9,6 +9,7 @@ use crate::js::runtime::{
         function::{BytecodeFunction, Closure},
     },
     class_names::ClassNames,
+    collections::array::{value_array_byte_size, value_array_visit_pointers},
     context::GlobalSymbolRegistryField,
     for_in_iterator::ForInIterator,
     generator_object::GeneratorObject,
@@ -42,6 +43,7 @@ use crate::js::runtime::{
         weak_ref_constructor::WeakRefObject,
         weak_set_object::{WeakSetObject, WeakSetObjectSetField},
     },
+    module::source_text_module::SourceTextModule,
     object_descriptor::{ObjectDescriptor, ObjectKind},
     object_value::{NamedPropertiesMapField, ObjectValue},
     promise_object::{PromiseCapability, PromiseObject, PromiseReaction},
@@ -141,6 +143,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::ScopeNames => self.cast::<ScopeNames>().byte_size(),
             ObjectKind::GlobalNames => self.cast::<GlobalNames>().byte_size(),
             ObjectKind::ClassNames => self.cast::<ClassNames>().byte_size(),
+            ObjectKind::SourceTextModule => self.cast::<SourceTextModule>().byte_size(),
             ObjectKind::Generator => self.cast::<GeneratorObject>().byte_size(),
             ObjectKind::AsyncGenerator => self.cast::<AsyncGeneratorObject>().byte_size(),
             ObjectKind::AsyncGeneratorRequest => self.cast::<AsyncGeneratorRequest>().byte_size(),
@@ -160,6 +163,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::InternedStringsMap => InternedStringsMapField::byte_size(&self.cast()),
             ObjectKind::InternedStringsSet => InternedStringsSetField::byte_size(&self.cast()),
             ObjectKind::LexicalNamesMap => LexicalNamesMapField::byte_size(&self.cast()),
+            ObjectKind::ValueArray => value_array_byte_size(self.cast()),
             ObjectKind::ArrayBufferDataArray => ArrayBufferDataField::byte_size(&self.cast()),
             ObjectKind::FinalizationRegistryCells => {
                 self.cast::<FinalizationRegistryCells>().byte_size()
@@ -247,6 +251,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::ScopeNames => self.cast::<ScopeNames>().visit_pointers(visitor),
             ObjectKind::GlobalNames => self.cast::<GlobalNames>().visit_pointers(visitor),
             ObjectKind::ClassNames => self.cast::<ClassNames>().visit_pointers(visitor),
+            ObjectKind::SourceTextModule => self.cast::<SourceTextModule>().visit_pointers(visitor),
             ObjectKind::Generator => self.cast::<GeneratorObject>().visit_pointers(visitor),
             ObjectKind::AsyncGenerator => {
                 self.cast::<AsyncGeneratorObject>().visit_pointers(visitor)
@@ -290,6 +295,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::LexicalNamesMap => {
                 LexicalNamesMapField::visit_pointers(self.cast_mut(), visitor)
             }
+            ObjectKind::ValueArray => value_array_visit_pointers(self.cast_mut(), visitor),
             ObjectKind::ArrayBufferDataArray => {
                 ArrayBufferDataField::visit_pointers(self.cast_mut(), visitor)
             }

--- a/src/js/runtime/intrinsics/aggregate_error_constructor.rs
+++ b/src/js/runtime/intrinsics/aggregate_error_constructor.rs
@@ -1,23 +1,27 @@
 use crate::{
-    js::runtime::{
-        abstract_operations::{
-            create_data_property_or_throw, create_non_enumerable_data_property_or_throw,
-            define_property_or_throw,
+    js::{
+        parser::LocalizedParseErrors,
+        runtime::{
+            abstract_operations::{
+                create_data_property_or_throw, create_non_enumerable_data_property_or_throw,
+                define_property_or_throw,
+            },
+            array_object::create_array_from_list,
+            builtin_function::BuiltinFunction,
+            completion::EvalResult,
+            error::syntax_error_value,
+            function::get_argument,
+            intrinsics::error_constructor::install_error_cause,
+            iterator::iter_iterator_values,
+            object_descriptor::ObjectKind,
+            object_value::ObjectValue,
+            ordinary_object::{object_create, object_create_from_constructor},
+            property_descriptor::PropertyDescriptor,
+            realm::Realm,
+            stack_trace::attach_stack_trace_to_error,
+            type_utilities::to_string,
+            Context, Handle, Value,
         },
-        array_object::create_array_from_list,
-        builtin_function::BuiltinFunction,
-        completion::EvalResult,
-        function::get_argument,
-        intrinsics::error_constructor::install_error_cause,
-        iterator::iter_iterator_values,
-        object_descriptor::ObjectKind,
-        object_value::ObjectValue,
-        ordinary_object::{object_create, object_create_from_constructor},
-        property_descriptor::PropertyDescriptor,
-        realm::Realm,
-        stack_trace::attach_stack_trace_to_error,
-        type_utilities::to_string,
-        Context, Handle, Value,
     },
     maybe, must,
 };
@@ -55,6 +59,21 @@ impl AggregateErrorObject {
         attach_stack_trace_to_error(cx, object, /* skip_current_frame */ true);
 
         object
+    }
+
+    pub fn new_from_localized_parse_errors(
+        cx: Context,
+        errors: &LocalizedParseErrors,
+    ) -> Handle<ErrorObject> {
+        let error_values = errors
+            .errors
+            .iter()
+            .map(|error| syntax_error_value(cx, &error.to_string()))
+            .collect::<Vec<_>>();
+
+        let errors_array = create_array_from_list(cx, &error_values);
+
+        Self::new(cx, errors_array.into())
     }
 }
 

--- a/src/js/runtime/intrinsics/mod.rs
+++ b/src/js/runtime/intrinsics/mod.rs
@@ -1,4 +1,4 @@
-mod aggregate_error_constructor;
+pub mod aggregate_error_constructor;
 mod aggregate_error_prototype;
 pub mod array_buffer_constructor;
 mod array_buffer_prototype;

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     js::runtime::{
         async_generator_object, bound_function_object::BoundFunctionObject, console::ConsoleObject,
-        gc_object::GcObject, global_names, object_value::ObjectValue,
+        error, gc_object::GcObject, global_names, module, object_value::ObjectValue,
         promise_object::PromiseCapability, test_262_object::Test262Object, Context, EvalResult,
         Handle, Value,
     },
@@ -300,6 +300,8 @@ rust_runtime_functions!(
     DatePrototype::value_of,
     ErrorConstructor::construct,
     ErrorPrototype::to_string,
+    error::panic_runtime,
+    error::print_eval_error_and_exit_runtime,
     EvalErrorConstructor::construct,
     FinalizationRegistryConstructor::construct,
     FinalizationRegistryPrototype::register,
@@ -380,6 +382,7 @@ rust_runtime_functions!(
     MathObject::tan,
     MathObject::tanh,
     MathObject::trunc,
+    module::execute::load_requested_modules_resolve,
     ObjectConstructor::construct,
     ObjectConstructor::assign,
     ObjectConstructor::create,

--- a/src/js/runtime/mod.rs
+++ b/src/js/runtime/mod.rs
@@ -24,6 +24,7 @@ pub mod global_names;
 mod interned_strings;
 pub mod intrinsics;
 mod iterator;
+pub mod module;
 mod numeric_constants;
 mod numeric_operations;
 mod object_descriptor;

--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -1,0 +1,55 @@
+use crate::{
+    js::runtime::{
+        builtin_function::BuiltinFunction,
+        intrinsics::{intrinsics::Intrinsic, promise_prototype::perform_promise_then},
+        object_value::ObjectValue,
+        promise_object::{PromiseCapability, PromiseObject},
+        Context, EvalResult, Handle, Value,
+    },
+    must,
+};
+
+use super::{loader::load_requested_modules, source_text_module::SourceTextModule};
+
+/// Action to take when the promise for an execution is rejected.
+pub enum ExecuteOnReject {
+    /// Print the error and exit the process.
+    PrintAndExit,
+    /// Panic the process.
+    #[allow(unused)]
+    Panic,
+}
+
+/// Execute a module - loading, linking, and evaluating it and its dependencies.
+///
+/// Returns a promise that resolves once the module has completed execution.
+pub fn execute_module(cx: Context, module: Handle<SourceTextModule>) -> Handle<PromiseObject> {
+    let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
+    let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
+
+    let promise = load_requested_modules(cx, module);
+
+    let on_resolve = BuiltinFunction::create(
+        cx,
+        load_requested_modules_resolve,
+        1,
+        cx.names.empty_string(),
+        cx.current_realm(),
+        None,
+        None,
+    );
+
+    perform_promise_then(cx, promise, on_resolve.into(), cx.undefined(), Some(capability));
+
+    // Guaranteed to be a PromiseObject since created with the Promise constructor
+    capability.promise().cast::<PromiseObject>()
+}
+
+pub fn load_requested_modules_resolve(
+    _: Context,
+    _: Handle<Value>,
+    _: &[Handle<Value>],
+    _: Option<Handle<ObjectValue>>,
+) -> EvalResult<Handle<Value>> {
+    unimplemented!("link and evaluate the modules");
+}

--- a/src/js/runtime/module/loader.rs
+++ b/src/js/runtime/module/loader.rs
@@ -1,0 +1,219 @@
+use std::{collections::HashSet, path::Path, rc::Rc};
+
+use crate::{
+    js::{
+        parser::{
+            analyze::analyze, parse_module, parser::ParseProgramResult, print_program,
+            source::Source, ParseResult,
+        },
+        runtime::{
+            abstract_operations::call_object,
+            bytecode::generator::BytecodeProgramGenerator,
+            completion::EvalResult,
+            error::syntax_error,
+            intrinsics::{
+                aggregate_error_constructor::AggregateErrorObject, intrinsics::Intrinsic,
+            },
+            promise_object::{PromiseCapability, PromiseObject},
+            string_value::FlatString,
+            Context, Handle, Realm,
+        },
+    },
+    must,
+};
+
+use super::source_text_module::{ModuleId, ModuleState, SourceTextModule};
+
+/// GraphLoadingStateRecord (https://tc39.es/ecma262/#graphloadingstate-record)
+struct GraphLoader {
+    is_loading: bool,
+    pending_modules_count: usize,
+    visited: HashSet<ModuleId>,
+    promise_capability: Handle<PromiseCapability>,
+    realm: Handle<Realm>,
+}
+
+impl GraphLoader {
+    /// InnerModuleLoading (https://tc39.es/ecma262/#sec-InnerModuleLoading)
+    fn inner_module_loading(&mut self, cx: Context, mut module: Handle<SourceTextModule>) {
+        if module.state() == ModuleState::New && self.visited.insert(module.id()) {
+            module.set_state(ModuleState::Unlinked);
+
+            let specifiers = module.requested_module_specifiers();
+            let loaded_modules = module.loaded_modules();
+
+            self.pending_modules_count += specifiers.len();
+
+            for i in 0..specifiers.len() {
+                match loaded_modules.as_slice()[i] {
+                    Some(loaded_module) => self.inner_module_loading(cx, loaded_module.to_handle()),
+                    None => {
+                        let module_specifier = specifiers.as_slice()[i].to_handle();
+
+                        // Create the SourceTextModule for the module with the given specifier,
+                        // or evaluate to an error.
+                        let load_result =
+                            self.host_load_imported_module(cx, module, module_specifier);
+
+                        // Continue module loading with the SourceTextModule or error result
+                        self.finish_loading_imported_module(
+                            cx,
+                            module,
+                            module_specifier,
+                            load_result,
+                        );
+                    }
+                }
+
+                if !self.is_loading {
+                    return;
+                }
+            }
+        }
+
+        self.pending_modules_count -= 1;
+
+        if self.pending_modules_count == 0 {
+            self.is_loading = false;
+
+            must!(call_object(
+                cx,
+                self.promise_capability.resolve(),
+                cx.undefined(),
+                &[cx.undefined()]
+            ));
+        }
+    }
+
+    /// HostLoadImportedModule (https://tc39.es/ecma262/#sec-HostLoadImportedModule)
+    fn host_load_imported_module(
+        &mut self,
+        mut cx: Context,
+        module: Handle<SourceTextModule>,
+        module_specifier: Handle<FlatString>,
+    ) -> EvalResult<Handle<SourceTextModule>> {
+        let source_file = module.program_function_ptr().source_file_ptr().unwrap();
+        let source_file_path = Path::new(&source_file.name().to_string())
+            .canonicalize()
+            .unwrap();
+        let source_file_dir = source_file_path.parent().unwrap();
+
+        // Join source file path with specifier path so that relative specifiers will be applied to
+        // source path and absolute specifiers will overwrite source path.
+        let new_module_path = source_file_dir
+            .join(Path::new(&module_specifier.to_string()))
+            .canonicalize();
+
+        let new_module_path = match new_module_path {
+            Ok(path) => path,
+            Err(error) => return syntax_error(cx, &error.to_string()),
+        };
+
+        let new_module_path_string = new_module_path.to_str().unwrap().to_string();
+
+        // Use the cached module if it has already been loaded
+        if let Some(module) = cx.modules.get(&new_module_path_string) {
+            return module.to_handle().into();
+        }
+
+        // Parse the file at the given path, returning AST
+        let mut parse_result = match Self::parse_file_at_path(new_module_path.as_path()) {
+            Ok(parse_result) => parse_result,
+            Err(error) => return syntax_error(cx, &error.to_string()),
+        };
+
+        // Analyze AST
+        if let Err(parse_errors) = analyze(&mut parse_result) {
+            let error = AggregateErrorObject::new_from_localized_parse_errors(cx, &parse_errors);
+            return EvalResult::Throw(error.into());
+        }
+
+        if cx.options.print_ast {
+            println!("{}", print_program(&parse_result.program));
+        }
+
+        // Finally generate the SourceTextModule for the parsed module
+        let bytecode_result = BytecodeProgramGenerator::generate_from_parse_module_result(
+            cx,
+            &Rc::new(parse_result),
+            self.realm,
+        );
+
+        let module = match bytecode_result {
+            Ok(module) => module,
+            Err(error) => return syntax_error(cx, &error.to_string()),
+        };
+
+        // Cache the module
+        cx.modules.insert(new_module_path_string, module.get_());
+
+        module.into()
+    }
+
+    fn parse_file_at_path(path: &Path) -> ParseResult<ParseProgramResult> {
+        let source = Rc::new(Source::new_from_file(path.to_str().unwrap())?);
+        parse_module(&source)
+    }
+
+    /// FinishLoadingImportedModule (https://tc39.es/ecma262/#sec-FinishLoadingImportedModule)
+    fn finish_loading_imported_module(
+        &mut self,
+        cx: Context,
+        mut referrer: Handle<SourceTextModule>,
+        specifier: Handle<FlatString>,
+        module_result: EvalResult<Handle<SourceTextModule>>,
+    ) {
+        if let EvalResult::Ok(module) = module_result {
+            let module_index = referrer.lookup_specifier_index(specifier.get_()).unwrap();
+            if !referrer.has_loaded_module_at(module_index) {
+                referrer.set_loaded_module_at(module_index, module.get_());
+            }
+        }
+
+        self.continue_module_loading(cx, module_result);
+    }
+
+    /// ContinueModuleLoading (https://tc39.es/ecma262/#sec-ContinueModuleLoading)
+    fn continue_module_loading(
+        &mut self,
+        cx: Context,
+        module_result: EvalResult<Handle<SourceTextModule>>,
+    ) {
+        if !self.is_loading {
+            return;
+        }
+
+        match module_result {
+            EvalResult::Ok(module) => {
+                self.inner_module_loading(cx, module);
+            }
+            EvalResult::Throw(error) => {
+                self.is_loading = false;
+                must!(call_object(cx, self.promise_capability.reject(), cx.undefined(), &[error]));
+            }
+        }
+    }
+}
+
+/// LoadRequestedModules (https://tc39.es/ecma262/#sec-LoadRequestedModules)
+pub fn load_requested_modules(
+    cx: Context,
+    module: Handle<SourceTextModule>,
+) -> Handle<PromiseObject> {
+    let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
+    let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
+    let realm = module.program_function_ptr().realm();
+
+    let mut graph_loader = GraphLoader {
+        is_loading: true,
+        pending_modules_count: 1,
+        visited: HashSet::new(),
+        promise_capability: capability,
+        realm,
+    };
+
+    graph_loader.inner_module_loading(cx, module);
+
+    // Known to be a PromiseObject since it was created by the intrinsic Promise constructor
+    capability.promise().cast::<PromiseObject>()
+}

--- a/src/js/runtime/module/mod.rs
+++ b/src/js/runtime/module/mod.rs
@@ -1,0 +1,3 @@
+pub mod execute;
+pub mod loader;
+pub mod source_text_module;

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -1,0 +1,340 @@
+use std::sync::{LazyLock, Mutex};
+
+use crate::{
+    field_offset,
+    js::runtime::{
+        bytecode::function::BytecodeFunction,
+        collections::{BsArray, InlineArray},
+        gc::{HeapObject, HeapVisitor},
+        object_descriptor::{ObjectDescriptor, ObjectKind},
+        object_value::ObjectValue,
+        scope::Scope,
+        string_value::FlatString,
+        Context, Handle, HeapPtr,
+    },
+    set_uninit,
+};
+
+/// Abstract Module Records (https://tc39.es/ecma262/#sec-abstract-module-records)
+/// Cyclic Modules Records (https://tc39.es/ecma262/#sec-cyclic-module-records)
+/// Source Text Module Records (https://tc39.es/ecma262/#sec-source-text-module-records)
+///
+/// Combination of SourceTextModule and its parent classes since it is the only type of module.
+#[repr(C)]
+pub struct SourceTextModule {
+    descriptor: HeapPtr<ObjectDescriptor>,
+    /// Unique identifier for this module. Can be used as a stable identifier.
+    id: ModuleId,
+    /// State of the module during load/link/evaluation.
+    state: ModuleState,
+    /// Function that evaluates the module when called in the module scope.
+    program_function: HeapPtr<BytecodeFunction>,
+    /// Scope for the module. Program function is executed in this scope.
+    module_scope: HeapPtr<Scope>,
+    /// The `import.meta` object for this module. This is lazily created when first accessed.
+    import_meta: Option<HeapPtr<ObjectValue>>,
+    /// The set of module specifiers that are requested by this module in imports and re-exports.
+    requested_module_specifiers: HeapPtr<StringArray>,
+    /// Each index corresponds to the specifier at the same index in `requested_module_specifiers`,
+    /// and contains the module object if one has been loaded.
+    loaded_modules: HeapPtr<ModuleOptionArray>,
+    /// All import and export entries in the module.
+    entries: InlineArray<ModuleEntry>,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum ModuleState {
+    New,
+    Unlinked,
+}
+
+type StringArray = BsArray<HeapPtr<FlatString>>;
+
+type ModuleOptionArray = BsArray<Option<HeapPtr<SourceTextModule>>>;
+
+impl SourceTextModule {
+    pub fn new(
+        cx: Context,
+        program_function: Handle<BytecodeFunction>,
+        module_scope: Handle<Scope>,
+        requested_module_specifiers: &[Handle<FlatString>],
+        imports: &[ImportEntry],
+        local_exports: &[LocalExportEntry],
+        named_re_exports: &[NamedReExportEntry],
+        direct_re_exports: &[DirectReExportEntry],
+    ) -> Handle<SourceTextModule> {
+        // First create arrays for requested and loaded modules. Requested modules are initialized
+        // from arguments, loaded modules are initialized to None.
+        let num_specifiers = requested_module_specifiers.len();
+        let mut heap_requested_module_specifiers =
+            BsArray::new_uninit(cx, ObjectKind::ValueArray, num_specifiers).to_handle();
+        for (dst, src) in heap_requested_module_specifiers
+            .as_mut_slice()
+            .iter_mut()
+            .zip(requested_module_specifiers.iter())
+        {
+            *dst = src.get_();
+        }
+
+        let loaded_modules =
+            BsArray::new(cx, ObjectKind::ValueArray, requested_module_specifiers.len(), None)
+                .to_handle();
+
+        // Then create the uninitialized module object
+        let num_entries =
+            imports.len() + local_exports.len() + named_re_exports.len() + direct_re_exports.len();
+        let size = Self::calculate_size_in_bytes(num_entries);
+        let mut object = cx.alloc_uninit_with_size::<SourceTextModule>(size);
+
+        set_uninit!(object.descriptor, cx.base_descriptors.get(ObjectKind::SourceTextModule));
+        set_uninit!(object.id, next_module_id());
+        set_uninit!(object.state, ModuleState::New);
+        set_uninit!(object.program_function, program_function.get_());
+        set_uninit!(object.module_scope, module_scope.get_());
+        set_uninit!(object.import_meta, None);
+        set_uninit!(object.requested_module_specifiers, heap_requested_module_specifiers.get_());
+        set_uninit!(object.loaded_modules, loaded_modules.get_());
+
+        let entries = &mut object.entries;
+        entries.init_with_uninit(num_entries);
+
+        // Add all import and export entries to the module
+        let mut i = 0;
+        for entry in imports {
+            entries.set_unchecked(i, ModuleEntry::Import(entry.to_heap()));
+            i += 1;
+        }
+        for entry in local_exports {
+            entries.set_unchecked(i, ModuleEntry::LocalExport(entry.to_heap()));
+            i += 1;
+        }
+        for entry in named_re_exports {
+            entries.set_unchecked(i, ModuleEntry::NamedReExport(entry.to_heap()));
+            i += 1;
+        }
+        for entry in direct_re_exports {
+            entries.set_unchecked(i, ModuleEntry::DirectReExport(entry.to_heap()));
+            i += 1;
+        }
+
+        object.to_handle()
+    }
+
+    const ENTRIES_OFFSET: usize = field_offset!(SourceTextModule, entries);
+
+    #[inline]
+    fn calculate_size_in_bytes(num_entries: usize) -> usize {
+        let entries_size = InlineArray::<ModuleEntry>::calculate_size_in_bytes(num_entries);
+        Self::ENTRIES_OFFSET + entries_size
+    }
+
+    #[inline]
+    pub fn id(&self) -> ModuleId {
+        self.id
+    }
+
+    #[inline]
+    pub fn state(&self) -> ModuleState {
+        self.state
+    }
+
+    #[inline]
+    pub fn set_state(&mut self, state: ModuleState) {
+        self.state = state;
+    }
+
+    #[inline]
+    pub fn program_function_ptr(&self) -> HeapPtr<BytecodeFunction> {
+        self.program_function
+    }
+
+    #[inline]
+    #[allow(unused)]
+    pub fn program_function(&self) -> Handle<BytecodeFunction> {
+        self.program_function_ptr().to_handle()
+    }
+
+    #[inline]
+    pub fn requested_module_specifiers(&self) -> Handle<StringArray> {
+        self.requested_module_specifiers.to_handle()
+    }
+
+    #[inline]
+    pub fn loaded_modules(&self) -> Handle<ModuleOptionArray> {
+        self.loaded_modules.to_handle()
+    }
+
+    pub fn lookup_specifier_index(&self, module_specifier: HeapPtr<FlatString>) -> Option<usize> {
+        self.requested_module_specifiers
+            .as_slice()
+            .iter()
+            .position(|&specifier| specifier == module_specifier)
+    }
+
+    pub fn has_loaded_module_at(&self, index: usize) -> bool {
+        self.loaded_modules.as_slice()[index].is_some()
+    }
+
+    pub fn set_loaded_module_at(&mut self, index: usize, module: HeapPtr<SourceTextModule>) {
+        self.loaded_modules.as_mut_slice()[index] = Some(module);
+    }
+}
+
+impl HeapObject for HeapPtr<SourceTextModule> {
+    fn byte_size(&self) -> usize {
+        SourceTextModule::calculate_size_in_bytes(self.entries.len())
+    }
+
+    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut self.descriptor);
+        visitor.visit_pointer(&mut self.program_function);
+        visitor.visit_pointer(&mut self.module_scope);
+        visitor.visit_pointer_opt(&mut self.import_meta);
+        visitor.visit_pointer(&mut self.requested_module_specifiers);
+        visitor.visit_pointer(&mut self.loaded_modules);
+
+        for entry in self.entries.as_mut_slice() {
+            match entry {
+                ModuleEntry::Import(import_entry) => {
+                    visitor.visit_pointer(&mut import_entry.module_request);
+                    visitor.visit_pointer_opt(&mut import_entry.import_name);
+                    visitor.visit_pointer(&mut import_entry.local_name);
+                }
+                ModuleEntry::LocalExport(local_export_entry) => {
+                    visitor.visit_pointer(&mut local_export_entry.export_name);
+                    visitor.visit_pointer(&mut local_export_entry.local_name);
+                }
+                ModuleEntry::NamedReExport(named_re_export_entry) => {
+                    visitor.visit_pointer(&mut named_re_export_entry.export_name);
+                    visitor.visit_pointer_opt(&mut named_re_export_entry.import_name);
+                    visitor.visit_pointer(&mut named_re_export_entry.module_request);
+                }
+                ModuleEntry::DirectReExport(direct_re_export_entry) => {
+                    visitor.visit_pointer(&mut direct_re_export_entry.module_request);
+                }
+            }
+        }
+    }
+}
+
+pub type ModuleId = usize;
+
+static NEXT_MODULE_ID: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+
+fn next_module_id() -> ModuleId {
+    let mut next_module_id = NEXT_MODULE_ID.lock().unwrap();
+    let module_id = *next_module_id;
+    *next_module_id += 1;
+
+    module_id
+}
+
+enum ModuleEntry {
+    Import(HeapImportEntry),
+    LocalExport(HeapLocalExportEntry),
+    NamedReExport(HeapNamedReExportEntry),
+    DirectReExport(HeapDirectReExportEntry),
+}
+
+/// ImportEntry, https://tc39.es/ecma262/#table-importentry-record-fields
+struct HeapImportEntry {
+    /// Name of the module that binding is being imported from.
+    module_request: HeapPtr<FlatString>,
+    /// Name of the binding in the module is was declared in. If None then this entry is for the
+    /// name object.
+    import_name: Option<HeapPtr<FlatString>>,
+    /// Name of the imported binding in this module.
+    local_name: HeapPtr<FlatString>,
+}
+
+pub struct ImportEntry {
+    pub module_request: Handle<FlatString>,
+    pub import_name: Option<Handle<FlatString>>,
+    pub local_name: Handle<FlatString>,
+}
+
+impl ImportEntry {
+    fn to_heap(&self) -> HeapImportEntry {
+        HeapImportEntry {
+            module_request: self.module_request.get_(),
+            import_name: self.import_name.map(|name| name.get_()),
+            local_name: self.local_name.get_(),
+        }
+    }
+}
+
+/// Subset of ExportEntry (https://tc39.es/ecma262/#table-exportentry-records) corresponding to
+/// the field SourceTextModule.[[LocalExportEntries]].
+///
+/// Corresponds to regular exports of local bindings including default exports.
+struct HeapLocalExportEntry {
+    /// The name of the export, i.e. the name that importers must reference.
+    export_name: HeapPtr<FlatString>,
+    /// The name of the exported binding within its module.
+    local_name: HeapPtr<FlatString>,
+}
+
+pub struct LocalExportEntry {
+    pub export_name: Handle<FlatString>,
+    pub local_name: Handle<FlatString>,
+}
+
+impl LocalExportEntry {
+    fn to_heap(&self) -> HeapLocalExportEntry {
+        HeapLocalExportEntry {
+            export_name: self.export_name.get_(),
+            local_name: self.local_name.get_(),
+        }
+    }
+}
+
+/// Subset of ExportEntry (https://tc39.es/ecma262/#table-exportentry-records) corresponding to
+/// the field SourceTextModule.[[IndirectExportEntries]].
+///
+/// Corresponds to named re-exports of bindings from other modules, including both
+/// `export {x} from "mod"` and `export * as x from "mod`.
+struct HeapNamedReExportEntry {
+    /// The name of the export, i.e. the name that importers must reference.
+    export_name: HeapPtr<FlatString>,
+    /// Name of the re-exported binding within its module. If None this is a named re-export of
+    /// a namespace object.
+    import_name: Option<HeapPtr<FlatString>>,
+    /// Name of the module that is having a bindings re-exported.
+    module_request: HeapPtr<FlatString>,
+}
+
+pub struct NamedReExportEntry {
+    pub export_name: Handle<FlatString>,
+    pub import_name: Option<Handle<FlatString>>,
+    pub module_request: Handle<FlatString>,
+}
+
+impl NamedReExportEntry {
+    fn to_heap(&self) -> HeapNamedReExportEntry {
+        HeapNamedReExportEntry {
+            export_name: self.export_name.get_(),
+            import_name: self.import_name.map(|name| name.get_()),
+            module_request: self.module_request.get_(),
+        }
+    }
+}
+
+/// Subset of ExportEntry (https://tc39.es/ecma262/#table-exportentry-records) corresponding to
+/// the field SourceTextModule.[[StarExportEntries]].
+///
+/// Coressponds to the direct re-export of all bindings from another module,
+/// i.e. `export * from "mod"`.
+struct HeapDirectReExportEntry {
+    /// Name of the module that is having its bindings re-exported.
+    module_request: HeapPtr<FlatString>,
+}
+
+pub struct DirectReExportEntry {
+    pub module_request: Handle<FlatString>,
+}
+
+impl DirectReExportEntry {
+    fn to_heap(&self) -> HeapDirectReExportEntry {
+        HeapDirectReExportEntry { module_request: self.module_request.get_() }
+    }
+}

--- a/src/js/runtime/object_descriptor.rs
+++ b/src/js/runtime/object_descriptor.rs
@@ -114,6 +114,8 @@ pub enum ObjectKind {
     GlobalNames,
     ClassNames,
 
+    SourceTextModule,
+
     Generator,
     AsyncGenerator,
     AsyncGeneratorRequest,
@@ -135,6 +137,7 @@ pub enum ObjectKind {
     LexicalNamesMap,
 
     // Arrays
+    ValueArray,
     ArrayBufferDataArray,
     FinalizationRegistryCells,
     GlobalScopes,
@@ -317,6 +320,8 @@ impl BaseDescriptors {
         other_heap_object_descriptor!(ObjectKind::GlobalNames);
         other_heap_object_descriptor!(ObjectKind::ClassNames);
 
+        other_heap_object_descriptor!(ObjectKind::SourceTextModule);
+
         ordinary_object_descriptor!(ObjectKind::Generator);
         ordinary_object_descriptor!(ObjectKind::AsyncGenerator);
         other_heap_object_descriptor!(ObjectKind::AsyncGeneratorRequest);
@@ -336,6 +341,7 @@ impl BaseDescriptors {
         other_heap_object_descriptor!(ObjectKind::InternedStringsSet);
         other_heap_object_descriptor!(ObjectKind::LexicalNamesMap);
 
+        other_heap_object_descriptor!(ObjectKind::ValueArray);
         other_heap_object_descriptor!(ObjectKind::ArrayBufferDataArray);
         other_heap_object_descriptor!(ObjectKind::FinalizationRegistryCells);
         other_heap_object_descriptor!(ObjectKind::GlobalScopes);

--- a/src/js/runtime/scope.rs
+++ b/src/js/runtime/scope.rs
@@ -71,6 +71,14 @@ impl Scope {
         Self::new(cx, ScopeKind::Global, None, scope_names, Some(global_object))
     }
 
+    pub fn new_module(
+        cx: Context,
+        scope_names: Handle<ScopeNames>,
+        global_object: Handle<ObjectValue>,
+    ) -> Handle<Scope> {
+        Self::new(cx, ScopeKind::Lexical, None, scope_names, Some(global_object))
+    }
+
     pub fn new_lexical(
         cx: Context,
         parent: Handle<Scope>,

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -159,7 +159,7 @@ impl Test262Object {
             Err(error) => return syntax_error(cx, &error.to_string()),
         };
 
-        let analyze_result = analyze(&mut parse_result, source);
+        let analyze_result = analyze(&mut parse_result);
         if let Err(errors) = analyze_result {
             // Choose an arbitrary syntax error to return
             let error = &errors.errors[0];
@@ -168,13 +168,13 @@ impl Test262Object {
 
         let realm = cx.current_realm();
         let gen_result =
-            BytecodeProgramGenerator::generate_from_program_parse_result(cx, &parse_result, realm);
-        let bytecode_program = match gen_result {
-            Ok(bytecode_program) => bytecode_program,
+            BytecodeProgramGenerator::generate_from_parse_script_result(cx, &parse_result, realm);
+        let bytecode_script = match gen_result {
+            Ok(bytecode_script) => bytecode_script,
             Err(error) => return syntax_error(cx, &error.to_string()),
         };
 
-        match cx.vm().execute_program(bytecode_program) {
+        match cx.vm().execute_script(bytecode_script) {
             Ok(value) => EvalResult::Ok(value),
             Err(error) => EvalResult::Throw(error),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,13 @@ use std::error::Error;
 use std::rc::Rc;
 
 use js::{
-    common::options::{Args, Options},
+    common::{
+        error::print_error_message_and_exit,
+        options::{Args, Options},
+    },
     runtime::{
-        bytecode::generator::BytecodeProgramGenerator, console::to_console_string, Context, Handle,
-        Realm, Value,
+        bytecode::generator::BytecodeProgramGenerator, error::print_eval_error_and_exit,
+        module::execute::ExecuteOnReject, Context, Handle, Realm,
     },
 };
 
@@ -30,7 +33,7 @@ fn main_impl() -> Result<(), Box<dyn Error>> {
 
     cx.execute_then_drop(|cx| {
         for file in &args.files {
-            evaluate_file(cx, realm, &args, options.clone(), file)?;
+            evaluate_file(cx, realm, &args, file)?;
         }
 
         Ok(())
@@ -41,7 +44,6 @@ fn evaluate_file(
     mut cx: Context,
     realm: Handle<Realm>,
     args: &Args,
-    options: Rc<Options>,
     file: &str,
 ) -> Result<(), Box<dyn Error>> {
     let source = Rc::new(js::parser::source::Source::new_from_file(file)?);
@@ -51,43 +53,34 @@ fn evaluate_file(
         js::parser::parse_script(&source)?
     };
 
-    js::parser::analyze::analyze(&mut parse_result, source.clone())?;
+    js::parser::analyze::analyze(&mut parse_result)?;
 
     let parse_result = Rc::new(parse_result);
 
     if args.print_ast {
-        println!("{}", js::parser::print_program(&parse_result.program, &source));
+        println!("{}", js::parser::print_program(&parse_result.program));
     }
 
     // Generate bytecode for the program
-    let bytecode_program =
-        BytecodeProgramGenerator::generate_from_program_parse_result(cx, &parse_result, realm)?;
+    if args.module {
+        let module =
+            BytecodeProgramGenerator::generate_from_parse_module_result(cx, &parse_result, realm)?;
 
-    if options.print_bytecode {
-        println!(
-            "{}",
-            bytecode_program
-                .script_function
-                .debug_print_recursive(false)
-        );
-    }
+        // Load modules and execute in the bytecode interpreter
+        if let Err(err) = cx.run_module(module, ExecuteOnReject::PrintAndExit) {
+            print_eval_error_and_exit(cx, err);
+        }
+    } else {
+        let bytecode_script =
+            BytecodeProgramGenerator::generate_from_parse_script_result(cx, &parse_result, realm)?;
 
-    // Execute in the bytecode interpreter
-    if let Err(err) = cx.run_program(bytecode_program) {
-        print_eval_error_and_exit(cx, err);
+        // Execute in the bytecode interpreter
+        if let Err(err) = cx.run_script(bytecode_script) {
+            print_eval_error_and_exit(cx, err);
+        }
     }
 
     Ok(())
-}
-
-fn print_error_message_and_exit(message: &str) {
-    eprintln!("{}", message);
-    std::process::exit(1);
-}
-
-fn print_eval_error_and_exit(cx: Context, error: Handle<Value>) {
-    let error_string = to_console_string(cx, error);
-    print_error_message_and_exit(&error_string);
 }
 
 /// Wrapper to pretty print errors


### PR DESCRIPTION
## Summary

Implements basic module loading and the beginnings of SourceTextModule. Parsing modules now is followed by generating bytecode for that module, which will return a SourceTextModule. This SourceTextModule can have all its dependencies loaded following the spec's loading algorithm. The later linking and evaluation phases are not yet implemented.

Also implements basic module execution. The entrypoint is `Context::run_module` which will run the module, loading, linking, and evaluating it and all its module dependencies. Note that these phases are all async so encapsulate the entire execution in a promise, then must specify the behavior when the promise rejects (print error and exit vs panic).

Modules are loaded treating the module specifier as a path which may be absolute or relative to the source file. The path to a source file is canonicalized and the module at that path will only be loaded once and the SourceTextModule is cached for later loads.