### PR TITLE
[runtime] Link imports with exports and initialize module scopes

### DIFF
--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -499,6 +499,8 @@ builtin_symbols!(
     (bound_arguments, ""),
     // Symbols used for private properties of revocable proxy closures
     (revocable_proxy, ""),
+    // Symbols used for private proprties of module functions
+    (module, ""),
     // Symbols used for private properties of resolve/reject functions
     (promise, ""),
     // Symbols used for private properties of capability executor function

--- a/src/js/runtime/module/linker.rs
+++ b/src/js/runtime/module/linker.rs
@@ -1,0 +1,218 @@
+use crate::{
+    js::runtime::{
+        boxed_value::BoxedValue, error::syntax_error, module::source_text_module::ModuleState,
+        object_descriptor::ObjectKind, object_value::ObjectValue, Context, EvalResult, Handle,
+        HeapPtr,
+    },
+    maybe,
+};
+
+use super::source_text_module::{
+    ModuleEntry, ResolveExportName, ResolveExportResult, SourceTextModule,
+};
+
+struct GraphLinker {
+    stack: Vec<Handle<SourceTextModule>>,
+}
+
+impl GraphLinker {
+    fn new() -> Self {
+        Self { stack: vec![] }
+    }
+
+    /// Link (https://tc39.es/ecma262/#sec-moduledeclarationlinking)
+    fn link(&mut self, cx: Context, module: Handle<SourceTextModule>) -> EvalResult<()> {
+        // Assert state precondition
+        debug_assert!(matches!(
+            module.state(),
+            ModuleState::Unlinked
+                | ModuleState::Linked
+                | ModuleState::EvaluatingAsync
+                | ModuleState::Evaluated
+        ));
+
+        match self.inner_link(cx, module, 0) {
+            EvalResult::Ok(_) => {
+                // Assert state postcondition
+                debug_assert!(matches!(
+                    module.state(),
+                    ModuleState::Linked | ModuleState::EvaluatingAsync | ModuleState::Evaluated
+                ));
+                debug_assert!(self.stack.is_empty());
+
+                ().into()
+            }
+            EvalResult::Throw(error) => {
+                // Any error should reset all modules in stack to unlinked
+                for module in &mut self.stack {
+                    debug_assert!(module.state() == ModuleState::Linking);
+                    module.set_state(ModuleState::Unlinked);
+                }
+
+                // Assert state postcondition
+                debug_assert!(module.state() == ModuleState::Unlinked);
+
+                EvalResult::Throw(error)
+            }
+        }
+    }
+
+    /// InnerModuleLinking (https://tc39.es/ecma262/#sec-InnerModuleLinking)
+    fn inner_link(
+        &mut self,
+        cx: Context,
+        mut module: Handle<SourceTextModule>,
+        index: u32,
+    ) -> EvalResult<u32> {
+        // Only start linking when in the unlinked state
+        if module.state() != ModuleState::Unlinked {
+            // Check for valid states
+            debug_assert!(matches!(
+                module.state(),
+                ModuleState::Linking
+                    | ModuleState::Linked
+                    | ModuleState::EvaluatingAsync
+                    | ModuleState::Evaluated
+            ));
+
+            return index.into();
+        }
+
+        module.set_state(ModuleState::Linking);
+        module.set_dfs_index(index);
+        module.set_dfs_ancestor_index(index);
+
+        self.stack.push(module);
+
+        let mut index = index + 1;
+
+        let loaded_modules = module.loaded_modules();
+        for i in 0..loaded_modules.len() {
+            let required_module = loaded_modules.as_slice()[i].unwrap().to_handle();
+
+            index = maybe!(self.inner_link(cx, required_module, index));
+
+            debug_assert!(matches!(
+                required_module.state(),
+                ModuleState::Linking
+                    | ModuleState::Linked
+                    | ModuleState::EvaluatingAsync
+                    | ModuleState::Evaluated
+            ));
+
+            if required_module.state() == ModuleState::Linking {
+                let new_index = module
+                    .dfs_ancestor_index()
+                    .min(required_module.dfs_ancestor_index());
+                module.set_dfs_ancestor_index(new_index)
+            }
+        }
+
+        maybe!(initialize_environment(cx, module));
+
+        debug_assert!(module.dfs_ancestor_index() <= module.dfs_index());
+
+        if module.dfs_index() == module.dfs_ancestor_index() {
+            loop {
+                let mut required_module = self.stack.pop().unwrap();
+                required_module.set_state(ModuleState::Linked);
+
+                if required_module.ptr_eq(&module.get_()) {
+                    break;
+                }
+            }
+        }
+
+        index.into()
+    }
+}
+
+/// InitializeEnvironment (https://tc39.es/ecma262/#sec-source-text-module-record-initialize-environment)
+fn initialize_environment(cx: Context, module: Handle<SourceTextModule>) -> EvalResult<()> {
+    // Check that all re-exported names are resolvable
+    for entry in module.entries_as_slice() {
+        if let ModuleEntry::NamedReExport(entry) = entry {
+            let resolution = module.resolve_export(cx, entry.export_name, &mut vec![]);
+            if !matches!(resolution, ResolveExportResult::Resolved { .. }) {
+                return syntax_error(cx, "could not resolve module specifier");
+            }
+        }
+    }
+
+    // Initialize import bindings
+    for i in 0..module.entries_as_slice().len() {
+        if let ModuleEntry::Import(entry) = &module.entries_as_slice()[i] {
+            let imported_module = module.get_imported_module(entry.module_request);
+
+            if let Some(import_name) = entry.import_name {
+                let resolution = imported_module.resolve_export(cx, import_name, &mut vec![]);
+
+                match resolution {
+                    // Regular imports are linked to their corresponding export by referencing
+                    // the same boxed value.
+                    ResolveExportResult::Resolved {
+                        name: ResolveExportName::Local { boxed_value, .. },
+                        ..
+                    } => {
+                        module
+                            .module_scope_ptr()
+                            .set_slot(entry.slot_index, boxed_value.cast::<ObjectValue>().into());
+                    }
+                    // Namespace object may be stored as a module or scope value
+                    ResolveExportResult::Resolved {
+                        name: ResolveExportName::Namespace,
+                        module: resolved_module,
+                    } => {
+                        let namespace_object = resolved_module.get_namespace_object(cx);
+                        set_namespace_object(
+                            module.get_(),
+                            namespace_object,
+                            entry.slot_index,
+                            entry.is_exported,
+                        );
+                    }
+                    _ => return syntax_error(cx, "could not resolve module specifier"),
+                }
+            } else {
+                // Namespace object may be stored as a module or scope value
+                let namespace_object = imported_module.get_namespace_object(cx);
+                set_namespace_object(
+                    module.get_(),
+                    namespace_object,
+                    entry.slot_index,
+                    entry.is_exported,
+                );
+            }
+        }
+    }
+
+    ().into()
+}
+
+fn set_namespace_object(
+    module: HeapPtr<SourceTextModule>,
+    namespace_object: HeapPtr<ObjectValue>,
+    slot_index: usize,
+    is_exported: bool,
+) {
+    if is_exported {
+        let boxed_value = module.module_scope_ptr().get_slot(slot_index);
+
+        debug_assert!(
+            boxed_value.is_pointer()
+                && boxed_value.as_pointer().descriptor().kind() == ObjectKind::BoxedValue
+        );
+
+        let mut boxed_value = boxed_value.as_pointer().cast::<BoxedValue>();
+        boxed_value.set(namespace_object.into());
+    } else {
+        module
+            .module_scope_ptr()
+            .set_slot(slot_index, namespace_object.into());
+    }
+}
+
+pub fn link(cx: Context, module: Handle<SourceTextModule>) -> EvalResult<()> {
+    let mut linker = GraphLinker::new();
+    linker.link(cx, module)
+}

--- a/src/js/runtime/module/mod.rs
+++ b/src/js/runtime/module/mod.rs
@@ -1,3 +1,4 @@
 pub mod execute;
+mod linker;
 pub mod loader;
 pub mod source_text_module;


### PR DESCRIPTION
Implements the link phase for modules following the spec. The module scope is now initialized with BoxedValues stored for every export (during loading). Imports are linked to exports during the link phase by referencing these same BoxedValues.

Note that namespace imports are normally stored as regular scope bindings, and are only stored as module bindings when exported.

Namespace imports are not yet implemented.