### PR TITLE
[runtime] Narrow type of Context::alloc_string to always return a FlatString

### DIFF
--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -31,7 +31,7 @@ macro_rules! builtin_names {
             pub fn init_builtin_names(&mut self) {
                 $(
                     self.names.$rust_name = {
-                        let string_value = self.alloc_string($js_name);
+                        let string_value = self.alloc_string($js_name).as_string();
                         PropertyKey::string_not_array_index(*self, string_value)
                     };
                 )*
@@ -470,7 +470,7 @@ macro_rules! builtin_symbols {
             pub fn init_builtin_symbols(&mut self) {
                 $(
                     self.well_known_symbols.$rust_name = {
-                        let description = self.alloc_string($description);
+                        let description = self.alloc_string($description).as_string();
                         PropertyKey::symbol(SymbolValue::new(*self, Some(description), /* is_private */ false)).get()
                     };
                 )*

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -255,7 +255,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
         // First generate all imports
         for toplevel in &program.toplevels {
             if let ast::Toplevel::Import(import) = toplevel {
-                let module_specifier = self.cx.alloc_wtf8_string(&import.source.value).as_flat();
+                let module_specifier = self.cx.alloc_wtf8_string(&import.source.value);
                 module_specifiers.insert(module_specifier);
 
                 // Each specifier will generate an import entry
@@ -268,14 +268,12 @@ impl<'a> BytecodeProgramGenerator<'a> {
                                 .imported
                                 .as_ref()
                                 .map(|imported| self.alloc_module_name_string(imported))
-                                .unwrap_or_else(|| {
-                                    self.cx.alloc_string(&import.local.name).as_flat()
-                                });
+                                .unwrap_or_else(|| self.cx.alloc_string(&import.local.name));
                             (&import.local, Some(imported))
                         }
                     };
 
-                    let local_name = self.cx.alloc_string(&local_id.name).as_flat();
+                    let local_name = self.cx.alloc_string(&local_id.name);
                     let slot_index = Self::id_module_slot_index(local_id);
                     let is_exported = local_id.get_binding().is_exported();
 
@@ -312,14 +310,14 @@ impl<'a> BytecodeProgramGenerator<'a> {
                 }
                 ast::Toplevel::ExportNamed(export) => {
                     let module_specifier = export.source.as_ref().map(|source| {
-                        let module_specifier = self.cx.alloc_wtf8_string(&source.value).as_flat();
+                        let module_specifier = self.cx.alloc_wtf8_string(&source.value);
                         module_specifiers.insert(module_specifier);
                         module_specifier
                     });
 
                     // Exporting a full named declaration adds export entries for each exported id
                     export.iter_declaration_ids(&mut |id| {
-                        let local_name = self.cx.alloc_string(&id.name).as_flat();
+                        let local_name = self.cx.alloc_string(&id.name);
                         let slot_index = Self::id_module_slot_index(id);
 
                         local_exports.push(LocalExportEntry {
@@ -331,7 +329,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
 
                     // Each specifier will generate an export entry of some form
                     for specifier in &export.specifiers {
-                        let local_name = self.cx.alloc_string(&specifier.local.name).as_flat();
+                        let local_name = self.cx.alloc_string(&specifier.local.name);
                         let export_name = specifier
                             .exported
                             .as_ref()
@@ -373,8 +371,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
                     }
                 }
                 ast::Toplevel::ExportAll(export) => {
-                    let module_specifier =
-                        self.cx.alloc_wtf8_string(&export.source.value).as_flat();
+                    let module_specifier = self.cx.alloc_wtf8_string(&export.source.value);
                     module_specifiers.insert(module_specifier);
 
                     if let Some(exported_name) = export.exported.as_ref() {
@@ -450,8 +447,8 @@ impl<'a> BytecodeProgramGenerator<'a> {
 
     fn alloc_module_name_string(&mut self, module_name: &ast::ModuleName) -> Handle<FlatString> {
         match module_name {
-            ast::ModuleName::Id(id) => self.cx.alloc_string(&id.name).as_flat(),
-            ast::ModuleName::String(lit) => self.cx.alloc_wtf8_string(&lit.value).as_flat(),
+            ast::ModuleName::Id(id) => self.cx.alloc_string(&id.name),
+            ast::ModuleName::String(lit) => self.cx.alloc_wtf8_string(&lit.value),
         }
     }
 
@@ -8458,7 +8455,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         };
 
         if let Some(id) = id {
-            cx.alloc_string(&id.name).as_flat()
+            cx.alloc_string(&id.name)
         } else {
             cx.names.default_name().as_string().as_flat()
         }

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -29,7 +29,7 @@ use super::{
     object_descriptor::{BaseDescriptors, ObjectKind},
     object_value::{NamedPropertiesMap, ObjectValue},
     realm::Realm,
-    string_value::{FlatString, StringValue},
+    string_value::FlatString,
     tasks::TaskQueue,
     value::SymbolValue,
     Handle, HeapPtr, Value,
@@ -270,13 +270,13 @@ impl Context {
     }
 
     #[inline]
-    pub fn alloc_string(&mut self, str: &str) -> Handle<StringValue> {
-        self.alloc_string_ptr(str).as_string().to_handle()
+    pub fn alloc_string(&mut self, str: &str) -> Handle<FlatString> {
+        self.alloc_string_ptr(str).to_handle()
     }
 
     #[inline]
-    pub fn alloc_wtf8_string(&mut self, str: &Wtf8String) -> Handle<StringValue> {
-        self.alloc_wtf8_string_ptr(str).as_string().to_handle()
+    pub fn alloc_wtf8_string(&mut self, str: &Wtf8String) -> Handle<FlatString> {
+        self.alloc_wtf8_string_ptr(str).to_handle()
     }
 
     #[inline]

--- a/src/js/runtime/eval/expression.rs
+++ b/src/js/runtime/eval/expression.rs
@@ -113,7 +113,7 @@ pub fn eval_typeof(mut cx: Context, value: Handle<Value>) -> Handle<StringValue>
         }
     };
 
-    cx.alloc_string(type_string)
+    cx.alloc_string(type_string).as_string()
 }
 
 pub fn eval_negate(cx: Context, value: Handle<Value>) -> EvalResult<Handle<Value>> {

--- a/src/js/runtime/function.rs
+++ b/src/js/runtime/function.rs
@@ -28,10 +28,10 @@ pub fn build_function_name(
         let symbol = name.as_symbol();
         if let Some(description) = symbol.description() {
             if symbol.is_private() {
-                StringValue::concat(cx, cx.alloc_string("#"), description.as_string())
+                StringValue::concat(cx, cx.alloc_string("#").as_string(), description.as_string())
             } else {
-                let left_paren = cx.alloc_string("[");
-                let right_paren = cx.alloc_string("]");
+                let left_paren = cx.alloc_string("[").as_string();
+                let right_paren = cx.alloc_string("]").as_string();
 
                 StringValue::concat_all(cx, &[left_paren, description.as_string(), right_paren])
             }
@@ -44,7 +44,7 @@ pub fn build_function_name(
 
     // Add prefix to name
     if let Some(prefix) = prefix {
-        let prefix_string = cx.alloc_string(&format!("{} ", prefix));
+        let prefix_string = cx.alloc_string(&format!("{} ", prefix)).as_string();
         StringValue::concat(cx, prefix_string, name_string)
     } else {
         name_string

--- a/src/js/runtime/intrinsics/bigint_prototype.rs
+++ b/src/js/runtime/intrinsics/bigint_prototype.rs
@@ -60,6 +60,7 @@ impl BigIntPrototype {
         };
 
         cx.alloc_string(&bigint_value.bigint().to_str_radix(radix))
+            .as_string()
             .into()
     }
 

--- a/src/js/runtime/intrinsics/boolean_prototype.rs
+++ b/src/js/runtime/intrinsics/boolean_prototype.rs
@@ -37,7 +37,7 @@ impl BooleanPrototype {
         let bool_value = maybe!(this_boolean_value(cx, this_value));
         let string_value = if bool_value { "true" } else { "false" };
 
-        cx.alloc_string(string_value).into()
+        cx.alloc_string(string_value).as_string().into()
     }
 
     /// Boolean.prototype.valueOf (https://tc39.es/ecma262/#sec-boolean.prototype.valueof)

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -1267,7 +1267,7 @@ impl DatePrototype {
         let mut string = String::new();
         date_string(&mut string, date_value);
 
-        cx.alloc_string(&string).into()
+        cx.alloc_string(&string).as_string().into()
     }
 
     /// Date.prototype.toISOString (https://tc39.es/ecma262/#sec-date.prototype.toisostring)
@@ -1310,7 +1310,7 @@ impl DatePrototype {
             millisecond_from_time(date_value) as i64
         );
 
-        cx.alloc_string(&string).into()
+        cx.alloc_string(&string).as_string().into()
     }
 
     /// Date.prototype.toJSON (https://tc39.es/ecma262/#sec-date.prototype.tojson)
@@ -1435,7 +1435,7 @@ impl DatePrototype {
         time_string(&mut string, local_date_value);
         time_zone_string(&mut string, date_value);
 
-        cx.alloc_string(&string).into()
+        cx.alloc_string(&string).as_string().into()
     }
 
     /// Date.prototype.toUTCString (https://tc39.es/ecma262/#sec-date.prototype.toutcstring)
@@ -1472,7 +1472,7 @@ impl DatePrototype {
 
         time_string(&mut string, date_value);
 
-        cx.alloc_string(&string).into()
+        cx.alloc_string(&string).as_string().into()
     }
 
     /// Date.prototype.valueOf (https://tc39.es/ecma262/#sec-date.prototype.valueof)
@@ -1612,7 +1612,7 @@ pub fn to_date_string(mut cx: Context, time_value: f64) -> Handle<StringValue> {
     time_string(&mut string, local_time_value);
     time_zone_string(&mut string, time_value);
 
-    cx.alloc_string(&string)
+    cx.alloc_string(&string).as_string()
 }
 
 #[inline]

--- a/src/js/runtime/intrinsics/error_prototype.rs
+++ b/src/js/runtime/intrinsics/error_prototype.rs
@@ -61,7 +61,7 @@ impl ErrorPrototype {
         } else if message_string.is_empty() {
             name_string.into()
         } else {
-            let separator = cx.alloc_string(": ");
+            let separator = cx.alloc_string(": ").as_string();
             StringValue::concat_all(cx, &[name_string, separator, message_string]).into()
         }
     }

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -206,7 +206,10 @@ impl FunctionPrototype {
 
             // First check for if the closure is a bound function
             if BoundFunctionObject::is_bound_function(cx, this_object.get_()) {
-                return cx.alloc_string("function () { [native code] }").into();
+                return cx
+                    .alloc_string("function () { [native code] }")
+                    .as_string()
+                    .into();
             }
 
             // Builtin functions have special formatting using the function name
@@ -237,7 +240,10 @@ impl FunctionPrototype {
         }
 
         if is_callable_object(this_object) {
-            return cx.alloc_string("function () { [native code] }").into();
+            return cx
+                .alloc_string("function () { [native code] }")
+                .as_string()
+                .into();
         }
 
         type_error(cx, "Function.prototype.toString expected a function")

--- a/src/js/runtime/intrinsics/json_object.rs
+++ b/src/js/runtime/intrinsics/json_object.rs
@@ -537,7 +537,7 @@ impl JSONSerializer {
     }
 
     fn build(self, mut cx: Context) -> Handle<StringValue> {
-        cx.alloc_wtf8_string(&self.builder)
+        cx.alloc_wtf8_string(&self.builder).as_string()
     }
 
     /// SerializeJSONProperty (https://tc39.es/ecma262/#sec-serializejsonproperty)

--- a/src/js/runtime/intrinsics/number_prototype.rs
+++ b/src/js/runtime/intrinsics/number_prototype.rs
@@ -70,7 +70,7 @@ impl NumberPrototype {
                 formatted.insert(exponent_index + 1, '+');
             }
 
-            return cx.alloc_string(&formatted).into();
+            return cx.alloc_string(&formatted).as_string().into();
         }
 
         // Otherwise format string ourselves so that we control rounding to precision. We cannot
@@ -114,7 +114,7 @@ impl NumberPrototype {
 
         result.push_str(&exponent.to_string());
 
-        cx.alloc_string(&result).into()
+        cx.alloc_string(&result).as_string().into()
     }
 
     /// Number.prototype.toFixed (https://tc39.es/ecma262/#sec-number.prototype.tofixed)
@@ -136,7 +136,10 @@ impl NumberPrototype {
         let num_fraction_digits = num_fraction_digits as u8;
 
         if !number.is_finite() {
-            return cx.alloc_string(&number_to_string(number)).into();
+            return cx
+                .alloc_string(&number_to_string(number))
+                .as_string()
+                .into();
         }
 
         let is_negative = number < 0.0;
@@ -160,7 +163,7 @@ impl NumberPrototype {
             m = format!("-{}", m);
         }
 
-        cx.alloc_string(&m).into()
+        cx.alloc_string(&m).as_string().into()
     }
 
     /// Number.prototype.toLocaleString (https://tc39.es/ecma262/#sec-number.prototype.tolocalestring)
@@ -238,7 +241,7 @@ impl NumberPrototype {
                 result.push(sign);
                 result.push_str(&exponent.to_string());
 
-                return cx.alloc_string(&result).into();
+                return cx.alloc_string(&result).as_string().into();
             }
         }
 
@@ -255,7 +258,7 @@ impl NumberPrototype {
             result.push_str(&mantissa);
         }
 
-        cx.alloc_string(&result).into()
+        cx.alloc_string(&result).as_string().into()
     }
 
     /// Number.prototype.toString (https://tc39.es/ecma262/#sec-number.prototype.tostring)
@@ -310,7 +313,7 @@ impl NumberPrototype {
                 number_value.as_double().to_string()
             };
 
-            return cx.alloc_string(&str).into();
+            return cx.alloc_string(&str).as_string().into();
         }
 
         // Float to string conversion based on SerenityOS's LibJS

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -150,9 +150,9 @@ impl ObjectPrototype {
         _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if this_value.is_undefined() {
-            return cx.alloc_string("[object Undefined]").into();
+            return cx.alloc_string("[object Undefined]").as_string().into();
         } else if this_value.is_null() {
-            return cx.alloc_string("[object Null]").into();
+            return cx.alloc_string("[object Null]").as_string().into();
         }
 
         let object = maybe!(to_object(cx, this_value));
@@ -163,8 +163,8 @@ impl ObjectPrototype {
         let tag = maybe!(get(cx, object, to_string_tag_key));
 
         let tag_string = if tag.is_string() {
-            let string_prefix = cx.alloc_string("[object ");
-            let string_suffix = cx.alloc_string("]");
+            let string_prefix = cx.alloc_string("[object ").as_string();
+            let string_suffix = cx.alloc_string("]").as_string();
 
             return StringValue::concat_all(cx, &[string_prefix, tag.as_string(), string_suffix])
                 .into();
@@ -190,7 +190,9 @@ impl ObjectPrototype {
             "Object"
         };
 
-        cx.alloc_string(&format!("[object {}]", tag_string)).into()
+        cx.alloc_string(&format!("[object {}]", tag_string))
+            .as_string()
+            .into()
     }
 
     /// Object.prototype.valueOf (https://tc39.es/ecma262/#sec-object.prototype.valueof)

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -369,7 +369,7 @@ fn escape_pattern_string(
         }
     }
 
-    cx.alloc_wtf8_string(&escaped_string)
+    cx.alloc_wtf8_string(&escaped_string).as_string()
 }
 
 impl HeapObject for HeapPtr<RegExpObject> {

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -158,7 +158,7 @@ impl RegExpPrototype {
         let flags_string = if flags_string.is_empty() {
             cx.names.empty_string().as_string()
         } else {
-            cx.alloc_string(&flags_string)
+            cx.alloc_string(&flags_string).as_string()
         };
 
         flags_string.into()
@@ -560,7 +560,7 @@ impl RegExpPrototype {
                 this_object.get_(),
                 cx.get_intrinsic_ptr(Intrinsic::RegExpPrototype),
             ) {
-                return cx.alloc_string("(?:)").into();
+                return cx.alloc_string("(?:)").as_string().into();
             }
         }
 

--- a/src/js/runtime/intrinsics/symbol_prototype.rs
+++ b/src/js/runtime/intrinsics/symbol_prototype.rs
@@ -118,10 +118,10 @@ pub fn symbol_descriptive_string(
     symbol: Handle<SymbolValue>,
 ) -> Handle<StringValue> {
     match symbol.description() {
-        None => cx.alloc_string("Symbol()"),
+        None => cx.alloc_string("Symbol()").as_string(),
         Some(description) => {
-            let symbol_prefix = cx.alloc_string("Symbol(");
-            let symbol_suffix = cx.alloc_string(")");
+            let symbol_prefix = cx.alloc_string("Symbol(").as_string();
+            let symbol_suffix = cx.alloc_string(")").as_string();
 
             StringValue::concat_all(cx, &[symbol_prefix, description.as_string(), symbol_suffix])
         }

--- a/src/js/runtime/property_key.rs
+++ b/src/js/runtime/property_key.rs
@@ -60,7 +60,7 @@ impl PropertyKey {
     #[inline]
     pub fn array_index(mut cx: Context, value: u32) -> PropertyKey {
         if value == u32::MAX {
-            let string_value = cx.alloc_string(&value.to_string());
+            let string_value = cx.alloc_string(&value.to_string()).as_string();
             return PropertyKey::string_not_array_index(cx, string_value);
         }
 
@@ -74,7 +74,7 @@ impl PropertyKey {
 
     pub fn from_u64(mut cx: Context, value: u64) -> PropertyKey {
         if value >= u32::MAX as u64 {
-            let string_value = cx.alloc_string(&value.to_string());
+            let string_value = cx.alloc_string(&value.to_string()).as_string();
             return PropertyKey::string_not_array_index(cx, string_value);
         }
 

--- a/src/js/runtime/source_file.rs
+++ b/src/js/runtime/source_file.rs
@@ -8,7 +8,7 @@ use super::{
     collections::InlineArray,
     gc::{HeapObject, HeapVisitor},
     object_descriptor::ObjectDescriptor,
-    string_value::StringValue,
+    string_value::FlatString,
     Context, Handle, HeapPtr,
 };
 
@@ -16,7 +16,7 @@ use super::{
 pub struct SourceFile {
     descriptor: HeapPtr<ObjectDescriptor>,
     /// The name of the source file
-    name: HeapPtr<StringValue>,
+    name: HeapPtr<FlatString>,
     /// Inlined source file contents as a WTF8 string
     contents: InlineArray<u8>,
 }
@@ -45,7 +45,7 @@ impl SourceFile {
     }
 
     #[inline]
-    pub fn name(&self) -> Handle<StringValue> {
+    pub fn name(&self) -> Handle<FlatString> {
         self.name.to_handle()
     }
 

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -30,19 +30,19 @@ impl Test262Object {
         let mut object =
             ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true);
 
-        let create_realm_string = cx.alloc_string("createRealm");
+        let create_realm_string = cx.alloc_string("createRealm").as_string();
         let create_realm_key = PropertyKey::string(cx, create_realm_string).to_handle(cx);
         object.intrinsic_func(cx, create_realm_key, Self::create_realm, 0, realm);
 
-        let eval_script_string = cx.alloc_string("evalScript");
+        let eval_script_string = cx.alloc_string("evalScript").as_string();
         let eval_script_key = PropertyKey::string(cx, eval_script_string).to_handle(cx);
         object.intrinsic_func(cx, eval_script_key, Self::eval_script, 1, realm);
 
-        let global_string = cx.alloc_string("global");
+        let global_string = cx.alloc_string("global").as_string();
         let global_key = PropertyKey::string(cx, global_string).to_handle(cx);
         object.intrinsic_data_prop(cx, global_key, realm.global_object().into());
 
-        let detach_array_buffer_string = cx.alloc_string("detachArrayBuffer");
+        let detach_array_buffer_string = cx.alloc_string("detachArrayBuffer").as_string();
         let detach_array_buffer_key =
             PropertyKey::string(cx, detach_array_buffer_string).to_handle(cx);
         object.intrinsic_func(cx, detach_array_buffer_key, Self::detach_array_buffer, 1, realm);
@@ -52,14 +52,14 @@ impl Test262Object {
 
     pub fn install(mut cx: Context, realm: Handle<Realm>, test_262_object: Handle<ObjectValue>) {
         // Install the the "$262" property on the global object
-        let test_262_string = cx.alloc_string("$262");
+        let test_262_string = cx.alloc_string("$262").as_string();
         let test_262_key = PropertyKey::string(cx, test_262_string).to_handle(cx);
         realm
             .global_object()
             .intrinsic_data_prop(cx, test_262_key, test_262_object.into());
 
         // Also install a global print function needed in tests
-        let print_string = cx.alloc_string("print");
+        let print_string = cx.alloc_string("print").as_string();
         let print_key = PropertyKey::string(cx, print_string).to_handle(cx);
         realm
             .global_object()
@@ -74,7 +74,7 @@ impl Test262Object {
     }
 
     fn print_log_key(mut cx: Context) -> Handle<PropertyKey> {
-        let print_log_string = cx.alloc_string("$$printLog");
+        let print_log_string = cx.alloc_string("$$printLog").as_string();
         PropertyKey::string(cx, print_log_string).to_handle(cx)
     }
 

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -533,7 +533,7 @@ pub fn to_string(mut cx: Context, value_handle: Handle<Value>) -> EvalResult<Han
             match value.as_pointer().descriptor().kind() {
                 ObjectKind::BigInt => {
                     let bigint_string = value.as_bigint().bigint().to_string();
-                    cx.alloc_string(&bigint_string).into()
+                    cx.alloc_string(&bigint_string).as_string().into()
                 }
                 ObjectKind::Symbol => type_error(cx, "symbol cannot be converted to string"),
                 _ => unreachable!(),
@@ -541,20 +541,20 @@ pub fn to_string(mut cx: Context, value_handle: Handle<Value>) -> EvalResult<Han
         }
     } else {
         match value.get_tag() {
-            NULL_TAG => cx.alloc_string("null").into(),
-            UNDEFINED_TAG => cx.alloc_string("undefined").into(),
+            NULL_TAG => cx.alloc_string("null").as_string().into(),
+            UNDEFINED_TAG => cx.alloc_string("undefined").as_string().into(),
             BOOL_TAG => {
                 let str = if value.as_bool() { "true" } else { "false" };
-                cx.alloc_string(str).into()
+                cx.alloc_string(str).as_string().into()
             }
             SMI_TAG => {
                 let smi_string = value.as_smi().to_string();
-                cx.alloc_string(&smi_string).into()
+                cx.alloc_string(&smi_string).as_string().into()
             }
             // Otherwise must be double
             _ => {
                 let double_string = number_to_string(value.as_double());
-                cx.alloc_string(&double_string).into()
+                cx.alloc_string(&double_string).as_string().into()
             }
         }
     }


### PR DESCRIPTION
## Summary

Narrow the return type of `Context::alloc_string` to always return a FlatString instead of a StringValue. This was already the case but was not represented in the type system. Many locations now need a `FlatString::as_string` cast.