### PR TITLE
[runtime] Patch exported functions into the module scope

### DIFF
--- a/src/js/runtime/module/linker.rs
+++ b/src/js/runtime/module/linker.rs
@@ -1,8 +1,7 @@
 use crate::{
     js::runtime::{
-        boxed_value::BoxedValue, error::syntax_error, module::source_text_module::ModuleState,
-        object_descriptor::ObjectKind, object_value::ObjectValue, Context, EvalResult, Handle,
-        HeapPtr,
+        error::syntax_error, module::source_text_module::ModuleState, object_value::ObjectValue,
+        Context, EvalResult, Handle, HeapPtr,
     },
     maybe,
 };
@@ -196,14 +195,7 @@ fn set_namespace_object(
     is_exported: bool,
 ) {
     if is_exported {
-        let boxed_value = module.module_scope_ptr().get_slot(slot_index);
-
-        debug_assert!(
-            boxed_value.is_pointer()
-                && boxed_value.as_pointer().descriptor().kind() == ObjectKind::BoxedValue
-        );
-
-        let mut boxed_value = boxed_value.as_pointer().cast::<BoxedValue>();
+        let mut boxed_value = module.module_scope_ptr().get_module_slot(slot_index);
         boxed_value.set(namespace_object.into());
     } else {
         module

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -194,6 +194,11 @@ impl SourceTextModule {
     }
 
     #[inline]
+    pub fn module_scope(&self) -> Handle<Scope> {
+        self.module_scope_ptr().to_handle()
+    }
+
+    #[inline]
     pub fn requested_module_specifiers(&self) -> Handle<StringArray> {
         self.requested_module_specifiers.to_handle()
     }
@@ -254,19 +259,10 @@ impl HeapPtr<SourceTextModule> {
         for entry in self.entries.as_slice() {
             if let ModuleEntry::LocalExport(entry) = entry {
                 if entry.export_name == export_name {
-                    let boxed_value = self.module_scope.get_slot(entry.slot_index);
-
-                    debug_assert!(
-                        boxed_value.is_pointer()
-                            && boxed_value.as_pointer().descriptor().kind()
-                                == ObjectKind::BoxedValue
-                    );
+                    let boxed_value = self.module_scope.get_module_slot(entry.slot_index);
 
                     return ResolveExportResult::Resolved {
-                        name: ResolveExportName::Local {
-                            name: entry.local_name,
-                            boxed_value: boxed_value.as_pointer().cast(),
-                        },
+                        name: ResolveExportName::Local { name: entry.local_name, boxed_value },
                         module: *self,
                     };
                 }

--- a/src/js/runtime/scope.rs
+++ b/src/js/runtime/scope.rs
@@ -2,6 +2,7 @@ use crate::{field_offset, js::runtime::object_descriptor::ObjectKind, maybe, set
 
 use super::{
     abstract_operations::{has_own_property, has_property},
+    boxed_value::BoxedValue,
     collections::InlineArray,
     error::{err_assign_constant, err_cannot_set_property},
     gc::{HeapObject, HeapVisitor},
@@ -138,6 +139,18 @@ impl Scope {
     #[inline]
     pub fn set_slot(&mut self, index: usize, value: Value) {
         self.slots.as_mut_slice()[index] = value;
+    }
+
+    /// Return the boxed value at the given slot index of a module scope.
+    #[inline]
+    pub fn get_module_slot(&self, index: usize) -> HeapPtr<BoxedValue> {
+        let value = self.get_slot(index);
+
+        debug_assert!(
+            value.is_pointer() && value.as_pointer().descriptor().kind() == ObjectKind::BoxedValue
+        );
+
+        value.as_pointer().cast::<BoxedValue>()
     }
 
     /// Return the realm stored in this global scope.


### PR DESCRIPTION
## Summary

Exported function bindings need to be initialized before the module evaluation phase begins. This is implemented by directly patching the closure for the exported function into the module scope once the exported function has had its bytecode generated.

This is done by generalizing the types of patches that can be applied to the pending functions after bytecode generation. We now support patching a parent function's constant table and patching the module scope.