### PR TITLE
[runtime] Evaluate synchronous module graph

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -1908,8 +1908,16 @@ impl<'a> BytecodeFunctionGenerator<'a> {
     }
 
     fn gen_program_body(&mut self, program: &ast::Program) -> EmitResult<()> {
+        let scope = program.scope.as_ref();
+
         // Start the program's global scope
-        self.gen_start_global_scope(program.scope.as_ref())?;
+        self.gen_start_global_scope(scope)?;
+
+        // Modules need to initialize the TDZ for the module scope. Scripts instead have TDZ
+        // initialized during GlobalDeclarationInstantiation.
+        if program.kind == ast::ProgramKind::Module {
+            self.gen_init_tdz_for_scope(scope)?;
+        }
 
         // Heuristic to ignore the use strict directive in common cases. Safe since there must
         // be a directive prologue which can be ignored if there is a use strict directive.

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -43,6 +43,7 @@ use crate::{
             rust_runtime::RustRuntimeFunctionId,
         },
         iterator::{get_iterator, iterator_complete, iterator_value, IteratorHint},
+        module::source_text_module::SourceTextModule,
         object_descriptor::ObjectKind,
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{object_create_from_constructor, ordinary_object_create},
@@ -246,6 +247,21 @@ impl VM {
             Closure::new_in_realm(self.cx(), bytecode_script.script_function, global_scope, realm);
 
         self.execute(program_closure, &[])
+    }
+
+    /// Execute a module. Must only be called during the evaluation phase, after loading and linking.
+    pub fn execute_module(
+        &mut self,
+        module: Handle<SourceTextModule>,
+    ) -> Result<Handle<Value>, Handle<Value>> {
+        let program_function = module.program_function();
+        let module_scope = module.module_scope();
+        let realm = program_function.realm();
+
+        let module_closure =
+            Closure::new_in_realm(self.cx(), program_function, module_scope, realm);
+
+        self.execute(module_closure, &[])
     }
 
     /// Execute a closure with the provided arguments.

--- a/src/js/runtime/collections/array.rs
+++ b/src/js/runtime/collections/array.rs
@@ -10,6 +10,7 @@ use crate::{
 
 use super::InlineArray;
 
+/// A fixed size array of values.
 #[repr(C)]
 pub struct BsArray<T> {
     descriptor: HeapPtr<ObjectDescriptor>,

--- a/src/js/runtime/collections/mod.rs
+++ b/src/js/runtime/collections/mod.rs
@@ -4,6 +4,7 @@ pub mod hash_set;
 pub mod index_map;
 pub mod index_set;
 mod inline_array;
+pub mod vec;
 
 pub use array::BsArray;
 pub use hash_map::{BsHashMap, BsHashMapField};
@@ -11,3 +12,4 @@ pub use hash_set::{BsHashSet, BsHashSetField};
 pub use index_map::{BsIndexMap, BsIndexMapField};
 pub use index_set::{BsIndexSet, BsIndexSetField};
 pub use inline_array::InlineArray;
+pub use vec::{BsVec, BsVecField};

--- a/src/js/runtime/collections/vec.rs
+++ b/src/js/runtime/collections/vec.rs
@@ -1,0 +1,136 @@
+use crate::{
+    field_offset,
+    js::runtime::{
+        gc::{HeapObject, HeapVisitor},
+        object_descriptor::{ObjectDescriptor, ObjectKind},
+        Context, HeapPtr, Value,
+    },
+    set_uninit,
+};
+
+use super::InlineArray;
+
+/// A growable array of values.
+#[repr(C)]
+pub struct BsVec<T> {
+    descriptor: HeapPtr<ObjectDescriptor>,
+    /// The number of elements stored in the array.
+    length: usize,
+    /// The array along with its capacity, which is always a power of 2.
+    array: InlineArray<T>,
+}
+
+impl<T: Clone + Copy> BsVec<T> {
+    /// Create a new BsVec with the given capacity.
+    pub fn new(cx: Context, kind: ObjectKind, capacity: usize) -> HeapPtr<Self> {
+        let size = Self::calculate_size_in_bytes(capacity);
+        let mut vec = cx.alloc_uninit_with_size::<BsVec<T>>(size);
+
+        set_uninit!(vec.descriptor, cx.base_descriptors.get(kind));
+        set_uninit!(vec.length, 0);
+        vec.array.init_with_uninit(capacity);
+
+        vec
+    }
+
+    const ARRAY_FIELD_OFFSET: usize = field_offset!(BsVec<u8>, array);
+
+    #[inline]
+    fn calculate_size_in_bytes(capacity: usize) -> usize {
+        Self::ARRAY_FIELD_OFFSET + InlineArray::<T>::calculate_size_in_bytes(capacity)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.length
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.array.len()
+    }
+
+    #[inline]
+    fn as_slice(&self) -> &[T] {
+        &self.array.as_slice()[..self.len()]
+    }
+
+    #[inline]
+    fn as_mut_slice(&mut self) -> &mut [T] {
+        let len = self.len();
+        &mut self.array.as_mut_slice()[..len]
+    }
+
+    /// Append an item to the BsVec. Should only be called if there is room to append an item.
+    pub fn push_without_growing(&mut self, item: T) {
+        let len = self.len();
+        self.array.as_mut_slice()[len] = item;
+        self.length += 1;
+    }
+}
+
+impl<T: Clone + Copy> HeapObject for HeapPtr<BsVec<T>> {
+    fn byte_size(&self) -> usize {
+        BsVec::<T>::calculate_size_in_bytes(self.capacity())
+    }
+
+    /// Visit pointers intrinsic to all BsVecs. Do not visit elements as they could be of any type.
+    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut self.descriptor);
+    }
+}
+
+/// A BsVec stored as the field of a heap object. Can create new BsVec objects and set the field to
+/// a new BsVec.
+pub trait BsVecField<T: Clone + Copy> {
+    fn new_vec(&self, cx: Context, capacity: usize) -> HeapPtr<BsVec<T>>;
+
+    fn get(&self) -> HeapPtr<BsVec<T>>;
+
+    fn set(&mut self, vec: HeapPtr<BsVec<T>>);
+
+    /// Prepare vec for appending a single item. This will grow the vec and update container to
+    /// point to new vec if there is no room to append another item to the vec.
+    #[inline]
+    fn maybe_grow_for_push(&mut self, cx: Context) -> HeapPtr<BsVec<T>> {
+        let old_vec = self.get();
+
+        // Check if we have room for another item in the vec
+        let old_len = old_vec.len();
+        let capacity = old_vec.capacity();
+        if old_len < capacity {
+            return old_vec;
+        }
+
+        // Save old vec behind handle before allocating
+        let old_vec = old_vec.to_handle();
+
+        // Double size of vector, starting at a length of 4
+        let new_capacity = (capacity * 2).max(4);
+        let mut new_vec = self.new_vec(cx, new_capacity);
+
+        // Update parent reference from old child to new child map
+        self.set(new_vec);
+
+        // Copy all values into new vec
+        new_vec.length = old_len;
+        new_vec.as_mut_slice().copy_from_slice(old_vec.as_slice());
+
+        new_vec
+    }
+}
+
+/// A generic vec of values. Corresponds to ObjectKind::ValueVec.
+type ValueVec = BsVec<Value>;
+
+pub fn value_vec_byte_size(value_array: HeapPtr<ValueVec>) -> usize {
+    BsVec::<Value>::calculate_size_in_bytes(value_array.capacity())
+}
+
+pub fn value_vec_visit_pointers(value_vec: &mut HeapPtr<ValueVec>, visitor: &mut impl HeapVisitor) {
+    value_vec.visit_pointers(visitor);
+
+    for value in value_vec.as_mut_slice() {
+        visitor.visit_value(value);
+    }
+}

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -10,7 +10,10 @@ use crate::js::runtime::{
         function::{BytecodeFunction, Closure},
     },
     class_names::ClassNames,
-    collections::array::{value_array_byte_size, value_array_visit_pointers},
+    collections::{
+        array::{value_array_byte_size, value_array_visit_pointers},
+        vec::{value_vec_byte_size, value_vec_visit_pointers},
+    },
     context::GlobalSymbolRegistryField,
     for_in_iterator::ForInIterator,
     generator_object::GeneratorObject,
@@ -166,6 +169,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::InternedStringsSet => InternedStringsSetField::byte_size(&self.cast()),
             ObjectKind::LexicalNamesMap => LexicalNamesMapField::byte_size(&self.cast()),
             ObjectKind::ValueArray => value_array_byte_size(self.cast()),
+            ObjectKind::ValueVec => value_vec_byte_size(self.cast()),
             ObjectKind::ArrayBufferDataArray => ArrayBufferDataField::byte_size(&self.cast()),
             ObjectKind::FinalizationRegistryCells => {
                 self.cast::<FinalizationRegistryCells>().byte_size()
@@ -299,6 +303,7 @@ impl HeapObject for HeapPtr<HeapItem> {
                 LexicalNamesMapField::visit_pointers(self.cast_mut(), visitor)
             }
             ObjectKind::ValueArray => value_array_visit_pointers(self.cast_mut(), visitor),
+            ObjectKind::ValueVec => value_vec_visit_pointers(self.cast_mut(), visitor),
             ObjectKind::ArrayBufferDataArray => {
                 ArrayBufferDataField::visit_pointers(self.cast_mut(), visitor)
             }

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -382,6 +382,7 @@ rust_runtime_functions!(
     MathObject::tan,
     MathObject::tanh,
     MathObject::trunc,
+    module::execute::load_requested_modules_reject,
     module::execute::load_requested_modules_resolve,
     ObjectConstructor::construct,
     ObjectConstructor::assign,

--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -4,16 +4,20 @@ use crate::{
     js::runtime::{
         abstract_operations::call_object,
         builtin_function::BuiltinFunction,
+        function::get_argument,
         intrinsics::{intrinsics::Intrinsic, promise_prototype::perform_promise_then},
         module::linker::link,
         object_value::ObjectValue,
         promise_object::{PromiseCapability, PromiseObject},
         Context, EvalResult, Handle, Value,
     },
-    must,
+    maybe, must,
 };
 
-use super::{loader::load_requested_modules, source_text_module::SourceTextModule};
+use super::{
+    loader::load_requested_modules,
+    source_text_module::{ModuleState, SourceTextModule},
+};
 
 /// Action to take when the promise for an execution is rejected.
 pub enum ExecuteOnReject {
@@ -45,21 +49,32 @@ pub fn execute_module(mut cx: Context, module: Handle<SourceTextModule>) -> Hand
 
     let promise = load_requested_modules(cx, module);
 
-    let on_resolve = BuiltinFunction::create(
+    // Resolve function needs access to module and capability
+    let on_resolve = BuiltinFunction::create_builtin_function_without_properties(
         cx,
         load_requested_modules_resolve,
-        1,
-        cx.names.empty_string(),
+        /* name */ None,
         cx.current_realm(),
-        None,
-        None,
-    );
-
-    // Pass module and capability to the resolve function
+        /* prototype */ None,
+        /* is_constructor */ false,
+    )
+    .into();
     set_module(cx, on_resolve, module);
     set_capability(cx, on_resolve, capability);
 
-    perform_promise_then(cx, promise, on_resolve.into(), cx.undefined(), Some(capability));
+    // Reject function needs access to capability
+    let on_reject = BuiltinFunction::create_builtin_function_without_properties(
+        cx,
+        load_requested_modules_reject,
+        /* name */ None,
+        cx.current_realm(),
+        /* prototype */ None,
+        /* is_constructor */ false,
+    )
+    .into();
+    set_capability(cx, on_reject, capability);
+
+    perform_promise_then(cx, promise, on_resolve.into(), cx.undefined(), None);
 
     // Guaranteed to be a PromiseObject since created with the Promise constructor
     capability.promise().cast::<PromiseObject>()
@@ -101,7 +116,7 @@ pub fn load_requested_modules_resolve(
     _: &[Handle<Value>],
     _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
-    // Fetch the promise and capbility passed from `execute_module`
+    // Fetch the module and capbility passed from `execute_module`
     let current_function = cx.current_function();
     let module = get_module(cx, current_function);
     let capability = get_capability(cx, current_function);
@@ -111,5 +126,196 @@ pub fn load_requested_modules_resolve(
         return cx.undefined().into();
     }
 
-    unimplemented!("evaluate the modules");
+    let evaluate_promise = module_evaluate(cx, module);
+
+    perform_promise_then(cx, evaluate_promise, cx.undefined(), cx.undefined(), Some(capability))
+        .into()
+}
+
+pub fn load_requested_modules_reject(
+    mut cx: Context,
+    _: Handle<Value>,
+    arguments: &[Handle<Value>],
+    _: Option<Handle<ObjectValue>>,
+) -> EvalResult<Handle<Value>> {
+    // Fetch the capbility passed from `execute_module`
+    let current_function = cx.current_function();
+    let capability = get_capability(cx, current_function);
+
+    let error = get_argument(cx, arguments, 0);
+    must!(call_object(cx, capability.reject(), cx.undefined(), &[error]));
+
+    cx.undefined().into()
+}
+
+fn module_evaluate(cx: Context, module: Handle<SourceTextModule>) -> Handle<PromiseObject> {
+    let mut evaluator = GraphEvaluator::new();
+    evaluator.evaluate(cx, module)
+}
+
+struct GraphEvaluator {
+    stack: Vec<Handle<SourceTextModule>>,
+}
+
+impl GraphEvaluator {
+    fn new() -> Self {
+        Self { stack: Vec::new() }
+    }
+
+    /// Evaluate (https://tc39.es/ecma262/#sec-moduleevaluation)
+    fn evaluate(
+        &mut self,
+        cx: Context,
+        mut module: Handle<SourceTextModule>,
+    ) -> Handle<PromiseObject> {
+        if matches!(module.state(), ModuleState::Evaluated | ModuleState::EvaluatingAsync) {
+            module = module.cycle_root().unwrap();
+        } else {
+            debug_assert!(module.state() == ModuleState::Linked);
+        }
+
+        if let Some(capability) = module.top_level_capability_ptr() {
+            // Was created with promise constructor
+            return capability.promise().cast::<PromiseObject>();
+        }
+
+        let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
+        let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
+        module.set_top_level_capability(capability.get_());
+
+        let evaluation_result = self.inner_evaluate(cx, module, 0);
+
+        match evaluation_result {
+            EvalResult::Ok(_) => {
+                debug_assert!(matches!(
+                    module.state(),
+                    ModuleState::Evaluated | ModuleState::EvaluatingAsync
+                ));
+                debug_assert!(module.evaluation_error_ptr().is_none());
+
+                if !module.is_async_evaluation() {
+                    debug_assert!(module.state() == ModuleState::Evaluated);
+                    must!(call_object(cx, capability.resolve(), cx.undefined(), &[cx.undefined()]));
+                }
+
+                debug_assert!(self.stack.is_empty());
+            }
+            EvalResult::Throw(error) => {
+                for module in &mut self.stack {
+                    debug_assert!(module.state() == ModuleState::Evaluating);
+                    module.set_state(ModuleState::Evaluated);
+                    module.set_evaluation_error(error.get());
+                }
+
+                debug_assert!(module.state() == ModuleState::Evaluated);
+
+                must!(call_object(cx, capability.reject(), cx.undefined(), &[error]));
+            }
+        }
+
+        // Known to be a PromiseObject since created with the Promise constructor
+        capability.promise().cast::<PromiseObject>()
+    }
+
+    /// InnerModuleEvaluation (https://tc39.es/ecma262/#sec-innermoduleevaluation)
+    fn inner_evaluate(
+        &mut self,
+        mut cx: Context,
+        mut module: Handle<SourceTextModule>,
+        index: u32,
+    ) -> EvalResult<u32> {
+        if matches!(module.state(), ModuleState::Evaluated | ModuleState::EvaluatingAsync) {
+            if let Some(error) = module.evaluation_error(cx) {
+                return EvalResult::Throw(error);
+            } else {
+                return index.into();
+            }
+        }
+
+        if module.state() == ModuleState::Evaluating {
+            return index.into();
+        }
+
+        debug_assert!(module.state() == ModuleState::Linked);
+
+        // Note that the value of [[PendingAsyncDependencies]] is already 0
+        module.set_state(ModuleState::Evaluating);
+        module.set_dfs_index(index);
+        module.set_dfs_ancestor_index(index);
+
+        self.stack.push(module);
+
+        let mut index = index + 1;
+
+        let loaded_modules = module.loaded_modules();
+        for i in 0..loaded_modules.len() {
+            let mut required_module = loaded_modules.as_slice()[i].unwrap().to_handle();
+
+            index = maybe!(self.inner_evaluate(cx, required_module, index));
+
+            if required_module.state() == ModuleState::Evaluating {
+                let new_index = module
+                    .dfs_ancestor_index()
+                    .min(required_module.dfs_ancestor_index());
+                module.set_dfs_ancestor_index(new_index)
+            } else {
+                debug_assert!(matches!(
+                    required_module.state(),
+                    ModuleState::EvaluatingAsync | ModuleState::Evaluated
+                ));
+
+                required_module = required_module.cycle_root().unwrap();
+
+                debug_assert!(matches!(
+                    required_module.state(),
+                    ModuleState::EvaluatingAsync | ModuleState::Evaluated
+                ));
+
+                if let Some(error) = required_module.evaluation_error(cx) {
+                    return EvalResult::Throw(error);
+                }
+            }
+
+            if required_module.is_async_evaluation() {
+                module.inc_pending_async_dependencies();
+                required_module.push_async_parent_module(cx, module);
+            }
+        }
+
+        if module.pending_async_dependencies() > 0 || module.has_top_level_await() {
+            debug_assert!(!module.is_async_evaluation());
+            module.set_async_evaluation(true);
+
+            if module.pending_async_dependencies() == 0 {
+                unimplemented!("ExecuteAsyncModule");
+            }
+        } else {
+            let eval_result = cx.vm().execute_module(module);
+            if let Err(error) = eval_result {
+                return EvalResult::Throw(error);
+            }
+        }
+
+        debug_assert!(module.dfs_ancestor_index() <= module.dfs_index());
+
+        if module.dfs_ancestor_index() == module.dfs_index() {
+            loop {
+                let mut required_module = self.stack.pop().unwrap();
+
+                if !required_module.is_async_evaluation() {
+                    required_module.set_state(ModuleState::Evaluated);
+                } else {
+                    required_module.set_state(ModuleState::EvaluatingAsync);
+                }
+
+                required_module.set_cycle_root(module.get_());
+
+                if required_module.ptr_eq(&module.get_()) {
+                    break;
+                }
+            }
+        }
+
+        index.into()
+    }
 }

--- a/src/js/runtime/object_descriptor.rs
+++ b/src/js/runtime/object_descriptor.rs
@@ -144,6 +144,9 @@ pub enum ObjectKind {
     FinalizationRegistryCells,
     GlobalScopes,
 
+    // Vectors
+    ValueVec,
+
     // Numerical value is the number of kinds in the enum
     Last,
 }
@@ -349,6 +352,8 @@ impl BaseDescriptors {
         other_heap_object_descriptor!(ObjectKind::ArrayBufferDataArray);
         other_heap_object_descriptor!(ObjectKind::FinalizationRegistryCells);
         other_heap_object_descriptor!(ObjectKind::GlobalScopes);
+
+        other_heap_object_descriptor!(ObjectKind::ValueVec);
 
         BaseDescriptors { descriptors }
     }


### PR DESCRIPTION
## Summary

Implement module evaluation for non-async modules following the spec. Many parts of async module evaluation are also implemented but will be completed in a future PR.

Async modules also require an resizable list of modules to be stored on the heap, so we create a `BsVec` heap object that implements a resizable array similar to the other heap collection types.