### PR TITLE
[test] Check whether errors occur during module resolution phase

### DIFF
--- a/src/js/runtime/error.rs
+++ b/src/js/runtime/error.rs
@@ -1,15 +1,8 @@
 use crate::js::common::error::print_error_message_and_exit;
 
 use super::{
-    builtin_function::BuiltinFunction,
     completion::EvalResult,
-    function::get_argument,
-    intrinsics::{
-        native_error::{RangeError, ReferenceError, SyntaxError, TypeError, URIError},
-        promise_prototype::perform_promise_then,
-    },
-    object_value::ObjectValue,
-    promise_object::PromiseObject,
+    intrinsics::native_error::{RangeError, ReferenceError, SyntaxError, TypeError, URIError},
     string_value::{FlatString, StringValue},
     to_console_string, Context, Handle, HeapPtr, Value,
 };
@@ -69,60 +62,4 @@ pub fn err_cannot_set_property<T>(cx: Context, name: impl std::fmt::Display) -> 
 pub fn print_eval_error_and_exit(cx: Context, error: Handle<Value>) {
     let error_string = to_console_string(cx, error);
     print_error_message_and_exit(&error_string);
-}
-
-/// Prints the error passed as the first argument then exits the process.
-pub fn print_eval_error_and_exit_runtime(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
-) -> EvalResult<Handle<Value>> {
-    let error = get_argument(cx, arguments, 0);
-    print_eval_error_and_exit(cx, error);
-
-    cx.undefined().into()
-}
-
-/// Panics with a message referencing the error passed as the first argument.
-pub fn panic_runtime(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
-) -> EvalResult<Handle<Value>> {
-    let error = get_argument(cx, arguments, 0);
-    let error_string = to_console_string(cx, error);
-
-    panic!("{}", error_string);
-}
-
-/// Print an error to the console and exit if the provided promise rejects.
-pub fn print_error_and_exit_if_rejects(cx: Context, promise: Handle<PromiseObject>) {
-    let on_reject = BuiltinFunction::create(
-        cx,
-        print_eval_error_and_exit_runtime,
-        1,
-        cx.names.empty_string(),
-        cx.current_realm(),
-        None,
-        None,
-    );
-
-    perform_promise_then(cx, promise, cx.undefined(), on_reject.into(), None);
-}
-
-/// Panic if the provided promise rejects.
-pub fn panic_if_rejects(cx: Context, promise: Handle<PromiseObject>) {
-    let on_reject = BuiltinFunction::create(
-        cx,
-        panic_runtime,
-        1,
-        cx.names.empty_string(),
-        cx.current_realm(),
-        None,
-        None,
-    );
-
-    perform_promise_then(cx, promise, cx.undefined(), on_reject.into(), None);
 }

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     js::runtime::{
         async_generator_object, bound_function_object::BoundFunctionObject, console::ConsoleObject,
-        error, gc_object::GcObject, global_names, module, object_value::ObjectValue,
+        gc_object::GcObject, global_names, module, object_value::ObjectValue,
         promise_object::PromiseCapability, test_262_object::Test262Object, Context, EvalResult,
         Handle, Value,
     },
@@ -300,8 +300,6 @@ rust_runtime_functions!(
     DatePrototype::value_of,
     ErrorConstructor::construct,
     ErrorPrototype::to_string,
-    error::panic_runtime,
-    error::print_eval_error_and_exit_runtime,
     EvalErrorConstructor::construct,
     FinalizationRegistryConstructor::construct,
     FinalizationRegistryPrototype::register,

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -121,6 +121,13 @@ impl PromiseObject {
         matches!(self.state, PromiseState::Pending { already_resolved: false, .. })
     }
 
+    pub fn rejected_value(&self) -> Option<Value> {
+        match self.state {
+            PromiseState::Rejected { result } => Some(result),
+            _ => None,
+        }
+    }
+
     pub fn set_already_resolved(&mut self, value: bool) {
         match self.state {
             PromiseState::Pending { ref mut already_resolved, .. } => *already_resolved = value,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ use js::{
         options::{Args, Options},
     },
     runtime::{
-        bytecode::generator::BytecodeProgramGenerator, error::print_eval_error_and_exit,
-        module::execute::ExecuteOnReject, Context, Handle, Realm,
+        bytecode::generator::BytecodeProgramGenerator, error::print_eval_error_and_exit, Context,
+        Handle, Realm,
     },
 };
 
@@ -67,7 +67,7 @@ fn evaluate_file(
             BytecodeProgramGenerator::generate_from_parse_module_result(cx, &parse_result, realm)?;
 
         // Load modules and execute in the bytecode interpreter
-        if let Err(err) = cx.run_module(module, ExecuteOnReject::PrintAndExit) {
+        if let Err(err) = cx.run_module(module) {
             print_eval_error_and_exit(cx, err);
         }
     } else {

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -7,7 +7,7 @@ use brimstone::js::{
             generator::{BytecodeProgramGenerator, BytecodeScript},
         },
         initialize_host_defined_realm,
-        module::{execute::ExecuteOnReject, source_text_module::SourceTextModule},
+        module::source_text_module::SourceTextModule,
         Context, Handle, Realm,
     },
 };
@@ -127,7 +127,7 @@ fn run_and_print_bytecode(path: &str) -> GenericResult<String> {
     // Execute bytecode. Can ignore return result since we only care about the dumped bytecode.
     let _ = cx.execute_then_drop(|mut cx| match bytecode_program {
         BytecodeResult::Script(script) => cx.run_script(script),
-        BytecodeResult::Module(module) => cx.run_module(module, ExecuteOnReject::Panic),
+        BytecodeResult::Module(module) => cx.run_module(module),
     });
 
     // Return a copy of the dump buffer

--- a/tests/test262/src/index.rs
+++ b/tests/test262/src/index.rs
@@ -29,7 +29,7 @@ pub enum ExpectedResult {
     Negative { phase: TestPhase, type_: String },
 }
 
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum TestPhase {
     Parse,
     Resolution,


### PR DESCRIPTION
## Summary

Fixes handling of module test errors in the test262 runner. We now check that expected errors occur in the correct phase - module resolution or runtime. This is accomplished with a flag on the Context which is set after module resolution completes.

In addition we have also changed how errors during module resolution and evaluation are handled in the top level `Context::run_module` function. Previously we added a promise then reaction which either panics or exists on promise rejection but this did not play well with the test262 runner. Instead we can check whether the toplevel promise for module execution has rejected after all tasks have completed, and if so return an error.