### PR TITLE
[parser] Restrict source text size to 4GB to guarantee 32 bit indices

### DIFF
--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -16,6 +16,7 @@ pub enum ParseError {
     UnknownToken(Box<String>),
     UnexpectedToken(Box<Token>),
     ExpectedToken(Box<(Token, Token)>),
+    SourceTooLarge(bool),
     InvalidUnicode,
     UnterminatedStringLiteral,
     UnterminatedRegExpLiteral,
@@ -148,6 +149,10 @@ impl fmt::Display for ParseError {
             ParseError::ExpectedToken(payload) => {
                 let (actual, expected) = payload.as_ref();
                 write!(f, "Unexpected token {}, expected {}", actual, expected)
+            }
+            ParseError::SourceTooLarge(is_file) => {
+                let source = if *is_file { "File" } else { "String" };
+                write!(f, "{} is too large, max size is 2^32 bytes", source)
             }
             ParseError::InvalidUnicode => write!(f, "Invalid utf-8 sequence"),
             ParseError::UnterminatedStringLiteral => write!(f, "Unterminated string literal"),
@@ -417,7 +422,7 @@ pub struct LocalizedParseError {
 }
 
 impl LocalizedParseError {
-    fn new_without_loc(error: ParseError) -> LocalizedParseError {
+    pub fn new_without_loc(error: ParseError) -> LocalizedParseError {
         LocalizedParseError { error, source_loc: None }
     }
 }

--- a/src/js/runtime/eval/create_dynamic_function.rs
+++ b/src/js/runtime/eval/create_dynamic_function.rs
@@ -109,24 +109,31 @@ pub fn create_dynamic_function(
 
     // Make sure that parameter list and body are valid by themselves. Only need to check that they
     // parse correctly, full analysis will be performed on entire function text.
-    let params_source = Source::new_from_wtf8_string("", params_string);
-    if let Err(err) = parse_function_params_for_function_constructor(
-        &Rc::new(params_source),
-        is_async,
-        is_generator,
-    ) {
+    let params_source = match Source::new_from_wtf8_string("", params_string) {
+        Ok(source) => Rc::new(source),
+        Err(err) => return syntax_error(cx, &err.to_string()),
+    };
+    if let Err(err) =
+        parse_function_params_for_function_constructor(&params_source, is_async, is_generator)
+    {
         return syntax_error(cx, &format!("could not parse function parameters: {}", err));
     }
 
-    let body_source = Source::new_from_wtf8_string("", body_string);
+    let body_source = match Source::new_from_wtf8_string("", body_string) {
+        Ok(source) => Rc::new(source),
+        Err(err) => return syntax_error(cx, &err.to_string()),
+    };
     if let Err(err) =
-        parse_function_body_for_function_constructor(&Rc::new(body_source), is_async, is_generator)
+        parse_function_body_for_function_constructor(&body_source, is_async, is_generator)
     {
         return syntax_error(cx, &format!("could not parse function body: {}", err));
     }
 
     // Parse and analyze entire function
-    let full_source = Rc::new(Source::new_from_wtf8_string("", source_string));
+    let full_source = match Source::new_from_wtf8_string("", source_string) {
+        Ok(source) => Rc::new(source),
+        Err(err) => return syntax_error(cx, &err.to_string()),
+    };
     let mut parse_result = match parse_function_for_function_constructor(&full_source) {
         Ok(parse_result) => parse_result,
         Err(err) => return syntax_error(cx, &format!("could not parse function: {}", err)),

--- a/src/js/runtime/eval/eval.rs
+++ b/src/js/runtime/eval/eval.rs
@@ -47,7 +47,11 @@ pub fn perform_eval(
     let private_names = get_private_names_from_scopes(direct_scope.map(|s| s.get_()));
 
     // Parse source code
-    let source = Rc::new(Source::new_from_wtf8_string("<eval>", code.to_wtf8_string()));
+    let source = match Source::new_from_wtf8_string("<eval>", code.to_wtf8_string()) {
+        Ok(source) => Rc::new(source),
+        Err(error) => return syntax_error(cx, &error.to_string()),
+    };
+
     let parse_result = parse_script_for_eval(&source, is_direct, is_strict_caller);
     let mut parse_result = match parse_result {
         Ok(parse_result) => parse_result,

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -149,10 +149,14 @@ impl Test262Object {
             return type_error(cx, "expected string");
         }
 
-        let source = Rc::new(Source::new_from_wtf8_string(
+        let source = match Source::new_from_wtf8_string(
             "<eval>",
             script_text.as_string().to_wtf8_string(),
-        ));
+        ) {
+            Ok(source) => Rc::new(source),
+            Err(error) => return syntax_error(cx, &error.to_string()),
+        };
+
         let parse_result = parse_script(&source);
         let mut parse_result = match parse_result {
             Ok(parse_result) => parse_result,


### PR DESCRIPTION
## Summary

Restrict the size of the source text to 2^32 bytes (4GB). This allows us to use 32 bit indices into the source text.