### PR TITLE
[runtime] SourceFile object has a lazily generated array of line offsets

### DIFF
--- a/src/js/runtime/boxed_value.rs
+++ b/src/js/runtime/boxed_value.rs
@@ -14,7 +14,6 @@ pub struct BoxedValue {
 }
 
 impl BoxedValue {
-    #[allow(unused)]
     pub fn new(cx: Context, value: Handle<Value>) -> HeapPtr<BoxedValue> {
         let mut scope = cx.alloc_uninit::<BoxedValue>();
 

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -11,7 +11,10 @@ use crate::js::runtime::{
     },
     class_names::ClassNames,
     collections::{
-        array::{value_array_byte_size, value_array_visit_pointers},
+        array::{
+            byte_array_byte_size, byte_array_visit_pointers, value_array_byte_size,
+            value_array_visit_pointers,
+        },
         vec::{value_vec_byte_size, value_vec_visit_pointers},
     },
     context::GlobalSymbolRegistryField,
@@ -20,7 +23,7 @@ use crate::js::runtime::{
     global_names::GlobalNames,
     interned_strings::{InternedStringsMapField, InternedStringsSetField},
     intrinsics::{
-        array_buffer_constructor::{ArrayBufferDataField, ArrayBufferObject},
+        array_buffer_constructor::ArrayBufferObject,
         array_iterator::ArrayIterator,
         async_from_sync_iterator_prototype::AsyncFromSyncIterator,
         bigint_constructor::BigIntObject,
@@ -169,12 +172,12 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::InternedStringsSet => InternedStringsSetField::byte_size(&self.cast()),
             ObjectKind::LexicalNamesMap => LexicalNamesMapField::byte_size(&self.cast()),
             ObjectKind::ValueArray => value_array_byte_size(self.cast()),
-            ObjectKind::ValueVec => value_vec_byte_size(self.cast()),
-            ObjectKind::ArrayBufferDataArray => ArrayBufferDataField::byte_size(&self.cast()),
+            ObjectKind::ByteArray => byte_array_byte_size(self.cast()),
             ObjectKind::FinalizationRegistryCells => {
                 self.cast::<FinalizationRegistryCells>().byte_size()
             }
             ObjectKind::GlobalScopes => self.cast::<GlobalScopes>().byte_size(),
+            ObjectKind::ValueVec => value_vec_byte_size(self.cast()),
             ObjectKind::Last => unreachable!("No objects are created with this descriptor"),
         }
     }
@@ -303,14 +306,12 @@ impl HeapObject for HeapPtr<HeapItem> {
                 LexicalNamesMapField::visit_pointers(self.cast_mut(), visitor)
             }
             ObjectKind::ValueArray => value_array_visit_pointers(self.cast_mut(), visitor),
-            ObjectKind::ValueVec => value_vec_visit_pointers(self.cast_mut(), visitor),
-            ObjectKind::ArrayBufferDataArray => {
-                ArrayBufferDataField::visit_pointers(self.cast_mut(), visitor)
-            }
+            ObjectKind::ByteArray => byte_array_visit_pointers(self.cast_mut(), visitor),
             ObjectKind::FinalizationRegistryCells => self
                 .cast::<FinalizationRegistryCells>()
                 .visit_pointers(visitor),
             ObjectKind::GlobalScopes => self.cast::<GlobalScopes>().visit_pointers(visitor),
+            ObjectKind::ValueVec => value_vec_visit_pointers(self.cast_mut(), visitor),
             ObjectKind::Last => unreachable!("No objects are created with this descriptor"),
         }
     }

--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -133,8 +133,7 @@ impl ArrayBufferPrototype {
         }
 
         // Create new data block with copy of old data at start
-        let mut new_data =
-            BsArray::<u8>::new_uninit(cx, ObjectKind::ArrayBufferDataArray, new_byte_length);
+        let mut new_data = BsArray::<u8>::new_uninit(cx, ObjectKind::ByteArray, new_byte_length);
         let old_byte_length = array_buffer.byte_length();
 
         unsafe {

--- a/src/js/runtime/mod.rs
+++ b/src/js/runtime/mod.rs
@@ -52,7 +52,6 @@ mod value;
 
 pub use abstract_operations::get;
 pub use completion::EvalResult;
-#[allow(unused_imports)]
 pub use console::to_console_string;
 pub use context::Context;
 pub use gc::{Handle, HeapPtr};

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -69,11 +69,8 @@ pub enum ModuleState {
     Unlinked,
     Linking,
     Linked,
-    #[allow(unused)]
     Evaluating,
-    #[allow(unused)]
     EvaluatingAsync,
-    #[allow(unused)]
     Evaluated,
 }
 
@@ -268,7 +265,6 @@ impl SourceTextModule {
     }
 
     #[inline]
-    #[allow(unused)]
     pub fn program_function(&self) -> Handle<BytecodeFunction> {
         self.program_function_ptr().to_handle()
     }

--- a/src/js/runtime/object_descriptor.rs
+++ b/src/js/runtime/object_descriptor.rs
@@ -140,7 +140,7 @@ pub enum ObjectKind {
 
     // Arrays
     ValueArray,
-    ArrayBufferDataArray,
+    ByteArray,
     FinalizationRegistryCells,
     GlobalScopes,
 
@@ -349,7 +349,7 @@ impl BaseDescriptors {
         other_heap_object_descriptor!(ObjectKind::LexicalNamesMap);
 
         other_heap_object_descriptor!(ObjectKind::ValueArray);
-        other_heap_object_descriptor!(ObjectKind::ArrayBufferDataArray);
+        other_heap_object_descriptor!(ObjectKind::ByteArray);
         other_heap_object_descriptor!(ObjectKind::FinalizationRegistryCells);
         other_heap_object_descriptor!(ObjectKind::GlobalScopes);
 


### PR DESCRIPTION
## Summary

We will want line offsets stored in the heap so that they can be used to determine source positions and extract lines of source text. Line offsets are stored in a BsArray as a field of the SourceFile object. The line offsets array is lazily generated when first requested.

Also generalizes the ArrayBuffer's DataArray to a ByteArray, which can be used for any opaque data stored on the heap (such as an array of u32 line offsets).

Finally cleans up some unnecessary `#[allow(unused)]` attributes.