### PR TITLE
[bytecode] Bytecode functions are printed in source order

### DIFF
--- a/src/js/runtime/bytecode/constant_table.rs
+++ b/src/js/runtime/bytecode/constant_table.rs
@@ -67,10 +67,6 @@ impl ConstantTable {
         self.constants.as_mut_slice()[index] = value;
     }
 
-    pub fn as_slice(&self) -> &[Value] {
-        self.constants.as_slice()
-    }
-
     fn get_metadata_ptr(&self) -> *const u8 {
         let ptr = self as *const ConstantTable as *const u8;
         unsafe { ptr.add(Self::metadata_offset(self.constants.len())) }

--- a/src/js/runtime/collections/vec.rs
+++ b/src/js/runtime/collections/vec.rs
@@ -51,12 +51,12 @@ impl<T: Clone + Copy> BsVec<T> {
     }
 
     #[inline]
-    fn as_slice(&self) -> &[T] {
+    pub fn as_slice(&self) -> &[T] {
         &self.array.as_slice()[..self.len()]
     }
 
     #[inline]
-    fn as_mut_slice(&mut self) -> &mut [T] {
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
         let len = self.len();
         &mut self.array.as_mut_slice()[..len]
     }
@@ -83,7 +83,7 @@ impl<T: Clone + Copy> HeapObject for HeapPtr<BsVec<T>> {
 /// A BsVec stored as the field of a heap object. Can create new BsVec objects and set the field to
 /// a new BsVec.
 pub trait BsVecField<T: Clone + Copy> {
-    fn new_vec(&self, cx: Context, capacity: usize) -> HeapPtr<BsVec<T>>;
+    fn new_vec(cx: Context, capacity: usize) -> HeapPtr<BsVec<T>>;
 
     fn get(&self) -> HeapPtr<BsVec<T>>;
 
@@ -107,7 +107,7 @@ pub trait BsVecField<T: Clone + Copy> {
 
         // Double size of vector, starting at a length of 4
         let new_capacity = (capacity * 2).max(4);
-        let mut new_vec = self.new_vec(cx, new_capacity);
+        let mut new_vec = Self::new_vec(cx, new_capacity);
 
         // Update parent reference from old child to new child map
         self.set(new_vec);

--- a/src/js/runtime/debug_print.rs
+++ b/src/js/runtime/debug_print.rs
@@ -60,10 +60,6 @@ impl DebugPrinter {
         self.result
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.result.is_empty()
-    }
-
     pub fn push_mode(&mut self, mode: DebugPrintMode) {
         self.mode_stack.push(mode);
     }

--- a/src/js/runtime/eval/create_dynamic_function.rs
+++ b/src/js/runtime/eval/create_dynamic_function.rs
@@ -13,10 +13,7 @@ use crate::{
             source::Source,
         },
         runtime::{
-            bytecode::{
-                function::{dump_bytecode_function, Closure},
-                generator::BytecodeProgramGenerator,
-            },
+            bytecode::{function::Closure, generator::BytecodeProgramGenerator},
             completion::EvalResult,
             error::syntax_error,
             intrinsics::{
@@ -159,10 +156,6 @@ pub fn create_dynamic_function(
         Ok(func) => func,
         Err(error) => return syntax_error(cx, &error.to_string()),
     };
-
-    if cx.options.print_bytecode {
-        dump_bytecode_function(cx, bytecode_function.get_());
-    }
 
     // Dynamic functions are always in the global scope
     let global_scope = realm.default_global_scope();

--- a/src/js/runtime/eval/eval.rs
+++ b/src/js/runtime/eval/eval.rs
@@ -11,9 +11,7 @@ use crate::{
         runtime::{
             abstract_operations::call_object,
             bytecode::{
-                function::{dump_bytecode_function, Closure},
-                generator::BytecodeProgramGenerator,
-                instruction::EvalFlags,
+                function::Closure, generator::BytecodeProgramGenerator, instruction::EvalFlags,
             },
             error::{syntax_error, type_error},
             global_names::{
@@ -91,11 +89,6 @@ pub fn perform_eval(
         Ok(func) => func,
         Err(error) => return syntax_error(cx, &error.to_string()),
     };
-
-    // Print the bytecode if necessary, optionally to the internal dump buffer
-    if cx.options.print_bytecode {
-        dump_bytecode_function(cx, bytecode_function.get_());
-    }
 
     // Eval function's parent scope is the global scope in an indirect eval
     let eval_scope = direct_scope.unwrap_or_else(|| cx.current_realm().default_global_scope());

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -661,7 +661,7 @@ type AsyncParentModulesVec = BsVec<HeapPtr<SourceTextModule>>;
 struct AsyncParentModulesField(Handle<SourceTextModule>);
 
 impl BsVecField<HeapPtr<SourceTextModule>> for AsyncParentModulesField {
-    fn new_vec(&self, cx: Context, capacity: usize) -> HeapPtr<AsyncParentModulesVec> {
+    fn new_vec(cx: Context, capacity: usize) -> HeapPtr<AsyncParentModulesVec> {
         BsVec::new(cx, ObjectKind::ValueVec, capacity)
     }
 

--- a/tests/js_bytecode/bytecode/use_strict_stripped.exp
+++ b/tests/js_bytecode/bytecode/use_strict_stripped.exp
@@ -24,7 +24,6 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 1
-    0: 03 ff 03   LoadImmediate r0, 3
-    3: 18 ff      Ret r0
+    0: LoadImmediate r0, 3
+    3: Ret r0
 }
-

--- a/tests/js_bytecode/class/declaration.exp
+++ b/tests/js_bytecode/class/declaration.exp
@@ -26,6 +26,12 @@
     9: [ClassNames]
 }
 
+[BytecodeFunction: C1] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
 [BytecodeFunction: tdzGlobals] {
   Parameters: 0, Registers: 1
     0: LoadFromScope r0, 1, 0
@@ -113,10 +119,4 @@
     0: DefaultSuperCall 
     1: CheckThisInitialized <this>
     3: Ret <this>
-}
-
-[BytecodeFunction: C1] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
 }

--- a/tests/js_bytecode/class/fields.exp
+++ b/tests/js_bytecode/class/fields.exp
@@ -93,16 +93,6 @@
     0: [BytecodeFunction: fieldsInitializer]
 }
 
-[BytecodeFunction: fieldsInitializer] {
-  Parameters: 0, Registers: 1
-    0: LoadImmediate r0, 2
-    3: DefineNamedProperty <this>, c0, r0
-    7: LoadUndefined r0
-    9: Ret r0
-  Constant Table:
-    0: [String: named1]
-}
-
 [BytecodeFunction: staticInitializer] {
   Parameters: 0, Registers: 1
     0: LoadImmediate r0, 3
@@ -111,6 +101,16 @@
     9: Ret r0
   Constant Table:
     0: [String: named2]
+}
+
+[BytecodeFunction: fieldsInitializer] {
+  Parameters: 0, Registers: 1
+    0: LoadImmediate r0, 2
+    3: DefineNamedProperty <this>, c0, r0
+    7: LoadUndefined r0
+    9: Ret r0
+  Constant Table:
+    0: [String: named1]
 }
 
 [BytecodeFunction: computed] {
@@ -150,19 +150,19 @@
     0: [BytecodeFunction: fieldsInitializer]
 }
 
-[BytecodeFunction: fieldsInitializer] {
+[BytecodeFunction: staticInitializer] {
   Parameters: 0, Registers: 2
-     0: LoadImmediate r0, 2
-     3: LoadFromScope r1, 0, 0
+     0: LoadImmediate r0, 4
+     3: LoadFromScope r1, 1, 0
      7: DefineProperty <this>, r1, r0, 0
     12: LoadUndefined r0
     14: Ret r0
 }
 
-[BytecodeFunction: staticInitializer] {
+[BytecodeFunction: fieldsInitializer] {
   Parameters: 0, Registers: 2
-     0: LoadImmediate r0, 4
-     3: LoadFromScope r1, 1, 0
+     0: LoadImmediate r0, 2
+     3: LoadFromScope r1, 0, 0
      7: DefineProperty <this>, r1, r0, 0
     12: LoadUndefined r0
     14: Ret r0
@@ -201,19 +201,19 @@
     0: [BytecodeFunction: fieldsInitializer]
 }
 
-[BytecodeFunction: fieldsInitializer] {
+[BytecodeFunction: staticInitializer] {
   Parameters: 0, Registers: 2
-     0: LoadImmediate r0, 1
-     3: LoadFromScope r1, 2, 0
+     0: LoadImmediate r0, 2
+     3: LoadFromScope r1, 3, 0
      7: DefinePrivateProperty <this>, r1, r0, 0
     12: LoadUndefined r0
     14: Ret r0
 }
 
-[BytecodeFunction: staticInitializer] {
+[BytecodeFunction: fieldsInitializer] {
   Parameters: 0, Registers: 2
-     0: LoadImmediate r0, 2
-     3: LoadFromScope r1, 3, 0
+     0: LoadImmediate r0, 1
+     3: LoadFromScope r1, 2, 0
      7: DefinePrivateProperty <this>, r1, r0, 0
     12: LoadUndefined r0
     14: Ret r0
@@ -262,22 +262,6 @@
     0: [BytecodeFunction: fieldsInitializer]
 }
 
-[BytecodeFunction: fieldsInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadUndefined r0
-     2: DefineNamedProperty <this>, c0, r0
-     6: LoadUndefined r0
-     8: LoadFromScope r1, 0, 0
-    12: DefineProperty <this>, r1, r0, 0
-    17: LoadUndefined r0
-    19: LoadFromScope r1, 4, 0
-    23: DefinePrivateProperty <this>, r1, r0, 0
-    28: LoadUndefined r0
-    30: Ret r0
-  Constant Table:
-    0: [String: named1]
-}
-
 [BytecodeFunction: staticInitializer] {
   Parameters: 0, Registers: 2
      0: LoadUndefined r0
@@ -292,6 +276,22 @@
     30: Ret r0
   Constant Table:
     0: [String: named2]
+}
+
+[BytecodeFunction: fieldsInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadUndefined r0
+     2: DefineNamedProperty <this>, c0, r0
+     6: LoadUndefined r0
+     8: LoadFromScope r1, 0, 0
+    12: DefineProperty <this>, r1, r0, 0
+    17: LoadUndefined r0
+    19: LoadFromScope r1, 4, 0
+    23: DefinePrivateProperty <this>, r1, r0, 0
+    28: LoadUndefined r0
+    30: Ret r0
+  Constant Table:
+    0: [String: named1]
 }
 
 [BytecodeFunction: withConstructor] {
@@ -457,24 +457,6 @@
     7: [ClassNames]
 }
 
-[BytecodeFunction: namedMethod] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
-}
-
-[BytecodeFunction: <anonymous>] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
-}
-
-[BytecodeFunction: #private2] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
-}
-
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
      0: NewClosure r0, c0
@@ -502,6 +484,24 @@
     46: Ret r0
   Constant Table:
     0: [String: namedField]
+}
+
+[BytecodeFunction: namedMethod] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: <anonymous>] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: #private2] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
 }
 
 [BytecodeFunction: withCapturedName] {
@@ -534,21 +534,6 @@
     5: [ClassNames]
 }
 
-[BytecodeFunction: #private1] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
-}
-
-[BytecodeFunction: method] {
-  Parameters: 0, Registers: 1
-    0: LoadFromScope r0, 2, 0
-    4: CheckTdz r0, c0
-    7: Ret r0
-  Constant Table:
-    0: [String: C]
-}
-
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
      0: NewClosure r0, c0
@@ -569,6 +554,21 @@
     20: DefineProperty <this>, r1, r0, 0
     25: LoadUndefined r0
     27: Ret r0
+}
+
+[BytecodeFunction: #private1] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: method] {
+  Parameters: 0, Registers: 1
+    0: LoadFromScope r0, 2, 0
+    4: CheckTdz r0, c0
+    7: Ret r0
+  Constant Table:
+    0: [String: C]
 }
 
 [BytecodeFunction: withStaticInitializers] {
@@ -659,6 +659,25 @@
     0: [BytecodeFunction: fieldsInitializer]
 }
 
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: NewClosure r0, c0
+     3: DefineNamedProperty <this>, c1, r0
+     7: NewClosure r0, c2
+    10: LoadFromScope r1, 1, 0
+    14: DefineProperty <this>, r1, r0, 1
+    19: NewClosure r0, c3
+    22: LoadFromScope r1, 5, 0
+    26: DefinePrivateProperty <this>, r1, r0, 0
+    31: LoadUndefined r0
+    33: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: named2]
+    1: [String: named2]
+    2: [BytecodeFunction: <anonymous>]
+    3: [BytecodeFunction: #private2]
+}
+
 [BytecodeFunction: fieldsInitializer] {
   Parameters: 0, Registers: 2
      0: NewClosure r0, c0
@@ -684,37 +703,6 @@
     2: Ret r0
 }
 
-[BytecodeFunction: <anonymous>] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
-}
-
-[BytecodeFunction: #private1] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: NewClosure r0, c0
-     3: DefineNamedProperty <this>, c1, r0
-     7: NewClosure r0, c2
-    10: LoadFromScope r1, 1, 0
-    14: DefineProperty <this>, r1, r0, 1
-    19: NewClosure r0, c3
-    22: LoadFromScope r1, 5, 0
-    26: DefinePrivateProperty <this>, r1, r0, 0
-    31: LoadUndefined r0
-    33: Ret r0
-  Constant Table:
-    0: [BytecodeFunction: named2]
-    1: [String: named2]
-    2: [BytecodeFunction: <anonymous>]
-    3: [BytecodeFunction: #private2]
-}
-
 [BytecodeFunction: named2] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
@@ -722,6 +710,18 @@
 }
 
 [BytecodeFunction: <anonymous>] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: <anonymous>] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: #private1] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
     2: Ret r0
@@ -760,18 +760,6 @@
     0: [BytecodeFunction: fieldsInitializer]
 }
 
-[BytecodeFunction: fieldsInitializer] {
-  Parameters: 0, Registers: 1
-     0: LoadFromScope r0, 0, 0
-     4: GetNamedSuperProperty r0, r0, <this>, c0
-     9: DefineNamedProperty <this>, c1, r0
-    13: LoadUndefined r0
-    15: Ret r0
-  Constant Table:
-    0: [String: foo]
-    1: [String: field1]
-}
-
 [BytecodeFunction: staticInitializer] {
   Parameters: 0, Registers: 1
      0: LoadFromScope r0, 1, 0
@@ -782,6 +770,18 @@
   Constant Table:
     0: [String: foo]
     1: [String: field2]
+}
+
+[BytecodeFunction: fieldsInitializer] {
+  Parameters: 0, Registers: 1
+     0: LoadFromScope r0, 0, 0
+     4: GetNamedSuperProperty r0, r0, <this>, c0
+     9: DefineNamedProperty <this>, c1, r0
+    13: LoadUndefined r0
+    15: Ret r0
+  Constant Table:
+    0: [String: foo]
+    1: [String: field1]
 }
 
 [BytecodeFunction: thisInFields] {
@@ -808,15 +808,6 @@
     0: [BytecodeFunction: fieldsInitializer]
 }
 
-[BytecodeFunction: fieldsInitializer] {
-  Parameters: 0, Registers: 1
-    0: DefineNamedProperty <this>, c0, <this>
-    4: LoadUndefined r0
-    6: Ret r0
-  Constant Table:
-    0: [String: field1]
-}
-
 [BytecodeFunction: staticInitializer] {
   Parameters: 0, Registers: 1
     0: DefineNamedProperty <this>, c0, <this>
@@ -824,6 +815,15 @@
     6: Ret r0
   Constant Table:
     0: [String: field2]
+}
+
+[BytecodeFunction: fieldsInitializer] {
+  Parameters: 0, Registers: 1
+    0: DefineNamedProperty <this>, c0, <this>
+    4: LoadUndefined r0
+    6: Ret r0
+  Constant Table:
+    0: [String: field1]
 }
 
 [BytecodeFunction: newTargetInFields] {
@@ -850,15 +850,6 @@
     0: [BytecodeFunction: fieldsInitializer]
 }
 
-[BytecodeFunction: fieldsInitializer] {
-  Parameters: 0, Registers: 2
-    0: DefineNamedProperty <this>, c0, r0
-    4: LoadUndefined r1
-    6: Ret r1
-  Constant Table:
-    0: [String: field1]
-}
-
 [BytecodeFunction: staticInitializer] {
   Parameters: 0, Registers: 2
     0: DefineNamedProperty <this>, c0, r0
@@ -866,6 +857,15 @@
     6: Ret r1
   Constant Table:
     0: [String: field2]
+}
+
+[BytecodeFunction: fieldsInitializer] {
+  Parameters: 0, Registers: 2
+    0: DefineNamedProperty <this>, c0, r0
+    4: LoadUndefined r1
+    6: Ret r1
+  Constant Table:
+    0: [String: field1]
 }
 
 [BytecodeFunction: fieldNoInitializer] {
@@ -892,16 +892,6 @@
     0: [BytecodeFunction: fieldsInitializer]
 }
 
-[BytecodeFunction: fieldsInitializer] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: DefineNamedProperty <this>, c0, r0
-    6: LoadUndefined r0
-    8: Ret r0
-  Constant Table:
-    0: [String: field1]
-}
-
 [BytecodeFunction: staticInitializer] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
@@ -910,6 +900,16 @@
     8: Ret r0
   Constant Table:
     0: [String: field2]
+}
+
+[BytecodeFunction: fieldsInitializer] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: DefineNamedProperty <this>, c0, r0
+    6: LoadUndefined r0
+    8: Ret r0
+  Constant Table:
+    0: [String: field1]
 }
 
 [BytecodeFunction: privateFieldNoInitializer] {
@@ -945,19 +945,19 @@
     0: [BytecodeFunction: fieldsInitializer]
 }
 
-[BytecodeFunction: fieldsInitializer] {
+[BytecodeFunction: staticInitializer] {
   Parameters: 0, Registers: 2
      0: LoadUndefined r0
-     2: LoadFromScope r1, 2, 0
+     2: LoadFromScope r1, 3, 0
      6: DefinePrivateProperty <this>, r1, r0, 0
     11: LoadUndefined r0
     13: Ret r0
 }
 
-[BytecodeFunction: staticInitializer] {
+[BytecodeFunction: fieldsInitializer] {
   Parameters: 0, Registers: 2
      0: LoadUndefined r0
-     2: LoadFromScope r1, 3, 0
+     2: LoadFromScope r1, 2, 0
      6: DefinePrivateProperty <this>, r1, r0, 0
     11: LoadUndefined r0
     13: Ret r0

--- a/tests/js_bytecode/class/methods.exp
+++ b/tests/js_bytecode/class/methods.exp
@@ -57,6 +57,12 @@
     15: [ClassNames]
 }
 
+[BytecodeFunction: C] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
 [BytecodeFunction: named1] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
@@ -130,12 +136,6 @@
 }
 
 [BytecodeFunction: <anonymous>] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
-}
-
-[BytecodeFunction: C] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
     2: Ret r0

--- a/tests/js_bytecode/class/private_member.exp
+++ b/tests/js_bytecode/class/private_member.exp
@@ -35,6 +35,25 @@
     12: [ClassNames]
 }
 
+[BytecodeFunction: C] {
+  Parameters: 0, Registers: 1
+     0: NewClosure r0, c0
+     3: CallWithReceiver r0, r0, <this>, r0, 0
+     9: LoadUndefined r0
+    11: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: fieldsInitializer]
+}
+
+[BytecodeFunction: fieldsInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r0, 1, 0
+     4: LoadFromScope r1, 0, 0
+     8: DefinePrivateProperty <this>, r0, r1, 1
+    13: LoadUndefined r0
+    15: Ret r0
+}
+
 [BytecodeFunction: #method] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
@@ -122,23 +141,4 @@
     14: Ret r0
   Constant Table:
     0: [String: x]
-}
-
-[BytecodeFunction: C] {
-  Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
-  Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: fieldsInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadFromScope r0, 1, 0
-     4: LoadFromScope r1, 0, 0
-     8: DefinePrivateProperty <this>, r0, r1, 1
-    13: LoadUndefined r0
-    15: Ret r0
 }

--- a/tests/js_bytecode/class/private_properties.exp
+++ b/tests/js_bytecode/class/private_properties.exp
@@ -46,18 +46,6 @@
     7: [BytecodeFunction: staticInitializer]
 }
 
-[BytecodeFunction: #method1] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
-}
-
-[BytecodeFunction: #method2] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
-}
-
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
      0: NewClosure r0, c0
@@ -66,6 +54,15 @@
     11: Ret r0
   Constant Table:
     0: [BytecodeFunction: fieldsInitializer]
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r0, 3, 0
+     4: LoadFromScope r1, 1, 0
+     8: DefinePrivateProperty <this>, r0, r1, 1
+    13: LoadUndefined r0
+    15: Ret r0
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -77,13 +74,16 @@
     15: Ret r0
 }
 
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadFromScope r0, 3, 0
-     4: LoadFromScope r1, 1, 0
-     8: DefinePrivateProperty <this>, r0, r1, 1
-    13: LoadUndefined r0
-    15: Ret r0
+[BytecodeFunction: #method1] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: #method2] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
 }
 
 [BytecodeFunction: individualAccessors] {
@@ -127,6 +127,40 @@
     11: [BytecodeFunction: staticInitializer]
 }
 
+[BytecodeFunction: C] {
+  Parameters: 0, Registers: 1
+     0: NewClosure r0, c0
+     3: CallWithReceiver r0, r0, <this>, r0, 0
+     9: LoadUndefined r0
+    11: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: fieldsInitializer]
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r0, 6, 0
+     4: LoadFromScope r1, 2, 0
+     8: DefinePrivateProperty <this>, r0, r1, 2
+    13: LoadFromScope r0, 7, 0
+    17: LoadFromScope r1, 3, 0
+    21: DefinePrivateProperty <this>, r0, r1, 4
+    26: LoadUndefined r0
+    28: Ret r0
+}
+
+[BytecodeFunction: fieldsInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r0, 4, 0
+     4: LoadFromScope r1, 0, 0
+     8: DefinePrivateProperty <this>, r0, r1, 2
+    13: LoadFromScope r0, 5, 0
+    17: LoadFromScope r1, 1, 0
+    21: DefinePrivateProperty <this>, r0, r1, 4
+    26: LoadUndefined r0
+    28: Ret r0
+}
+
 [BytecodeFunction: get #getter1] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
@@ -149,40 +183,6 @@
   Parameters: 1, Registers: 1
     0: LoadUndefined r0
     2: Ret r0
-}
-
-[BytecodeFunction: C] {
-  Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
-  Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: fieldsInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadFromScope r0, 4, 0
-     4: LoadFromScope r1, 0, 0
-     8: DefinePrivateProperty <this>, r0, r1, 2
-    13: LoadFromScope r0, 5, 0
-    17: LoadFromScope r1, 1, 0
-    21: DefinePrivateProperty <this>, r0, r1, 4
-    26: LoadUndefined r0
-    28: Ret r0
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadFromScope r0, 6, 0
-     4: LoadFromScope r1, 2, 0
-     8: DefinePrivateProperty <this>, r0, r1, 2
-    13: LoadFromScope r0, 7, 0
-    17: LoadFromScope r1, 3, 0
-    21: DefinePrivateProperty <this>, r0, r1, 4
-    26: LoadUndefined r0
-    28: Ret r0
 }
 
 [BytecodeFunction: accessorPairs] {
@@ -235,10 +235,35 @@
     15: [BytecodeFunction: staticInitializer]
 }
 
-[BytecodeFunction: set #acc1] {
-  Parameters: 1, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
+[BytecodeFunction: C] {
+  Parameters: 0, Registers: 1
+     0: NewClosure r0, c0
+     3: CallWithReceiver r0, r0, <this>, r0, 0
+     9: LoadUndefined r0
+    11: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: fieldsInitializer]
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r0, 4, 0
+     4: LoadFromScope r1, 1, 0
+     8: DefinePrivateProperty <this>, r0, r1, 6
+    13: LoadUndefined r0
+    15: Ret r0
+}
+
+[BytecodeFunction: fieldsInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r0, 3, 0
+     4: LoadFromScope r1, 0, 0
+     8: DefinePrivateProperty <this>, r0, r1, 6
+    13: LoadFromScope r0, 5, 0
+    17: LoadFromScope r1, 2, 0
+    21: DefinePrivateProperty <this>, r0, r1, 6
+    26: LoadUndefined r0
+    28: Ret r0
 }
 
 [BytecodeFunction: get #acc1] {
@@ -247,8 +272,8 @@
     2: Ret r0
 }
 
-[BytecodeFunction: get #acc2] {
-  Parameters: 0, Registers: 1
+[BytecodeFunction: set #acc1] {
+  Parameters: 1, Registers: 1
     0: LoadUndefined r0
     2: Ret r0
 }
@@ -259,7 +284,19 @@
     2: Ret r0
 }
 
+[BytecodeFunction: get #acc2] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
 [BytecodeFunction: method1] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: get #acc3] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
     2: Ret r0
@@ -277,45 +314,8 @@
     2: Ret r0
 }
 
-[BytecodeFunction: get #acc3] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
-}
-
 [BytecodeFunction: method3] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
     2: Ret r0
-}
-
-[BytecodeFunction: C] {
-  Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
-  Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: fieldsInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadFromScope r0, 3, 0
-     4: LoadFromScope r1, 0, 0
-     8: DefinePrivateProperty <this>, r0, r1, 6
-    13: LoadFromScope r0, 5, 0
-    17: LoadFromScope r1, 2, 0
-    21: DefinePrivateProperty <this>, r0, r1, 6
-    26: LoadUndefined r0
-    28: Ret r0
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadFromScope r0, 4, 0
-     4: LoadFromScope r1, 1, 0
-     8: DefinePrivateProperty <this>, r0, r1, 6
-    13: LoadUndefined r0
-    15: Ret r0
 }

--- a/tests/js_bytecode/class/scope.exp
+++ b/tests/js_bytecode/class/scope.exp
@@ -42,13 +42,13 @@
     2: [ClassNames]
 }
 
-[BytecodeFunction: method] {
+[BytecodeFunction: C] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
     2: Ret r0
 }
 
-[BytecodeFunction: C] {
+[BytecodeFunction: method] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
     2: Ret r0
@@ -73,6 +73,12 @@
     3: [ClassNames]
 }
 
+[BytecodeFunction: C] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
 [BytecodeFunction: method] {
   Parameters: 0, Registers: 1
     0: LoadFromScope r0, 0, 0
@@ -81,12 +87,6 @@
     9: Ret r0
   Constant Table:
     0: [String: C]
-}
-
-[BytecodeFunction: C] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
 }
 
 [BytecodeFunction: capturedByStaticInitializer] {
@@ -144,6 +144,12 @@
     3: [ClassNames]
 }
 
+[BytecodeFunction: C] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
 [BytecodeFunction: method] {
   Parameters: 0, Registers: 1
     0: LoadFromScope r0, 0, 0
@@ -152,12 +158,6 @@
     9: Ret r0
   Constant Table:
     0: [String: C]
-}
-
-[BytecodeFunction: C] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
 }
 
 [BytecodeFunction: capturedByEval] {
@@ -188,6 +188,12 @@
     4: [ClassNames]
 }
 
+[BytecodeFunction: C] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
 [BytecodeFunction: method] {
   Parameters: 0, Registers: 2
      0: PushFunctionScope c0
@@ -204,12 +210,6 @@
     0: [ScopeNames]
     1: [String: eval]
     2: [String: ]
-}
-
-[BytecodeFunction: C] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
 }
 
 [BytecodeFunction: canReassignOutsideBodyButNotInside] {
@@ -232,6 +232,12 @@
     3: [ClassNames]
 }
 
+[BytecodeFunction: C] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
 [BytecodeFunction: method] {
   Parameters: 0, Registers: 2
      0: LoadImmediate r0, 1
@@ -243,10 +249,4 @@
     18: Ret r0
   Constant Table:
     0: [String: C]
-}
-
-[BytecodeFunction: C] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
 }

--- a/tests/js_bytecode/class/static_initializer.exp
+++ b/tests/js_bytecode/class/static_initializer.exp
@@ -84,12 +84,6 @@
     22: Ret r0
 }
 
-[BytecodeFunction: method1] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
-}
-
 [BytecodeFunction: StaticInitializerAfterCreateClass] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
@@ -103,6 +97,12 @@
      6: Add r0, r0, r1
     10: LoadUndefined r0
     12: Ret r0
+}
+
+[BytecodeFunction: method1] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
 }
 
 [BytecodeFunction: MultipleStaticInitializers] {
@@ -168,16 +168,6 @@
     8: Ret r2
 }
 
-[BytecodeFunction: method] {
-  Parameters: 0, Registers: 1
-     0: LoadFromScope r0, 0, 0
-     4: GetNamedSuperProperty r0, r0, <this>, c0
-     9: LoadUndefined r0
-    11: Ret r0
-  Constant Table:
-    0: [String: foo]
-}
-
 [BytecodeFunction: SpecialExpressionAccess] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
@@ -196,6 +186,16 @@
     26: Add r1, r1, r2
     30: LoadUndefined r1
     32: Ret r1
+  Constant Table:
+    0: [String: foo]
+}
+
+[BytecodeFunction: method] {
+  Parameters: 0, Registers: 1
+     0: LoadFromScope r0, 0, 0
+     4: GetNamedSuperProperty r0, r0, <this>, c0
+     9: LoadUndefined r0
+    11: Ret r0
   Constant Table:
     0: [String: foo]
 }

--- a/tests/js_bytecode/class/super_member.exp
+++ b/tests/js_bytecode/class/super_member.exp
@@ -26,6 +26,23 @@
     8: [ClassNames]
 }
 
+[BytecodeFunction: C1] {
+  Parameters: 0, Registers: 3
+     0: LoadEmpty <this>
+     2: Mov r0, <closure>
+     5: GetSuperConstructor r2, r0
+     8: Construct r2, r2, r1, r1, 0
+    14: CheckSuperAlreadyCalled <this>
+    16: Mov <this>, r2
+    19: CheckThisInitialized <this>
+    21: LoadFromScope r2, 0, 0
+    25: GetNamedSuperProperty r2, r2, <this>, c0
+    30: CheckThisInitialized <this>
+    32: Ret <this>
+  Constant Table:
+    0: [String: x]
+}
+
 [BytecodeFunction: instanceSuperMember] {
   Parameters: 0, Registers: 1
     0: LoadFromScope r0, 0, 0
@@ -40,23 +57,6 @@
     0: LoadFromScope r0, 1, 0
     4: GetNamedSuperProperty r0, r0, <this>, c0
     9: Ret r0
-  Constant Table:
-    0: [String: x]
-}
-
-[BytecodeFunction: C1] {
-  Parameters: 0, Registers: 3
-     0: LoadEmpty <this>
-     2: Mov r0, <closure>
-     5: GetSuperConstructor r2, r0
-     8: Construct r2, r2, r1, r1, 0
-    14: CheckSuperAlreadyCalled <this>
-    16: Mov <this>, r2
-    19: CheckThisInitialized <this>
-    21: LoadFromScope r2, 0, 0
-    25: GetNamedSuperProperty r2, r2, <this>, c0
-    30: CheckThisInitialized <this>
-    32: Ret <this>
   Constant Table:
     0: [String: x]
 }

--- a/tests/js_bytecode/eval/completion.exp
+++ b/tests/js_bytecode/eval/completion.exp
@@ -114,15 +114,15 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 3
-     0: 04 ff 00      LoadConstant r0, c0
-     3: 03 fe 01      LoadImmediate r1, 1
-     6: 03 fd 02      LoadImmediate r2, 2
-     9: 19 ff fe fd   Add r0, r1, r2
-    13: 0d fe 01      LoadDynamic r1, c1
-    16: 0d fd 02      LoadDynamic r2, c2
-    19: 19 ff fe fd   Add r0, r1, r2
-    23: 04 ff 03      LoadConstant r0, c3
-    26: 18 ff         Ret r0
+     0: LoadConstant r0, c0
+     3: LoadImmediate r1, 1
+     6: LoadImmediate r2, 2
+     9: Add r0, r1, r2
+    13: LoadDynamic r1, c1
+    16: LoadDynamic r2, c2
+    19: Add r0, r1, r2
+    23: LoadConstant r0, c3
+    26: Ret r0
   Constant Table:
     0: [String: expression statement completions]
     1: [String: a]
@@ -132,18 +132,18 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 04 ff 00   LoadConstant r0, c0
-     3: 03 fe 01   LoadImmediate r1, 1
-     6: 0f fe 01   StoreDynamic r1, c1
-     9: 05 ff      LoadUndefined r0
-    11: 0d fe 01   LoadDynamic r1, c1
-    14: 42 fe 08   JumpToBooleanFalse r1, 8 (.L0)
-    17: 03 ff 01   LoadImmediate r0, 1
-    20: 3a 05      Jump 5 (.L1)
+     0: LoadConstant r0, c0
+     3: LoadImmediate r1, 1
+     6: StoreDynamic r1, c1
+     9: LoadUndefined r0
+    11: LoadDynamic r1, c1
+    14: JumpToBooleanFalse r1, 8 (.L0)
+    17: LoadImmediate r0, 1
+    20: Jump 5 (.L1)
   .L0:
-    22: 03 ff 02   LoadImmediate r0, 2
+    22: LoadImmediate r0, 2
   .L1:
-    25: 18 ff      Ret r0
+    25: Ret r0
   Constant Table:
     0: [String: inner completions]
     1: [String: a]
@@ -151,68 +151,68 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 04 ff 00   LoadConstant r0, c0
-     3: 05 ff      LoadUndefined r0
-     5: 08 fe      LoadTrue r1
-     7: 40 fe 06   JumpFalse r1, 6 (.L0)
-    10: 03 ff 01   LoadImmediate r0, 1
+     0: LoadConstant r0, c0
+     3: LoadUndefined r0
+     5: LoadTrue r1
+     7: JumpFalse r1, 6 (.L0)
+    10: LoadImmediate r0, 1
   .L0:
-    13: 18 ff      Ret r0
+    13: Ret r0
   Constant Table:
     0: [String: if completion]
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-    0: 04 ff 00   LoadConstant r0, c0
-    3: 05 ff      LoadUndefined r0
-    5: 08 fe      LoadTrue r1
-    7: 3a 02      Jump 2 (.L0)
+    0: LoadConstant r0, c0
+    3: LoadUndefined r0
+    5: LoadTrue r1
+    7: Jump 2 (.L0)
   .L0:
-    9: 18 ff      Ret r0
+    9: Ret r0
   Constant Table:
     0: [String: switch completion]
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 04 ff 00   LoadConstant r0, c0
-     3: 05 ff      LoadUndefined r0
+     0: LoadConstant r0, c0
+     3: LoadUndefined r0
   .L0:
-     5: 09 fe      LoadFalse r1
-     7: 40 fe 08   JumpFalse r1, 8 (.L1)
-    10: 03 ff 01   LoadImmediate r0, 1
-    13: 3a f8      Jump -8 (.L0)
+     5: LoadFalse r1
+     7: JumpFalse r1, 8 (.L1)
+    10: LoadImmediate r0, 1
+    13: Jump -8 (.L0)
   .L1:
-    15: 18 ff      Ret r0
+    15: Ret r0
   Constant Table:
     0: [String: while completion]
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 04 ff 00   LoadConstant r0, c0
-     3: 05 ff      LoadUndefined r0
+     0: LoadConstant r0, c0
+     3: LoadUndefined r0
   .L0:
-     5: 03 ff 01   LoadImmediate r0, 1
-     8: 09 fe      LoadFalse r1
-    10: 3c fe fb   JumpTrue r1, -5 (.L0)
-    13: 18 ff      Ret r0
+     5: LoadImmediate r0, 1
+     8: LoadFalse r1
+    10: JumpTrue r1, -5 (.L0)
+    13: Ret r0
   Constant Table:
     0: [String: do-while completion]
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 68 00         PushLexicalScope c0
-     2: 6e 07 00 00   StoreToScope <this>, 0, 0
-     6: 04 ff 01      LoadConstant r0, c1
-     9: 05 ff         LoadUndefined r0
-    11: 4e fe         NewObject r1
-    13: 6a fe 02      PushWithScope r1, c2
-    16: 03 ff 01      LoadImmediate r0, 1
-    19: 6b            PopScope 
-    20: 18 ff         Ret r0
+     0: PushLexicalScope c0
+     2: StoreToScope <this>, 0, 0
+     6: LoadConstant r0, c1
+     9: LoadUndefined r0
+    11: NewObject r1
+    13: PushWithScope r1, c2
+    16: LoadImmediate r0, 1
+    19: PopScope 
+    20: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: with completion]
@@ -221,34 +221,34 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 04 ff 00   LoadConstant r0, c0
-     3: 05 ff      LoadUndefined r0
+     0: LoadConstant r0, c0
+     3: LoadUndefined r0
   .L0:
-     5: 09 fe      LoadFalse r1
-     7: 40 fe 08   JumpFalse r1, 8 (.L1)
-    10: 03 ff 01   LoadImmediate r0, 1
-    13: 3a f8      Jump -8 (.L0)
+     5: LoadFalse r1
+     7: JumpFalse r1, 8 (.L1)
+    10: LoadImmediate r0, 1
+    13: Jump -8 (.L0)
   .L1:
-    15: 18 ff      Ret r0
+    15: Ret r0
   Constant Table:
     0: [String: for completion]
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 3
-     0: 04 ff 00   LoadConstant r0, c0
-     3: 05 ff      LoadUndefined r0
-     5: 4e fe      NewObject r1
-     7: 46 fe 14   JumpNullish r1, 20 (.L1)
-    10: 7b fe fe   NewForInIterator r1, r1
+     0: LoadConstant r0, c0
+     3: LoadUndefined r0
+     5: NewObject r1
+     7: JumpNullish r1, 20 (.L1)
+    10: NewForInIterator r1, r1
   .L0:
-    13: 7c fd fe   ForInNext r2, r1
-    16: 46 fd 0b   JumpNullish r2, 11 (.L1)
-    19: 0f fd 01   StoreDynamic r2, c1
-    22: 03 ff 01   LoadImmediate r0, 1
-    25: 3a f4      Jump -12 (.L0)
+    13: ForInNext r2, r1
+    16: JumpNullish r2, 11 (.L1)
+    19: StoreDynamic r2, c1
+    22: LoadImmediate r0, 1
+    25: Jump -12 (.L0)
   .L1:
-    27: 18 ff      Ret r0
+    27: Ret r0
   Constant Table:
     0: [String: for-in completion]
     1: [String: x]
@@ -256,25 +256,25 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 6
-     0: 04 ff 00         LoadConstant r0, c0
-     3: 05 ff            LoadUndefined r0
-     5: 4f fc            NewArray r3
-     7: 7d fe fd fc      GetIterator r1, r2, r3
+     0: LoadConstant r0, c0
+     3: LoadUndefined r0
+     5: NewArray r3
+     7: GetIterator r1, r2, r3
   .L0:
-    11: 7f fc fb fe fd   IteratorNext r3, r4, r1, r2
-    16: 3c fb 1a         JumpTrue r4, 26 (.L2)
-    19: 0f fc 01         StoreDynamic r3, c1
-    22: 02 fa 03         Mov r5, <scope>
-    25: 03 ff 01         LoadImmediate r0, 1
-    28: 3a 0c            Jump 12 (.L1)
-    30: 03 fc 00         LoadImmediate r3, 0
-    33: 02 03 fa         Mov <scope>, r5
-    36: 81 fe            IteratorClose r1
-    38: 71 fb            Throw r4
+    11: IteratorNext r3, r4, r1, r2
+    16: JumpTrue r4, 26 (.L2)
+    19: StoreDynamic r3, c1
+    22: Mov r5, <scope>
+    25: LoadImmediate r0, 1
+    28: Jump 12 (.L1)
+    30: LoadImmediate r3, 0
+    33: Mov <scope>, r5
+    36: IteratorClose r1
+    38: Throw r4
   .L1:
-    40: 3a e3            Jump -29 (.L0)
+    40: Jump -29 (.L0)
   .L2:
-    42: 18 ff            Ret r0
+    42: Ret r0
   Constant Table:
     0: [String: for-of completion]
     1: [String: x]
@@ -285,15 +285,15 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 04 ff 00   LoadConstant r0, c0
-     3: 05 ff      LoadUndefined r0
-     5: 02 fe 03   Mov r1, <scope>
-     8: 03 ff 01   LoadImmediate r0, 1
-    11: 3a 08      Jump 8 (.L0)
-    13: 02 03 fe   Mov <scope>, r1
-    16: 03 ff 02   LoadImmediate r0, 2
+     0: LoadConstant r0, c0
+     3: LoadUndefined r0
+     5: Mov r1, <scope>
+     8: LoadImmediate r0, 1
+    11: Jump 8 (.L0)
+    13: Mov <scope>, r1
+    16: LoadImmediate r0, 2
   .L0:
-    19: 18 ff      Ret r0
+    19: Ret r0
   Constant Table:
     0: [String: try-catch completion]
   Exception Handlers:
@@ -302,27 +302,27 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 5
-     0: 04 ff 00      LoadConstant r0, c0
-     3: 02 fc 03      Mov r3, <scope>
-     6: 05 ff         LoadUndefined r0
-     8: 03 ff 01      LoadImmediate r0, 1
-    11: 03 fe 01      LoadImmediate r1, 1
-    14: 3a 05         Jump 5 (.L0)
-    16: 03 fe 00      LoadImmediate r1, 0
+     0: LoadConstant r0, c0
+     3: Mov r3, <scope>
+     6: LoadUndefined r0
+     8: LoadImmediate r0, 1
+    11: LoadImmediate r1, 1
+    14: Jump 5 (.L0)
+    16: LoadImmediate r1, 0
   .L0:
-    19: 02 03 fc      Mov <scope>, r3
-    22: 02 fc ff      Mov r3, r0
-    25: 05 ff         LoadUndefined r0
-    27: 03 ff 02      LoadImmediate r0, 2
-    30: 03 fb 00      LoadImmediate r4, 0
-    33: 27 fb fe fb   StrictEqual r4, r1, r4
-    37: 40 fb 05      JumpFalse r4, 5 (.L1)
-    40: 71 fd         Throw r2
+    19: Mov <scope>, r3
+    22: Mov r3, r0
+    25: LoadUndefined r0
+    27: LoadImmediate r0, 2
+    30: LoadImmediate r4, 0
+    33: StrictEqual r4, r1, r4
+    37: JumpFalse r4, 5 (.L1)
+    40: Throw r2
   .L1:
-    42: 02 ff fc      Mov r0, r3
-    45: 3a 02         Jump 2 (.L2)
+    42: Mov r0, r3
+    45: Jump 2 (.L2)
   .L2:
-    47: 18 ff         Ret r0
+    47: Ret r0
   Constant Table:
     0: [String: try-finally completion]
   Exception Handlers:
@@ -331,35 +331,34 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 5
-     0: 04 ff 00      LoadConstant r0, c0
-     3: 02 fc 03      Mov r3, <scope>
-     6: 05 ff         LoadUndefined r0
-     8: 03 ff 01      LoadImmediate r0, 1
-    11: 03 fe 01      LoadImmediate r1, 1
-    14: 3a 10         Jump 16 (.L0)
-    16: 02 03 fc      Mov <scope>, r3
-    19: 03 ff 02      LoadImmediate r0, 2
-    22: 03 fe 01      LoadImmediate r1, 1
-    25: 3a 05         Jump 5 (.L0)
-    27: 03 fe 00      LoadImmediate r1, 0
+     0: LoadConstant r0, c0
+     3: Mov r3, <scope>
+     6: LoadUndefined r0
+     8: LoadImmediate r0, 1
+    11: LoadImmediate r1, 1
+    14: Jump 16 (.L0)
+    16: Mov <scope>, r3
+    19: LoadImmediate r0, 2
+    22: LoadImmediate r1, 1
+    25: Jump 5 (.L0)
+    27: LoadImmediate r1, 0
   .L0:
-    30: 02 03 fc      Mov <scope>, r3
-    33: 02 fc ff      Mov r3, r0
-    36: 05 ff         LoadUndefined r0
-    38: 03 ff 03      LoadImmediate r0, 3
-    41: 03 fb 00      LoadImmediate r4, 0
-    44: 27 fb fe fb   StrictEqual r4, r1, r4
-    48: 40 fb 05      JumpFalse r4, 5 (.L1)
-    51: 71 fd         Throw r2
+    30: Mov <scope>, r3
+    33: Mov r3, r0
+    36: LoadUndefined r0
+    38: LoadImmediate r0, 3
+    41: LoadImmediate r4, 0
+    44: StrictEqual r4, r1, r4
+    48: JumpFalse r4, 5 (.L1)
+    51: Throw r2
   .L1:
-    53: 02 ff fc      Mov r0, r3
-    56: 3a 02         Jump 2 (.L2)
+    53: Mov r0, r3
+    56: Jump 2 (.L2)
   .L2:
-    58: 18 ff         Ret r0
+    58: Ret r0
   Constant Table:
     0: [String: try-catch-finally completion]
   Exception Handlers:
     8-11 -> 16
     16-22 -> 27 (r2)
 }
-

--- a/tests/js_bytecode/eval/delete.exp
+++ b/tests/js_bytecode/eval/delete.exp
@@ -35,14 +35,14 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 4a fe 00   NewClosure r1, c0
-     3: 0f fe 01   StoreDynamic r1, c1
-     6: 04 ff 02   LoadConstant r0, c2
-     9: 03 fe 01   LoadImmediate r1, 1
-    12: 0f fe 03   StoreDynamic r1, c3
-    15: 60 ff 03   DeleteBinding r0, c3
-    18: 60 ff 01   DeleteBinding r0, c1
-    21: 18 ff      Ret r0
+     0: NewClosure r1, c0
+     3: StoreDynamic r1, c1
+     6: LoadConstant r0, c2
+     9: LoadImmediate r1, 1
+    12: StoreDynamic r1, c3
+    15: DeleteBinding r0, c3
+    18: DeleteBinding r0, c1
+    21: Ret r0
   Constant Table:
     0: [BytecodeFunction: f]
     1: [String: f]
@@ -52,20 +52,20 @@
 
 [BytecodeFunction: f] {
   Parameters: 0, Registers: 1
-    0: 05 ff   LoadUndefined r0
-    2: 18 ff   Ret r0
+    0: LoadUndefined r0
+    2: Ret r0
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 4a fe 00   NewClosure r1, c0
-     3: 0f fe 01   StoreDynamic r1, c1
-     6: 04 ff 02   LoadConstant r0, c2
-     9: 03 fe 01   LoadImmediate r1, 1
-    12: 0f fe 03   StoreDynamic r1, c3
-    15: 60 ff 03   DeleteBinding r0, c3
-    18: 60 ff 01   DeleteBinding r0, c1
-    21: 18 ff      Ret r0
+     0: NewClosure r1, c0
+     3: StoreDynamic r1, c1
+     6: LoadConstant r0, c2
+     9: LoadImmediate r1, 1
+    12: StoreDynamic r1, c3
+    15: DeleteBinding r0, c3
+    18: DeleteBinding r0, c1
+    21: Ret r0
   Constant Table:
     0: [BytecodeFunction: f]
     1: [String: f]
@@ -75,7 +75,6 @@
 
 [BytecodeFunction: f] {
   Parameters: 0, Registers: 1
-    0: 05 ff   LoadUndefined r0
-    2: 18 ff   Ret r0
+    0: LoadUndefined r0
+    2: Ret r0
 }
-

--- a/tests/js_bytecode/eval/dynamic_lookup_out_of_eval.exp
+++ b/tests/js_bytecode/eval/dynamic_lookup_out_of_eval.exp
@@ -84,46 +84,46 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 0d ff 00   LoadDynamic r0, c0
-     3: 03 fe 01   LoadImmediate r1, 1
-     6: 0f fe 00   StoreDynamic r1, c0
-     9: 02 ff fe   Mov r0, r1
-    12: 18 ff      Ret r0
+     0: LoadDynamic r0, c0
+     3: LoadImmediate r1, 1
+     6: StoreDynamic r1, c0
+     9: Mov r0, r1
+    12: Ret r0
   Constant Table:
     0: [String: x]
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-    0: 03 fe 01   LoadImmediate r1, 1
-    3: 0f fe 00   StoreDynamic r1, c0
-    6: 0d ff 00   LoadDynamic r0, c0
-    9: 18 ff      Ret r0
+    0: LoadImmediate r1, 1
+    3: StoreDynamic r1, c0
+    6: LoadDynamic r0, c0
+    9: Ret r0
   Constant Table:
     0: [String: x]
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-    0: 03 ff 01   LoadImmediate r0, 1
-    3: 02 fe ff   Mov r1, r0
-    6: 18 fe      Ret r1
+    0: LoadImmediate r0, 1
+    3: Mov r1, r0
+    6: Ret r1
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 3
-     0: 03 ff 01      LoadImmediate r0, 1
-     3: 03 fe 02      LoadImmediate r1, 2
-     6: 19 fd ff fe   Add r2, r0, r1
-    10: 18 fd         Ret r2
+     0: LoadImmediate r0, 1
+     3: LoadImmediate r1, 2
+     6: Add r2, r0, r1
+    10: Ret r2
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 3
-    0: 4a fd 00   NewClosure r2, c0
-    3: 0f fd 01   StoreDynamic r2, c1
-    6: 4a ff 02   NewClosure r0, c2
-    9: 18 fe      Ret r1
+    0: NewClosure r2, c0
+    3: StoreDynamic r2, c1
+    6: NewClosure r0, c2
+    9: Ret r1
   Constant Table:
     0: [BytecodeFunction: varFunc]
     1: [String: varFunc]
@@ -132,49 +132,48 @@
 
 [BytecodeFunction: varFunc] {
   Parameters: 0, Registers: 1
-    0: 03 ff 01   LoadImmediate r0, 1
-    3: 18 ff      Ret r0
+    0: LoadImmediate r0, 1
+    3: Ret r0
 }
 
 [BytecodeFunction: lexFunc] {
   Parameters: 0, Registers: 1
-    0: 03 ff 02   LoadImmediate r0, 2
-    3: 18 ff      Ret r0
+    0: LoadImmediate r0, 2
+    3: Ret r0
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 0a ff 00   LoadGlobal r0, c0
-     3: 03 fe 01   LoadImmediate r1, 1
-     6: 0c fe 00   StoreGlobal r1, c0
-     9: 02 ff fe   Mov r0, r1
-    12: 18 ff      Ret r0
+     0: LoadGlobal r0, c0
+     3: LoadImmediate r1, 1
+     6: StoreGlobal r1, c0
+     9: Mov r0, r1
+    12: Ret r0
   Constant Table:
     0: [String: x]
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-    0: 03 fe 01   LoadImmediate r1, 1
-    3: 0f fe 00   StoreDynamic r1, c0
-    6: 0d ff 00   LoadDynamic r0, c0
-    9: 18 ff      Ret r0
+    0: LoadImmediate r1, 1
+    3: StoreDynamic r1, c0
+    6: LoadDynamic r0, c0
+    9: Ret r0
   Constant Table:
     0: [String: x]
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-    0: 03 ff 01   LoadImmediate r0, 1
-    3: 02 fe ff   Mov r1, r0
-    6: 18 fe      Ret r1
+    0: LoadImmediate r0, 1
+    3: Mov r1, r0
+    6: Ret r1
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 1
-    0: 0d ff 00   LoadDynamic r0, c0
-    3: 18 ff      Ret r0
+    0: LoadDynamic r0, c0
+    3: Ret r0
   Constant Table:
     0: [String: %new.target]
 }
-

--- a/tests/js_bytecode/eval/empty.exp
+++ b/tests/js_bytecode/eval/empty.exp
@@ -32,21 +32,20 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 1
-    0: 18 ff   Ret r0
+    0: Ret r0
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 1
-    0: 18 ff   Ret r0
+    0: Ret r0
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 1
-    0: 18 ff   Ret r0
+    0: Ret r0
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 1
-    0: 18 ff   Ret r0
+    0: Ret r0
 }
-

--- a/tests/js_bytecode/eval/flags.exp
+++ b/tests/js_bytecode/eval/flags.exp
@@ -40,6 +40,78 @@
     11: [ClassNames]
 }
 
+[BytecodeFunction: C1] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: LoadEmpty <this>
+     4: StoreToScope <this>, 0, 0
+     8: StoreToScope r0, 3, 0
+    12: StoreToScope <closure>, 1, 0
+    16: NewUnmappedArguments r0
+    18: StoreToScope r0, 2, 0
+    22: LoadGlobal r0, c1
+    25: LoadConstant r1, c2
+    28: CallMaybeEval r0, r0, r1, 1, 11
+    34: LoadFromScope r0, 1, 0
+    38: GetSuperConstructor r0, r0
+    41: LoadFromScope r1, 3, 0
+    45: Construct r0, r0, r1, r1, 0
+    51: LoadFromScope r1, 0, 0
+    55: CheckSuperAlreadyCalled r1
+    57: StoreToScope r0, 0, 0
+    61: NewClosure r1, c3
+    64: CallWithReceiver r1, r1, r0, r1, 0
+    70: LoadFromScope r0, 0, 0
+    74: CheckThisInitialized r0
+    76: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: ]
+    3: [BytecodeFunction: fieldsInitializer]
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: StoreToScope <this>, 0, 0
+     6: StoreToScope r0, 2, 0
+    10: LoadGlobal r0, c1
+    13: LoadConstant r1, c2
+    16: CallMaybeEval r0, r0, r1, 1, 19
+    22: LoadGlobal r0, c1
+    25: LoadConstant r1, c2
+    28: CallMaybeEval r0, r0, r1, 1, 39
+    34: DefineNamedProperty <this>, c3, r0
+    38: PopScope 
+    39: LoadUndefined r0
+    41: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: ]
+    3: [String: field2]
+}
+
+[BytecodeFunction: fieldsInitializer] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: StoreToScope <this>, 0, 0
+     6: StoreToScope r0, 2, 0
+    10: LoadGlobal r0, c1
+    13: LoadConstant r1, c2
+    16: CallMaybeEval r0, r0, r1, 1, 35
+    22: DefineNamedProperty <this>, c3, r0
+    26: PopScope 
+    27: LoadUndefined r0
+    29: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: ]
+    3: [String: field1]
+}
+
 [BytecodeFunction: method1] {
   Parameters: 0, Registers: 2
      0: PushFunctionScope c0
@@ -74,78 +146,6 @@
     0: [ScopeNames]
     1: [String: eval]
     2: [String: ]
-}
-
-[BytecodeFunction: C1] {
-  Parameters: 0, Registers: 2
-     0: PushFunctionScope c0
-     2: LoadEmpty <this>
-     4: StoreToScope <this>, 0, 0
-     8: StoreToScope r0, 3, 0
-    12: StoreToScope <closure>, 1, 0
-    16: NewUnmappedArguments r0
-    18: StoreToScope r0, 2, 0
-    22: LoadGlobal r0, c1
-    25: LoadConstant r1, c2
-    28: CallMaybeEval r0, r0, r1, 1, 11
-    34: LoadFromScope r0, 1, 0
-    38: GetSuperConstructor r0, r0
-    41: LoadFromScope r1, 3, 0
-    45: Construct r0, r0, r1, r1, 0
-    51: LoadFromScope r1, 0, 0
-    55: CheckSuperAlreadyCalled r1
-    57: StoreToScope r0, 0, 0
-    61: NewClosure r1, c3
-    64: CallWithReceiver r1, r1, r0, r1, 0
-    70: LoadFromScope r0, 0, 0
-    74: CheckThisInitialized r0
-    76: Ret r0
-  Constant Table:
-    0: [ScopeNames]
-    1: [String: eval]
-    2: [String: ]
-    3: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: fieldsInitializer] {
-  Parameters: 0, Registers: 2
-     0: PushFunctionScope c0
-     2: StoreToScope <this>, 0, 0
-     6: StoreToScope r0, 2, 0
-    10: LoadGlobal r0, c1
-    13: LoadConstant r1, c2
-    16: CallMaybeEval r0, r0, r1, 1, 35
-    22: DefineNamedProperty <this>, c3, r0
-    26: PopScope 
-    27: LoadUndefined r0
-    29: Ret r0
-  Constant Table:
-    0: [ScopeNames]
-    1: [String: eval]
-    2: [String: ]
-    3: [String: field1]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: PushFunctionScope c0
-     2: StoreToScope <this>, 0, 0
-     6: StoreToScope r0, 2, 0
-    10: LoadGlobal r0, c1
-    13: LoadConstant r1, c2
-    16: CallMaybeEval r0, r0, r1, 1, 19
-    22: LoadGlobal r0, c1
-    25: LoadConstant r1, c2
-    28: CallMaybeEval r0, r0, r1, 1, 39
-    34: DefineNamedProperty <this>, c3, r0
-    38: PopScope 
-    39: LoadUndefined r0
-    41: Ret r0
-  Constant Table:
-    0: [ScopeNames]
-    1: [String: eval]
-    2: [String: ]
-    3: [String: field2]
 }
 
 [BytecodeFunction: C2] {

--- a/tests/js_bytecode/eval/function_constructor.exp
+++ b/tests/js_bytecode/eval/function_constructor.exp
@@ -27,29 +27,28 @@
 
 [BytecodeFunction: anonymous] {
   Parameters: 0, Registers: 1
-    0: 05 ff   LoadUndefined r0
-    2: 18 ff   Ret r0
+    0: LoadUndefined r0
+    2: Ret r0
 }
 
 [BytecodeFunction: anonymous] {
   Parameters: 0, Registers: 2
-     0: 0a ff 00      LoadGlobal r0, c0
-     3: 03 fe 01      LoadImmediate r1, 1
-     6: 19 ff ff fe   Add r0, r0, r1
-    10: 05 ff         LoadUndefined r0
-    12: 18 ff         Ret r0
+     0: LoadGlobal r0, c0
+     3: LoadImmediate r1, 1
+     6: Add r0, r0, r1
+    10: LoadUndefined r0
+    12: Ret r0
   Constant Table:
     0: [String: y]
 }
 
 [BytecodeFunction: anonymous] {
   Parameters: 2, Registers: 2
-     0: 19 ff 08 09   Add r0, a0, a1
-     4: 0a fe 00      LoadGlobal r1, c0
-     7: 19 ff ff fe   Add r0, r0, r1
-    11: 05 ff         LoadUndefined r0
-    13: 18 ff         Ret r0
+     0: Add r0, a0, a1
+     4: LoadGlobal r1, c0
+     7: Add r0, r0, r1
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
     0: [String: z]
 }
-

--- a/tests/js_bytecode/eval/nested_eval.exp
+++ b/tests/js_bytecode/eval/nested_eval.exp
@@ -34,6 +34,12 @@
     8: [String: method2]
 }
 
+[BytecodeFunction: C1] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
 [BytecodeFunction: method1] {
   Parameters: 0, Registers: 2
      0: PushFunctionScope c0
@@ -70,20 +76,14 @@
     2: [String: (function () { eval("") })()]
 }
 
-[BytecodeFunction: C1] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
-}
-
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 3
-     0: 68 00               PushLexicalScope c0
-     2: 6e 07 00 00         StoreToScope <this>, 0, 0
-     6: 0d fe 01            LoadDynamic r1, c1
-     9: 04 fd 02            LoadConstant r2, c2
-    12: 13 ff fe fd 01 03   CallMaybeEval r0, r1, r2, 1, 3
-    18: 18 ff               Ret r0
+     0: PushLexicalScope c0
+     2: StoreToScope <this>, 0, 0
+     6: LoadDynamic r1, c1
+     9: LoadConstant r2, c2
+    12: CallMaybeEval r0, r1, r2, 1, 3
+    18: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: eval]
@@ -92,16 +92,16 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 1
-    0: 18 ff   Ret r0
+    0: Ret r0
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 68 00            PushLexicalScope c0
-     2: 6e 07 00 00      StoreToScope <this>, 0, 0
-     6: 4a fe 01         NewClosure r1, c1
-     9: 10 ff fe fe 00   Call r0, r1, r1, 0
-    14: 18 ff            Ret r0
+     0: PushLexicalScope c0
+     2: StoreToScope <this>, 0, 0
+     6: NewClosure r1, c1
+     9: Call r0, r1, r1, 0
+    14: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [BytecodeFunction: <anonymous>]
@@ -109,16 +109,16 @@
 
 [BytecodeFunction: <anonymous>] {
   Parameters: 0, Registers: 2
-     0: 69 00               PushFunctionScope c0
-     2: 6e 07 00 00         StoreToScope <this>, 0, 0
-     6: 6e ff 02 00         StoreToScope r0, 2, 0
-    10: 52 ff               NewUnmappedArguments r0
-    12: 6e ff 01 00         StoreToScope r0, 1, 0
-    16: 0d ff 01            LoadDynamic r0, c1
-    19: 04 fe 02            LoadConstant r1, c2
-    22: 13 ff ff fe 01 01   CallMaybeEval r0, r0, r1, 1, 1
-    28: 05 ff               LoadUndefined r0
-    30: 18 ff               Ret r0
+     0: PushFunctionScope c0
+     2: StoreToScope <this>, 0, 0
+     6: StoreToScope r0, 2, 0
+    10: NewUnmappedArguments r0
+    12: StoreToScope r0, 1, 0
+    16: LoadDynamic r0, c1
+    19: LoadConstant r1, c2
+    22: CallMaybeEval r0, r0, r1, 1, 1
+    28: LoadUndefined r0
+    30: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: eval]
@@ -127,6 +127,5 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 1
-    0: 18 ff   Ret r0
+    0: Ret r0
 }
-

--- a/tests/js_bytecode/eval/private_names.exp
+++ b/tests/js_bytecode/eval/private_names.exp
@@ -27,24 +27,6 @@
     6: [String: method1]
 }
 
-[BytecodeFunction: method1] {
-  Parameters: 0, Registers: 2
-     0: PushFunctionScope c0
-     2: StoreToScope <this>, 0, 0
-     6: StoreToScope r0, 2, 0
-    10: NewUnmappedArguments r0
-    12: StoreToScope r0, 1, 0
-    16: LoadGlobal r0, c1
-    19: LoadConstant r1, c2
-    22: CallMaybeEval r0, r0, r1, 1, 7
-    28: LoadUndefined r0
-    30: Ret r0
-  Constant Table:
-    0: [ScopeNames]
-    1: [String: eval]
-    2: [String: this.#field]
-}
-
 [BytecodeFunction: C1] {
   Parameters: 0, Registers: 1
      0: NewClosure r0, c0
@@ -64,12 +46,29 @@
     14: Ret r0
 }
 
+[BytecodeFunction: method1] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: StoreToScope <this>, 0, 0
+     6: StoreToScope r0, 2, 0
+    10: NewUnmappedArguments r0
+    12: StoreToScope r0, 1, 0
+    16: LoadGlobal r0, c1
+    19: LoadConstant r1, c2
+    22: CallMaybeEval r0, r0, r1, 1, 7
+    28: LoadUndefined r0
+    30: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: this.#field]
+}
+
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-    0: 0d fe 00      LoadDynamic r1, c0
-    3: 61 ff 07 fe   GetPrivateProperty r0, <this>, r1
-    7: 18 ff         Ret r0
+    0: LoadDynamic r1, c0
+    3: GetPrivateProperty r0, <this>, r1
+    7: Ret r0
   Constant Table:
     0: [String: #field]
 }
-

--- a/tests/js_bytecode/eval/super_members.exp
+++ b/tests/js_bytecode/eval/super_members.exp
@@ -39,6 +39,55 @@
     10: [String: method2]
 }
 
+[BytecodeFunction: C] {
+  Parameters: 0, Registers: 2
+     0: DefaultSuperCall 
+     1: NewClosure r1, c0
+     4: CallWithReceiver r1, r1, <this>, r1, 0
+    10: CheckThisInitialized <this>
+    12: Ret <this>
+  Constant Table:
+    0: [BytecodeFunction: fieldsInitializer]
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: StoreToScope <this>, 0, 0
+     6: StoreToScope r0, 2, 0
+    10: LoadGlobal r0, c1
+    13: LoadConstant r1, c2
+    16: CallMaybeEval r0, r0, r1, 1, 39
+    22: DefineNamedProperty <this>, c3, r0
+    26: PopScope 
+    27: LoadUndefined r0
+    29: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: super.member]
+    3: [String: field]
+}
+
+[BytecodeFunction: fieldsInitializer] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: StoreToScope <this>, 0, 0
+     6: StoreToScope r0, 2, 0
+    10: LoadGlobal r0, c1
+    13: LoadConstant r1, c2
+    16: CallMaybeEval r0, r0, r1, 1, 35
+    22: DefineNamedProperty <this>, c3, r0
+    26: PopScope 
+    27: LoadUndefined r0
+    29: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: super.member]
+    3: [String: field]
+}
+
 [BytecodeFunction: method1] {
   Parameters: 0, Registers: 2
      0: PushFunctionScope c0
@@ -75,60 +124,11 @@
     2: [String: super.method]
 }
 
-[BytecodeFunction: C] {
-  Parameters: 0, Registers: 2
-     0: DefaultSuperCall 
-     1: NewClosure r1, c0
-     4: CallWithReceiver r1, r1, <this>, r1, 0
-    10: CheckThisInitialized <this>
-    12: Ret <this>
-  Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: fieldsInitializer] {
-  Parameters: 0, Registers: 2
-     0: PushFunctionScope c0
-     2: StoreToScope <this>, 0, 0
-     6: StoreToScope r0, 2, 0
-    10: LoadGlobal r0, c1
-    13: LoadConstant r1, c2
-    16: CallMaybeEval r0, r0, r1, 1, 35
-    22: DefineNamedProperty <this>, c3, r0
-    26: PopScope 
-    27: LoadUndefined r0
-    29: Ret r0
-  Constant Table:
-    0: [ScopeNames]
-    1: [String: eval]
-    2: [String: super.member]
-    3: [String: field]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: PushFunctionScope c0
-     2: StoreToScope <this>, 0, 0
-     6: StoreToScope r0, 2, 0
-    10: LoadGlobal r0, c1
-    13: LoadConstant r1, c2
-    16: CallMaybeEval r0, r0, r1, 1, 39
-    22: DefineNamedProperty <this>, c3, r0
-    26: PopScope 
-    27: LoadUndefined r0
-    29: Ret r0
-  Constant Table:
-    0: [ScopeNames]
-    1: [String: eval]
-    2: [String: super.member]
-    3: [String: field]
-}
-
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-    0: 0d fe 00         LoadDynamic r1, c0
-    3: 5d ff fe 07 01   GetNamedSuperProperty r0, r1, <this>, c1
-    8: 18 ff            Ret r0
+    0: LoadDynamic r1, c0
+    3: GetNamedSuperProperty r0, r1, <this>, c1
+    8: Ret r0
   Constant Table:
     0: [String: %staticHomeObject]
     1: [String: member]
@@ -136,9 +136,9 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-    0: 0d fe 00         LoadDynamic r1, c0
-    3: 5d ff fe 07 01   GetNamedSuperProperty r0, r1, <this>, c1
-    8: 18 ff            Ret r0
+    0: LoadDynamic r1, c0
+    3: GetNamedSuperProperty r0, r1, <this>, c1
+    8: Ret r0
   Constant Table:
     0: [String: %homeObject]
     1: [String: member]
@@ -146,9 +146,9 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-    0: 0d fe 00         LoadDynamic r1, c0
-    3: 5d ff fe 07 01   GetNamedSuperProperty r0, r1, <this>, c1
-    8: 18 ff            Ret r0
+    0: LoadDynamic r1, c0
+    3: GetNamedSuperProperty r0, r1, <this>, c1
+    8: Ret r0
   Constant Table:
     0: [String: %homeObject]
     1: [String: method]
@@ -156,11 +156,10 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-    0: 0d fe 00         LoadDynamic r1, c0
-    3: 5d ff fe 07 01   GetNamedSuperProperty r0, r1, <this>, c1
-    8: 18 ff            Ret r0
+    0: LoadDynamic r1, c0
+    3: GetNamedSuperProperty r0, r1, <this>, c1
+    8: Ret r0
   Constant Table:
     0: [String: %staticHomeObject]
     1: [String: method]
 }
-

--- a/tests/js_bytecode/expression/assign.exp
+++ b/tests/js_bytecode/expression/assign.exp
@@ -186,6 +186,82 @@
     2: [String: bar]
 }
 
+[BytecodeFunction: testSuperNamedMemberAssign] {
+  Parameters: 1, Registers: 5
+      0: LoadFromScope r1, 0, 0
+      4: LoadConstant r2, c0
+      7: LoadImmediate r0, 1
+     10: SetSuperProperty r1, <this>, r2, r0
+     15: LoadGlobal r0, c1
+     18: LoadFromScope r2, 0, 0
+     22: LoadConstant r3, c0
+     25: LoadImmediate r1, 2
+     28: SetSuperProperty r2, <this>, r3, r1
+     33: Call r0, r0, r1, 1
+     38: LoadFromScope r1, 0, 0
+     42: LoadConstant r2, c0
+     45: LoadFromScope r3, 0, 0
+     49: LoadConstant r4, c2
+     52: LoadImmediate r0, 3
+     55: SetSuperProperty r3, <this>, r4, r0
+     60: SetSuperProperty r1, <this>, r2, r0
+     65: LoadGlobal r0, c1
+     68: LoadFromScope r2, 0, 0
+     72: LoadConstant r3, c0
+     75: Mov r1, a0
+     78: SetSuperProperty r2, <this>, r3, r1
+     83: Call r0, r0, r1, 1
+     88: LoadFromScope r1, 0, 0
+     92: LoadConstant r2, c0
+     95: LoadImmediate r0, 4
+     98: SetSuperProperty r1, <this>, r2, r0
+    103: Mov a0, r0
+    106: LoadUndefined r0
+    108: Ret r0
+  Constant Table:
+    0: [String: foo]
+    1: [String: use]
+    2: [String: bar]
+}
+
+[BytecodeFunction: testSuperComputedMemberAssign] {
+  Parameters: 1, Registers: 5
+      0: LoadFromScope r1, 0, 0
+      4: LoadConstant r2, c0
+      7: LoadImmediate r0, 1
+     10: SetSuperProperty r1, <this>, r2, r0
+     15: LoadGlobal r0, c1
+     18: LoadFromScope r2, 0, 0
+     22: LoadConstant r3, c0
+     25: LoadImmediate r1, 2
+     28: SetSuperProperty r2, <this>, r3, r1
+     33: Call r0, r0, r1, 1
+     38: LoadFromScope r1, 0, 0
+     42: LoadConstant r2, c0
+     45: LoadFromScope r3, 0, 0
+     49: LoadConstant r4, c2
+     52: LoadImmediate r0, 3
+     55: SetSuperProperty r3, <this>, r4, r0
+     60: SetSuperProperty r1, <this>, r2, r0
+     65: LoadGlobal r0, c1
+     68: LoadFromScope r2, 0, 0
+     72: LoadConstant r3, c0
+     75: Mov r1, a0
+     78: SetSuperProperty r2, <this>, r3, r1
+     83: Call r0, r0, r1, 1
+     88: LoadFromScope r1, 0, 0
+     92: LoadConstant r2, c0
+     95: LoadImmediate r0, 4
+     98: SetSuperProperty r1, <this>, r2, r0
+    103: Mov a0, r0
+    106: LoadUndefined r0
+    108: Ret r0
+  Constant Table:
+    0: [String: foo]
+    1: [String: use]
+    2: [String: bar]
+}
+
 [BytecodeFunction: named] {
   Parameters: 0, Registers: 2
      0: LoadImmediate r0, 1
@@ -464,80 +540,4 @@
     9: Ret r0
   Constant Table:
     0: [String: x]
-}
-
-[BytecodeFunction: testSuperNamedMemberAssign] {
-  Parameters: 1, Registers: 5
-      0: LoadFromScope r1, 0, 0
-      4: LoadConstant r2, c0
-      7: LoadImmediate r0, 1
-     10: SetSuperProperty r1, <this>, r2, r0
-     15: LoadGlobal r0, c1
-     18: LoadFromScope r2, 0, 0
-     22: LoadConstant r3, c0
-     25: LoadImmediate r1, 2
-     28: SetSuperProperty r2, <this>, r3, r1
-     33: Call r0, r0, r1, 1
-     38: LoadFromScope r1, 0, 0
-     42: LoadConstant r2, c0
-     45: LoadFromScope r3, 0, 0
-     49: LoadConstant r4, c2
-     52: LoadImmediate r0, 3
-     55: SetSuperProperty r3, <this>, r4, r0
-     60: SetSuperProperty r1, <this>, r2, r0
-     65: LoadGlobal r0, c1
-     68: LoadFromScope r2, 0, 0
-     72: LoadConstant r3, c0
-     75: Mov r1, a0
-     78: SetSuperProperty r2, <this>, r3, r1
-     83: Call r0, r0, r1, 1
-     88: LoadFromScope r1, 0, 0
-     92: LoadConstant r2, c0
-     95: LoadImmediate r0, 4
-     98: SetSuperProperty r1, <this>, r2, r0
-    103: Mov a0, r0
-    106: LoadUndefined r0
-    108: Ret r0
-  Constant Table:
-    0: [String: foo]
-    1: [String: use]
-    2: [String: bar]
-}
-
-[BytecodeFunction: testSuperComputedMemberAssign] {
-  Parameters: 1, Registers: 5
-      0: LoadFromScope r1, 0, 0
-      4: LoadConstant r2, c0
-      7: LoadImmediate r0, 1
-     10: SetSuperProperty r1, <this>, r2, r0
-     15: LoadGlobal r0, c1
-     18: LoadFromScope r2, 0, 0
-     22: LoadConstant r3, c0
-     25: LoadImmediate r1, 2
-     28: SetSuperProperty r2, <this>, r3, r1
-     33: Call r0, r0, r1, 1
-     38: LoadFromScope r1, 0, 0
-     42: LoadConstant r2, c0
-     45: LoadFromScope r3, 0, 0
-     49: LoadConstant r4, c2
-     52: LoadImmediate r0, 3
-     55: SetSuperProperty r3, <this>, r4, r0
-     60: SetSuperProperty r1, <this>, r2, r0
-     65: LoadGlobal r0, c1
-     68: LoadFromScope r2, 0, 0
-     72: LoadConstant r3, c0
-     75: Mov r1, a0
-     78: SetSuperProperty r2, <this>, r3, r1
-     83: Call r0, r0, r1, 1
-     88: LoadFromScope r1, 0, 0
-     92: LoadConstant r2, c0
-     95: LoadImmediate r0, 4
-     98: SetSuperProperty r1, <this>, r2, r0
-    103: Mov a0, r0
-    106: LoadUndefined r0
-    108: Ret r0
-  Constant Table:
-    0: [String: foo]
-    1: [String: use]
-    2: [String: bar]
 }

--- a/tests/js_bytecode/expression/binary.exp
+++ b/tests/js_bytecode/expression/binary.exp
@@ -63,14 +63,6 @@
     4: [ClassNames]
 }
 
-[BytecodeFunction: method] {
-  Parameters: 0, Registers: 1
-     0: LoadFromScope r0, 1, 0
-     4: In r0, <this>, r0
-     8: LoadUndefined r0
-    10: Ret r0
-}
-
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
      0: NewClosure r0, c0
@@ -88,4 +80,12 @@
      7: DefinePrivateProperty <this>, r1, r0, 0
     12: LoadUndefined r0
     14: Ret r0
+}
+
+[BytecodeFunction: method] {
+  Parameters: 0, Registers: 1
+     0: LoadFromScope r0, 1, 0
+     4: In r0, <this>, r0
+     8: LoadUndefined r0
+    10: Ret r0
 }

--- a/tests/js_bytecode/expression/class.exp
+++ b/tests/js_bytecode/expression/class.exp
@@ -76,12 +76,6 @@
     3: [BytecodeFunction: staticInitializer]
 }
 
-[BytecodeFunction: method] {
-  Parameters: 0, Registers: 1
-    0: LoadImmediate r0, 1
-    3: Ret r0
-}
-
 [BytecodeFunction: ] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
@@ -93,6 +87,12 @@
     0: LoadImmediate r0, 2
     3: LoadUndefined r0
     5: Ret r0
+}
+
+[BytecodeFunction: method] {
+  Parameters: 0, Registers: 1
+    0: LoadImmediate r0, 1
+    3: Ret r0
 }
 
 [BytecodeFunction: nonEmptyNamed] {
@@ -110,12 +110,6 @@
     3: [BytecodeFunction: staticInitializer]
 }
 
-[BytecodeFunction: method] {
-  Parameters: 0, Registers: 1
-    0: LoadImmediate r0, 1
-    3: Ret r0
-}
-
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
@@ -127,6 +121,12 @@
     0: LoadImmediate r0, 2
     3: LoadUndefined r0
     5: Ret r0
+}
+
+[BytecodeFunction: method] {
+  Parameters: 0, Registers: 1
+    0: LoadImmediate r0, 1
+    3: Ret r0
 }
 
 [BytecodeFunction: storeToParam] {

--- a/tests/js_bytecode/expression/update.exp
+++ b/tests/js_bytecode/expression/update.exp
@@ -250,28 +250,6 @@
     0: [String: prop]
 }
 
-[BytecodeFunction: decrement] {
-  Parameters: 1, Registers: 2
-     0: ToNumeric a0, a0
-     3: Dec a0
-     5: ToNumeric a0, a0
-     8: Mov r0, a0
-    11: Dec a0
-    13: GetNamedProperty r0, a0, c0
-    17: ToNumeric r0, r0
-    20: Dec r0
-    22: SetNamedProperty a0, c0, r0
-    26: GetNamedProperty r0, a0, c0
-    30: ToNumeric r0, r0
-    33: Mov r1, r0
-    36: Dec r1
-    38: SetNamedProperty a0, c0, r1
-    42: LoadUndefined r0
-    44: Ret r0
-  Constant Table:
-    0: [String: prop]
-}
-
 [BytecodeFunction: prefixSuperMember] {
   Parameters: 1, Registers: 3
      0: LoadFromScope r1, 0, 0
@@ -323,6 +301,28 @@
     66: Mov a0, r0
     69: LoadUndefined r0
     71: Ret r0
+  Constant Table:
+    0: [String: prop]
+}
+
+[BytecodeFunction: decrement] {
+  Parameters: 1, Registers: 2
+     0: ToNumeric a0, a0
+     3: Dec a0
+     5: ToNumeric a0, a0
+     8: Mov r0, a0
+    11: Dec a0
+    13: GetNamedProperty r0, a0, c0
+    17: ToNumeric r0, r0
+    20: Dec r0
+    22: SetNamedProperty a0, c0, r0
+    26: GetNamedProperty r0, a0, c0
+    30: ToNumeric r0, r0
+    33: Mov r1, r0
+    36: Dec r1
+    38: SetNamedProperty a0, c0, r1
+    42: LoadUndefined r0
+    44: Ret r0
   Constant Table:
     0: [String: prop]
 }

--- a/tests/js_bytecode/function/declaration.exp
+++ b/tests/js_bytecode/function/declaration.exp
@@ -21,6 +21,12 @@
     2: Ret r0
 }
 
+[BytecodeFunction: test2] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
 [BytecodeFunction: test3] {
   Parameters: 0, Registers: 2
     0: NewClosure r0, c0
@@ -31,12 +37,6 @@
 }
 
 [BytecodeFunction: test4] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
-}
-
-[BytecodeFunction: test2] {
   Parameters: 0, Registers: 1
     0: LoadUndefined r0
     2: Ret r0

--- a/tests/js_bytecode/function/generator.exp
+++ b/tests/js_bytecode/function/generator.exp
@@ -286,15 +286,15 @@
     4: Ret r1
 }
 
+[BytecodeFunction: C] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
 [BytecodeFunction: generatorMethod] {
   Parameters: 0, Registers: 2
     0: GeneratorStart r0
     2: LoadUndefined r1
     4: Ret r1
-}
-
-[BytecodeFunction: C] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: Ret r0
 }

--- a/tests/js_bytecode/scope/captured_this.exp
+++ b/tests/js_bytecode/scope/captured_this.exp
@@ -17,6 +17,14 @@
     5: [BytecodeFunction: <anonymous>]
 }
 
+[BytecodeFunction: <anonymous>] {
+  Parameters: 0, Registers: 2
+     0: LoadImmediate r0, 1
+     3: LoadFromScope r1, 1, 0
+     7: Add r0, r0, r1
+    11: Ret r0
+}
+
 [BytecodeFunction: capturedFunctionThis] {
   Parameters: 0, Registers: 2
      0: PushFunctionScope c0
@@ -83,12 +91,4 @@
     0: Mov r0, <this>
     3: LoadUndefined r1
     5: Ret r1
-}
-
-[BytecodeFunction: <anonymous>] {
-  Parameters: 0, Registers: 2
-     0: LoadImmediate r0, 1
-     3: LoadFromScope r1, 1, 0
-     7: Add r0, r0, r1
-    11: Ret r0
 }

--- a/tests/js_bytecode/scope/eval.exp
+++ b/tests/js_bytecode/scope/eval.exp
@@ -46,25 +46,25 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 07 ff      LoadEmpty r0
-     2: 74 ff 00   CheckTdz r0, c0
-     5: 02 fe ff   Mov r1, r0
-     8: 03 ff 01   LoadImmediate r0, 1
-    11: 18 fe      Ret r1
+     0: LoadEmpty r0
+     2: CheckTdz r0, c0
+     5: Mov r1, r0
+     8: LoadImmediate r0, 1
+    11: Ret r1
   Constant Table:
     0: [String: x]
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 2
-     0: 68 00         PushLexicalScope c0
-     2: 07 fe         LoadEmpty r1
-     4: 6e fe 00 00   StoreToScope r1, 0, 0
-     8: 4a fe 01      NewClosure r1, c1
-    11: 0f fe 02      StoreDynamic r1, c2
-    14: 03 fe 01      LoadImmediate r1, 1
-    17: 6e fe 00 00   StoreToScope r1, 0, 0
-    21: 18 ff         Ret r0
+     0: PushLexicalScope c0
+     2: LoadEmpty r1
+     4: StoreToScope r1, 0, 0
+     8: NewClosure r1, c1
+    11: StoreDynamic r1, c2
+    14: LoadImmediate r1, 1
+    17: StoreToScope r1, 0, 0
+    21: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [BytecodeFunction: inner]
@@ -73,22 +73,22 @@
 
 [BytecodeFunction: inner] {
   Parameters: 0, Registers: 1
-    0: 6d ff 00 00   LoadFromScope r0, 0, 0
-    4: 74 ff 00      CheckTdz r0, c0
-    7: 05 ff         LoadUndefined r0
-    9: 18 ff         Ret r0
+    0: LoadFromScope r0, 0, 0
+    4: CheckTdz r0, c0
+    7: LoadUndefined r0
+    9: Ret r0
   Constant Table:
     0: [String: x]
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 3
-     0: 68 00               PushLexicalScope c0
-     2: 6e 07 00 00         StoreToScope <this>, 0, 0
-     6: 0d fe 01            LoadDynamic r1, c1
-     9: 04 fd 02            LoadConstant r2, c2
-    12: 13 ff fe fd 01 00   CallMaybeEval r0, r1, r2, 1, 0
-    18: 18 ff               Ret r0
+     0: PushLexicalScope c0
+     2: StoreToScope <this>, 0, 0
+     6: LoadDynamic r1, c1
+     9: LoadConstant r2, c2
+    12: CallMaybeEval r0, r1, r2, 1, 0
+    18: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: eval]
@@ -97,17 +97,17 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 1
-    0: 18 ff   Ret r0
+    0: Ret r0
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 3
-     0: 68 00               PushLexicalScope c0
-     2: 6e 07 00 00         StoreToScope <this>, 0, 0
-     6: 0d fe 01            LoadDynamic r1, c1
-     9: 04 fd 02            LoadConstant r2, c2
-    12: 13 ff fe fd 01 00   CallMaybeEval r0, r1, r2, 1, 0
-    18: 18 ff               Ret r0
+     0: PushLexicalScope c0
+     2: StoreToScope <this>, 0, 0
+     6: LoadDynamic r1, c1
+     9: LoadConstant r2, c2
+    12: CallMaybeEval r0, r1, r2, 1, 0
+    18: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: eval]
@@ -116,17 +116,17 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 1
-    0: 18 ff   Ret r0
+    0: Ret r0
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 3
-     0: 68 00               PushLexicalScope c0
-     2: 6e 07 00 00         StoreToScope <this>, 0, 0
-     6: 0a fe 01            LoadGlobal r1, c1
-     9: 04 fd 02            LoadConstant r2, c2
-    12: 13 ff fe fd 01 00   CallMaybeEval r0, r1, r2, 1, 0
-    18: 18 ff               Ret r0
+     0: PushLexicalScope c0
+     2: StoreToScope <this>, 0, 0
+     6: LoadGlobal r1, c1
+     9: LoadConstant r2, c2
+    12: CallMaybeEval r0, r1, r2, 1, 0
+    18: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: eval]
@@ -135,17 +135,17 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 1
-    0: 18 ff   Ret r0
+    0: Ret r0
 }
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 3
-     0: 68 00               PushLexicalScope c0
-     2: 6e 07 00 00         StoreToScope <this>, 0, 0
-     6: 0a fe 01            LoadGlobal r1, c1
-     9: 04 fd 02            LoadConstant r2, c2
-    12: 13 ff fe fd 01 00   CallMaybeEval r0, r1, r2, 1, 0
-    18: 18 ff               Ret r0
+     0: PushLexicalScope c0
+     2: StoreToScope <this>, 0, 0
+     6: LoadGlobal r1, c1
+     9: LoadConstant r2, c2
+    12: CallMaybeEval r0, r1, r2, 1, 0
+    18: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: eval]
@@ -154,6 +154,5 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 1
-    0: 18 ff   Ret r0
+    0: Ret r0
 }
-


### PR DESCRIPTION
## Summary

Refactors bytecode printing to print functions in their original order in the source text. This is done by saving all bytecode functions to a vector of all functions during generation, then sorting by the function's starting source position and printing once bytecode generation is complete.

While here some other improvements are made:
- Printing eval functions ignores raw bytes
- Class field and static initializer functions have source range of their entire class

## Tests

All bytecode snapshot tests are re-recorded. The only known changes are:
- Methods of classes are reordered, order is now class function, static initializer, fields initializer, methods
- Method properties of object literals are now printed at the correct location