### PR TITLE
[runtime] Lexical function declarations are hoisted to top of scope

### DIFF
--- a/tests/js_bytecode/scope/block.exp
+++ b/tests/js_bytecode/scope/block.exp
@@ -33,9 +33,9 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 0, 0
-     8: LoadImmediate r1, 1
-    11: StoreToScope r1, 0, 0
-    15: NewClosure r0, c1
+     8: NewClosure r0, c1
+    11: LoadImmediate r1, 1
+    14: StoreToScope r1, 0, 0
     18: PopScope 
     19: LoadUndefined r1
     21: Ret r1

--- a/tests/js_bytecode/scope/captured.exp
+++ b/tests/js_bytecode/scope/captured.exp
@@ -363,9 +363,9 @@
     39: PushLexicalScope c3
     41: LoadEmpty r1
     43: StoreToScope r1, 0, 0
-    47: LoadImmediate r1, 4
-    50: StoreToScope r1, 0, 0
-    54: NewClosure r0, c4
+    47: NewClosure r0, c4
+    50: LoadImmediate r1, 4
+    53: StoreToScope r1, 0, 0
     57: PopScope 
     58: PopScope 
     59: PopScope 
@@ -403,16 +403,16 @@
      0: PushLexicalScope c0
      2: LoadEmpty r2
      4: StoreToScope r2, 0, 0
-     8: LoadImmediate r2, 1
-    11: StoreToScope r2, 0, 0
-    15: NewClosure r1, c1
+     8: NewClosure r1, c1
+    11: LoadImmediate r2, 1
+    14: StoreToScope r2, 0, 0
     18: PopScope 
     19: PushLexicalScope c2
     21: LoadEmpty r2
     23: StoreToScope r2, 0, 0
-    27: LoadImmediate r2, 2
-    30: StoreToScope r2, 0, 0
-    34: NewClosure r0, c3
+    27: NewClosure r0, c3
+    30: LoadImmediate r2, 2
+    33: StoreToScope r2, 0, 0
     37: PopScope 
     38: LoadUndefined r2
     40: Ret r2

--- a/tests/js_bytecode/scope/catch.exp
+++ b/tests/js_bytecode/scope/catch.exp
@@ -63,9 +63,9 @@
     23: PushLexicalScope c1
     25: LoadEmpty r2
     27: StoreToScope r2, 0, 0
-    31: LoadImmediate r2, 1
-    34: StoreToScope r2, 0, 0
-    38: NewClosure r0, c2
+    31: NewClosure r0, c2
+    34: LoadImmediate r2, 1
+    37: StoreToScope r2, 0, 0
     41: PopScope 
   .L0:
     42: LoadUndefined r1
@@ -100,9 +100,9 @@
     11: PushLexicalScope c0
     13: LoadEmpty r2
     15: StoreToScope r2, 0, 0
-    19: LoadImmediate r2, 1
-    22: StoreToScope r2, 0, 0
-    26: NewClosure r0, c1
+    19: NewClosure r0, c1
+    22: LoadImmediate r2, 1
+    25: StoreToScope r2, 0, 0
     29: PopScope 
   .L0:
     30: LoadUndefined r1
@@ -132,10 +132,10 @@
     11: PushLexicalScope c0
     13: LoadEmpty r3
     15: StoreToScope r3, 0, 0
-    19: LoadImmediate r3, 1
-    22: Add r3, r3, r0
-    26: StoreToScope r3, 0, 0
-    30: NewClosure r1, c1
+    19: NewClosure r1, c1
+    22: LoadImmediate r3, 1
+    25: Add r3, r3, r0
+    29: StoreToScope r3, 0, 0
     33: PopScope 
   .L0:
     34: LoadUndefined r2

--- a/tests/js_bytecode/scope/for.exp
+++ b/tests/js_bytecode/scope/for.exp
@@ -98,9 +98,9 @@
     33: PushLexicalScope c2
     35: LoadEmpty r1
     37: StoreToScope r1, 0, 0
-    41: LoadImmediate r1, 2
-    44: StoreToScope r1, 0, 0
-    48: NewClosure r0, c3
+    41: NewClosure r0, c3
+    44: LoadImmediate r1, 2
+    47: StoreToScope r1, 0, 0
     51: PopScope 
     52: DupScope 
     53: LoadFromScope r1, 0, 0

--- a/tests/js_bytecode/scope/for_break.exp
+++ b/tests/js_bytecode/scope/for_break.exp
@@ -46,16 +46,16 @@
     46: PushLexicalScope c2
     48: LoadEmpty r1
     50: StoreToScope r1, 0, 0
-    54: LoadImmediate r1, 3
-    57: StoreToScope r1, 0, 0
-    61: LoadImmediate r1, 4
-    64: JumpToBooleanFalse r1, 8 (.L2)
-    67: PopScope 
-    68: PopScope 
-    69: PopScope 
-    70: Jump 11 (.L4)
+    54: NewClosure r0, c3
+    57: LoadImmediate r1, 3
+    60: StoreToScope r1, 0, 0
+    64: LoadImmediate r1, 4
+    67: JumpToBooleanFalse r1, 8 (.L2)
+    70: PopScope 
+    71: PopScope 
+    72: PopScope 
+    73: Jump 8 (.L4)
   .L2:
-    72: NewClosure r0, c3
     75: PopScope 
     76: PopScope 
     77: DupScope 
@@ -108,15 +108,15 @@
     30: PushLexicalScope c1
     32: LoadEmpty r1
     34: StoreToScope r1, 0, 0
-    38: LoadImmediate r1, 3
-    41: StoreToScope r1, 0, 0
-    45: LoadImmediate r1, 4
-    48: JumpToBooleanFalse r1, 7 (.L2)
-    51: PopScope 
-    52: PopScope 
-    53: Jump 10 (.L4)
+    38: NewClosure r0, c2
+    41: LoadImmediate r1, 3
+    44: StoreToScope r1, 0, 0
+    48: LoadImmediate r1, 4
+    51: JumpToBooleanFalse r1, 7 (.L2)
+    54: PopScope 
+    55: PopScope 
+    56: Jump 7 (.L4)
   .L2:
-    55: NewClosure r0, c2
     58: PopScope 
     59: DupScope 
     60: Jump -44 (.L0)
@@ -165,15 +165,15 @@
     38: PushLexicalScope c2
     40: LoadEmpty r1
     42: StoreToScope r1, 0, 0
-    46: LoadImmediate r1, 3
-    49: StoreToScope r1, 0, 0
-    53: LoadImmediate r1, 4
-    56: JumpToBooleanFalse r1, 7 (.L2)
-    59: PopScope 
-    60: PopScope 
-    61: Jump 9 (.L3)
+    46: NewClosure r0, c3
+    49: LoadImmediate r1, 3
+    52: StoreToScope r1, 0, 0
+    56: LoadImmediate r1, 4
+    59: JumpToBooleanFalse r1, 7 (.L2)
+    62: PopScope 
+    63: PopScope 
+    64: Jump 6 (.L3)
   .L2:
-    63: NewClosure r0, c3
     66: PopScope 
     67: PopScope 
     68: Jump -59 (.L0)
@@ -219,14 +219,14 @@
     29: PushLexicalScope c1
     31: LoadEmpty r1
     33: StoreToScope r1, 0, 0
-    37: LoadImmediate r1, 3
-    40: StoreToScope r1, 0, 0
-    44: LoadImmediate r1, 4
-    47: JumpToBooleanFalse r1, 6 (.L2)
-    50: PopScope 
-    51: Jump 8 (.L3)
+    37: NewClosure r0, c2
+    40: LoadImmediate r1, 3
+    43: StoreToScope r1, 0, 0
+    47: LoadImmediate r1, 4
+    50: JumpToBooleanFalse r1, 6 (.L2)
+    53: PopScope 
+    54: Jump 5 (.L3)
   .L2:
-    53: NewClosure r0, c2
     56: PopScope 
     57: Jump -48 (.L0)
   .L3:

--- a/tests/js_bytecode/scope/for_continue.exp
+++ b/tests/js_bytecode/scope/for_continue.exp
@@ -45,15 +45,15 @@
     45: PushLexicalScope c2
     47: LoadEmpty r1
     49: StoreToScope r1, 0, 0
-    53: LoadImmediate r1, 3
-    56: StoreToScope r1, 0, 0
-    60: LoadImmediate r1, 4
-    63: JumpToBooleanFalse r1, 7 (.L2)
-    66: PopScope 
-    67: PopScope 
-    68: Jump 7 (.L3)
+    53: NewClosure r0, c3
+    56: LoadImmediate r1, 3
+    59: StoreToScope r1, 0, 0
+    63: LoadImmediate r1, 4
+    66: JumpToBooleanFalse r1, 7 (.L2)
+    69: PopScope 
+    70: PopScope 
+    71: Jump 4 (.L3)
   .L2:
-    70: NewClosure r0, c3
     73: PopScope 
     74: PopScope 
   .L3:
@@ -105,14 +105,14 @@
     29: PushLexicalScope c1
     31: LoadEmpty r1
     33: StoreToScope r1, 0, 0
-    37: LoadImmediate r1, 3
-    40: StoreToScope r1, 0, 0
-    44: LoadImmediate r1, 4
-    47: JumpToBooleanFalse r1, 6 (.L2)
-    50: PopScope 
-    51: Jump 6 (.L3)
+    37: NewClosure r0, c2
+    40: LoadImmediate r1, 3
+    43: StoreToScope r1, 0, 0
+    47: LoadImmediate r1, 4
+    50: JumpToBooleanFalse r1, 6 (.L2)
+    53: PopScope 
+    54: Jump 3 (.L3)
   .L2:
-    53: NewClosure r0, c2
     56: PopScope 
   .L3:
     57: DupScope 
@@ -161,15 +161,15 @@
     38: PushLexicalScope c2
     40: LoadEmpty r1
     42: StoreToScope r1, 0, 0
-    46: LoadImmediate r1, 3
-    49: StoreToScope r1, 0, 0
-    53: LoadImmediate r1, 4
-    56: JumpToBooleanFalse r1, 7 (.L2)
-    59: PopScope 
-    60: PopScope 
-    61: Jump 7 (.L3)
+    46: NewClosure r0, c3
+    49: LoadImmediate r1, 3
+    52: StoreToScope r1, 0, 0
+    56: LoadImmediate r1, 4
+    59: JumpToBooleanFalse r1, 7 (.L2)
+    62: PopScope 
+    63: PopScope 
+    64: Jump 4 (.L3)
   .L2:
-    63: NewClosure r0, c3
     66: PopScope 
     67: PopScope 
   .L3:
@@ -216,14 +216,14 @@
     29: PushLexicalScope c1
     31: LoadEmpty r1
     33: StoreToScope r1, 0, 0
-    37: LoadImmediate r1, 3
-    40: StoreToScope r1, 0, 0
-    44: LoadImmediate r1, 4
-    47: JumpToBooleanFalse r1, 6 (.L2)
-    50: PopScope 
-    51: Jump 6 (.L3)
+    37: NewClosure r0, c2
+    40: LoadImmediate r1, 3
+    43: StoreToScope r1, 0, 0
+    47: LoadImmediate r1, 4
+    50: JumpToBooleanFalse r1, 6 (.L2)
+    53: PopScope 
+    54: Jump 3 (.L3)
   .L2:
-    53: NewClosure r0, c2
     56: PopScope 
   .L3:
     57: Jump -48 (.L0)

--- a/tests/js_bytecode/scope/for_in.exp
+++ b/tests/js_bytecode/scope/for_in.exp
@@ -60,9 +60,9 @@
     35: PushLexicalScope c1
     37: LoadEmpty r2
     39: StoreToScope r2, 0, 0
-    43: LoadImmediate r2, 2
-    46: StoreToScope r2, 0, 0
-    50: NewClosure r0, c2
+    43: NewClosure r0, c2
+    46: LoadImmediate r2, 2
+    49: StoreToScope r2, 0, 0
     53: PopScope 
     54: PopScope 
     55: Jump -38 (.L0)

--- a/tests/js_bytecode/scope/for_in_break.exp
+++ b/tests/js_bytecode/scope/for_in_break.exp
@@ -51,16 +51,16 @@
     60: PushLexicalScope c2
     62: LoadEmpty r2
     64: StoreToScope r2, 0, 0
-    68: LoadImmediate r2, 3
-    71: StoreToScope r2, 0, 0
-    75: LoadImmediate r2, 4
-    78: JumpToBooleanFalse r2, 8 (.L2)
-    81: PopScope 
-    82: PopScope 
-    83: PopScope 
-    84: Jump 11 (.L4)
+    68: NewClosure r0, c3
+    71: LoadImmediate r2, 3
+    74: StoreToScope r2, 0, 0
+    78: LoadImmediate r2, 4
+    81: JumpToBooleanFalse r2, 8 (.L2)
+    84: PopScope 
+    85: PopScope 
+    86: PopScope 
+    87: Jump 8 (.L4)
   .L2:
-    86: NewClosure r0, c3
     89: PopScope 
     90: PopScope 
     91: PopScope 
@@ -118,15 +118,15 @@
     44: PushLexicalScope c1
     46: LoadEmpty r2
     48: StoreToScope r2, 0, 0
-    52: LoadImmediate r2, 3
-    55: StoreToScope r2, 0, 0
-    59: LoadImmediate r2, 4
-    62: JumpToBooleanFalse r2, 7 (.L2)
-    65: PopScope 
-    66: PopScope 
-    67: Jump 10 (.L4)
+    52: NewClosure r0, c2
+    55: LoadImmediate r2, 3
+    58: StoreToScope r2, 0, 0
+    62: LoadImmediate r2, 4
+    65: JumpToBooleanFalse r2, 7 (.L2)
+    68: PopScope 
+    69: PopScope 
+    70: Jump 7 (.L4)
   .L2:
-    69: NewClosure r0, c2
     72: PopScope 
     73: PopScope 
     74: Jump -57 (.L0)
@@ -177,15 +177,15 @@
     44: PushLexicalScope c2
     46: LoadEmpty r2
     48: StoreToScope r2, 0, 0
-    52: LoadImmediate r2, 3
-    55: StoreToScope r2, 0, 0
-    59: LoadImmediate r2, 4
-    62: JumpToBooleanFalse r2, 7 (.L2)
-    65: PopScope 
-    66: PopScope 
-    67: Jump 9 (.L3)
+    52: NewClosure r0, c3
+    55: LoadImmediate r2, 3
+    58: StoreToScope r2, 0, 0
+    62: LoadImmediate r2, 4
+    65: JumpToBooleanFalse r2, 7 (.L2)
+    68: PopScope 
+    69: PopScope 
+    70: Jump 6 (.L3)
   .L2:
-    69: NewClosure r0, c3
     72: PopScope 
     73: PopScope 
     74: Jump -64 (.L0)
@@ -233,14 +233,14 @@
     35: PushLexicalScope c1
     37: LoadEmpty r2
     39: StoreToScope r2, 0, 0
-    43: LoadImmediate r2, 3
-    46: StoreToScope r2, 0, 0
-    50: LoadImmediate r2, 4
-    53: JumpToBooleanFalse r2, 6 (.L2)
-    56: PopScope 
-    57: Jump 8 (.L3)
+    43: NewClosure r0, c2
+    46: LoadImmediate r2, 3
+    49: StoreToScope r2, 0, 0
+    53: LoadImmediate r2, 4
+    56: JumpToBooleanFalse r2, 6 (.L2)
+    59: PopScope 
+    60: Jump 5 (.L3)
   .L2:
-    59: NewClosure r0, c2
     62: PopScope 
     63: Jump -53 (.L0)
   .L3:

--- a/tests/js_bytecode/scope/for_in_continue.exp
+++ b/tests/js_bytecode/scope/for_in_continue.exp
@@ -51,16 +51,16 @@
     60: PushLexicalScope c2
     62: LoadEmpty r2
     64: StoreToScope r2, 0, 0
-    68: LoadImmediate r2, 3
-    71: StoreToScope r2, 0, 0
-    75: LoadImmediate r2, 4
-    78: JumpToBooleanFalse r2, 8 (.L2)
-    81: PopScope 
-    82: PopScope 
-    83: PopScope 
-    84: Jump -67 (.L0)
+    68: NewClosure r0, c3
+    71: LoadImmediate r2, 3
+    74: StoreToScope r2, 0, 0
+    78: LoadImmediate r2, 4
+    81: JumpToBooleanFalse r2, 8 (.L2)
+    84: PopScope 
+    85: PopScope 
+    86: PopScope 
+    87: Jump -70 (.L0)
   .L2:
-    86: NewClosure r0, c3
     89: PopScope 
     90: PopScope 
     91: PopScope 
@@ -117,15 +117,15 @@
     44: PushLexicalScope c1
     46: LoadEmpty r2
     48: StoreToScope r2, 0, 0
-    52: LoadImmediate r2, 3
-    55: StoreToScope r2, 0, 0
-    59: LoadImmediate r2, 4
-    62: JumpToBooleanFalse r2, 7 (.L2)
-    65: PopScope 
-    66: PopScope 
-    67: Jump -50 (.L0)
+    52: NewClosure r0, c2
+    55: LoadImmediate r2, 3
+    58: StoreToScope r2, 0, 0
+    62: LoadImmediate r2, 4
+    65: JumpToBooleanFalse r2, 7 (.L2)
+    68: PopScope 
+    69: PopScope 
+    70: Jump -53 (.L0)
   .L2:
-    69: NewClosure r0, c2
     72: PopScope 
     73: PopScope 
     74: Jump -57 (.L0)
@@ -175,15 +175,15 @@
     44: PushLexicalScope c2
     46: LoadEmpty r2
     48: StoreToScope r2, 0, 0
-    52: LoadImmediate r2, 3
-    55: StoreToScope r2, 0, 0
-    59: LoadImmediate r2, 4
-    62: JumpToBooleanFalse r2, 7 (.L2)
-    65: PopScope 
-    66: PopScope 
-    67: Jump -57 (.L0)
+    52: NewClosure r0, c3
+    55: LoadImmediate r2, 3
+    58: StoreToScope r2, 0, 0
+    62: LoadImmediate r2, 4
+    65: JumpToBooleanFalse r2, 7 (.L2)
+    68: PopScope 
+    69: PopScope 
+    70: Jump -60 (.L0)
   .L2:
-    69: NewClosure r0, c3
     72: PopScope 
     73: PopScope 
     74: Jump -64 (.L0)
@@ -231,14 +231,14 @@
     35: PushLexicalScope c1
     37: LoadEmpty r2
     39: StoreToScope r2, 0, 0
-    43: LoadImmediate r2, 3
-    46: StoreToScope r2, 0, 0
-    50: LoadImmediate r2, 4
-    53: JumpToBooleanFalse r2, 6 (.L2)
-    56: PopScope 
-    57: Jump -47 (.L0)
+    43: NewClosure r0, c2
+    46: LoadImmediate r2, 3
+    49: StoreToScope r2, 0, 0
+    53: LoadImmediate r2, 4
+    56: JumpToBooleanFalse r2, 6 (.L2)
+    59: PopScope 
+    60: Jump -50 (.L0)
   .L2:
-    59: NewClosure r0, c2
     62: PopScope 
     63: Jump -53 (.L0)
   .L3:

--- a/tests/js_bytecode/scope/for_of.exp
+++ b/tests/js_bytecode/scope/for_of.exp
@@ -70,9 +70,9 @@
     38: PushLexicalScope c1
     40: LoadEmpty r6
     42: StoreToScope r6, 0, 0
-    46: LoadImmediate r6, 2
-    49: StoreToScope r6, 0, 0
-    53: NewClosure r0, c2
+    46: NewClosure r0, c2
+    49: LoadImmediate r6, 2
+    52: StoreToScope r6, 0, 0
     56: PopScope 
     57: Jump 12 (.L1)
     59: LoadImmediate r3, 0

--- a/tests/js_bytecode/scope/for_of_break.exp
+++ b/tests/js_bytecode/scope/for_of_break.exp
@@ -42,14 +42,14 @@
      64: PushLexicalScope c2
      66: LoadEmpty r6
      68: StoreToScope r6, 0, 0
-     72: LoadImmediate r6, 3
-     75: StoreToScope r6, 0, 0
-     79: LoadImmediate r6, 4
-     82: JumpToBooleanFalse r6, 8 (.L2)
-     85: LoadImmediate r3, 1
-     88: Jump 12 (.L3)
+     72: NewClosure r0, c3
+     75: LoadImmediate r6, 3
+     78: StoreToScope r6, 0, 0
+     82: LoadImmediate r6, 4
+     85: JumpToBooleanFalse r6, 8 (.L2)
+     88: LoadImmediate r3, 1
+     91: Jump 9 (.L3)
   .L2:
-     90: NewClosure r0, c3
      93: PopScope 
      94: PopScope 
      95: Jump 42 (.L7)
@@ -130,14 +130,14 @@
      49: PushLexicalScope c2
      51: LoadEmpty r6
      53: StoreToScope r6, 0, 0
-     57: LoadImmediate r6, 3
-     60: StoreToScope r6, 0, 0
-     64: LoadImmediate r6, 4
-     67: JumpToBooleanFalse r6, 8 (.L2)
-     70: LoadImmediate r3, 1
-     73: Jump 12 (.L3)
+     57: NewClosure r0, c3
+     60: LoadImmediate r6, 3
+     63: StoreToScope r6, 0, 0
+     67: LoadImmediate r6, 4
+     70: JumpToBooleanFalse r6, 8 (.L2)
+     73: LoadImmediate r3, 1
+     76: Jump 9 (.L3)
   .L2:
-     75: NewClosure r0, c3
      78: PopScope 
      79: PopScope 
      80: Jump 41 (.L7)

--- a/tests/js_bytecode/scope/for_of_continue.exp
+++ b/tests/js_bytecode/scope/for_of_continue.exp
@@ -43,16 +43,16 @@
      63: PushLexicalScope c2
      65: LoadEmpty r6
      67: StoreToScope r6, 0, 0
-     71: LoadImmediate r6, 3
-     74: StoreToScope r6, 0, 0
-     78: LoadImmediate r6, 4
-     81: JumpToBooleanFalse r6, 8 (.L2)
-     84: PopScope 
-     85: PopScope 
-     86: PopScope 
-     87: Jump -72 (.L0)
+     71: NewClosure r0, c3
+     74: LoadImmediate r6, 3
+     77: StoreToScope r6, 0, 0
+     81: LoadImmediate r6, 4
+     84: JumpToBooleanFalse r6, 8 (.L2)
+     87: PopScope 
+     88: PopScope 
+     89: PopScope 
+     90: Jump -75 (.L0)
   .L2:
-     89: NewClosure r0, c3
      92: PopScope 
      93: PopScope 
      94: Jump 12 (.L3)
@@ -117,15 +117,15 @@
     47: PushLexicalScope c2
     49: LoadEmpty r6
     51: StoreToScope r6, 0, 0
-    55: LoadImmediate r6, 3
-    58: StoreToScope r6, 0, 0
-    62: LoadImmediate r6, 4
-    65: JumpToBooleanFalse r6, 7 (.L2)
-    68: PopScope 
-    69: PopScope 
-    70: Jump -62 (.L0)
+    55: NewClosure r0, c3
+    58: LoadImmediate r6, 3
+    61: StoreToScope r6, 0, 0
+    65: LoadImmediate r6, 4
+    68: JumpToBooleanFalse r6, 7 (.L2)
+    71: PopScope 
+    72: PopScope 
+    73: Jump -65 (.L0)
   .L2:
-    72: NewClosure r0, c3
     75: PopScope 
     76: PopScope 
     77: Jump 12 (.L3)

--- a/tests/js_bytecode/scope/global.exp
+++ b/tests/js_bytecode/scope/global.exp
@@ -11,9 +11,9 @@
     26: PushLexicalScope c3
     28: LoadEmpty r1
     30: StoreToScope r1, 0, 0
-    34: LoadImmediate r1, 1
-    37: StoreToScope r1, 0, 0
-    41: NewClosure r0, c4
+    34: NewClosure r0, c4
+    37: LoadImmediate r1, 1
+    40: StoreToScope r1, 0, 0
     44: PopScope 
     45: LoadUndefined r1
     47: Ret r1

--- a/tests/js_bytecode/scope/labeled_break.exp
+++ b/tests/js_bytecode/scope/labeled_break.exp
@@ -22,14 +22,14 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 0, 0
-     8: LoadImmediate r1, 0
-    11: StoreToScope r1, 0, 0
-    15: LoadImmediate r1, 1
-    18: JumpToBooleanFalse r1, 6 (.L0)
-    21: PopScope 
-    22: Jump 6 (.L1)
+     8: NewClosure r0, c1
+    11: LoadImmediate r1, 0
+    14: StoreToScope r1, 0, 0
+    18: LoadImmediate r1, 1
+    21: JumpToBooleanFalse r1, 6 (.L0)
+    24: PopScope 
+    25: Jump 3 (.L1)
   .L0:
-    24: NewClosure r0, c1
     27: PopScope 
   .L1:
     28: LoadImmediate r1, 2
@@ -80,27 +80,27 @@
      58: PushLexicalScope c2
      60: LoadEmpty r1
      62: StoreToScope r1, 0, 0
-     66: LoadImmediate r1, 2
-     69: StoreToScope r1, 0, 0
-     73: LoadImmediate r1, 1
-     76: JumpToBooleanFalse r1, 8 (.L3)
-     79: PopScope 
-     80: PopScope 
-     81: PopScope 
-     82: Jump 27 (.L8)
+     66: NewClosure r0, c3
+     69: LoadImmediate r1, 2
+     72: StoreToScope r1, 0, 0
+     76: LoadImmediate r1, 1
+     79: JumpToBooleanFalse r1, 8 (.L3)
+     82: PopScope 
+     83: PopScope 
+     84: PopScope 
+     85: Jump 24 (.L8)
   .L3:
-     84: LoadImmediate r1, 2
-     87: JumpToBooleanFalse r1, 7 (.L4)
-     90: PopScope 
-     91: PopScope 
-     92: Jump 16 (.L7)
+     87: LoadImmediate r1, 2
+     90: JumpToBooleanFalse r1, 7 (.L4)
+     93: PopScope 
+     94: PopScope 
+     95: Jump 13 (.L7)
   .L4:
-     94: LoadImmediate r1, 3
-     97: JumpToBooleanFalse r1, 6 (.L5)
-    100: PopScope 
-    101: Jump 6 (.L6)
+     97: LoadImmediate r1, 3
+    100: JumpToBooleanFalse r1, 6 (.L5)
+    103: PopScope 
+    104: Jump 3 (.L6)
   .L5:
-    103: NewClosure r0, c3
     106: PopScope 
   .L6:
     107: PopScope 
@@ -140,12 +140,11 @@
      4: StoreToScope r1, 0, 0
      8: LoadImmediate r1, 0
     11: StoreToScope r1, 0, 0
-    15: LoadImmediate r1, 1
-    18: JumpToBooleanFalse r1, 5 (.L0)
-    21: Jump 5 (.L1)
+    15: NewClosure r0, c1
+    18: LoadImmediate r1, 1
+    21: JumpToBooleanFalse r1, 5 (.L0)
+    24: Jump 2 (.L0)
   .L0:
-    23: NewClosure r0, c1
-  .L1:
     26: LoadImmediate r1, 2
     29: LoadUndefined r1
     31: Ret r1

--- a/tests/js_bytecode/scope/switch.exp
+++ b/tests/js_bytecode/scope/switch.exp
@@ -85,30 +85,29 @@
      3: PushLexicalScope c0
      5: LoadEmpty r3
      7: StoreToScope r3, 0, 0
-    11: LoadImmediate r3, 1
-    14: StrictEqual r3, r2, r3
-    18: JumpTrue r3, 25 (.L0)
-    21: LoadImmediate r3, 2
-    24: StrictEqual r3, r2, r3
-    28: JumpTrue r3, 22 (.L1)
-    31: LoadImmediate r3, 3
-    34: StrictEqual r3, r2, r3
-    38: JumpTrue r3, 15 (.L2)
-    41: Jump 31 (.L3)
+    11: NewClosure r0, c1
+    14: LoadImmediate r3, 1
+    17: StrictEqual r3, r2, r3
+    21: JumpTrue r3, 25 (.L0)
+    24: LoadImmediate r3, 2
+    27: StrictEqual r3, r2, r3
+    31: JumpTrue r3, 22 (.L1)
+    34: LoadImmediate r3, 3
+    37: StrictEqual r3, r2, r3
+    41: JumpTrue r3, 12 (.L1)
+    44: Jump 28 (.L2)
   .L0:
-    43: LoadImmediate r2, 1
-    46: StoreToScope r2, 0, 0
+    46: LoadImmediate r2, 1
+    49: StoreToScope r2, 0, 0
   .L1:
-    50: NewClosure r0, c1
-  .L2:
     53: PushLexicalScope c2
     55: LoadEmpty r2
     57: StoreToScope r2, 0, 0
-    61: LoadImmediate r2, 1
-    64: StoreToScope r2, 0, 0
-    68: NewClosure r1, c3
+    61: NewClosure r1, c3
+    64: LoadImmediate r2, 1
+    67: StoreToScope r2, 0, 0
     71: PopScope 
-  .L3:
+  .L2:
     72: PopScope 
     73: LoadUndefined r2
     75: Ret r2

--- a/tests/js_bytecode/scope/with.exp
+++ b/tests/js_bytecode/scope/with.exp
@@ -32,11 +32,11 @@
     31: StoreToScope r1, 0, 0
     35: LoadEmpty r1
     37: StoreToScope r1, 1, 0
-    41: LoadImmediate r1, 1
-    44: StoreToScope r1, 0, 0
-    48: LoadImmediate r1, 2
-    51: StoreToScope r1, 1, 0
-    55: NewClosure r0, c3
+    41: NewClosure r0, c3
+    44: LoadImmediate r1, 1
+    47: StoreToScope r1, 0, 0
+    51: LoadImmediate r1, 2
+    54: StoreToScope r1, 1, 0
     58: PopScope 
     59: PopScope 
     60: LoadUndefined r1

--- a/tests/js_bytecode/statement/try/finally_break.exp
+++ b/tests/js_bytecode/statement/try/finally_break.exp
@@ -212,9 +212,9 @@
      38: PushLexicalScope c2
      40: LoadEmpty r4
      42: StoreToScope r4, 0, 0
-     46: LoadImmediate r4, 3
-     49: StoreToScope r4, 0, 0
-     53: NewClosure r0, c3
+     46: NewClosure r0, c3
+     49: LoadImmediate r4, 3
+     52: StoreToScope r4, 0, 0
      56: JumpToBooleanFalse a0, 8 (.L1)
      59: LoadImmediate r1, 1
      62: Jump 11 (.L2)

--- a/tests/js_bytecode/statement/try/finally_continue.exp
+++ b/tests/js_bytecode/statement/try/finally_continue.exp
@@ -212,9 +212,9 @@
      38: PushLexicalScope c2
      40: LoadEmpty r4
      42: StoreToScope r4, 0, 0
-     46: LoadImmediate r4, 3
-     49: StoreToScope r4, 0, 0
-     53: NewClosure r0, c3
+     46: NewClosure r0, c3
+     49: LoadImmediate r4, 3
+     52: StoreToScope r4, 0, 0
      56: JumpToBooleanFalse a0, 8 (.L1)
      59: LoadImmediate r1, 1
      62: Jump 11 (.L2)


### PR DESCRIPTION
## Summary

Lexical function declarations were previously created inline instead of being hoisted to the top of their scope. We now create all function declarations when the scope starts and then ignore function declarations while generating statements normally.

## Tests

Re-recorded bytecode snapshot tests since many lexical function declarations were moved.