### PR TITLE
[test] Basic bytecode tests for module scope, exported bindings, named imports

### DIFF
--- a/tests/js_bytecode/module/exported_bindings.exp
+++ b/tests/js_bytecode/module/exported_bindings.exp
@@ -1,0 +1,70 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 3
+     0: NewClosure r0, c0
+     3: LoadImmediate r1, 1
+     6: StoreToModule r1, 1, 0
+    10: LoadImmediate r1, 2
+    13: StoreToModule r1, 2, 0
+    17: LoadImmediate r1, 3
+    20: StoreToModule r1, 3, 0
+    24: LoadEmpty r2
+    26: NewClass r1, c2, c1, r2, r1
+    32: StoreToModule r1, 4, 0
+    36: LoadUndefined r1
+    38: Ret r1
+  Constant Table:
+    0: [BytecodeFunction: testAccessExportedBinding]
+    1: [BytecodeFunction: Class1]
+    2: [ClassNames]
+}
+
+[BytecodeFunction: Class1] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: func1] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: testAccessExportedBinding] {
+  Parameters: 0, Registers: 3
+     0: LoadFromModule r1, 1, 0
+     4: LoadFromModule r2, 2, 0
+     8: Add r1, r1, r2
+    12: LoadFromModule r2, 3, 0
+    16: Add r1, r1, r2
+    20: LoadFromModule r2, 4, 0
+    24: Add r1, r1, r2
+    28: LoadFromModule r2, 5, 0
+    32: Add r1, r1, r2
+    36: PushLexicalScope c0
+    38: LoadEmpty r1
+    40: StoreToScope r1, 0, 0
+    44: NewClosure r0, c1
+    47: LoadImmediate r1, 4
+    50: StoreToScope r1, 0, 0
+    54: LoadFromModule r1, 3, 1
+    58: Call r1, r0, r1, 1
+    63: PopScope 
+    64: LoadUndefined r1
+    66: Ret r1
+  Constant Table:
+    0: [ScopeNames]
+    1: [BytecodeFunction: capturing]
+}
+
+[BytecodeFunction: capturing] {
+  Parameters: 0, Registers: 2
+     0: LoadFromModule r0, 3, 1
+     4: LoadFromScope r1, 0, 0
+     8: CheckTdz r1, c0
+    11: Add r0, r0, r1
+    15: LoadUndefined r0
+    17: Ret r0
+  Constant Table:
+    0: [String: const2]
+}

--- a/tests/js_bytecode/module/exported_bindings.js
+++ b/tests/js_bytecode/module/exported_bindings.js
@@ -1,0 +1,20 @@
+export var var1 = 1;
+export let let1 = 2;
+export const const1 = 3;
+export class Class1 {}
+
+// Initialized when linking, does not need to be initialized at runtime
+export function func1() {}
+
+function testAccessExportedBinding() {
+  var1 + let1 + const1 + Class1 + func1;
+
+  {
+    // Create another scope
+    const const2 = 4;
+    function capturing() { const1 + const2 }
+
+    // Access from nested scope
+    capturing(const1);
+  }
+}

--- a/tests/js_bytecode/module/import_named/import_named.exp
+++ b/tests/js_bytecode/module/import_named/import_named.exp
@@ -1,0 +1,45 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 2
+    0: NewClosure r0, c0
+    3: LoadUndefined r1
+    5: Ret r1
+  Constant Table:
+    0: [BytecodeFunction: testAccess]
+}
+
+[BytecodeFunction: testAccess] {
+  Parameters: 0, Registers: 3
+     0: LoadFromModule r1, 1, 0
+     4: LoadFromModule r2, 2, 0
+     8: Add r1, r1, r2
+    12: LoadFromModule r2, 3, 0
+    16: Add r1, r1, r2
+    20: LoadFromModule r2, 4, 0
+    24: Add r1, r1, r2
+    28: PushLexicalScope c0
+    30: LoadEmpty r1
+    32: StoreToScope r1, 0, 0
+    36: NewClosure r0, c1
+    39: LoadImmediate r1, 0
+    42: StoreToScope r1, 0, 0
+    46: LoadFromModule r1, 1, 1
+    50: Call r1, r0, r1, 1
+    55: PopScope 
+    56: LoadUndefined r1
+    58: Ret r1
+  Constant Table:
+    0: [ScopeNames]
+    1: [BytecodeFunction: capturing]
+}
+
+[BytecodeFunction: capturing] {
+  Parameters: 0, Registers: 2
+     0: LoadFromModule r0, 1, 1
+     4: LoadFromScope r1, 0, 0
+     8: CheckTdz r1, c0
+    11: Add r0, r0, r1
+    15: LoadUndefined r0
+    17: Ret r0
+  Constant Table:
+    0: [String: c]
+}

--- a/tests/js_bytecode/module/import_named/import_named.js
+++ b/tests/js_bytecode/module/import_named/import_named.js
@@ -1,0 +1,16 @@
+import { named1 } from './import_named_1.js';
+import { named2, named3 } from './import_named_1.js';
+import { named1 as renamed1 } from './import_named_1.js';
+
+function testAccess() {
+  named1 + named2 + named3 + renamed1;
+
+  {
+    // Create a nested scope
+    const c = 0;
+    function capturing() { named1 + c }
+
+    // Acces from nested scope
+    capturing(named1);
+  }
+}

--- a/tests/js_bytecode/module/import_named/import_named_1.exp
+++ b/tests/js_bytecode/module/import_named/import_named_1.exp
@@ -1,0 +1,11 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 1
+     0: LoadImmediate r0, 1
+     3: StoreToModule r0, 1, 0
+     7: LoadImmediate r0, 2
+    10: StoreToModule r0, 2, 0
+    14: LoadImmediate r0, 3
+    17: StoreToModule r0, 3, 0
+    21: LoadUndefined r0
+    23: Ret r0
+}

--- a/tests/js_bytecode/module/import_named/import_named_1.js
+++ b/tests/js_bytecode/module/import_named/import_named_1.js
@@ -1,0 +1,3 @@
+export var named1 = 1;
+export var named2 = 2;
+export var named3 = 3;

--- a/tests/js_bytecode/module/toplevel.exp
+++ b/tests/js_bytecode/module/toplevel.exp
@@ -1,0 +1,56 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 4
+     0: NewClosure r2, c0
+     3: StoreToScope r2, 4, 0
+     7: NewClosure r0, c1
+    10: LoadEmpty r2
+    12: StoreToScope r2, 2, 0
+    16: LoadEmpty r2
+    18: StoreToScope r2, 3, 0
+    22: LoadImmediate r2, 1
+    25: StoreToScope r2, 1, 0
+    29: LoadImmediate r2, 2
+    32: StoreToScope r2, 2, 0
+    36: LoadImmediate r2, 3
+    39: StoreToScope r2, 3, 0
+    43: NewClosure r1, c2
+    46: LoadImmediate r2, 100
+    49: LoadFromScope r3, 1, 0
+    53: Add r2, r2, r3
+    57: LoadUndefined r2
+    59: Ret r2
+  Constant Table:
+    0: [BytecodeFunction: toplevelMethod]
+    1: [BytecodeFunction: testToplevelBinding]
+    2: [BytecodeFunction: inBlock]
+}
+
+[BytecodeFunction: toplevelMethod] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: inBlock] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: testToplevelBinding] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r0, 1, 0
+     4: LoadFromScope r1, 2, 0
+     8: CheckTdz r1, c0
+    11: Add r0, r0, r1
+    15: LoadFromScope r1, 3, 0
+    19: CheckTdz r1, c1
+    22: Add r0, r0, r1
+    26: LoadFromScope r1, 4, 0
+    30: Add r0, r0, r1
+    34: LoadUndefined r0
+    36: Ret r0
+  Constant Table:
+    0: [String: x2]
+    1: [String: x3]
+}

--- a/tests/js_bytecode/module/toplevel.js
+++ b/tests/js_bytecode/module/toplevel.js
@@ -1,0 +1,17 @@
+// Regular lexical scope - all variables in registers
+var x1 = 1;
+let x2 = 2;
+const x3 = 3;
+
+// Lexical declaration
+function toplevelMethod() {}
+
+{
+  function inBlock() {}
+}
+
+100 + x1;
+
+function testToplevelBinding() {
+  x1 + x2 + x3 + toplevelMethod;
+}


### PR DESCRIPTION
## Summary

Add some basic bytecode snapshot tests for module scopes, exported bindings, and named imports.