### PR TITLE
[analyze] Resolve export specifiers

### DIFF
--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -913,7 +913,11 @@ impl<'a> AstVisitor for Analyzer<'a> {
         });
 
         for specifier in &mut export.specifiers {
-            specifier.local.get_binding().set_is_exported(true);
+            // Only need to resolve the specifier's local binding if it is not a re-export
+            if export.source.is_none() {
+                self.resolve_identifier_use(&mut specifier.local);
+                specifier.local.get_binding().set_is_exported(true);
+            }
         }
     }
 

--- a/tests/js_bytecode/module/exported_bindings.exp
+++ b/tests/js_bytecode/module/exported_bindings.exp
@@ -1,21 +1,27 @@
 [BytecodeFunction: <module>] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: NewClosure r0, c0
-     3: LoadImmediate r1, 1
-     6: StoreToModule r1, 1, 0
-    10: LoadImmediate r1, 2
-    13: StoreToModule r1, 2, 0
-    17: LoadImmediate r1, 3
-    20: StoreToModule r1, 3, 0
-    24: LoadEmpty r2
-    26: NewClass r1, c2, c1, r2, r1
-    32: StoreToModule r1, 4, 0
-    36: LoadUndefined r1
-    38: Ret r1
+     3: NewClosure r1, c1
+     6: LoadImmediate r2, 1
+     9: StoreToModule r2, 1, 0
+    13: LoadImmediate r2, 2
+    16: StoreToModule r2, 2, 0
+    20: LoadImmediate r2, 3
+    23: StoreToModule r2, 3, 0
+    27: LoadEmpty r3
+    29: NewClass r2, c3, c2, r3, r2
+    35: StoreToModule r2, 4, 0
+    39: LoadImmediate r2, 5
+    42: StoreToModule r2, 6, 0
+    46: LoadImmediate r2, 6
+    49: StoreToModule r2, 7, 0
+    53: LoadUndefined r2
+    55: Ret r2
   Constant Table:
-    0: [BytecodeFunction: testAccessExportedBinding]
-    1: [BytecodeFunction: Class1]
-    2: [ClassNames]
+    0: [BytecodeFunction: testAccessSimpleExportedBinding]
+    1: [BytecodeFunction: testAccessExportedInSeparateDeclaration]
+    2: [BytecodeFunction: Class1]
+    3: [ClassNames]
 }
 
 [BytecodeFunction: Class1] {
@@ -30,7 +36,7 @@
     2: Ret r0
 }
 
-[BytecodeFunction: testAccessExportedBinding] {
+[BytecodeFunction: testAccessSimpleExportedBinding] {
   Parameters: 0, Registers: 3
      0: LoadFromModule r1, 1, 0
      4: LoadFromModule r2, 2, 0
@@ -67,4 +73,17 @@
     17: Ret r0
   Constant Table:
     0: [String: const2]
+}
+
+[BytecodeFunction: testAccessExportedInSeparateDeclaration] {
+  Parameters: 0, Registers: 2
+     0: LoadFromModule r0, 6, 0
+     4: LoadFromModule r1, 7, 0
+     8: Add r0, r0, r1
+    12: LoadGlobal r1, c0
+    15: Add r0, r0, r1
+    19: LoadUndefined r0
+    21: Ret r0
+  Constant Table:
+    0: [String: renamedVar3]
 }

--- a/tests/js_bytecode/module/exported_bindings.js
+++ b/tests/js_bytecode/module/exported_bindings.js
@@ -6,7 +6,7 @@ export class Class1 {}
 // Initialized when linking, does not need to be initialized at runtime
 export function func1() {}
 
-function testAccessExportedBinding() {
+function testAccessSimpleExportedBinding() {
   var1 + let1 + const1 + Class1 + func1;
 
   {
@@ -17,4 +17,17 @@ function testAccessExportedBinding() {
     // Access from nested scope
     capturing(const1);
   }
+}
+
+// Exported in a separate declaration
+var var2 = 5;
+
+// Exported under a different name
+var var3 = 6;
+
+export { var2, var3 as renamedVar3 };
+
+function testAccessExportedInSeparateDeclaration() {
+  // Renamed variable is not resolved
+  var2 + var3 + renamedVar3;
 }

--- a/tests/js_bytecode/module/reexport_named/exporting.exp
+++ b/tests/js_bytecode/module/reexport_named/exporting.exp
@@ -1,0 +1,13 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 1
+    0: LoadImmediate r0, 1
+    3: StoreToModule r0, 2, 0
+    7: LoadUndefined r0
+    9: Ret r0
+}
+
+[BytecodeFunction: func1] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}

--- a/tests/js_bytecode/module/reexport_named/exporting.js
+++ b/tests/js_bytecode/module/reexport_named/exporting.js
@@ -1,0 +1,2 @@
+export function func1() {}
+export var var1 = 1;

--- a/tests/js_bytecode/module/reexport_named/importing.exp
+++ b/tests/js_bytecode/module/reexport_named/importing.exp
@@ -1,0 +1,17 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 2
+    0: NewClosure r0, c0
+    3: LoadUndefined r1
+    5: Ret r1
+  Constant Table:
+    0: [BytecodeFunction: testAccessImportedBindings]
+}
+
+[BytecodeFunction: testAccessImportedBindings] {
+  Parameters: 0, Registers: 2
+     0: LoadFromModule r0, 1, 0
+     4: LoadFromModule r1, 2, 0
+     8: Add r0, r0, r1
+    12: LoadUndefined r0
+    14: Ret r0
+}

--- a/tests/js_bytecode/module/reexport_named/importing.js
+++ b/tests/js_bytecode/module/reexport_named/importing.js
@@ -1,0 +1,5 @@
+import { func1, var2 } from "./exporting.js";
+
+function testAccessImportedBindings() {
+  func1 + var2;
+}

--- a/tests/js_bytecode/module/reexport_named/reexporting.exp
+++ b/tests/js_bytecode/module/reexport_named/reexporting.exp
@@ -1,0 +1,5 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}

--- a/tests/js_bytecode/module/reexport_named/reexporting.js
+++ b/tests/js_bytecode/module/reexport_named/reexporting.js
@@ -1,0 +1,1 @@
+export { func1, var1 as var2 } from './exporting.js';


### PR DESCRIPTION
## Summary

Export specifiers were not yet working because we were failing to resolve the local identifier to its definition. With this fixed export specifiers are now working.

Note that we should only resolve the local identifier when the export is not a re-export.

Also adds bytecode snapshot tests for named export specifiers, including re-exports.