### PR TITLE
[bytecode] Fix TDZ checks when storing exported binding

### DIFF
--- a/src/js/parser/scope_tree.rs
+++ b/src/js/parser/scope_tree.rs
@@ -1136,16 +1136,9 @@ impl Binding {
         self.vm_location = Some(location);
     }
 
-    /// Whether this binding needs to be initialized to support the TDZ.
-    pub fn needs_tdz_init(&self) -> bool {
-        self.kind().has_tdz() && self.needs_tdz_check.get()
-    }
-
     /// Whether this binding needs TDZ checks when accessed.
     pub fn needs_tdz_check(&self) -> bool {
-        // Exported bindings will always have an implicit TDZ check inside the LoadFromModule and
-        // StoreToModule instructions.
-        self.needs_tdz_init() && !self.is_exported()
+        self.kind().has_tdz() && self.needs_tdz_check.get()
     }
 
     fn set_needs_tdz_check(&self, value: bool) {

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -475,7 +475,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
         for (_, binding) in ast_node.iter_bindings() {
             if binding.is_exported() {
                 // We need to initialize with empty if TDZ checks are needed
-                let init_value = if binding.needs_tdz_init() {
+                let init_value = if binding.needs_tdz_check() {
                     self.cx.empty()
                 } else {
                     self.cx.undefined()
@@ -2191,7 +2191,10 @@ impl<'a> BytecodeFunctionGenerator<'a> {
     ) -> EmitResult<GenRegister> {
         // For bindings that could be accessed during their TDZ we must generate a TDZ check. Must
         // ensure that TDZ check occurs before writing to a non-temporary register.
-        let add_tdz_check = binding.needs_tdz_check();
+        //
+        // No explicit TDZ check is needed for exported bindings since LoadFromModule has an
+        // implicit TDZ check.
+        let add_tdz_check = binding.needs_tdz_check() && !binding.is_exported();
 
         match binding.vm_location().unwrap() {
             // Fixed registers may directly reference the register

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -3866,13 +3866,9 @@ impl VM {
         let parent_depth = instr.parent_depth().value().to_usize();
         let value = self.read_register(instr.value());
 
-        // Module values are guaranteed to be boxed
+        // Module values are guaranteed to be boxed. No need to check for uninitialized values -
+        // TDZ checks are performed by a LoadFromModule instruction preceding the store when needed.
         let mut boxed_value = self.load_from_module_scope_at_depth(scope_index, parent_depth);
-
-        // Check for uninitialized values
-        if boxed_value.get().is_empty() {
-            return reference_error(self.cx(), "module value is not initialized");
-        }
 
         boxed_value.set(value);
 

--- a/tests/js_bytecode/module/export_tdz.exp
+++ b/tests/js_bytecode/module/export_tdz.exp
@@ -1,0 +1,27 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 3
+     0: NewClosure r0, c0
+     3: LoadImmediate r1, 1
+     6: StoreToModule r1, 1, 0
+    10: LoadImmediate r1, 2
+    13: LoadFromModule r2, 1, 0
+    17: StoreToModule r1, 1, 0
+    21: LoadImmediate r1, 4
+    24: LoadFromModule r2, 2, 0
+    28: StoreToModule r1, 2, 0
+    32: LoadImmediate r1, 5
+    35: StoreToModule r1, 2, 0
+    39: LoadUndefined r1
+    41: Ret r1
+  Constant Table:
+    0: [BytecodeFunction: testAccessWithTDZ]
+}
+
+[BytecodeFunction: testAccessWithTDZ] {
+  Parameters: 0, Registers: 2
+     0: LoadImmediate r0, 3
+     3: LoadFromModule r1, 1, 0
+     7: StoreToModule r0, 1, 0
+    11: LoadUndefined r0
+    13: Ret r0
+}

--- a/tests/js_bytecode/module/export_tdz.js
+++ b/tests/js_bytecode/module/export_tdz.js
@@ -1,0 +1,13 @@
+// No TDZ check needed
+export let x1 = 1;
+// TDZ check needed
+x1 = 2;
+
+function testAccessWithTDZ() {
+  x1 = 3;
+}
+
+// TDZ check needed
+x2 = 4;
+// No TDZ check needed
+export let x2 = 5;


### PR DESCRIPTION
## Summary

We currently have a bug when storing exported bindings that require TDZ checks. We check for uninitialized values during StoreToModule, but this will error when the binding is first initialized.

Instead we should not check for uninitialized values during StoreToModule and instead emit LoadFromModule instructions before the store when TDZ checks are necessary.