### PR TITLE
[analyze][bytecode] Implement anonymous default exports

### DIFF
--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -1490,18 +1490,23 @@ pub struct ExportSpecifier {
 
 pub struct ExportDefaultDeclaration {
     pub loc: Loc,
-    // Must be function declaration, class declaration, or expression statement
-    pub declaration: P<Statement>,
+    pub declaration: ExportDefaultKind,
 }
 
 impl ExportDefaultDeclaration {
     pub fn id(&self) -> Option<&Identifier> {
-        match self.declaration.as_ref() {
-            Statement::FuncDecl(func) => func.id.as_deref(),
-            Statement::ClassDecl(class) => class.id.as_deref(),
-            _ => None,
+        match &self.declaration {
+            ExportDefaultKind::Function(func) => func.id.as_deref(),
+            ExportDefaultKind::Class(class) => class.id.as_deref(),
+            ExportDefaultKind::Expression(_) => None,
         }
     }
+}
+
+pub enum ExportDefaultKind {
+    Function(P<Function>),
+    Class(P<Class>),
+    Expression(P<OuterExpression>),
 }
 
 pub struct ExportAllDeclaration {

--- a/src/js/parser/ast_visitor.rs
+++ b/src/js/parser/ast_visitor.rs
@@ -386,6 +386,10 @@ pub trait AstVisitor: Sized {
         default_visit_export_default_declaration(self, export)
     }
 
+    fn visit_export_default_kind(&mut self, kind: &mut ExportDefaultKind) {
+        default_visit_export_default_kind(self, kind)
+    }
+
     fn visit_export_named_declaration(&mut self, export: &mut ExportNamedDeclaration) {
         default_visit_export_named_declaration(self, export)
     }
@@ -852,7 +856,18 @@ pub fn default_visit_export_default_declaration<V: AstVisitor>(
     visitor: &mut V,
     export: &mut ExportDefaultDeclaration,
 ) {
-    visitor.visit_statement(&mut export.declaration);
+    visitor.visit_export_default_kind(&mut export.declaration);
+}
+
+pub fn default_visit_export_default_kind<V: AstVisitor>(
+    visitor: &mut V,
+    kind: &mut ExportDefaultKind,
+) {
+    match kind {
+        ExportDefaultKind::Function(func) => visitor.visit_function_declaration(func),
+        ExportDefaultKind::Class(class) => visitor.visit_class_declaration(class),
+        ExportDefaultKind::Expression(expr) => visitor.visit_outer_expression(expr),
+    }
 }
 
 pub fn default_visit_export_named_declaration<V: AstVisitor>(

--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -2,6 +2,8 @@ use std::error::Error;
 use std::rc::Rc;
 use std::{fmt, io};
 
+use crate::js::parser::scope_tree::ANONYMOUS_DEFAULT_EXPORT_NAME;
+
 use super::scope_tree::BindingKind;
 use super::{
     loc::{find_line_col_for_pos, Loc},
@@ -225,23 +227,28 @@ impl fmt::Display for ParseError {
             }
             ParseError::NameRedeclaration(payload) => {
                 let (name, kind) = payload.as_ref();
-                let kind_string = match kind {
-                    BindingKind::Var => "var",
-                    BindingKind::Const { .. } => "const",
-                    BindingKind::Let { .. } => "let",
-                    BindingKind::Function { .. } => "function",
-                    BindingKind::FunctionParameter { .. } => "function parameter",
-                    BindingKind::Class { .. } => "class",
-                    BindingKind::CatchParameter { .. } => "catch parameter",
-                    BindingKind::Import { .. } => "import",
-                    BindingKind::ImplicitThis { .. } => "`this`",
-                    BindingKind::ImplicitArguments => "`arguments`",
-                    BindingKind::ImplicitNewTarget => "`new.target`",
-                    BindingKind::DerivedConstructor => "constructor",
-                    BindingKind::HomeObject => "homo object",
-                    BindingKind::PrivateName => "private name",
-                };
-                write!(f, "Redeclaration of {} {}", kind_string, name)
+                if name == ANONYMOUS_DEFAULT_EXPORT_NAME {
+                    write!(f, "Default export was already declared in this module")
+                } else {
+                    let kind_string = match kind {
+                        BindingKind::Var => "var",
+                        BindingKind::Const { .. } => "const",
+                        BindingKind::Let { .. } => "let",
+                        BindingKind::Function { .. } => "function",
+                        BindingKind::FunctionParameter { .. } => "function parameter",
+                        BindingKind::Class { .. } => "class",
+                        BindingKind::CatchParameter { .. } => "catch parameter",
+                        BindingKind::Import { .. } => "import",
+                        BindingKind::ImplicitThis { .. } => "`this`",
+                        BindingKind::ImplicitArguments => "`arguments`",
+                        BindingKind::ImplicitNewTarget => "`new.target`",
+                        BindingKind::DerivedConstructor => "constructor",
+                        BindingKind::HomeObject => "home object",
+                        BindingKind::PrivateName => "private name",
+                        BindingKind::DefaultExportExpression => "default export",
+                    };
+                    write!(f, "Redeclaration of {} {}", kind_string, name)
+                }
             }
             ParseError::DuplicateLabel => write!(f, "Duplicate label"),
             ParseError::LabelNotFound => write!(f, "Label not found"),

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -1067,8 +1067,18 @@ impl<'a> Printer<'a> {
 
     fn print_export_default_declaration(&mut self, export: &ExportDefaultDeclaration) {
         self.start_node("ExportDefaultDeclaration", &export.loc);
-        self.property("declaration", export.declaration.as_ref(), Printer::print_statement);
+        self.property("declaration", &export.declaration, Printer::print_export_default_kind);
         self.end_node();
+    }
+
+    fn print_export_default_kind(&mut self, kind: &ExportDefaultKind) {
+        match kind {
+            ExportDefaultKind::Function(func) => {
+                self.print_function(func.as_ref(), "FunctionDeclaration")
+            }
+            ExportDefaultKind::Class(class) => self.print_class(class.as_ref(), "ClassDeclaration"),
+            ExportDefaultKind::Expression(expr) => self.print_outer_expression(expr),
+        }
     }
 
     fn print_export_named_declaration(&mut self, export: &ExportNamedDeclaration) {

--- a/src/js/parser/scope_tree.rs
+++ b/src/js/parser/scope_tree.rs
@@ -991,6 +991,8 @@ pub enum BindingKind {
     HomeObject,
     /// A private name introduced in a class. Includes the "#" prefix.
     PrivateName,
+    /// A default exported expression
+    DefaultExportExpression,
 }
 
 impl BindingKind {
@@ -1014,7 +1016,8 @@ impl BindingKind {
             | BindingKind::Let { .. }
             | BindingKind::Class { .. }
             | BindingKind::CatchParameter { .. }
-            | BindingKind::Import { .. } => true,
+            | BindingKind::Import { .. }
+            | BindingKind::DefaultExportExpression => true,
         }
     }
 
@@ -1063,6 +1066,7 @@ impl BindingKind {
                 | BindingKind::Class { .. }
                 | BindingKind::CatchParameter { .. }
                 | BindingKind::FunctionParameter { .. }
+                | BindingKind::DefaultExportExpression
         )
     }
 
@@ -1203,4 +1207,5 @@ pub const NEW_TARGET_BINDING_NAME: &str = "%new.target";
 pub const DERIVED_CONSTRUCTOR_BINDING_NAME: &str = "%constructor";
 pub const HOME_OBJECT_BINDING_NAME: &str = "%homeObject";
 pub const STATIC_HOME_OBJECT_BINDING_NAME: &str = "%staticHomeObject";
+pub const ANONYMOUS_DEFAULT_EXPORT_NAME: &str = "%defaultExport";
 const CLASS_FIELD_SLOT_NAME: &str = "%classField";

--- a/tests/js_bytecode/module/export_default_class.exp
+++ b/tests/js_bytecode/module/export_default_class.exp
@@ -1,0 +1,35 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 3
+     0: PushLexicalScope c0
+     2: LoadEmpty r1
+     4: StoreToScope r1, 0, 0
+     8: LoadEmpty r1
+    10: NewClosure r2, c1
+    13: NewClass r0, c3, c2, r1, r2
+    19: StoreToScope r0, 0, 0
+    23: PopScope 
+    24: StoreToModule r0, 1, 0
+    28: LoadUndefined r0
+    30: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [BytecodeFunction: method]
+    2: [BytecodeFunction: Named]
+    3: [ClassNames]
+}
+
+[BytecodeFunction: Named] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: method] {
+  Parameters: 0, Registers: 1
+    0: LoadFromScope r0, 0, 0
+    4: CheckTdz r0, c0
+    7: LoadUndefined r0
+    9: Ret r0
+  Constant Table:
+    0: [String: Named]
+}

--- a/tests/js_bytecode/module/export_default_class.js
+++ b/tests/js_bytecode/module/export_default_class.js
@@ -1,0 +1,6 @@
+export default class Named {
+  method() {
+    // Loaded from regular scope instead of module
+    Named;
+  }
+}

--- a/tests/js_bytecode/module/export_default_class_anonymous_custom_constructor.exp
+++ b/tests/js_bytecode/module/export_default_class_anonymous_custom_constructor.exp
@@ -1,0 +1,17 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 2
+     0: LoadEmpty r1
+     2: NewClass r0, c1, c0, r1, r0
+     8: StoreToModule r0, 1, 0
+    12: LoadUndefined r0
+    14: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: default]
+    1: [ClassNames]
+}
+
+[BytecodeFunction: default] {
+  Parameters: 0, Registers: 1
+    0: LoadImmediate r0, 1
+    3: Ret r0
+}

--- a/tests/js_bytecode/module/export_default_class_anonymous_custom_constructor.js
+++ b/tests/js_bytecode/module/export_default_class_anonymous_custom_constructor.js
@@ -1,0 +1,5 @@
+export default class {
+  constructor() {
+    return 1;
+  }
+}

--- a/tests/js_bytecode/module/export_default_class_anonymous_default_constructor.exp
+++ b/tests/js_bytecode/module/export_default_class_anonymous_default_constructor.exp
@@ -1,0 +1,17 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 2
+     0: LoadEmpty r1
+     2: NewClass r0, c1, c0, r1, r0
+     8: StoreToModule r0, 1, 0
+    12: LoadUndefined r0
+    14: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: default]
+    1: [ClassNames]
+}
+
+[BytecodeFunction: default] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}

--- a/tests/js_bytecode/module/export_default_class_anonymous_default_constructor.js
+++ b/tests/js_bytecode/module/export_default_class_anonymous_default_constructor.js
@@ -1,0 +1,1 @@
+export default class {}

--- a/tests/js_bytecode/module/export_default_expression.exp
+++ b/tests/js_bytecode/module/export_default_expression.exp
@@ -1,0 +1,9 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 2
+     0: LoadImmediate r0, 1
+     3: LoadImmediate r1, 2
+     6: Add r0, r0, r1
+    10: StoreToModule r0, 1, 0
+    14: LoadUndefined r0
+    16: Ret r0
+}

--- a/tests/js_bytecode/module/export_default_expression.js
+++ b/tests/js_bytecode/module/export_default_expression.js
@@ -1,0 +1,1 @@
+export default (1 + 2);

--- a/tests/js_bytecode/module/export_default_function.exp
+++ b/tests/js_bytecode/module/export_default_function.exp
@@ -1,0 +1,12 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: named] {
+  Parameters: 0, Registers: 1
+    0: LoadFromModule r0, 1, 0
+    4: LoadUndefined r0
+    6: Ret r0
+}

--- a/tests/js_bytecode/module/export_default_function.js
+++ b/tests/js_bytecode/module/export_default_function.js
@@ -1,0 +1,3 @@
+export default function named() {
+  named;
+}

--- a/tests/js_bytecode/module/export_default_function_anonymous.exp
+++ b/tests/js_bytecode/module/export_default_function_anonymous.exp
@@ -1,0 +1,11 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: default] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}

--- a/tests/js_bytecode/module/export_default_function_anonymous.js
+++ b/tests/js_bytecode/module/export_default_function_anonymous.js
@@ -1,0 +1,1 @@
+export default function() {}

--- a/tests/js_parser/module/export.exp
+++ b/tests/js_parser/module/export.exp
@@ -1,6 +1,6 @@
 {
   type: "Program",
-  loc: "1:0-37:29",
+  loc: "1:0-28:29",
   body: [
     {
       type: "ExportNamedDeclaration",
@@ -416,189 +416,48 @@
     },
     {
       type: "ExportDefaultDeclaration",
-      loc: "24:0-24:33",
+      loc: "24:0-24:18",
       declaration: {
-        type: "FunctionDeclaration",
-        loc: "24:15-24:33",
-        id: {
-          type: "Identifier",
-          loc: "24:24-24:28",
-          name: "foo3",
-        },
-        params: [],
-        body: {
-          type: "Block",
-          loc: "24:31-24:33",
-          body: [],
-        },
-        async: false,
-        generator: false,
-        has_use_strict_directive: false,
-      },
-    },
-    {
-      type: "ExportDefaultDeclaration",
-      loc: "25:0-25:29",
-      declaration: {
-        type: "FunctionDeclaration",
-        loc: "25:15-25:29",
-        id: null,
-        params: [],
-        body: {
-          type: "Block",
-          loc: "25:27-25:29",
-          body: [],
-        },
-        async: false,
-        generator: false,
-        has_use_strict_directive: false,
-      },
-    },
-    {
-      type: "ExportDefaultDeclaration",
-      loc: "26:0-26:39",
-      declaration: {
-        type: "FunctionDeclaration",
-        loc: "26:15-26:39",
-        id: {
-          type: "Identifier",
-          loc: "26:30-26:34",
-          name: "foo4",
-        },
-        params: [],
-        body: {
-          type: "Block",
-          loc: "26:37-26:39",
-          body: [],
-        },
-        async: true,
-        generator: false,
-        has_use_strict_directive: false,
-      },
-    },
-    {
-      type: "ExportDefaultDeclaration",
-      loc: "27:0-27:35",
-      declaration: {
-        type: "FunctionDeclaration",
-        loc: "27:15-27:35",
-        id: null,
-        params: [],
-        body: {
-          type: "Block",
-          loc: "27:33-27:35",
-          body: [],
-        },
-        async: true,
-        generator: false,
-        has_use_strict_directive: false,
-      },
-    },
-    {
-      type: "ExportDefaultDeclaration",
-      loc: "29:0-29:26",
-      declaration: {
-        type: "ClassDeclaration",
-        loc: "29:15-29:26",
-        id: {
-          type: "Identifier",
-          loc: "29:21-29:23",
-          name: "C2",
-        },
-        superClass: null,
-        body: {
-          type: "ClassBody",
-          loc: "29:15-29:26",
-          body: [],
-        },
-      },
-    },
-    {
-      type: "ExportDefaultDeclaration",
-      loc: "30:0-30:23",
-      declaration: {
-        type: "ClassDeclaration",
-        loc: "30:15-30:23",
-        id: null,
-        superClass: null,
-        body: {
-          type: "ClassBody",
-          loc: "30:15-30:23",
-          body: [],
-        },
-      },
-    },
-    {
-      type: "ExportDefaultDeclaration",
-      loc: "32:0-32:18",
-      declaration: {
-        type: "ExpressionStatement",
-        loc: "32:15-32:18",
-        kind: {
-          type: "Identifier",
-          loc: "32:15-32:17",
-          name: "a6",
-        },
-      },
-    },
-    {
-      type: "ExportDefaultDeclaration",
-      loc: "33:0-33:21",
-      declaration: {
-        type: "ExpressionStatement",
-        loc: "33:15-33:21",
-        kind: {
-          type: "BinaryExpression",
-          loc: "33:15-33:20",
-          operator: "+",
-          left: {
-            type: "Literal",
-            loc: "33:15-33:16",
-            value: 1,
-          },
-          right: {
-            type: "Literal",
-            loc: "33:19-33:20",
-            value: 2,
-          },
-        },
+        type: "Identifier",
+        loc: "24:15-24:17",
+        name: "a6",
       },
     },
     {
       type: "ExportAllDeclaration",
-      loc: "35:0-35:22",
+      loc: "26:0-26:22",
       exported: null,
       source: {
         type: "Literal",
-        loc: "35:14-35:21",
+        loc: "26:14-26:21",
         value: "other",
       },
     },
     {
       type: "ExportAllDeclaration",
-      loc: "36:0-36:27",
+      loc: "27:0-27:27",
       exported: {
         type: "Identifier",
-        loc: "36:12-36:13",
+        loc: "27:12-27:13",
         name: "a",
       },
       source: {
         type: "Literal",
-        loc: "36:19-36:26",
+        loc: "27:19-27:26",
         value: "other",
       },
     },
     {
       type: "ExportAllDeclaration",
-      loc: "37:0-37:29",
+      loc: "28:0-28:29",
       exported: {
         type: "Literal",
-        loc: "37:12-37:15",
+        loc: "28:12-28:15",
         value: "a",
       },
       source: {
         type: "Literal",
-        loc: "37:21-37:28",
+        loc: "28:21-28:28",
         value: "other",
       },
     },

--- a/tests/js_parser/module/export.js
+++ b/tests/js_parser/module/export.js
@@ -21,16 +21,7 @@ export class C {};
 export function foo() {}
 export async function foo2() {}
 
-export default function foo3() {}
-export default function () {}
-export default async function foo4() {}
-export default async function () {}
-
-export default class C2 {}
-export default class {}
-
 export default a6;
-export default 1 + 2;
 
 export * from 'other';
 export * as a from 'other';

--- a/tests/js_parser/module/export_default_class.exp
+++ b/tests/js_parser/module/export_default_class.exp
@@ -1,0 +1,27 @@
+{
+  type: "Program",
+  loc: "1:0-1:25",
+  body: [
+    {
+      type: "ExportDefaultDeclaration",
+      loc: "1:0-1:25",
+      declaration: {
+        type: "ClassDeclaration",
+        loc: "1:15-1:25",
+        id: {
+          type: "Identifier",
+          loc: "1:21-1:22",
+          name: "C",
+        },
+        superClass: null,
+        body: {
+          type: "ClassBody",
+          loc: "1:15-1:25",
+          body: [],
+        },
+      },
+    },
+  ],
+  sourceType: "module",
+  has_use_strict_directive: false,
+}

--- a/tests/js_parser/module/export_default_class.js
+++ b/tests/js_parser/module/export_default_class.js
@@ -1,0 +1,1 @@
+export default class C {}

--- a/tests/js_parser/module/export_default_class_anonymousjs
+++ b/tests/js_parser/module/export_default_class_anonymousjs
@@ -1,0 +1,1 @@
+export default class {}

--- a/tests/js_parser/module/export_default_expression.exp
+++ b/tests/js_parser/module/export_default_expression.exp
@@ -1,0 +1,27 @@
+{
+  type: "Program",
+  loc: "1:0-1:21",
+  body: [
+    {
+      type: "ExportDefaultDeclaration",
+      loc: "1:0-1:21",
+      declaration: {
+        type: "BinaryExpression",
+        loc: "1:15-1:20",
+        operator: "+",
+        left: {
+          type: "Literal",
+          loc: "1:15-1:16",
+          value: 1,
+        },
+        right: {
+          type: "Literal",
+          loc: "1:19-1:20",
+          value: 2,
+        },
+      },
+    },
+  ],
+  sourceType: "module",
+  has_use_strict_directive: false,
+}

--- a/tests/js_parser/module/export_default_expression.js
+++ b/tests/js_parser/module/export_default_expression.js
@@ -1,0 +1,1 @@
+export default 1 + 2;

--- a/tests/js_parser/module/export_default_function.exp
+++ b/tests/js_parser/module/export_default_function.exp
@@ -1,0 +1,30 @@
+{
+  type: "Program",
+  loc: "1:0-1:32",
+  body: [
+    {
+      type: "ExportDefaultDeclaration",
+      loc: "1:0-1:32",
+      declaration: {
+        type: "FunctionDeclaration",
+        loc: "1:15-1:32",
+        id: {
+          type: "Identifier",
+          loc: "1:24-1:27",
+          name: "foo",
+        },
+        params: [],
+        body: {
+          type: "Block",
+          loc: "1:30-1:32",
+          body: [],
+        },
+        async: false,
+        generator: false,
+        has_use_strict_directive: false,
+      },
+    },
+  ],
+  sourceType: "module",
+  has_use_strict_directive: false,
+}

--- a/tests/js_parser/module/export_default_function.js
+++ b/tests/js_parser/module/export_default_function.js
@@ -1,0 +1,1 @@
+export default function foo() {}

--- a/tests/js_parser/module/export_default_function_anonymous.exp
+++ b/tests/js_parser/module/export_default_function_anonymous.exp
@@ -1,0 +1,26 @@
+{
+  type: "Program",
+  loc: "1:0-1:29",
+  body: [
+    {
+      type: "ExportDefaultDeclaration",
+      loc: "1:0-1:29",
+      declaration: {
+        type: "FunctionDeclaration",
+        loc: "1:15-1:29",
+        id: null,
+        params: [],
+        body: {
+          type: "Block",
+          loc: "1:27-1:29",
+          body: [],
+        },
+        async: false,
+        generator: false,
+        has_use_strict_directive: false,
+      },
+    },
+  ],
+  sourceType: "module",
+  has_use_strict_directive: false,
+}

--- a/tests/js_parser/module/export_default_function_anonymous.js
+++ b/tests/js_parser/module/export_default_function_anonymous.js
@@ -1,0 +1,1 @@
+export default function () {}

--- a/tests/js_parser/module/export_default_function_async.exp
+++ b/tests/js_parser/module/export_default_function_async.exp
@@ -1,0 +1,30 @@
+{
+  type: "Program",
+  loc: "1:0-1:38",
+  body: [
+    {
+      type: "ExportDefaultDeclaration",
+      loc: "1:0-1:38",
+      declaration: {
+        type: "FunctionDeclaration",
+        loc: "1:15-1:38",
+        id: {
+          type: "Identifier",
+          loc: "1:30-1:33",
+          name: "foo",
+        },
+        params: [],
+        body: {
+          type: "Block",
+          loc: "1:36-1:38",
+          body: [],
+        },
+        async: true,
+        generator: false,
+        has_use_strict_directive: false,
+      },
+    },
+  ],
+  sourceType: "module",
+  has_use_strict_directive: false,
+}

--- a/tests/js_parser/module/export_default_function_async.js
+++ b/tests/js_parser/module/export_default_function_async.js
@@ -1,0 +1,1 @@
+export default async function foo() {}

--- a/tests/js_parser/module/export_default_function_async_anonymous.exp
+++ b/tests/js_parser/module/export_default_function_async_anonymous.exp
@@ -1,0 +1,26 @@
+{
+  type: "Program",
+  loc: "1:0-1:35",
+  body: [
+    {
+      type: "ExportDefaultDeclaration",
+      loc: "1:0-1:35",
+      declaration: {
+        type: "FunctionDeclaration",
+        loc: "1:15-1:35",
+        id: null,
+        params: [],
+        body: {
+          type: "Block",
+          loc: "1:33-1:35",
+          body: [],
+        },
+        async: true,
+        generator: false,
+        has_use_strict_directive: false,
+      },
+    },
+  ],
+  sourceType: "module",
+  has_use_strict_directive: false,
+}

--- a/tests/js_parser/module/export_default_function_async_anonymous.js
+++ b/tests/js_parser/module/export_default_function_async_anonymous.js
@@ -1,0 +1,1 @@
+export default async function () {}


### PR DESCRIPTION
## Summary

Implement anonymous default exports (i.e. default exported functions and classes without an identifier, and default exported expressions). The main complication is that a binding is needed but there is no corresponding identifier to attach it to. Instead we detect this case and explicitly introduce a binding of the appropriate type - function, class, or a new default exported expression binding that requires TDZ checks.

## Tests

Adds bytecode snapshot tests for default exports of functions, classes, and expressions. Check both named and anonymous functions and classes, as well as both default and custom constructors.

Also separates parser snapshot tests for default exports into individual files to avoid duplicate default export errors.