### PR TITLE
[runtime] Implement module namespace objects

### DIFF
--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -93,6 +93,7 @@ builtin_names!(
     (json, "JSON"),
     (map, "Map"),
     (math, "Math"),
+    (module, "Module"),
     (number, "Number"),
     (object, "Object"),
     (promise, "Promise"),

--- a/src/js/runtime/gc/handle.rs
+++ b/src/js/runtime/gc/handle.rs
@@ -424,6 +424,13 @@ impl Escapable for () {
     fn escape(&self, _: Context) -> Self {}
 }
 
+impl Escapable for u32 {
+    #[inline]
+    fn escape(&self, _: Context) -> Self {
+        *self
+    }
+}
+
 impl Escapable for Handle<Value> {
     #[inline]
     fn escape(&self, cx: Context) -> Self {

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -50,7 +50,10 @@ use crate::js::runtime::{
         weak_ref_constructor::WeakRefObject,
         weak_set_object::{WeakSetObject, WeakSetObjectSetField},
     },
-    module::source_text_module::SourceTextModule,
+    module::{
+        module_namespace_object::ModuleNamespaceObject,
+        source_text_module::{ExportMapField, SourceTextModule},
+    },
     object_descriptor::{ObjectDescriptor, ObjectKind},
     object_value::{NamedPropertiesMapField, ObjectValue},
     promise_object::{PromiseCapability, PromiseObject, PromiseReaction},
@@ -151,6 +154,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::GlobalNames => self.cast::<GlobalNames>().byte_size(),
             ObjectKind::ClassNames => self.cast::<ClassNames>().byte_size(),
             ObjectKind::SourceTextModule => self.cast::<SourceTextModule>().byte_size(),
+            ObjectKind::ModuleNamespaceObject => self.cast::<ModuleNamespaceObject>().byte_size(),
             ObjectKind::Generator => self.cast::<GeneratorObject>().byte_size(),
             ObjectKind::AsyncGenerator => self.cast::<AsyncGeneratorObject>().byte_size(),
             ObjectKind::AsyncGeneratorRequest => self.cast::<AsyncGeneratorRequest>().byte_size(),
@@ -163,6 +167,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             }
             ObjectKind::MapObjectValueMap => MapObjectMapField::byte_size(&self.cast()),
             ObjectKind::SetObjectValueSet => SetObjectSetField::byte_size(&self.cast()),
+            ObjectKind::ExportMap => ExportMapField::byte_size(&self.cast()),
             ObjectKind::WeakMapObjectWeakValueMap => WeakMapObjectMapField::byte_size(&self.cast()),
             ObjectKind::WeakSetObjectWeakValueSet => WeakSetObjectSetField::byte_size(&self.cast()),
             ObjectKind::GlobalSymbolRegistryMap => {
@@ -261,6 +266,9 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::GlobalNames => self.cast::<GlobalNames>().visit_pointers(visitor),
             ObjectKind::ClassNames => self.cast::<ClassNames>().visit_pointers(visitor),
             ObjectKind::SourceTextModule => self.cast::<SourceTextModule>().visit_pointers(visitor),
+            ObjectKind::ModuleNamespaceObject => {
+                self.cast::<ModuleNamespaceObject>().visit_pointers(visitor)
+            }
             ObjectKind::Generator => self.cast::<GeneratorObject>().visit_pointers(visitor),
             ObjectKind::AsyncGenerator => {
                 self.cast::<AsyncGeneratorObject>().visit_pointers(visitor)
@@ -287,6 +295,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::SetObjectValueSet => {
                 SetObjectSetField::visit_pointers(self.cast_mut(), visitor)
             }
+            ObjectKind::ExportMap => ExportMapField::visit_pointers(self.cast_mut(), visitor),
             ObjectKind::WeakMapObjectWeakValueMap => {
                 WeakMapObjectMapField::visit_pointers(self.cast_mut(), visitor)
             }

--- a/src/js/runtime/module/mod.rs
+++ b/src/js/runtime/module/mod.rs
@@ -1,4 +1,5 @@
 pub mod execute;
 mod linker;
 pub mod loader;
+pub mod module_namespace_object;
 pub mod source_text_module;

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -1,0 +1,245 @@
+use wrap_ordinary_object::wrap_ordinary_object;
+
+use crate::{
+    extend_object,
+    js::runtime::{
+        boxed_value::BoxedValue,
+        error::reference_error,
+        gc::{HeapObject, HeapVisitor},
+        object_descriptor::ObjectKind,
+        object_value::{ObjectValue, VirtualObject},
+        ordinary_object::{
+            object_create_with_optional_proto, ordinary_define_own_property, ordinary_delete,
+            ordinary_get, ordinary_get_own_property, ordinary_has_property,
+            ordinary_own_string_symbol_property_keys,
+        },
+        property::Property,
+        type_utilities::same_value,
+        Context, EvalResult, Handle, HeapPtr, PropertyDescriptor, PropertyKey, Value,
+    },
+    maybe, set_uninit,
+};
+
+use super::source_text_module::SourceTextModule;
+
+// Module Namespace Exotic Objects (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects)
+extend_object! {
+    pub struct ModuleNamespaceObject {
+        // The module which the namespace object holds the exports of. Exports are actually stored
+        // within the module itself and the namespace object is just a proxy to access them.
+        module: HeapPtr<SourceTextModule>,
+    }
+}
+
+impl ModuleNamespaceObject {
+    pub fn new(cx: Context, module: Handle<SourceTextModule>) -> HeapPtr<ModuleNamespaceObject> {
+        // Module namespace object does not have a prototype. This satisfies:
+        // - [[GetPrototypeOf]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getprototypeof)
+        // - [[SetPrototypeOf]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-setprototypeof-v)
+        let mut object = object_create_with_optional_proto::<ModuleNamespaceObject>(
+            cx,
+            ObjectKind::ModuleNamespaceObject,
+            None,
+        );
+
+        // Mark as non-extensible. This satisifes:
+        // - [[IsExtensible]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-isextensible)
+        // - [[PreventExtensions]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-preventextensions)
+        object.cast::<ObjectValue>().set_is_extensible_field(false);
+
+        set_uninit!(object.module, module.get_());
+
+        let object = object.to_handle();
+
+        // Module Namepace Objects [ %Symbol.toStringTag% ] (https://tc39.es/ecma262/#sec-%symbol.tostringtag%)
+        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        object.object().set_property(
+            cx,
+            to_string_tag_key,
+            Property::data(cx.names.module().as_string().into(), false, false, false),
+        );
+
+        object.get_()
+    }
+}
+
+impl HeapPtr<ModuleNamespaceObject> {
+    /// Looks up an export name from the module. Returns the exported value if an export with that
+    /// name exists, otherwise returns `None`.
+    ///
+    /// Error if the export binding has not yet been initialized.
+    fn lookup_export(&self, cx: Context, key: PropertyKey) -> EvalResult<Option<Value>> {
+        let exports = self.module.exports_ptr();
+        let heap_item = match exports.get(&key) {
+            Some(heap_item) => heap_item,
+            None => return None.into(),
+        };
+
+        if heap_item.descriptor().kind() == ObjectKind::BoxedValue {
+            let boxed_value = heap_item.cast::<BoxedValue>();
+            let value = boxed_value.get();
+
+            // Error if value has TDZ and has not yet been initialized
+            if value.is_empty() {
+                reference_error(cx, "module value is not initialized")
+            } else {
+                Some(value).into()
+            }
+        } else {
+            // Otherwise a SourceTextModule is which represents a namespace export of that module
+            debug_assert!(heap_item.descriptor().kind() == ObjectKind::SourceTextModule);
+
+            let mut module = heap_item.cast::<SourceTextModule>().to_handle();
+            let namespace_object: HeapPtr<ObjectValue> = module.get_namespace_object(cx).into();
+
+            Some(namespace_object.into()).into()
+        }
+    }
+}
+
+#[wrap_ordinary_object]
+impl VirtualObject for Handle<ModuleNamespaceObject> {
+    /// [[GetOwnProperty]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getownproperty-p)
+    fn get_own_property(
+        &self,
+        cx: Context,
+        key: Handle<PropertyKey>,
+    ) -> EvalResult<Option<PropertyDescriptor>> {
+        if key.is_symbol() {
+            return ordinary_get_own_property(cx, (*self).into(), key).into();
+        }
+
+        match maybe!(self.lookup_export(cx, key.get())) {
+            None => None.into(),
+            Some(value) => {
+                let value = value.to_handle(cx);
+                let desc = PropertyDescriptor::data(value, true, true, false);
+                Some(desc).into()
+            }
+        }
+    }
+
+    /// [[DefineOwnProperty]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-defineownproperty-p-desc)
+    fn define_own_property(
+        &mut self,
+        cx: Context,
+        key: Handle<PropertyKey>,
+        desc: PropertyDescriptor,
+    ) -> EvalResult<bool> {
+        if key.is_symbol() {
+            return ordinary_define_own_property(cx, (*self).into(), key, desc);
+        }
+
+        let current_desc = match maybe!(self.get_own_property(cx, key)) {
+            None => return false.into(),
+            Some(desc) => desc,
+        };
+
+        // Property descriptor attributes must match (writable, enumerable, non-configurable)
+        if desc.is_configurable == Some(true)
+            || desc.is_enumerable == Some(false)
+            || desc.is_accessor_descriptor()
+            || desc.is_writable == Some(false)
+        {
+            return false.into();
+        }
+
+        // If a value was provided it must match the current value
+        if let Some(desc_value) = desc.value {
+            return same_value(desc_value, current_desc.value.unwrap()).into();
+        }
+
+        true.into()
+    }
+
+    /// [[HasProperty]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-hasproperty-p)
+    fn has_property(&self, cx: Context, key: Handle<PropertyKey>) -> EvalResult<bool> {
+        if key.is_symbol() {
+            return ordinary_has_property(cx, (*self).into(), key);
+        }
+
+        self.module.exports_ptr().contains_key(&key.get()).into()
+    }
+
+    /// [[Get]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-get-p-receiver)
+    fn get(
+        &self,
+        cx: Context,
+        key: Handle<PropertyKey>,
+        receiver: Handle<Value>,
+    ) -> EvalResult<Handle<Value>> {
+        if key.is_symbol() {
+            return ordinary_get(cx, (*self).into(), key, receiver);
+        }
+
+        match maybe!(self.lookup_export(cx, key.get())) {
+            None => cx.undefined().into(),
+            Some(value) => value.to_handle(cx).into(),
+        }
+    }
+
+    /// [[Set]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-set-p-v-receiver)
+    fn set(
+        &mut self,
+        _: Context,
+        _: Handle<PropertyKey>,
+        _: Handle<Value>,
+        _: Handle<Value>,
+    ) -> EvalResult<bool> {
+        false.into()
+    }
+
+    /// [[Delete]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-delete-p)
+    fn delete(&mut self, cx: Context, key: Handle<PropertyKey>) -> EvalResult<bool> {
+        if key.is_symbol() {
+            return ordinary_delete(cx, (*self).into(), key);
+        }
+
+        (!self.module.exports_ptr().contains_key(&key.get())).into()
+    }
+
+    /// [[OwnPropertyKeys]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-ownpropertykeys)
+    fn own_property_keys(&self, cx: Context) -> EvalResult<Vec<Handle<Value>>> {
+        // Gather all exported keys
+        let raw_keys = self
+            .module
+            .exports_ptr()
+            .iter_gc_unsafe()
+            .map(|(key, _)| key.to_handle(cx))
+            .collect::<Vec<_>>();
+
+        // Convert all keys to strings
+        let mut string_keys = raw_keys
+            .into_iter()
+            .map(|key| {
+                // Safe since key is guaranteed to not be a symbol
+                key.to_value(cx).as_string().as_flat()
+            })
+            .collect::<Vec<_>>();
+
+        // Sort the keys in lexicographic order
+        string_keys.sort_unstable();
+
+        // Finally convert to vector of values
+        let mut keys = string_keys
+            .into_iter()
+            .map(|key| key.into())
+            .collect::<Vec<_>>();
+
+        // Add keys on object which may only be symbol keys
+        ordinary_own_string_symbol_property_keys(self.object(), &mut keys);
+
+        keys.into()
+    }
+}
+
+impl HeapObject for HeapPtr<ModuleNamespaceObject> {
+    fn byte_size(&self) -> usize {
+        size_of::<ModuleNamespaceObject>()
+    }
+
+    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+        self.cast::<ObjectValue>().visit_pointers(visitor);
+        visitor.visit_pointer(&mut self.module);
+    }
+}

--- a/src/js/runtime/object_descriptor.rs
+++ b/src/js/runtime/object_descriptor.rs
@@ -4,7 +4,9 @@ use bitflags::bitflags;
 
 use crate::{
     js::runtime::{
-        arguments_object::MappedArgumentsObject, ordinary_object::OrdinaryObject, Value,
+        arguments_object::MappedArgumentsObject,
+        module::module_namespace_object::ModuleNamespaceObject, ordinary_object::OrdinaryObject,
+        Value,
     },
     set_uninit,
 };
@@ -115,6 +117,7 @@ pub enum ObjectKind {
     ClassNames,
 
     SourceTextModule,
+    ModuleNamespaceObject,
 
     Generator,
     AsyncGenerator,
@@ -131,6 +134,7 @@ pub enum ObjectKind {
     ObjectNamedPropertiesMap,
     MapObjectValueMap,
     SetObjectValueSet,
+    ExportMap,
     WeakSetObjectWeakValueSet,
     WeakMapObjectWeakValueMap,
     GlobalSymbolRegistryMap,
@@ -326,6 +330,11 @@ impl BaseDescriptors {
         other_heap_object_descriptor!(ObjectKind::ClassNames);
 
         other_heap_object_descriptor!(ObjectKind::SourceTextModule);
+        register_descriptor!(
+            ObjectKind::ModuleNamespaceObject,
+            ModuleNamespaceObject,
+            DescFlags::IS_OBJECT
+        );
 
         ordinary_object_descriptor!(ObjectKind::Generator);
         ordinary_object_descriptor!(ObjectKind::AsyncGenerator);
@@ -341,6 +350,7 @@ impl BaseDescriptors {
         other_heap_object_descriptor!(ObjectKind::ObjectNamedPropertiesMap);
         other_heap_object_descriptor!(ObjectKind::MapObjectValueMap);
         other_heap_object_descriptor!(ObjectKind::SetObjectValueSet);
+        other_heap_object_descriptor!(ObjectKind::ExportMap);
         other_heap_object_descriptor!(ObjectKind::WeakMapObjectWeakValueMap);
         other_heap_object_descriptor!(ObjectKind::WeakSetObjectWeakValueSet);
         other_heap_object_descriptor!(ObjectKind::GlobalSymbolRegistryMap);

--- a/tests/js_bytecode/module/import_namespace/exporting.exp
+++ b/tests/js_bytecode/module/import_namespace/exporting.exp
@@ -1,0 +1,7 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 1
+    0: LoadImmediate r0, 1
+    3: StoreToModule r0, 1, 0
+    7: LoadUndefined r0
+    9: Ret r0
+}

--- a/tests/js_bytecode/module/import_namespace/exporting.js
+++ b/tests/js_bytecode/module/import_namespace/exporting.js
@@ -1,0 +1,1 @@
+export var foo = 1;

--- a/tests/js_bytecode/module/import_namespace/importing.exp
+++ b/tests/js_bytecode/module/import_namespace/importing.exp
@@ -1,0 +1,16 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 2
+    0: NewClosure r0, c0
+    3: LoadUndefined r1
+    5: Ret r1
+  Constant Table:
+    0: [BytecodeFunction: testAccess]
+}
+
+[BytecodeFunction: testAccess] {
+  Parameters: 0, Registers: 1
+     0: LoadFromScope r0, 1, 0
+     4: LoadFromModule r0, 2, 0
+     8: LoadUndefined r0
+    10: Ret r0
+}

--- a/tests/js_bytecode/module/import_namespace/importing.js
+++ b/tests/js_bytecode/module/import_namespace/importing.js
@@ -1,0 +1,11 @@
+// Should be stored in scope
+import * as import1 from './exporting.js';
+
+// Should be stored in module scope
+import * as import2 from './exporting.js';
+export { import2 }
+
+function testAccess() {
+  import1;
+  import2;
+}

--- a/tests/js_bytecode/module/reexport_named/importing.js
+++ b/tests/js_bytecode/module/reexport_named/importing.js
@@ -1,5 +1,5 @@
-import { func1, var2 } from "./exporting.js";
+import { func1, var2, reexport1 } from "./reexporting.js";
 
 function testAccessImportedBindings() {
-  func1 + var2;
+  func1 + var2 + reexport1;
 }

--- a/tests/js_bytecode/module/reexport_named/reexporting.js
+++ b/tests/js_bytecode/module/reexport_named/reexporting.js
@@ -1,1 +1,2 @@
 export { func1, var1 as var2 } from './exporting.js';
+export * as reexport1 from './exporting.js';

--- a/tests/js_bytecode/module/reexport_star/exporting.exp
+++ b/tests/js_bytecode/module/reexport_star/exporting.exp
@@ -1,0 +1,13 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 1
+    0: LoadImmediate r0, 1
+    3: StoreToModule r0, 2, 0
+    7: LoadUndefined r0
+    9: Ret r0
+}
+
+[BytecodeFunction: func1] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}

--- a/tests/js_bytecode/module/reexport_star/exporting.js
+++ b/tests/js_bytecode/module/reexport_star/exporting.js
@@ -1,0 +1,2 @@
+export function func1() {}
+export var var1 = 1;

--- a/tests/js_bytecode/module/reexport_star/importing.exp
+++ b/tests/js_bytecode/module/reexport_star/importing.exp
@@ -12,8 +12,6 @@
      0: LoadFromModule r0, 1, 0
      4: LoadFromModule r1, 2, 0
      8: Add r0, r0, r1
-    12: LoadFromModule r1, 3, 0
-    16: Add r0, r0, r1
-    20: LoadUndefined r0
-    22: Ret r0
+    12: LoadUndefined r0
+    14: Ret r0
 }

--- a/tests/js_bytecode/module/reexport_star/importing.js
+++ b/tests/js_bytecode/module/reexport_star/importing.js
@@ -1,0 +1,5 @@
+import { func1, var2 } from "./reexporting.js";
+
+function testAccessImportedBindings() {
+  func1 + var2;
+}

--- a/tests/js_bytecode/module/reexport_star/reexporting.exp
+++ b/tests/js_bytecode/module/reexport_star/reexporting.exp
@@ -1,0 +1,5 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}

--- a/tests/js_bytecode/module/reexport_star/reexporting.js
+++ b/tests/js_bytecode/module/reexport_star/reexporting.js
@@ -1,0 +1,1 @@
+export * from './exporting.js';


### PR DESCRIPTION
## Summary

Implements module namespace objects. ModuleNamespaceObject is a new exotic object that references a SourceTextModule. Each SourceTextModule now lazily creates a namespace object along with a map of exports when the namespace object is first accessed.

Object methods on a ModuleNamespaceObject now defer to the exports map for non-symbol keys but have ordinary behavior for symbol keys. Also note that ModuleNamespaceObject has no prototype and is non-extensible in order to keep using ordinary prototype and extensibility methods.

## Tests

Added bytecode snapshot tests for import namespace bindings and re-export star declarations.