### PR TITLE
[runtime] Fix dynamic lookup of module bindings

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -7031,6 +7031,10 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 flags |= ScopeNameFlags::IS_PRIVATE_NAME;
             }
 
+            if binding.is_module_binding() {
+                flags |= ScopeNameFlags::IS_MODULE_BINDING;
+            }
+
             all_flags.push(flags);
         }
 

--- a/src/js/runtime/scope_names.rs
+++ b/src/js/runtime/scope_names.rs
@@ -47,6 +47,8 @@ bitflags! {
         const IS_FUNCTION_EXPRESSION_NAME = 1 << 3;
         /// Whether this is a private name binding.
         const IS_PRIVATE_NAME = 1 << 4;
+        /// Whether this is a module binding.
+        const IS_MODULE_BINDING = 1 << 5;
     }
 }
 
@@ -170,6 +172,12 @@ impl ScopeNames {
     pub fn is_private_name(&self, index: usize) -> bool {
         self.get_name_flags(index)
             .contains(ScopeNameFlags::IS_PRIVATE_NAME)
+    }
+
+    /// Return whether the binding at index is a module binding.
+    pub fn is_module_binding(&self, index: usize) -> bool {
+        self.get_name_flags(index)
+            .contains(ScopeNameFlags::IS_MODULE_BINDING)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes dynamic lookup of module bindings which previously were loading/storing the entire BoxedValue instead of the inner value. This is accomplished by adding a scope name flag for module bindings and checking this flag during dynamic lookup, treating value in slot as a BoxedValue if the flag is set.

Note that we also introduce a ScopeKind::Module which also gates the module binding check during dynamic lookup.