### PR TITLE
[bytecode] Default exported expressions have named evaluation

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -6795,7 +6795,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             // Default exported expressions are evaluated and stored as the anonymous default in
             // the current scope.
             ast::ExportDefaultKind::Expression(expr) => {
-                let value = self.gen_outer_expression(expr)?;
+                let value =
+                    self.gen_named_outer_expression(AnyStr::Str("default"), expr, ExprDest::Any)?;
 
                 let anonymous_binding = scope.get_binding(ANONYMOUS_DEFAULT_EXPORT_NAME);
                 self.gen_store_binding(

--- a/tests/js_bytecode/module/export_default_arrow_function.exp
+++ b/tests/js_bytecode/module/export_default_arrow_function.exp
@@ -1,0 +1,15 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 1
+    0: NewClosure r0, c0
+    3: StoreToModule r0, 1, 0
+    7: LoadUndefined r0
+    9: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: default]
+}
+
+[BytecodeFunction: default] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}

--- a/tests/js_bytecode/module/export_default_arrow_function.js
+++ b/tests/js_bytecode/module/export_default_arrow_function.js
@@ -1,0 +1,1 @@
+export default () => {}

--- a/tests/js_bytecode/module/export_default_class_expression_anonymous.exp
+++ b/tests/js_bytecode/module/export_default_class_expression_anonymous.exp
@@ -1,0 +1,17 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 2
+     0: LoadEmpty r1
+     2: NewClass r0, c1, c0, r1, r0
+     8: StoreToModule r0, 1, 0
+    12: LoadUndefined r0
+    14: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: default]
+    1: [ClassNames]
+}
+
+[BytecodeFunction: default] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}

--- a/tests/js_bytecode/module/export_default_class_expression_anonymous.js
+++ b/tests/js_bytecode/module/export_default_class_expression_anonymous.js
@@ -1,0 +1,1 @@
+export default (class {})

--- a/tests/js_bytecode/module/export_default_function_expression_anonymous.exp
+++ b/tests/js_bytecode/module/export_default_function_expression_anonymous.exp
@@ -1,0 +1,15 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 1
+    0: NewClosure r0, c0
+    3: StoreToModule r0, 1, 0
+    7: LoadUndefined r0
+    9: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: default]
+}
+
+[BytecodeFunction: default] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}

--- a/tests/js_bytecode/module/export_default_function_expression_anonymous.js
+++ b/tests/js_bytecode/module/export_default_function_expression_anonymous.js
@@ -1,0 +1,1 @@
+export default (function () {})


### PR DESCRIPTION
## Summary

Named evaluation with the name "default" should be performed for default exported expressions. This means that anonymous function, class, and arrow function expressions will be named "default".

## Tests

Added bytecode snapshot tests for default exported anonymous functions, classes, and arrow function expressions.