### PR TITLE
[runtime] Module specifiers from imports and exports are evaluated interleaved in source code order

### DIFF
--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -3,6 +3,8 @@ use std::{
     sync::{LazyLock, Mutex},
 };
 
+use indexmap::IndexSet;
+
 use crate::{
     field_offset,
     js::runtime::{
@@ -97,7 +99,7 @@ impl SourceTextModule {
         cx: Context,
         program_function: Handle<BytecodeFunction>,
         module_scope: Handle<Scope>,
-        requested_module_specifiers: &[Handle<FlatString>],
+        requested_module_specifiers: &IndexSet<Handle<FlatString>>,
         imports: &[ImportEntry],
         local_exports: &[LocalExportEntry],
         named_re_exports: &[NamedReExportEntry],


### PR DESCRIPTION
## Summary

Imports and re-exports both reference module specifiers which evaluate the requested module. Imports and exports can be interleaved and the referenced modules should be evaluated in source code order. We previously were evaluating all modules from imports and then all modules from exports.