### PR TITLE
[runtime] Import of re-exported namespace object creates BoxedValue during linking

### DIFF
--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -673,7 +673,7 @@ pub enum ModuleEntry {
 pub struct HeapImportEntry {
     /// Name of the module that binding is being imported from.
     pub module_request: HeapPtr<FlatString>,
-    /// Name of the binding in the module is was declared in. If None then this entry is for the
+    /// Name of the binding in the module it was declared in. If None then this entry is for the
     /// namespace object, meaning the slot_index may refer to an unboxed value.
     pub import_name: Option<HeapPtr<FlatString>>,
     /// Name of the imported binding in this module.


### PR DESCRIPTION
## Summary

All exported bindings have the BoxedValue that holds their value created during `gen_module_scope`. However named re-exports of namespace objects do not actually have a binding to reference their BoxedValue was never being created.

We now create BoxedValues for each import of a re-exported namespace object during linking. Note that we create a separate BoxedValue for each import of the same re-exported namespace object - deduplicating these could be a future optimization.