### PR TITLE
[parser] Only enforce identifier restrictions on ExportName when it is a local name without from clause

### DIFF
--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -915,8 +915,10 @@ impl<'a> AstVisitor for Analyzer<'a> {
         for specifier in &mut export.specifiers {
             // Only need to resolve the specifier's local binding if it is not a re-export
             if export.source.is_none() {
-                self.resolve_identifier_use(&mut specifier.local);
-                specifier.local.get_binding().set_is_exported(true);
+                // Local is guaranteed to be an identifier if this is not a re-export
+                let local_id = specifier.local.to_id_mut();
+                self.resolve_identifier_use(local_id);
+                local_id.get_binding().set_is_exported(true);
             }
         }
     }

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -1437,7 +1437,7 @@ pub struct ImportDefaultSpecifier {
 
 pub struct ImportNamedSpecifier {
     pub loc: Loc,
-    pub imported: Option<P<ModuleName>>,
+    pub imported: Option<P<ExportName>>,
     pub local: P<Identifier>,
 }
 
@@ -1484,8 +1484,9 @@ impl ExportNamedDeclaration {
 
 pub struct ExportSpecifier {
     pub loc: Loc,
-    pub local: P<Identifier>,
-    pub exported: Option<P<ModuleName>>,
+    /// Guaranteed to be an identifier if declaration is not a re-export declaration.
+    pub local: P<ExportName>,
+    pub exported: Option<P<ExportName>>,
 }
 
 pub struct ExportDefaultDeclaration {
@@ -1511,11 +1512,29 @@ pub enum ExportDefaultKind {
 
 pub struct ExportAllDeclaration {
     pub loc: Loc,
-    pub exported: Option<P<ModuleName>>,
+    pub exported: Option<P<ExportName>>,
     pub source: P<StringLiteral>,
 }
 
-pub enum ModuleName {
+/// The name of an export that other modules must reference when importing. Must be well formed
+/// unicode (which is already implicitly true for Identifiers).
+pub enum ExportName {
     Id(Identifier),
     String(StringLiteral),
+}
+
+impl ExportName {
+    pub fn to_id(&self) -> &Identifier {
+        match self {
+            ExportName::Id(id) => id,
+            _ => panic!("Expected identifier export name"),
+        }
+    }
+
+    pub fn to_id_mut(&mut self) -> &mut Identifier {
+        match self {
+            ExportName::Id(id) => id,
+            _ => panic!("Expected identifier export name"),
+        }
+    }
 }

--- a/src/js/parser/ast_visitor.rs
+++ b/src/js/parser/ast_visitor.rs
@@ -402,7 +402,7 @@ pub trait AstVisitor: Sized {
         default_visit_export_all_declaration(self, export)
     }
 
-    fn visit_module_name(&mut self, _: &mut ModuleName) {}
+    fn visit_export_name(&mut self, _: &mut ExportName) {}
 }
 
 #[macro_export]
@@ -848,7 +848,7 @@ pub fn default_visit_import_named_specifier<V: AstVisitor>(
     visitor: &mut V,
     spec: &mut ImportNamedSpecifier,
 ) {
-    visit_opt!(visitor, spec.imported, visit_module_name);
+    visit_opt!(visitor, spec.imported, visit_export_name);
     visitor.visit_identifier(&mut spec.local);
 }
 
@@ -880,15 +880,15 @@ pub fn default_visit_export_named_declaration<V: AstVisitor>(
 }
 
 pub fn default_visit_export_specifier<V: AstVisitor>(visitor: &mut V, spec: &mut ExportSpecifier) {
-    visitor.visit_identifier(&mut spec.local);
-    visit_opt!(visitor, spec.exported, visit_module_name);
+    visitor.visit_export_name(&mut spec.local);
+    visit_opt!(visitor, spec.exported, visit_export_name);
 }
 
 pub fn default_visit_export_all_declaration<V: AstVisitor>(
     visitor: &mut V,
     export: &mut ExportAllDeclaration,
 ) {
-    visit_opt!(visitor, export.exported, visit_module_name);
+    visit_opt!(visitor, export.exported, visit_export_name);
     visitor.visit_string_literal(&mut export.source);
 }
 

--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -85,9 +85,9 @@ pub enum ParseError {
     AwaitInStaticInitializer,
     AwaitInParameters,
     YieldInParameters,
-    ModuleNameNotWellFormed,
-    ModuleNameIsReservedWord,
-    // RegExpr parsing errors
+    ExportNameNotWellFormed,
+    DirectExportNameIsString,
+    // RegExp parsing errors
     UnexpectedRegExpToken,
     InvalidRegExpFlag,
     DuplicateRegExpFlag,
@@ -368,11 +368,11 @@ impl fmt::Display for ParseError {
             ParseError::YieldInParameters => {
                 write!(f, "Yield expression not allowed in function parameters")
             }
-            ParseError::ModuleNameNotWellFormed => {
-                write!(f, "Module name is not well formed")
+            ParseError::ExportNameNotWellFormed => {
+                write!(f, "Exported name is not well formed")
             }
-            ParseError::ModuleNameIsReservedWord => {
-                write!(f, "Module name is a reserved word")
+            ParseError::DirectExportNameIsString => {
+                write!(f, "String export names are only allowed when there is a `from` clause")
             }
             ParseError::UnexpectedRegExpToken => {
                 write!(f, "Unexpected token")

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -1054,7 +1054,7 @@ impl<'a> Printer<'a> {
 
     fn print_import_named_specifier(&mut self, spec: &ImportNamedSpecifier) {
         self.start_node("ImportSpecifier", &spec.loc);
-        self.property("imported", spec.imported.as_ref(), Printer::print_optional_module_name);
+        self.property("imported", spec.imported.as_ref(), Printer::print_optional_export_name);
         self.property("local", spec.local.as_ref(), Printer::print_identifier);
         self.end_node();
     }
@@ -1099,22 +1099,22 @@ impl<'a> Printer<'a> {
 
     fn print_export_all_declaration(&mut self, export: &ExportAllDeclaration) {
         self.start_node("ExportAllDeclaration", &export.loc);
-        self.property("exported", export.exported.as_ref(), Printer::print_optional_module_name);
+        self.property("exported", export.exported.as_ref(), Printer::print_optional_export_name);
         self.property("source", export.source.as_ref(), Printer::print_string_literal);
         self.end_node();
     }
 
     fn print_export_specifier(&mut self, spec: &ExportSpecifier) {
         self.start_node("ExportSpecifier", &spec.loc);
-        self.property("exported", spec.exported.as_ref(), Printer::print_optional_module_name);
-        self.property("local", spec.local.as_ref(), Printer::print_identifier);
+        self.property("exported", spec.exported.as_ref(), Printer::print_optional_export_name);
+        self.property("local", spec.local.as_ref(), Printer::print_export_name);
         self.end_node();
     }
 
-    fn print_module_name(&mut self, module_name: &ModuleName) {
-        match module_name {
-            ModuleName::Id(id) => self.print_identifier_parts(&id.loc, &id.name),
-            ModuleName::String(lit) => self.print_string_literal(lit),
+    fn print_export_name(&mut self, export_name: &ExportName) {
+        match export_name {
+            ExportName::Id(id) => self.print_identifier_parts(&id.loc, &id.name),
+            ExportName::String(lit) => self.print_string_literal(lit),
         }
     }
 
@@ -1195,10 +1195,10 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn print_optional_module_name(&mut self, module_name: Option<&P<ModuleName>>) {
-        match module_name {
+    fn print_optional_export_name(&mut self, export_name: Option<&P<ExportName>>) {
+        match export_name {
             None => self.print_null(),
-            Some(module_name) => self.print_module_name(module_name),
+            Some(export_name) => self.print_export_name(export_name),
         }
     }
 

--- a/tests/js_parser/module/export.exp
+++ b/tests/js_parser/module/export.exp
@@ -1,6 +1,6 @@
 {
   type: "Program",
-  loc: "1:0-28:29",
+  loc: "1:0-34:29",
   body: [
     {
       type: "ExportNamedDeclaration",
@@ -202,20 +202,20 @@
     },
     {
       type: "ExportNamedDeclaration",
-      loc: "12:0-12:18",
+      loc: "13:0-13:18",
       declaration: null,
       specifiers: [
         {
           type: "ExportSpecifier",
-          loc: "12:8-12:16",
+          loc: "13:8-13:16",
           exported: {
             type: "Literal",
-            loc: "12:13-12:16",
+            loc: "13:13-13:16",
             value: "b",
           },
           local: {
             type: "Identifier",
-            loc: "12:8-12:9",
+            loc: "13:8-13:9",
             name: "a",
           },
         },
@@ -225,22 +225,96 @@
     {
       type: "ExportNamedDeclaration",
       loc: "14:0-14:17",
+      declaration: null,
+      specifiers: [
+        {
+          type: "ExportSpecifier",
+          loc: "14:8-14:15",
+          exported: {
+            type: "Identifier",
+            loc: "14:13-14:15",
+            name: "if",
+          },
+          local: {
+            type: "Identifier",
+            loc: "14:8-14:9",
+            name: "a",
+          },
+        },
+      ],
+      source: null,
+    },
+    {
+      type: "ExportNamedDeclaration",
+      loc: "17:0-17:33",
+      declaration: null,
+      specifiers: [
+        {
+          type: "ExportSpecifier",
+          loc: "17:8-17:18",
+          exported: {
+            type: "Literal",
+            loc: "17:15-17:18",
+            value: "b",
+          },
+          local: {
+            type: "Literal",
+            loc: "17:8-17:11",
+            value: "a",
+          },
+        },
+      ],
+      source: {
+        type: "Literal",
+        loc: "17:25-17:32",
+        value: "other",
+      },
+    },
+    {
+      type: "ExportNamedDeclaration",
+      loc: "18:0-18:31",
+      declaration: null,
+      specifiers: [
+        {
+          type: "ExportSpecifier",
+          loc: "18:8-18:16",
+          exported: {
+            type: "Identifier",
+            loc: "18:14-18:16",
+            name: "if",
+          },
+          local: {
+            type: "Identifier",
+            loc: "18:8-18:10",
+            name: "if",
+          },
+        },
+      ],
+      source: {
+        type: "Literal",
+        loc: "18:23-18:30",
+        value: "other",
+      },
+    },
+    {
+      type: "ExportNamedDeclaration",
+      loc: "20:0-20:17",
       declaration: {
         type: "VariableDeclaration",
-        loc: "14:7-14:17",
+        loc: "20:7-20:17",
         kind: "var",
         declarations: [
           {
             type: "VariableDeclarator",
-            loc: "14:11-14:16",
+            loc: "20:11-20:16",
             id: {
               type: "Identifier",
-              loc: "14:11-14:12",
+              loc: "20:11-20:12",
               name: "a",
             },
             init: {
               type: "Literal",
-              loc: "14:15-14:16",
+              loc: "20:15-20:16",
               value: 1,
             },
           },
@@ -251,23 +325,23 @@
     },
     {
       type: "ExportNamedDeclaration",
-      loc: "15:0-15:18",
+      loc: "21:0-21:18",
       declaration: {
         type: "VariableDeclaration",
-        loc: "15:7-15:18",
+        loc: "21:7-21:18",
         kind: "let",
         declarations: [
           {
             type: "VariableDeclarator",
-            loc: "15:11-15:17",
+            loc: "21:11-21:17",
             id: {
               type: "Identifier",
-              loc: "15:11-15:13",
+              loc: "21:11-21:13",
               name: "a2",
             },
             init: {
               type: "Literal",
-              loc: "15:16-15:17",
+              loc: "21:16-21:17",
               value: 1,
             },
           },
@@ -278,23 +352,23 @@
     },
     {
       type: "ExportNamedDeclaration",
-      loc: "16:0-16:20",
+      loc: "22:0-22:20",
       declaration: {
         type: "VariableDeclaration",
-        loc: "16:7-16:20",
+        loc: "22:7-22:20",
         kind: "const",
         declarations: [
           {
             type: "VariableDeclarator",
-            loc: "16:13-16:19",
+            loc: "22:13-22:19",
             id: {
               type: "Identifier",
-              loc: "16:13-16:15",
+              loc: "22:13-22:15",
               name: "a3",
             },
             init: {
               type: "Literal",
-              loc: "16:18-16:19",
+              loc: "22:18-22:19",
               value: 1,
             },
           },
@@ -305,34 +379,34 @@
     },
     {
       type: "ExportNamedDeclaration",
-      loc: "17:0-17:26",
+      loc: "23:0-23:26",
       declaration: {
         type: "VariableDeclaration",
-        loc: "17:7-17:26",
+        loc: "23:7-23:26",
         kind: "const",
         declarations: [
           {
             type: "VariableDeclarator",
-            loc: "17:13-17:25",
+            loc: "23:13-23:25",
             id: {
               type: "ArrayPattern",
-              loc: "17:13-17:21",
+              loc: "23:13-23:21",
               elements: [
                 {
                   type: "Identifier",
-                  loc: "17:14-17:16",
+                  loc: "23:14-23:16",
                   name: "a4",
                 },
                 {
                   type: "Identifier",
-                  loc: "17:18-17:20",
+                  loc: "23:18-23:20",
                   name: "b5",
                 },
               ],
             },
             init: {
               type: "Literal",
-              loc: "17:24-17:25",
+              loc: "23:24-23:25",
               value: 1,
             },
           },
@@ -343,19 +417,19 @@
     },
     {
       type: "ExportNamedDeclaration",
-      loc: "19:0-19:17",
+      loc: "25:0-25:17",
       declaration: {
         type: "ClassDeclaration",
-        loc: "19:7-19:17",
+        loc: "25:7-25:17",
         id: {
           type: "Identifier",
-          loc: "19:13-19:14",
+          loc: "25:13-25:14",
           name: "C",
         },
         superClass: null,
         body: {
           type: "ClassBody",
-          loc: "19:7-19:17",
+          loc: "25:7-25:17",
           body: [],
         },
       },
@@ -364,23 +438,23 @@
     },
     {
       type: "EmptyStatement",
-      loc: "19:17-19:18",
+      loc: "25:17-25:18",
     },
     {
       type: "ExportNamedDeclaration",
-      loc: "21:0-21:24",
+      loc: "27:0-27:24",
       declaration: {
         type: "FunctionDeclaration",
-        loc: "21:7-21:24",
+        loc: "27:7-27:24",
         id: {
           type: "Identifier",
-          loc: "21:16-21:19",
+          loc: "27:16-27:19",
           name: "foo",
         },
         params: [],
         body: {
           type: "Block",
-          loc: "21:22-21:24",
+          loc: "27:22-27:24",
           body: [],
         },
         async: false,
@@ -392,19 +466,19 @@
     },
     {
       type: "ExportNamedDeclaration",
-      loc: "22:0-22:31",
+      loc: "28:0-28:31",
       declaration: {
         type: "FunctionDeclaration",
-        loc: "22:7-22:31",
+        loc: "28:7-28:31",
         id: {
           type: "Identifier",
-          loc: "22:22-22:26",
+          loc: "28:22-28:26",
           name: "foo2",
         },
         params: [],
         body: {
           type: "Block",
-          loc: "22:29-22:31",
+          loc: "28:29-28:31",
           body: [],
         },
         async: true,
@@ -416,48 +490,48 @@
     },
     {
       type: "ExportDefaultDeclaration",
-      loc: "24:0-24:18",
+      loc: "30:0-30:18",
       declaration: {
         type: "Identifier",
-        loc: "24:15-24:17",
+        loc: "30:15-30:17",
         name: "a6",
       },
     },
     {
       type: "ExportAllDeclaration",
-      loc: "26:0-26:22",
+      loc: "32:0-32:22",
       exported: null,
       source: {
         type: "Literal",
-        loc: "26:14-26:21",
+        loc: "32:14-32:21",
         value: "other",
       },
     },
     {
       type: "ExportAllDeclaration",
-      loc: "27:0-27:27",
+      loc: "33:0-33:27",
       exported: {
         type: "Identifier",
-        loc: "27:12-27:13",
+        loc: "33:12-33:13",
         name: "a",
       },
       source: {
         type: "Literal",
-        loc: "27:19-27:26",
+        loc: "33:19-33:26",
         value: "other",
       },
     },
     {
       type: "ExportAllDeclaration",
-      loc: "28:0-28:29",
+      loc: "34:0-34:29",
       exported: {
         type: "Literal",
-        loc: "28:12-28:15",
+        loc: "34:12-34:15",
         value: "a",
       },
       source: {
         type: "Literal",
-        loc: "28:21-28:28",
+        loc: "34:21-34:28",
         value: "other",
       },
     },

--- a/tests/js_parser/module/export.js
+++ b/tests/js_parser/module/export.js
@@ -9,7 +9,13 @@ export {a} from 'b'
 
 export {a as b, c, d as e}
 
+// Strings and reserved words allowed as exported name
 export {a as 'b'};
+export {a as if};
+
+// Strings and reserved words are allowed as both local and exported names when `from` clause is present
+export {'a' as 'b'} from 'other';
+export {if as if} from 'other';
 
 export var a = 1;
 export let a2 = 1;


### PR DESCRIPTION
## Summary

Export specifiers should always allow string literals and reserved words as the ExportName except for local names in export declarations without a `from` clause. This means that the local name of export specifiers can now be a string literal or reserved word for re-export declarations.

Also renamed the ModuleName AST node to ExportName for clarity.

## Tests

Added parser snapshot tests for the newly allowed ExportNames.