### PR TITLE
[runtime] Fix misc module bugs

### DIFF
--- a/src/js/runtime/intrinsics/aggregate_error_constructor.rs
+++ b/src/js/runtime/intrinsics/aggregate_error_constructor.rs
@@ -1,27 +1,23 @@
 use crate::{
-    js::{
-        parser::LocalizedParseErrors,
-        runtime::{
-            abstract_operations::{
-                create_data_property_or_throw, create_non_enumerable_data_property_or_throw,
-                define_property_or_throw,
-            },
-            array_object::create_array_from_list,
-            builtin_function::BuiltinFunction,
-            completion::EvalResult,
-            error::syntax_error_value,
-            function::get_argument,
-            intrinsics::error_constructor::install_error_cause,
-            iterator::iter_iterator_values,
-            object_descriptor::ObjectKind,
-            object_value::ObjectValue,
-            ordinary_object::{object_create, object_create_from_constructor},
-            property_descriptor::PropertyDescriptor,
-            realm::Realm,
-            stack_trace::attach_stack_trace_to_error,
-            type_utilities::to_string,
-            Context, Handle, Value,
+    js::runtime::{
+        abstract_operations::{
+            create_data_property_or_throw, create_non_enumerable_data_property_or_throw,
+            define_property_or_throw,
         },
+        array_object::create_array_from_list,
+        builtin_function::BuiltinFunction,
+        completion::EvalResult,
+        function::get_argument,
+        intrinsics::error_constructor::install_error_cause,
+        iterator::iter_iterator_values,
+        object_descriptor::ObjectKind,
+        object_value::ObjectValue,
+        ordinary_object::{object_create, object_create_from_constructor},
+        property_descriptor::PropertyDescriptor,
+        realm::Realm,
+        stack_trace::attach_stack_trace_to_error,
+        type_utilities::to_string,
+        Context, Handle, Value,
     },
     maybe, must,
 };
@@ -59,21 +55,6 @@ impl AggregateErrorObject {
         attach_stack_trace_to_error(cx, object, /* skip_current_frame */ true);
 
         object
-    }
-
-    pub fn new_from_localized_parse_errors(
-        cx: Context,
-        errors: &LocalizedParseErrors,
-    ) -> Handle<ErrorObject> {
-        let error_values = errors
-            .errors
-            .iter()
-            .map(|error| syntax_error_value(cx, &error.to_string()))
-            .collect::<Vec<_>>();
-
-        let errors_array = create_array_from_list(cx, &error_values);
-
-        Self::new(cx, errors_array.into())
     }
 }
 

--- a/src/js/runtime/module/loader.rs
+++ b/src/js/runtime/module/loader.rs
@@ -11,9 +11,7 @@ use crate::{
             bytecode::generator::BytecodeProgramGenerator,
             completion::EvalResult,
             error::syntax_error,
-            intrinsics::{
-                aggregate_error_constructor::AggregateErrorObject, intrinsics::Intrinsic,
-            },
+            intrinsics::intrinsics::Intrinsic,
             promise_object::{PromiseCapability, PromiseObject},
             string_value::FlatString,
             Context, Handle, Realm,
@@ -123,8 +121,7 @@ impl GraphLoader {
 
         // Analyze AST
         if let Err(parse_errors) = analyze(&mut parse_result) {
-            let error = AggregateErrorObject::new_from_localized_parse_errors(cx, &parse_errors);
-            return EvalResult::Throw(error.into());
+            return syntax_error(cx, &parse_errors.errors[0].to_string());
         }
 
         if cx.options.print_ast {


### PR DESCRIPTION
## Summary

Fix all remaining known bugs with modules. Now only top-level-await, dynamic import, and import.meta tests are failing.

- Return single SyntaxError instead of AggregateError if analysis fails during loading
- Fix namespace object creation to visit multiple export star declarations