### PR TITLE
[parser] Allow meta properties and super properties as callee in new expression

### DIFF
--- a/tests/js_parser/expression/new.exp
+++ b/tests/js_parser/expression/new.exp
@@ -1,6 +1,6 @@
 {
   type: "Program",
-  loc: "1:0-25:10",
+  loc: "1:0-30:14",
   body: [
     {
       type: "ExpressionStatement",
@@ -313,6 +313,75 @@
         },
         computed: false,
         optional: false,
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "28:0-28:16",
+      kind: {
+        type: "NewExpression",
+        loc: "28:0-28:15",
+        callee: {
+          type: "MetaProperty",
+          loc: "28:4-28:15",
+          meta: {
+            type: "Identifier",
+            loc: "28:4-28:15",
+            name: "import",
+          },
+          property: {
+            type: "Identifier",
+            loc: "28:4-28:15",
+            name: "meta",
+          },
+        },
+        arguments: [],
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "29:0-29:15",
+      kind: {
+        type: "NewExpression",
+        loc: "29:0-29:14",
+        callee: {
+          type: "MetaProperty",
+          loc: "29:4-29:14",
+          meta: {
+            type: "Identifier",
+            loc: "29:4-29:14",
+            name: "new",
+          },
+          property: {
+            type: "Identifier",
+            loc: "29:4-29:14",
+            name: "target",
+          },
+        },
+        arguments: [],
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "30:0-30:14",
+      kind: {
+        type: "NewExpression",
+        loc: "30:0-30:13",
+        callee: {
+          type: "MemberExpression",
+          loc: "30:4-30:13",
+          object: {
+            type: "Super",
+            loc: "30:4-30:9",
+          },
+          property: {
+            type: "Identifier",
+            loc: "30:10-30:13",
+            name: "foo",
+          },
+          computed: false,
+        },
+        arguments: [],
       },
     },
   ],

--- a/tests/js_parser/expression/new.js
+++ b/tests/js_parser/expression/new.js
@@ -23,3 +23,8 @@ new new a;
 new new a();
 
 new a().b;
+
+// Meta properties and super properties are allowed as MemberExpressions
+new import.meta;
+new new.target;
+new super.foo;


### PR DESCRIPTION
## Summary

The callee in a new expression should be a MemberExpression, however we were failing to parse meta properties and super properties even though they are MemberExpressions. We should parse these property expression but not import expressions or super calls.

## Tests

Added parser snapshot tests for meta and super properties in a new expression.