### PR TITLE
[parser][bytecode] Implement import.meta expressions

### DIFF
--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -40,6 +40,7 @@ pub enum ParseError {
     IdentifierIsReservedWord,
     ExpectedNewTarget,
     ExpectedImportMeta,
+    ImportMetaOutsideModule,
     ExponentLHSUnary,
     TaggedTemplateInChain,
     NullishCoalesceMixedWithLogical,
@@ -209,6 +210,9 @@ impl fmt::Display for ParseError {
             }
             ParseError::ExpectedImportMeta => {
                 write!(f, "Expected import.meta")
+            }
+            ParseError::ImportMetaOutsideModule => {
+                write!(f, "import.meta is only allowed in modules")
             }
             ParseError::ExponentLHSUnary => {
                 write!(

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1205,6 +1205,11 @@ define_instructions!(
         [0] promise: Register,
         [1] value: Register,
     }
+
+    /// Load the `import.meta` object into dest.
+    ImportMeta(ImportMetaInstruction, import_meta_instruction) {
+        [0] dest: Register,
+    }
 );
 
 bitflags! {

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -15,6 +15,7 @@ use crate::{
         module::module_namespace_object::ModuleNamespaceObject,
         object_descriptor::{ObjectDescriptor, ObjectKind},
         object_value::ObjectValue,
+        ordinary_object::object_create_with_optional_proto,
         promise_object::PromiseCapability,
         scope::Scope,
         string_value::FlatString,
@@ -587,6 +588,22 @@ impl Handle<SourceTextModule> {
         self.namespace_object = Some(namespace_object);
 
         namespace_object
+    }
+
+    /// Returns the `import.meta` object for this module. Lazily creates and caches the object when
+    /// first accessed.
+    pub fn get_import_meta_object(&mut self, cx: Context) -> HeapPtr<ObjectValue> {
+        if let Some(import_meta) = self.import_meta {
+            return import_meta;
+        }
+
+        // No properties are added to the `import.meta` object - this is up to the implementation
+        let object =
+            object_create_with_optional_proto::<ObjectValue>(cx, ObjectKind::OrdinaryObject, None);
+
+        self.import_meta = Some(object);
+
+        object
     }
 }
 

--- a/src/js/runtime/scope.rs
+++ b/src/js/runtime/scope.rs
@@ -7,6 +7,7 @@ use super::{
     error::{err_assign_constant, err_cannot_set_property},
     gc::{HeapObject, HeapVisitor},
     get,
+    module::source_text_module::SourceTextModule,
     object_descriptor::ObjectDescriptor,
     object_value::ObjectValue,
     ordinary_object::ordinary_object_create,
@@ -161,6 +162,15 @@ impl Scope {
     pub fn global_scope_realm(&mut self) -> HeapPtr<Realm> {
         debug_assert!(self.kind == ScopeKind::Global);
         self.get_slot(0).as_pointer().cast::<Realm>()
+    }
+
+    /// Return the module stored in this module scope.
+    ///
+    /// Should only be called on module scopes.
+    #[inline]
+    pub fn module_scope_module(&mut self) -> HeapPtr<SourceTextModule> {
+        debug_assert!(self.kind == ScopeKind::Module);
+        self.get_slot(0).as_pointer().cast::<SourceTextModule>()
     }
 }
 

--- a/tests/js_bytecode/module/import_meta.exp
+++ b/tests/js_bytecode/module/import_meta.exp
@@ -1,0 +1,8 @@
+[BytecodeFunction: <module>] {
+  Parameters: 0, Registers: 2
+     0: ImportMeta r0
+     2: LoadImmediate r1, 1
+     5: Add r0, r0, r1
+     9: LoadUndefined r0
+    11: Ret r0
+}

--- a/tests/js_bytecode/module/import_meta.js
+++ b/tests/js_bytecode/module/import_meta.js
@@ -1,0 +1,1 @@
+import.meta + 1;

--- a/tests/js_parser/expression/meta_property.exp
+++ b/tests/js_parser/expression/meta_property.exp
@@ -1,6 +1,6 @@
 {
   type: "Program",
-  loc: "1:0-3:12",
+  loc: "1:0-1:11",
   body: [
     {
       type: "ExpressionStatement",
@@ -17,24 +17,6 @@
           type: "Identifier",
           loc: "1:0-1:10",
           name: "target",
-        },
-      },
-    },
-    {
-      type: "ExpressionStatement",
-      loc: "3:0-3:12",
-      kind: {
-        type: "MetaProperty",
-        loc: "3:0-3:11",
-        meta: {
-          type: "Identifier",
-          loc: "3:0-3:11",
-          name: "import",
-        },
-        property: {
-          type: "Identifier",
-          loc: "3:0-3:11",
-          name: "meta",
         },
       },
     },

--- a/tests/js_parser/expression/meta_property.js
+++ b/tests/js_parser/expression/meta_property.js
@@ -1,3 +1,1 @@
 new.target;
-
-import.meta;

--- a/tests/js_parser/expression/new.exp
+++ b/tests/js_parser/expression/new.exp
@@ -1,6 +1,6 @@
 {
   type: "Program",
-  loc: "1:0-30:14",
+  loc: "1:0-29:14",
   body: [
     {
       type: "ExpressionStatement",
@@ -317,44 +317,21 @@
     },
     {
       type: "ExpressionStatement",
-      loc: "28:0-28:16",
+      loc: "28:0-28:15",
       kind: {
         type: "NewExpression",
-        loc: "28:0-28:15",
+        loc: "28:0-28:14",
         callee: {
           type: "MetaProperty",
-          loc: "28:4-28:15",
+          loc: "28:4-28:14",
           meta: {
             type: "Identifier",
-            loc: "28:4-28:15",
-            name: "import",
-          },
-          property: {
-            type: "Identifier",
-            loc: "28:4-28:15",
-            name: "meta",
-          },
-        },
-        arguments: [],
-      },
-    },
-    {
-      type: "ExpressionStatement",
-      loc: "29:0-29:15",
-      kind: {
-        type: "NewExpression",
-        loc: "29:0-29:14",
-        callee: {
-          type: "MetaProperty",
-          loc: "29:4-29:14",
-          meta: {
-            type: "Identifier",
-            loc: "29:4-29:14",
+            loc: "28:4-28:14",
             name: "new",
           },
           property: {
             type: "Identifier",
-            loc: "29:4-29:14",
+            loc: "28:4-28:14",
             name: "target",
           },
         },
@@ -363,20 +340,20 @@
     },
     {
       type: "ExpressionStatement",
-      loc: "30:0-30:14",
+      loc: "29:0-29:14",
       kind: {
         type: "NewExpression",
-        loc: "30:0-30:13",
+        loc: "29:0-29:13",
         callee: {
           type: "MemberExpression",
-          loc: "30:4-30:13",
+          loc: "29:4-29:13",
           object: {
             type: "Super",
-            loc: "30:4-30:9",
+            loc: "29:4-29:9",
           },
           property: {
             type: "Identifier",
-            loc: "30:10-30:13",
+            loc: "29:10-29:13",
             name: "foo",
           },
           computed: false,

--- a/tests/js_parser/expression/new.js
+++ b/tests/js_parser/expression/new.js
@@ -25,6 +25,5 @@ new new a();
 new a().b;
 
 // Meta properties and super properties are allowed as MemberExpressions
-new import.meta;
 new new.target;
 new super.foo;

--- a/tests/js_parser/module/import_meta.exp
+++ b/tests/js_parser/module/import_meta.exp
@@ -1,0 +1,191 @@
+{
+  type: "Program",
+  loc: "1:0-16:1",
+  body: [
+    {
+      type: "ExpressionStatement",
+      loc: "2:0-2:12",
+      kind: {
+        type: "MetaProperty",
+        loc: "2:0-2:11",
+        meta: {
+          type: "Identifier",
+          loc: "2:0-2:11",
+          name: "import",
+        },
+        property: {
+          type: "Identifier",
+          loc: "2:0-2:11",
+          name: "meta",
+        },
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "3:0-3:11",
+      kind: {
+        type: "MetaProperty",
+        loc: "3:0-3:11",
+        meta: {
+          type: "Identifier",
+          loc: "3:0-3:11",
+          name: "import",
+        },
+        property: {
+          type: "Identifier",
+          loc: "3:0-3:11",
+          name: "meta",
+        },
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "6:0-6:15",
+      kind: {
+        type: "CallExpression",
+        loc: "6:0-6:14",
+        callee: {
+          type: "MetaProperty",
+          loc: "6:0-6:11",
+          meta: {
+            type: "Identifier",
+            loc: "6:0-6:11",
+            name: "import",
+          },
+          property: {
+            type: "Identifier",
+            loc: "6:0-6:11",
+            name: "meta",
+          },
+        },
+        arguments: [
+          {
+            type: "Literal",
+            loc: "6:12-6:13",
+            value: 1,
+          },
+        ],
+        optional: false,
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "7:0-7:16",
+      kind: {
+        type: "BinaryExpression",
+        loc: "7:0-7:15",
+        operator: "+",
+        left: {
+          type: "MetaProperty",
+          loc: "7:0-7:11",
+          meta: {
+            type: "Identifier",
+            loc: "7:0-7:11",
+            name: "import",
+          },
+          property: {
+            type: "Identifier",
+            loc: "7:0-7:11",
+            name: "meta",
+          },
+        },
+        right: {
+          type: "Literal",
+          loc: "7:14-7:15",
+          value: 1,
+        },
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "8:0-8:16",
+      kind: {
+        type: "MemberExpression",
+        loc: "8:0-8:15",
+        object: {
+          type: "MetaProperty",
+          loc: "8:0-8:11",
+          meta: {
+            type: "Identifier",
+            loc: "8:0-8:11",
+            name: "import",
+          },
+          property: {
+            type: "Identifier",
+            loc: "8:0-8:11",
+            name: "meta",
+          },
+        },
+        property: {
+          type: "Identifier",
+          loc: "8:12-8:15",
+          name: "foo",
+        },
+        computed: false,
+        optional: false,
+      },
+    },
+    {
+      type: "FunctionDeclaration",
+      loc: "10:0-16:1",
+      id: {
+        type: "Identifier",
+        loc: "10:9-10:13",
+        name: "test",
+      },
+      params: [],
+      body: {
+        type: "Block",
+        loc: "10:16-16:1",
+        body: [
+          {
+            type: "ExpressionStatement",
+            loc: "12:2-12:14",
+            kind: {
+              type: "MetaProperty",
+              loc: "12:2-12:13",
+              meta: {
+                type: "Identifier",
+                loc: "12:2-12:13",
+                name: "import",
+              },
+              property: {
+                type: "Identifier",
+                loc: "12:2-12:13",
+                name: "meta",
+              },
+            },
+          },
+          {
+            type: "ExpressionStatement",
+            loc: "15:2-15:18",
+            kind: {
+              type: "NewExpression",
+              loc: "15:2-15:17",
+              callee: {
+                type: "MetaProperty",
+                loc: "15:6-15:17",
+                meta: {
+                  type: "Identifier",
+                  loc: "15:6-15:17",
+                  name: "import",
+                },
+                property: {
+                  type: "Identifier",
+                  loc: "15:6-15:17",
+                  name: "meta",
+                },
+              },
+              arguments: [],
+            },
+          },
+        ],
+      },
+      async: false,
+      generator: false,
+      has_use_strict_directive: false,
+    },
+  ],
+  sourceType: "module",
+  has_use_strict_directive: false,
+}

--- a/tests/js_parser/module/import_meta.js
+++ b/tests/js_parser/module/import_meta.js
@@ -1,0 +1,16 @@
+// Parse in toplevel position
+import.meta;
+import.meta
+
+// Parse when start of expression
+import.meta(1);
+import.meta + 1;
+import.meta.foo;
+
+function test() {
+  // Parse in expression position
+  import.meta;
+
+  // Meta properties are allowed as MemberExpressions
+  new import.meta;
+}


### PR DESCRIPTION
## Summary

Implement `import.meta` expressions, adding a new bytecode instruction which lazily generates the `import.meta` object for a module. Currently the `import.meta` object doesn't have any properties, as this is implementation defined.

Also fix parsing of `import.meta` and import expressions at the toplevel. If we see an `import` keyword followed by a period or left paren then defer to regular expression parsing instead of having custom parsing code, since the custom code did not properly handle more complex expressions.

## Tests

Add parser and bytecode snapshot tests for `import.meta` expressions.