### PR TITLE
[runtime] Fix remaining dynamic import bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ For more information on testing see the [testing README](./tests/README.md).
 
 All features up to ES2024 have been implemented (as well as all stage 4 proposals as of 2024-09-15), except for the following features:
 
-- ECMAScript modules (next up)
 - UnicodeSets proposal
 - SharedArrayBuffer
 - Atomics

--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -520,7 +520,7 @@ pub fn format_localized_parse_errors(errors: &[LocalizedParseError]) -> String {
     // Sort errors with locs
     errors_with_loc.sort_by(|a, b| {
         a.1.file_path()
-            .cmp(&b.1.file_path())
+            .cmp(b.1.file_path())
             .then_with(|| a.2.cmp(&b.2))
             .then_with(|| a.3.cmp(&b.3))
     });

--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -456,7 +456,7 @@ impl fmt::Display for LocalizedParseError {
             Some((loc, source)) => {
                 let offsets = source.line_offsets();
                 let (line, col) = find_line_col_for_pos(loc.start, offsets);
-                write!(f, "SyntaxError: {}:{}:{} {}", source.file_path, line, col, self.error)
+                write!(f, "SyntaxError: {}:{}:{} {}", source.display_name(), line, col, self.error)
             }
         }
     }
@@ -519,8 +519,8 @@ pub fn format_localized_parse_errors(errors: &[LocalizedParseError]) -> String {
 
     // Sort errors with locs
     errors_with_loc.sort_by(|a, b| {
-        a.1.file_path
-            .cmp(&b.1.file_path)
+        a.1.file_path()
+            .cmp(&b.1.file_path())
             .then_with(|| a.2.cmp(&b.2))
             .then_with(|| a.3.cmp(&b.3))
     });

--- a/src/js/runtime/eval/eval.rs
+++ b/src/js/runtime/eval/eval.rs
@@ -44,8 +44,11 @@ pub fn perform_eval(
 
     let private_names = get_private_names_from_scopes(direct_scope.map(|s| s.get_()));
 
+    // Use the file path of the active source file
+    let file_path = cx.vm().current_source_file().path().to_string();
+
     // Parse source code
-    let source = match Source::new_from_wtf8_string("<eval>", code.to_wtf8_string()) {
+    let source = match Source::new_for_eval(file_path, code.to_wtf8_string()) {
         Ok(source) => Rc::new(source),
         Err(error) => return syntax_error(cx, &error.to_string()),
     };

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -375,7 +375,7 @@ impl SourceTextModule {
 
     pub fn source_file_path(&self) -> Handle<FlatString> {
         let source_file = self.program_function_ptr().source_file_ptr().unwrap();
-        source_file.name()
+        source_file.path()
     }
 }
 

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -77,7 +77,7 @@ pub struct SourceTextModule {
     entries: InlineArray<ModuleEntry>,
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ModuleState {
     New,
     Unlinked,

--- a/src/js/runtime/source_file.rs
+++ b/src/js/runtime/source_file.rs
@@ -33,9 +33,9 @@ type LineOffsetArray = BsArray<u32>;
 impl SourceFile {
     #[inline]
     pub fn new(mut cx: Context, source: &Source) -> Handle<SourceFile> {
-        let path = cx.alloc_string(&source.file_path());
+        let path = cx.alloc_string(source.file_path());
         let display_name = if source.has_display_name() {
-            Some(cx.alloc_string(&source.display_name()))
+            Some(cx.alloc_string(source.display_name()))
         } else {
             None
         };

--- a/src/js/runtime/stack_trace.rs
+++ b/src/js/runtime/stack_trace.rs
@@ -50,7 +50,7 @@ pub fn attach_stack_trace_to_error(
         stack_trace.push_str(" (");
 
         // Followed by the file where the function was defined
-        if let Some(file_name) = func.source_file_ptr().map(|file| file.name()) {
+        if let Some(file_name) = func.source_file_ptr().map(|file| file.display_name()) {
             stack_trace.push_str(&file_name.to_string());
         } else {
             stack_trace.push_str("<native>");

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -149,10 +149,11 @@ impl Test262Object {
             return type_error(cx, "expected string");
         }
 
-        let source = match Source::new_from_wtf8_string(
-            "<eval>",
-            script_text.as_string().to_wtf8_string(),
-        ) {
+        // Use the file path of the active source file
+        let file_path = cx.vm().current_source_file().path().to_string();
+
+        let source = match Source::new_for_eval(file_path, script_text.as_string().to_wtf8_string())
+        {
             Ok(source) => Rc::new(source),
             Err(error) => return syntax_error(cx, &error.to_string()),
         };

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -105,10 +105,6 @@
   // Tests for unimplemented features. Counts against test262 progress.
   "unimplemented": {
     "features": [
-      // Features requiring modules to be implemented
-      "import.meta",
-      "top-level-await",
-      "dynamic-import",
       // Other unimplemented features
       "regexp-v-flag",
       "SharedArrayBuffer",


### PR DESCRIPTION
## Summary

Fix all known remaining dynamic import bugs. With this PR modules have been fully implemented, with all test262 tests passing.

- Dynamic import inside an eval should use it's creator's script or module as the base path when resolving specifiers. This requires passing the parent path through when creating the Source for an eval. We also separate out the display name from the path to continue displaying the eval source as "\<eval\>".
- Work around a [spec bug](https://github.com/tc39/ecma262/issues/2823) where the import of a module whose evaluation had previously thrown an error failed. This was because the call to Evaluate for an already evaluated module expects the modules's [[CycleRoot]] to be set, but [[CycleRoot]] is not set if the module had an evaluation error. The only place this can currently happen is in dynamic imports, so check for an already evaluated module with an evaluation error before calling Evaluate.

## Tests

Fixes the following tests. Now all test262 module tests pass.

- `language/expressions/dynamic-import/for-await-resolution-and-error-agen-yield.js`
- `language/expressions/dynamic-import/usage-from-eval.js`