### PR TITLE
[tests] Enable modules when reporting test262 progress, update test262 progress on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Brimstone is a JavaScript engine written from scratch in Rust, aiming to have full support for the JavaScript language.
 
-Brimstone is a work in progress but already supports most of the JavaScript language (>94% of the ECMAScript language in test262). Not ready for use in production.
+Brimstone is a work in progress but already supports almost all of the JavaScript language (>97% of the ECMAScript language in test262). Not ready for use in production.
 
 Implements the [ECMAScript specification](https://tc39.es/ecma262/). Heavy inspiration is taken from the design of [V8](https://v8.dev/) and SerenityOS's [LibJS](https://github.com/LadybirdBrowser/ladybird). Brimstone chooses to implement almost all components of the engine from scratch with minimal dependencies, with the notable exception of [ICU4X](https://github.com/unicode-org/icu4x).
 

--- a/tests/test262/README.md
+++ b/tests/test262/README.md
@@ -18,7 +18,7 @@ Install the test262 repo at the pinned commit by running the following script:
 
 The test runner is run with `cargo run` in this directory. Run `cargo run -- --help` to see the full set of options for the test runner.
 
-Before running any tests, the test runner must first create an index of the test262 tests for fast consumption later on. This only needs to be run after you pull in a new version of the test272 repo.:
+Before running any tests, the test runner must first create an index of the test262 tests for fast consumption later on. This only needs to be run after you pull in a new version of the test262 repo.:
 
 ```
 cargo run -- --reindex


### PR DESCRIPTION
## Summary

Now that modules have been implemented we can stop counting them as failures when reporting test262 progress. When running `cargo run -- --report-test262-progress` we now have 97.66% test262 compliance!

Update the README with the latest test262 progress numbers.