### PR TITLE
[runtime] Fix message of SyntaxError object created from LocalizedParseError

### DIFF
--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -445,20 +445,25 @@ impl LocalizedParseError {
     pub fn new_without_loc(error: ParseError) -> LocalizedParseError {
         LocalizedParseError { error, source_loc: None }
     }
+
+    /// Format as a string to display to the user without the "SyntaxError:" prefix
+    pub fn to_string_without_name(&self) -> String {
+        match &self.source_loc {
+            None => self.error.to_string(),
+            Some((loc, source)) => {
+                let offsets = source.line_offsets();
+                let (line, col) = find_line_col_for_pos(loc.start, offsets);
+                format!("{}:{}:{} {}", source.display_name(), line, col, self.error)
+            }
+        }
+    }
 }
 
 impl Error for LocalizedParseError {}
 
 impl fmt::Display for LocalizedParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match &self.source_loc {
-            None => write!(f, "SyntaxError: {}", self.error),
-            Some((loc, source)) => {
-                let offsets = source.line_offsets();
-                let (line, col) = find_line_col_for_pos(loc.start, offsets);
-                write!(f, "SyntaxError: {}:{}:{} {}", source.display_name(), line, col, self.error)
-            }
-        }
+        write!(f, "SyntaxError: {}", self.to_string_without_name())
     }
 }
 

--- a/src/js/runtime/error.rs
+++ b/src/js/runtime/error.rs
@@ -1,4 +1,4 @@
-use crate::js::common::error::print_error_message_and_exit;
+use crate::js::{common::error::print_error_message_and_exit, parser::LocalizedParseError};
 
 use super::{
     completion::EvalResult,
@@ -62,4 +62,10 @@ pub fn err_cannot_set_property<T>(cx: Context, name: impl std::fmt::Display) -> 
 pub fn print_eval_error_and_exit(cx: Context, error: Handle<Value>) {
     let error_string = to_console_string(cx, error);
     print_error_message_and_exit(&error_string);
+}
+
+pub fn syntax_parse_error<T>(cx: Context, error: &LocalizedParseError) -> EvalResult<T> {
+    // Need error string without "SyntaxError:" prefix, since prefix will be added when printing
+    // the SyntaxError object.
+    syntax_error(cx, &error.to_string_without_name())
 }

--- a/src/js/runtime/eval/create_dynamic_function.rs
+++ b/src/js/runtime/eval/create_dynamic_function.rs
@@ -15,7 +15,7 @@ use crate::{
         runtime::{
             bytecode::{function::Closure, generator::BytecodeProgramGenerator},
             completion::EvalResult,
-            error::syntax_error,
+            error::{syntax_error, syntax_parse_error},
             intrinsics::{
                 async_generator_prototype::AsyncGeneratorPrototype,
                 generator_prototype::GeneratorPrototype, intrinsics::Intrinsic,
@@ -111,32 +111,32 @@ pub fn create_dynamic_function(
     // parse correctly, full analysis will be performed on entire function text.
     let params_source = match Source::new_for_eval(file_path.clone(), params_string) {
         Ok(source) => Rc::new(source),
-        Err(err) => return syntax_error(cx, &err.to_string()),
+        Err(err) => return syntax_parse_error(cx, &err),
     };
     if let Err(err) =
         parse_function_params_for_function_constructor(&params_source, is_async, is_generator)
     {
-        return syntax_error(cx, &format!("could not parse function parameters: {}", err));
+        return syntax_parse_error(cx, &err);
     }
 
     let body_source = match Source::new_for_eval(file_path.clone(), body_string) {
         Ok(source) => Rc::new(source),
-        Err(err) => return syntax_error(cx, &err.to_string()),
+        Err(err) => return syntax_parse_error(cx, &err),
     };
     if let Err(err) =
         parse_function_body_for_function_constructor(&body_source, is_async, is_generator)
     {
-        return syntax_error(cx, &format!("could not parse function body: {}", err));
+        return syntax_parse_error(cx, &err);
     }
 
     // Parse and analyze entire function
     let full_source = match Source::new_for_eval(file_path, source_string) {
         Ok(source) => Rc::new(source),
-        Err(err) => return syntax_error(cx, &err.to_string()),
+        Err(err) => return syntax_parse_error(cx, &err),
     };
     let mut parse_result = match parse_function_for_function_constructor(&full_source) {
         Ok(parse_result) => parse_result,
-        Err(err) => return syntax_error(cx, &format!("could not parse function: {}", err)),
+        Err(err) => return syntax_parse_error(cx, &err),
     };
 
     if let Err(errs) =

--- a/src/js/runtime/eval/eval.rs
+++ b/src/js/runtime/eval/eval.rs
@@ -13,7 +13,7 @@ use crate::{
             bytecode::{
                 function::Closure, generator::BytecodeProgramGenerator, instruction::EvalFlags,
             },
-            error::{syntax_error, type_error},
+            error::{syntax_error, syntax_parse_error, type_error},
             global_names::{
                 can_declare_global_function, can_declare_global_var,
                 create_global_function_binding, create_global_var_binding,
@@ -50,13 +50,13 @@ pub fn perform_eval(
     // Parse source code
     let source = match Source::new_for_eval(file_path, code.to_wtf8_string()) {
         Ok(source) => Rc::new(source),
-        Err(error) => return syntax_error(cx, &error.to_string()),
+        Err(error) => return syntax_parse_error(cx, &error),
     };
 
     let parse_result = parse_script_for_eval(&source, is_direct, is_strict_caller);
     let mut parse_result = match parse_result {
         Ok(parse_result) => parse_result,
-        Err(error) => return syntax_error(cx, &error.to_string()),
+        Err(error) => return syntax_parse_error(cx, &error),
     };
 
     // Analyze source code
@@ -74,7 +74,7 @@ pub fn perform_eval(
 
     // Return the first syntax error
     if let Err(errors) = analyze_result {
-        return syntax_error(cx, &errors.errors[0].to_string());
+        return syntax_parse_error(cx, &errors.errors[0]);
     }
 
     // Sloppy direct evals must perform EvalDeclarationInstantiation as var scoped bindings will

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -16,7 +16,7 @@ use crate::{
             abstract_operations::{define_property_or_throw, set},
             builtin_function::BuiltinFunction,
             completion::EvalResult,
-            error::syntax_error,
+            error::syntax_parse_error,
             function::get_argument,
             gc::{Handle, HeapObject, HeapVisitor},
             get,
@@ -279,7 +279,7 @@ fn parse_flags(cx: Context, flags_string: Handle<StringValue>) -> EvalResult<Reg
     fn parse_lexer_stream(cx: Context, lexer_stream: impl LexerStream) -> EvalResult<RegExpFlags> {
         match RegExpParser::parse_flags(lexer_stream) {
             Ok(flags) => flags.into(),
-            Err(error) => syntax_error(cx, &error.to_string()),
+            Err(error) => syntax_parse_error(cx, &error),
         }
     }
 
@@ -310,7 +310,7 @@ fn parse_pattern(
     ) -> EvalResult<RegExp> {
         match RegExpParser::parse_regexp(lexer_stream, flags) {
             Ok(regexp) => regexp.into(),
-            Err(error) => syntax_error(cx, &error.to_string()),
+            Err(error) => syntax_parse_error(cx, &error),
         }
     }
 

--- a/src/js/runtime/module/loader.rs
+++ b/src/js/runtime/module/loader.rs
@@ -10,7 +10,7 @@ use crate::{
             abstract_operations::call_object,
             bytecode::generator::BytecodeProgramGenerator,
             completion::EvalResult,
-            error::syntax_error,
+            error::{syntax_error, syntax_parse_error},
             intrinsics::intrinsics::Intrinsic,
             promise_object::{PromiseCapability, PromiseObject},
             string_value::FlatString,
@@ -183,12 +183,12 @@ pub fn host_load_imported_module(
     // Parse the file at the given path, returning AST
     let mut parse_result = match parse_file_at_path(new_module_path.as_path()) {
         Ok(parse_result) => parse_result,
-        Err(error) => return syntax_error(cx, &error.to_string()),
+        Err(error) => return syntax_parse_error(cx, &error),
     };
 
     // Analyze AST
     if let Err(parse_errors) = analyze(&mut parse_result) {
-        return syntax_error(cx, &parse_errors.errors[0].to_string());
+        return syntax_parse_error(cx, &parse_errors.errors[0]);
     }
 
     if cx.options.print_ast {

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use super::{
     abstract_operations::set,
-    error::{syntax_error, type_error},
+    error::{syntax_error, syntax_parse_error, type_error},
     function::get_argument,
     intrinsics::{
         array_buffer_constructor::ArrayBufferObject, global_object::set_default_global_bindings,
@@ -155,20 +155,20 @@ impl Test262Object {
         let source = match Source::new_for_eval(file_path, script_text.as_string().to_wtf8_string())
         {
             Ok(source) => Rc::new(source),
-            Err(error) => return syntax_error(cx, &error.to_string()),
+            Err(error) => return syntax_parse_error(cx, &error),
         };
 
         let parse_result = parse_script(&source);
         let mut parse_result = match parse_result {
             Ok(parse_result) => parse_result,
-            Err(error) => return syntax_error(cx, &error.to_string()),
+            Err(error) => return syntax_parse_error(cx, &error),
         };
 
         let analyze_result = analyze(&mut parse_result);
         if let Err(errors) = analyze_result {
             // Choose an arbitrary syntax error to return
             let error = &errors.errors[0];
-            return syntax_error(cx, &error.to_string());
+            return syntax_parse_error(cx, error);
         }
 
         let realm = cx.current_realm();


### PR DESCRIPTION
## Summary

When a SyntaxError object was created from a LocalizedParseError we were accidentally adding two "SyntaxError:" prefixes to the message. One was coming from Error.prototype.toString, and the other was coming from the LocalizedParseError's Display implementation.

We do not want to include this second prefix when creating a SyntaxError from a LocalizedParseError. Instead we break out a LocalizedParseError::to_string_without_name method that is used.