### PR TITLE
[runtime] Enqueue tasks for finalizer cleanup callbacks

### DIFF
--- a/src/js/runtime/intrinsics/finalization_registry_object.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_object.rs
@@ -30,13 +30,6 @@ extend_object! {
     }
 }
 
-/// A single finalizer callback for a target that has been garbage collected. Contains both the
-/// callback to run and the held value to pass to it.
-pub struct FinalizerCallback {
-    pub cleanup_callback: HeapPtr<ObjectValue>,
-    pub held_value: Value,
-}
-
 impl FinalizationRegistryObject {
     pub fn new_from_constructor(
         cx: Context,


### PR DESCRIPTION
## Summary

We previously were never running finalizer cleanup callbacks since FinalizationRegistry was implemented before we had an event loop. Now that we have an event loop we should enqueue these finalizer cleanup callbacks onto the task queue, using a new generic task that calls any function with a single argument.