### PR TITLE
[runtime] Error when stack overflows

### DIFF
--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -183,7 +183,9 @@ impl Context {
         // Loading, linking, and evaluation should all have a current realm set as some objects
         // needing a realm will be created.
         let realm = module.program_function_ptr().realm_ptr();
-        self.vm().push_initial_realm_stack_frame(realm);
+        self.vm()
+            .push_initial_realm_stack_frame(realm)
+            .into_rust_result()?;
 
         let promise = execute_module(*self, module);
 

--- a/src/js/runtime/tasks.rs
+++ b/src/js/runtime/tasks.rs
@@ -191,8 +191,9 @@ impl AwaitResumeTask {
 
             // Must execute in the realm of the async generator since AsyncGeneratorResume may need
             // to drain the async queue when the VM stack is empty.
-            cx.vm()
-                .push_initial_realm_stack_frame(async_generator.realm_ptr());
+            maybe!(cx
+                .vm()
+                .push_initial_realm_stack_frame(async_generator.realm_ptr()));
 
             async_generator_resume(cx, async_generator, completion_value, completion_type);
 
@@ -229,7 +230,7 @@ impl PromiseThenReactionTask {
 
     fn execute(&self, mut cx: Context) -> EvalResult<()> {
         if let Some(realm) = self.realm {
-            cx.vm().push_initial_realm_stack_frame(realm);
+            maybe!(cx.vm().push_initial_realm_stack_frame(realm));
         }
 
         let result = self.result.to_handle(cx);
@@ -299,7 +300,7 @@ impl PromiseThenSettleTask {
     }
 
     fn execute(&self, mut cx: Context) -> EvalResult<()> {
-        cx.vm().push_initial_realm_stack_frame(self.realm);
+        maybe!(cx.vm().push_initial_realm_stack_frame(self.realm));
 
         let then_function = self.then_function.to_handle();
         let resolution = self.resolution.to_handle().into();


### PR DESCRIPTION
## Summary

Let's add an explicit stack overflow check before creating a new stack frame. This requires calculating the frame size before pushing the frame. If the stack overflows we throw a RangeError.

Currently we print the entire stack trace in the error, but if this may be changed in the future it it proves to be too unwieldy.