### PR TITLE
[runtime] Add ArrayBuffer throw_if_detached utility

### DIFF
--- a/src/js/runtime/intrinsics/array_buffer_constructor.rs
+++ b/src/js/runtime/intrinsics/array_buffer_constructor.rs
@@ -225,9 +225,7 @@ pub fn array_buffer_copy_and_detach(
         maybe!(to_index(cx, new_length))
     };
 
-    if array_buffer.is_detached() {
-        return type_error(cx, "array buffer is detached");
-    }
+    maybe!(throw_if_detached(cx, array_buffer.get_()));
 
     // Can only remain auto-resizable if ArrayBuffer was already resizable and we are not forced
     // to fix the length.
@@ -295,6 +293,15 @@ fn get_array_buffer_max_byte_length_option(
     }
 
     Some(maybe!(to_index(cx, max_byte_length))).into()
+}
+
+#[inline]
+pub fn throw_if_detached(cx: Context, array_buffer: HeapPtr<ArrayBufferObject>) -> EvalResult<()> {
+    if array_buffer.is_detached() {
+        type_error(cx, "array buffer is detached")
+    } else {
+        ().into()
+    }
 }
 
 impl HeapObject for HeapPtr<ArrayBufferObject> {

--- a/src/js/runtime/intrinsics/data_view_constructor.rs
+++ b/src/js/runtime/intrinsics/data_view_constructor.rs
@@ -8,6 +8,7 @@ use crate::{
         error::{range_error, type_error},
         function::get_argument,
         gc::{HeapObject, HeapVisitor},
+        intrinsics::array_buffer_constructor::throw_if_detached,
         object_descriptor::ObjectKind,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -122,9 +123,7 @@ impl DataViewConstructor {
         let offset_arg = get_argument(cx, arguments, 1);
         let offset = maybe!(to_index(cx, offset_arg));
 
-        if buffer_object.is_detached() {
-            return type_error(cx, "array buffer is detached");
-        }
+        maybe!(throw_if_detached(cx, buffer_object.get_()));
 
         let buffer_byte_length = buffer_object.byte_length();
         if offset > buffer_byte_length {
@@ -163,9 +162,7 @@ impl DataViewConstructor {
         ));
 
         // Be sure to check for array buffer detachment since constructor may invoke user code
-        if buffer_object.is_detached() {
-            return type_error(cx, "array buffer is detached");
-        }
+        maybe!(throw_if_detached(cx, buffer_object.get_()));
 
         // Also check if underlying buffer was resized during construction and redo bounds checks
         let buffer_byte_length = buffer_object.byte_length();

--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -29,9 +29,6 @@ pub fn execute_module(mut cx: Context, module: Handle<SourceTextModule>) -> Hand
     let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
 
     // Cache the module at its canonical source path
-    //
-    // TODO: Move module caching right at module creation. May require first switching to storing
-    // absolute paths in Source but relative paths in the heap.
     let source_file_path = Path::new(&module.source_file_path().to_string())
         .canonicalize()
         .unwrap()


### PR DESCRIPTION
## Summary

Create a throw_if_detached utility to simplify repeated ArrayBuffer detached checks.

Also clean up a TODO that we've decided against.