### PR TITLE
[runtime] Introduce value creation functions for smis, numbers, and common constants

### DIFF
--- a/src/js/runtime/abstract_operations.rs
+++ b/src/js/runtime/abstract_operations.rs
@@ -437,14 +437,14 @@ pub fn enumerable_own_property_names(
         if let Some(desc) = desc {
             if let Some(true) = desc.is_enumerable {
                 match kind {
-                    KeyOrValue::Key => properties.push(key_value.to_handle(cx)),
+                    KeyOrValue::Key => properties.push(key_value),
                     KeyOrValue::Value => {
                         let value = get(cx, object, key)?;
                         properties.push(value);
                     }
                     KeyOrValue::KeyAndValue => {
                         let value = get(cx, object, key)?;
-                        let key_and_value = [key_value.to_handle(cx), value];
+                        let key_and_value = [key_value, value];
                         let entry = create_array_from_list(cx, &key_and_value);
                         properties.push(entry.into());
                     }

--- a/src/js/runtime/abstract_operations.rs
+++ b/src/js/runtime/abstract_operations.rs
@@ -650,7 +650,7 @@ pub fn group_by(
         if !found_group {
             // Canonicalize key
             let key = if key.is_negative_zero() {
-                Value::from(0).to_handle(cx)
+                cx.zero()
             } else {
                 key
             };
@@ -672,7 +672,7 @@ pub fn group_by(
 
 pub fn canonicalize_keyed_collection_key(cx: Context, key: Handle<Value>) -> Handle<Value> {
     if key.is_negative_zero() {
-        Value::from(0).to_handle(cx)
+        cx.zero()
     } else {
         key
     }

--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -281,7 +281,7 @@ pub fn create_unmapped_arguments_object(cx: Context, arguments: &[Handle<Value>]
     let object = UnmappedArgumentsObject::new(cx);
 
     // Set length property
-    let length_value = Value::smi(arguments.len() as i32).to_handle(cx);
+    let length_value = cx.smi(arguments.len() as i32);
     let length_desc = PropertyDescriptor::data(length_value, true, false, true);
     must!(define_property_or_throw(cx, object, cx.names.length(), length_desc));
 

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -299,11 +299,6 @@ impl Context {
     }
 
     #[inline]
-    pub fn smi(&self, value: i32) -> Handle<Value> {
-        Value::smi(value).to_handle(*self)
-    }
-
-    #[inline]
     pub fn zero(&self) -> Handle<Value> {
         Handle::<Value>::from_fixed_non_heap_ptr(&self.zero)
     }
@@ -321,6 +316,16 @@ impl Context {
     #[inline]
     pub fn nan(&self) -> Handle<Value> {
         Handle::<Value>::from_fixed_non_heap_ptr(&self.nan)
+    }
+
+    #[inline]
+    pub fn smi(&self, value: i32) -> Handle<Value> {
+        Value::smi(value).to_handle(*self)
+    }
+
+    #[inline]
+    pub fn number(&self, value: f64) -> Handle<Value> {
+        Value::number(value).to_handle(*self)
     }
 
     pub fn visit_roots(&mut self, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -290,6 +290,11 @@ impl Context {
         }
     }
 
+    #[inline]
+    pub fn smi(&self, value: i32) -> Handle<Value> {
+        Value::smi(value).to_handle(*self)
+    }
+
     pub fn visit_roots(&mut self, visitor: &mut impl HeapVisitor) {
         self.heap.visit_roots(visitor);
 

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -67,6 +67,10 @@ pub struct ContextCell {
     empty: Value,
     true_: Value,
     false_: Value,
+    zero: Value,
+    one: Value,
+    negative_one: Value,
+    nan: Value,
 
     /// Canonical string values for strings that appear in the AST
     pub interned_strings: InternedStrings,
@@ -110,6 +114,10 @@ impl Context {
             empty: Value::empty(),
             true_: Value::bool(true),
             false_: Value::bool(false),
+            zero: Value::smi(0),
+            one: Value::smi(1),
+            negative_one: Value::smi(-1),
+            nan: Value::nan(),
             interned_strings: InternedStrings::uninit(),
             modules: HashMap::new(),
             default_named_properties: HeapPtr::uninit(),
@@ -293,6 +301,26 @@ impl Context {
     #[inline]
     pub fn smi(&self, value: i32) -> Handle<Value> {
         Value::smi(value).to_handle(*self)
+    }
+
+    #[inline]
+    pub fn zero(&self) -> Handle<Value> {
+        Handle::<Value>::from_fixed_non_heap_ptr(&self.zero)
+    }
+
+    #[inline]
+    pub fn one(&self) -> Handle<Value> {
+        Handle::<Value>::from_fixed_non_heap_ptr(&self.one)
+    }
+
+    #[inline]
+    pub fn negative_one(&self) -> Handle<Value> {
+        Handle::<Value>::from_fixed_non_heap_ptr(&self.negative_one)
+    }
+
+    #[inline]
+    pub fn nan(&self) -> Handle<Value> {
+        Handle::<Value>::from_fixed_non_heap_ptr(&self.nan)
     }
 
     pub fn visit_roots(&mut self, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/eval/expression.rs
+++ b/src/js/runtime/eval/expression.rs
@@ -134,7 +134,7 @@ pub fn eval_bitwise_not(cx: Context, value: Handle<Value>) -> EvalResult<Handle<
         Ok(BigIntValue::new(cx, not_bignum).into())
     } else {
         let value = must!(to_int32(cx, value));
-        Ok(Value::smi(!value).to_handle(cx))
+        Ok(cx.smi(!value))
     }
 }
 
@@ -381,7 +381,7 @@ pub fn eval_bitwise_and(
         let left_smi = must!(to_int32(cx, left_value));
         let right_smi = must!(to_int32(cx, right_value));
 
-        Ok(Value::smi(left_smi & right_smi).to_handle(cx))
+        Ok(cx.smi(left_smi & right_smi))
     }
 }
 
@@ -405,7 +405,7 @@ pub fn eval_bitwise_or(
         let left_smi = must!(to_int32(cx, left_value));
         let right_smi = must!(to_int32(cx, right_value));
 
-        Ok(Value::smi(left_smi | right_smi).to_handle(cx))
+        Ok(cx.smi(left_smi | right_smi))
     }
 }
 
@@ -429,7 +429,7 @@ pub fn eval_bitwise_xor(
         let left_smi = must!(to_int32(cx, left_value));
         let right_smi = must!(to_int32(cx, right_value));
 
-        Ok(Value::smi(left_smi ^ right_smi).to_handle(cx))
+        Ok(cx.smi(left_smi ^ right_smi))
     }
 }
 
@@ -461,7 +461,7 @@ pub fn eval_shift_left(
         // Shift modulus 32
         let shift = right_u32 & 0x1F;
 
-        Ok(Value::smi(left_smi << shift).to_handle(cx))
+        Ok(cx.smi(left_smi << shift))
     }
 }
 
@@ -493,7 +493,7 @@ pub fn eval_shift_right_arithmetic(
         // Shift modulus 32
         let shift = right_u32 & 0x1F;
 
-        Ok(Value::smi(left_smi >> shift).to_handle(cx))
+        Ok(cx.smi(left_smi >> shift))
     }
 }
 

--- a/src/js/runtime/eval/expression.rs
+++ b/src/js/runtime/eval/expression.rs
@@ -122,7 +122,7 @@ pub fn eval_negate(cx: Context, value: Handle<Value>) -> EvalResult<Handle<Value
         let neg_bignum = -value.as_bigint().bigint();
         Ok(BigIntValue::new(cx, neg_bignum).into())
     } else {
-        Ok(Value::number(-value.as_number()).to_handle(cx))
+        Ok(cx.number(-value.as_number()))
     }
 }
 
@@ -164,7 +164,7 @@ pub fn eval_add(
         let result = left_num.as_bigint().bigint() + right_num.as_bigint().bigint();
         Ok(BigIntValue::new(cx, result).into())
     } else {
-        Ok(Value::number(left_num.as_number() + right_num.as_number()).to_handle(cx))
+        Ok(cx.number(left_num.as_number() + right_num.as_number()))
     }
 }
 
@@ -185,7 +185,7 @@ pub fn eval_subtract(
         let result = left_num.as_bigint().bigint() - right_num.as_bigint().bigint();
         Ok(BigIntValue::new(cx, result).into())
     } else {
-        Ok(Value::number(left_num.as_number() - right_num.as_number()).to_handle(cx))
+        Ok(cx.number(left_num.as_number() - right_num.as_number()))
     }
 }
 
@@ -206,7 +206,7 @@ pub fn eval_multiply(
         let result = left_num.as_bigint().bigint() * right_num.as_bigint().bigint();
         Ok(BigIntValue::new(cx, result).into())
     } else {
-        Ok(Value::number(left_num.as_number() * right_num.as_number()).to_handle(cx))
+        Ok(cx.number(left_num.as_number() * right_num.as_number()))
     }
 }
 
@@ -232,7 +232,7 @@ pub fn eval_divide(
         let result = left_num.as_bigint().bigint() / bigint_right;
         Ok(BigIntValue::new(cx, result).into())
     } else {
-        Ok(Value::number(left_num.as_number() / right_num.as_number()).to_handle(cx))
+        Ok(cx.number(left_num.as_number() / right_num.as_number()))
     }
 }
 
@@ -263,7 +263,7 @@ pub fn eval_remainder(
         let result = bigint_left % bigint_right;
         Ok(BigIntValue::new(cx, result).into())
     } else {
-        Ok(Value::number(left_num.as_number() % right_num.as_number()).to_handle(cx))
+        Ok(cx.number(left_num.as_number() % right_num.as_number()))
     }
 }
 
@@ -298,8 +298,7 @@ pub fn eval_exponentiation(
             range_error(cx, "BigInt is too large")
         }
     } else {
-        Ok(Value::number(number_exponentiate(left_num.as_number(), right_num.as_number()))
-            .to_handle(cx))
+        Ok(cx.number(number_exponentiate(left_num.as_number(), right_num.as_number())))
     }
 }
 

--- a/src/js/runtime/function.rs
+++ b/src/js/runtime/function.rs
@@ -67,7 +67,7 @@ pub fn set_function_length_maybe_infinity(
     let length = if let Some(length) = length {
         Value::from(length).to_handle(cx)
     } else {
-        Value::number(f64::INFINITY).to_handle(cx)
+        cx.number(f64::INFINITY)
     };
 
     let desc = PropertyDescriptor::data(length, false, false, true);

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -526,7 +526,7 @@ impl ArrayPrototype {
 
         match find_result {
             Some((_, index_value)) => Ok(index_value),
-            None => Ok(cx.smi(-1)),
+            None => Ok(cx.negative_one()),
         }
     }
 
@@ -580,7 +580,7 @@ impl ArrayPrototype {
 
         match find_result {
             Some((_, index_value)) => Ok(index_value),
-            None => Ok(cx.smi(-1)),
+            None => Ok(cx.negative_one()),
         }
     }
 
@@ -805,7 +805,7 @@ impl ArrayPrototype {
         let length = length_of_array_like(cx, object)?;
 
         if length == 0 {
-            return Ok(cx.smi(-1));
+            return Ok(cx.negative_one());
         }
 
         let search_element = get_argument(cx, arguments, 0);
@@ -813,7 +813,7 @@ impl ArrayPrototype {
         let n_arg = get_argument(cx, arguments, 1);
         let mut n = to_integer_or_infinity(cx, n_arg)?;
         if n == f64::INFINITY {
-            return Ok(cx.smi(-1));
+            return Ok(cx.negative_one());
         } else if n == f64::NEG_INFINITY {
             n = 0.0;
         }
@@ -837,7 +837,7 @@ impl ArrayPrototype {
             }
         }
 
-        Ok(cx.smi(-1))
+        Ok(cx.negative_one())
     }
 
     /// Array.prototype.join (https://tc39.es/ecma262/#sec-array.prototype.join)
@@ -901,7 +901,7 @@ impl ArrayPrototype {
         let length = length_of_array_like(cx, object)?;
 
         if length == 0 {
-            return Ok(cx.smi(-1));
+            return Ok(cx.negative_one());
         }
 
         let search_element = get_argument(cx, arguments, 0);
@@ -910,7 +910,7 @@ impl ArrayPrototype {
             let start_arg = get_argument(cx, arguments, 1);
             let n = to_integer_or_infinity(cx, start_arg)?;
             if n == f64::NEG_INFINITY {
-                return Ok(cx.smi(-1));
+                return Ok(cx.negative_one());
             }
 
             if n >= 0.0 {
@@ -919,7 +919,7 @@ impl ArrayPrototype {
                 let start_index = length as i64 + n as i64;
 
                 if start_index < 0 {
-                    return Ok(cx.smi(-1));
+                    return Ok(cx.negative_one());
                 }
 
                 start_index as u64
@@ -941,7 +941,7 @@ impl ArrayPrototype {
             }
         }
 
-        Ok(cx.smi(-1))
+        Ok(cx.negative_one())
     }
 
     /// Array.prototype.map (https://tc39.es/ecma262/#sec-array.prototype.map)
@@ -995,7 +995,7 @@ impl ArrayPrototype {
         let length = length_of_array_like(cx, object)?;
 
         if length == 0 {
-            let length_zero = cx.smi(0);
+            let length_zero = cx.zero();
             set(cx, object, cx.names.length(), length_zero, true)?;
             return Ok(cx.undefined());
         }
@@ -1229,7 +1229,7 @@ impl ArrayPrototype {
         let length = length_of_array_like(cx, object)?;
 
         if length == 0 {
-            let zero_value = cx.smi(0);
+            let zero_value = cx.zero();
             set(cx, object, cx.names.length(), zero_value, true)?;
             return Ok(cx.undefined());
         }

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -526,7 +526,7 @@ impl ArrayPrototype {
 
         match find_result {
             Some((_, index_value)) => Ok(index_value),
-            None => Ok(Value::smi(-1).to_handle(cx)),
+            None => Ok(cx.smi(-1)),
         }
     }
 
@@ -580,7 +580,7 @@ impl ArrayPrototype {
 
         match find_result {
             Some((_, index_value)) => Ok(index_value),
-            None => Ok(Value::smi(-1).to_handle(cx)),
+            None => Ok(cx.smi(-1)),
         }
     }
 
@@ -805,7 +805,7 @@ impl ArrayPrototype {
         let length = length_of_array_like(cx, object)?;
 
         if length == 0 {
-            return Ok(Value::smi(-1).to_handle(cx));
+            return Ok(cx.smi(-1));
         }
 
         let search_element = get_argument(cx, arguments, 0);
@@ -813,7 +813,7 @@ impl ArrayPrototype {
         let n_arg = get_argument(cx, arguments, 1);
         let mut n = to_integer_or_infinity(cx, n_arg)?;
         if n == f64::INFINITY {
-            return Ok(Value::smi(-1).to_handle(cx));
+            return Ok(cx.smi(-1));
         } else if n == f64::NEG_INFINITY {
             n = 0.0;
         }
@@ -837,7 +837,7 @@ impl ArrayPrototype {
             }
         }
 
-        Ok(Value::smi(-1).to_handle(cx))
+        Ok(cx.smi(-1))
     }
 
     /// Array.prototype.join (https://tc39.es/ecma262/#sec-array.prototype.join)
@@ -901,7 +901,7 @@ impl ArrayPrototype {
         let length = length_of_array_like(cx, object)?;
 
         if length == 0 {
-            return Ok(Value::smi(-1).to_handle(cx));
+            return Ok(cx.smi(-1));
         }
 
         let search_element = get_argument(cx, arguments, 0);
@@ -910,7 +910,7 @@ impl ArrayPrototype {
             let start_arg = get_argument(cx, arguments, 1);
             let n = to_integer_or_infinity(cx, start_arg)?;
             if n == f64::NEG_INFINITY {
-                return Ok(Value::smi(-1).to_handle(cx));
+                return Ok(cx.smi(-1));
             }
 
             if n >= 0.0 {
@@ -919,7 +919,7 @@ impl ArrayPrototype {
                 let start_index = length as i64 + n as i64;
 
                 if start_index < 0 {
-                    return Ok(Value::smi(-1).to_handle(cx));
+                    return Ok(cx.smi(-1));
                 }
 
                 start_index as u64
@@ -941,7 +941,7 @@ impl ArrayPrototype {
             }
         }
 
-        Ok(Value::smi(-1).to_handle(cx))
+        Ok(cx.smi(-1))
     }
 
     /// Array.prototype.map (https://tc39.es/ecma262/#sec-array.prototype.map)
@@ -995,7 +995,7 @@ impl ArrayPrototype {
         let length = length_of_array_like(cx, object)?;
 
         if length == 0 {
-            let length_zero = Value::smi(0).to_handle(cx);
+            let length_zero = cx.smi(0);
             set(cx, object, cx.names.length(), length_zero, true)?;
             return Ok(cx.undefined());
         }
@@ -1229,7 +1229,7 @@ impl ArrayPrototype {
         let length = length_of_array_like(cx, object)?;
 
         if length == 0 {
-            let zero_value = Value::smi(0).to_handle(cx);
+            let zero_value = cx.smi(0);
             set(cx, object, cx.names.length(), zero_value, true)?;
             return Ok(cx.undefined());
         }

--- a/src/js/runtime/intrinsics/date_constructor.rs
+++ b/src/js/runtime/intrinsics/date_constructor.rs
@@ -168,7 +168,7 @@ impl DateConstructor {
         if let Some(date_value) = parse_string_to_date(string) {
             Ok(Value::from(date_value).to_handle(cx))
         } else {
-            Ok(Value::nan().to_handle(cx))
+            Ok(cx.nan())
         }
     }
 

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -141,7 +141,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let date = date_from_time(local_time(date_value));
@@ -163,7 +163,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let day = week_day(local_time(date_value));
@@ -188,7 +188,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let year = year_from_time(local_time(date_value));
@@ -210,7 +210,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let hour = hour_from_time(local_time(date_value));
@@ -235,7 +235,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let millisecond = millisecond_from_time(local_time(date_value));
@@ -260,7 +260,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let minute = minute_from_time(local_time(date_value));
@@ -282,7 +282,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let month = month_from_time(local_time(date_value));
@@ -307,7 +307,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let second = second_from_time(local_time(date_value));
@@ -343,7 +343,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let timezone_offset = (date_value - local_time(date_value)) / MS_PER_MINUTE;
@@ -365,7 +365,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let date = date_from_time(date_value);
@@ -387,7 +387,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let hour = week_day(date_value);
@@ -409,7 +409,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let year = year_from_time(date_value);
@@ -431,7 +431,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let hour = hour_from_time(date_value);
@@ -456,7 +456,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let millisecond = millisecond_from_time(date_value);
@@ -481,7 +481,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let minute = minute_from_time(date_value);
@@ -506,7 +506,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let month = month_from_time(date_value);
@@ -531,7 +531,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let second = second_from_time(date_value);
@@ -556,7 +556,7 @@ impl DatePrototype {
         let date = to_number(cx, date_arg)?.as_number();
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let date_value = local_time(date_value);
@@ -659,7 +659,7 @@ impl DatePrototype {
         }
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let date_value = local_time(date_value);
@@ -706,7 +706,7 @@ impl DatePrototype {
         let milliseconds = to_number(cx, milliseconds_arg)?.as_number();
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let date_value = local_time(date_value);
@@ -762,7 +762,7 @@ impl DatePrototype {
         }
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let date_value = local_time(date_value);
@@ -810,7 +810,7 @@ impl DatePrototype {
         }
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let date_value = local_time(date_value);
@@ -857,7 +857,7 @@ impl DatePrototype {
         }
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let date_value = local_time(date_value);
@@ -920,7 +920,7 @@ impl DatePrototype {
         let date = to_number(cx, date_arg)?.as_number();
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let new_date = time_clip(make_date(
@@ -1022,7 +1022,7 @@ impl DatePrototype {
         }
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         if !has_minutes {
@@ -1065,7 +1065,7 @@ impl DatePrototype {
         let milliseconds = to_number(cx, milliseconds_arg)?.as_number();
 
         if milliseconds.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let new_date = time_clip(make_date(
@@ -1119,7 +1119,7 @@ impl DatePrototype {
         }
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         if !has_seconds {
@@ -1168,7 +1168,7 @@ impl DatePrototype {
         }
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         if !has_date {
@@ -1213,7 +1213,7 @@ impl DatePrototype {
         }
 
         if date_value.is_nan() {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         if !has_milliseconds {

--- a/src/js/runtime/intrinsics/global_object.rs
+++ b/src/js/runtime/intrinsics/global_object.rs
@@ -72,7 +72,7 @@ pub fn set_default_global_bindings(
         }
 
         // Value Properties of the Global Object (https://tc39.es/ecma262/#sec-value-properties-of-the-global-object)
-        let infinity_value = Value::number(f64::INFINITY).to_handle(cx);
+        let infinity_value = cx.number(f64::INFINITY);
         let nan_value = cx.nan();
 
         value_prop!(cx.names.global_this(), realm.global_object().into(), true, false, true);
@@ -214,7 +214,7 @@ pub fn parse_float(
     let input_string = to_string(cx, input_string_arg)?;
 
     match parse_float_with_string_lexer(input_string) {
-        Some(float) => Ok(Value::number(float).to_handle(cx)),
+        Some(float) => Ok(cx.number(float)),
         None => Ok(cx.nan()),
     }
 }
@@ -240,7 +240,7 @@ pub fn parse_int(
     let radix = to_int32(cx, radix_arg)?;
 
     match parse_int_impl(input_string, radix) {
-        Some(number) => Ok(Value::number(number).to_handle(cx)),
+        Some(number) => Ok(cx.number(number)),
         None => Ok(cx.nan()),
     }
 }

--- a/src/js/runtime/intrinsics/global_object.rs
+++ b/src/js/runtime/intrinsics/global_object.rs
@@ -73,7 +73,7 @@ pub fn set_default_global_bindings(
 
         // Value Properties of the Global Object (https://tc39.es/ecma262/#sec-value-properties-of-the-global-object)
         let infinity_value = Value::number(f64::INFINITY).to_handle(cx);
-        let nan_value = Value::nan().to_handle(cx);
+        let nan_value = cx.nan();
 
         value_prop!(cx.names.global_this(), realm.global_object().into(), true, false, true);
         value_prop!(cx.names.infinity(), infinity_value, false, false, false);
@@ -215,7 +215,7 @@ pub fn parse_float(
 
     match parse_float_with_string_lexer(input_string) {
         Some(float) => Ok(Value::number(float).to_handle(cx)),
-        None => Ok(Value::nan().to_handle(cx)),
+        None => Ok(cx.nan()),
     }
 }
 
@@ -241,7 +241,7 @@ pub fn parse_int(
 
     match parse_int_impl(input_string, radix) {
         Some(number) => Ok(Value::number(number).to_handle(cx)),
-        None => Ok(Value::nan().to_handle(cx)),
+        None => Ok(cx.nan()),
     }
 }
 

--- a/src/js/runtime/intrinsics/intrinsics.rs
+++ b/src/js/runtime/intrinsics/intrinsics.rs
@@ -496,7 +496,7 @@ fn create_throw_type_error_intrinsic(cx: Context, realm: Handle<Realm>) -> Handl
     )
     .into();
 
-    let zero_value = cx.smi(0);
+    let zero_value = cx.zero();
     let length_desc = PropertyDescriptor::data(zero_value, false, false, false);
     must!(define_property_or_throw(
         cx,

--- a/src/js/runtime/intrinsics/intrinsics.rs
+++ b/src/js/runtime/intrinsics/intrinsics.rs
@@ -496,7 +496,7 @@ fn create_throw_type_error_intrinsic(cx: Context, realm: Handle<Realm>) -> Handl
     )
     .into();
 
-    let zero_value = Value::smi(0).to_handle(cx);
+    let zero_value = cx.smi(0);
     let length_desc = PropertyDescriptor::data(zero_value, false, false, false);
     must!(define_property_or_throw(
         cx,

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -222,7 +222,7 @@ impl MapPrototype {
 
         // Convert negative zero to positive zero for key in map
         if key.is_negative_zero() {
-            key = Value::number(0.0).to_handle(cx);
+            key = cx.zero();
         }
 
         map.insert(cx, key, value);

--- a/src/js/runtime/intrinsics/math_object.rs
+++ b/src/js/runtime/intrinsics/math_object.rs
@@ -238,7 +238,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_uint32(cx, argument)?;
-        Ok(Value::smi(n.leading_zeros() as i32).to_handle(cx))
+        Ok(cx.smi(n.leading_zeros() as i32))
     }
 
     /// Math.cos (https://tc39.es/ecma262/#sec-math.cos)
@@ -378,7 +378,7 @@ impl MathObject {
 
         let mod_mul = ((x as u64) * (y as u64)) as u32;
 
-        Ok(Value::smi(mod_mul as i32).to_handle(cx))
+        Ok(cx.smi(mod_mul as i32))
     }
 
     /// Math.log (https://tc39.es/ecma262/#sec-math.log)

--- a/src/js/runtime/intrinsics/math_object.rs
+++ b/src/js/runtime/intrinsics/math_object.rs
@@ -560,28 +560,26 @@ impl MathObject {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?.get();
 
-        let value = if n.is_smi() {
+        if n.is_smi() {
             let n_smi = n.as_smi();
             if n_smi == 0 {
-                n
+                Ok(n.to_handle(cx))
             } else if n_smi > 0 {
-                Value::smi(1)
+                Ok(cx.one())
             } else {
-                Value::smi(-1)
+                Ok(cx.negative_one())
             }
         } else {
             if n.is_negative_zero() || n.is_positive_zero() {
-                n
+                Ok(n.to_handle(cx))
             } else if n.as_double() > 0.0 {
-                Value::smi(1)
+                Ok(cx.one())
             } else if n.is_nan() {
-                Value::nan()
+                Ok(cx.nan())
             } else {
-                Value::smi(-1)
+                Ok(cx.negative_one())
             }
-        };
-
-        Ok(value.to_handle(cx))
+        }
     }
 
     /// Math.sin (https://tc39.es/ecma262/#sec-math.sin)

--- a/src/js/runtime/intrinsics/math_object.rs
+++ b/src/js/runtime/intrinsics/math_object.rs
@@ -23,28 +23,28 @@ impl MathObject {
             ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true);
 
         // Value Properties of the Math Object (https://tc39.es/ecma262/#sec-value-properties-of-the-math-object)
-        let e_value = Value::number(std::f64::consts::E).to_handle(cx);
+        let e_value = cx.number(std::f64::consts::E);
         object.intrinsic_frozen_property(cx, cx.names.e(), e_value);
 
-        let ln_10_value = Value::number(std::f64::consts::LN_10).to_handle(cx);
+        let ln_10_value = cx.number(std::f64::consts::LN_10);
         object.intrinsic_frozen_property(cx, cx.names.ln10(), ln_10_value);
 
-        let ln_2_value = Value::number(std::f64::consts::LN_2).to_handle(cx);
+        let ln_2_value = cx.number(std::f64::consts::LN_2);
         object.intrinsic_frozen_property(cx, cx.names.ln2(), ln_2_value);
 
-        let log10_e_value = Value::number(std::f64::consts::LOG10_E).to_handle(cx);
+        let log10_e_value = cx.number(std::f64::consts::LOG10_E);
         object.intrinsic_frozen_property(cx, cx.names.log10e(), log10_e_value);
 
-        let log2_e_value = Value::number(std::f64::consts::LOG2_E).to_handle(cx);
+        let log2_e_value = cx.number(std::f64::consts::LOG2_E);
         object.intrinsic_frozen_property(cx, cx.names.log2e(), log2_e_value);
 
-        let pi_value = Value::number(std::f64::consts::PI).to_handle(cx);
+        let pi_value = cx.number(std::f64::consts::PI);
         object.intrinsic_frozen_property(cx, cx.names.pi(), pi_value);
 
-        let sqrt1_2_value = Value::number(std::f64::consts::FRAC_1_SQRT_2).to_handle(cx);
+        let sqrt1_2_value = cx.number(std::f64::consts::FRAC_1_SQRT_2);
         object.intrinsic_frozen_property(cx, cx.names.sqrt1_2(), sqrt1_2_value);
 
-        let sqrt_2_value = Value::number(std::f64::consts::SQRT_2).to_handle(cx);
+        let sqrt_2_value = cx.number(std::f64::consts::SQRT_2);
         object.intrinsic_frozen_property(cx, cx.names.sqrt2(), sqrt_2_value);
 
         // Math [ @@toStringTag ] (https://tc39.es/ecma262/#sec-math-%symbol.tostringtag%)
@@ -106,9 +106,9 @@ impl MathObject {
         let n = to_number(cx, argument)?;
 
         if n.is_smi() {
-            Ok(Value::smi(i32::abs(n.as_smi())).to_handle(cx))
+            Ok(cx.smi(i32::abs(n.as_smi())))
         } else {
-            Ok(Value::number(f64::abs(n.as_double())).to_handle(cx))
+            Ok(cx.number(f64::abs(n.as_double())))
         }
     }
 
@@ -121,7 +121,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::acos(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::acos(n.as_number())))
     }
 
     /// Math.acosh (https://tc39.es/ecma262/#sec-math.acosh)
@@ -133,7 +133,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::acosh(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::acosh(n.as_number())))
     }
 
     /// Math.asin (https://tc39.es/ecma262/#sec-math.asin)
@@ -145,7 +145,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::asin(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::asin(n.as_number())))
     }
 
     /// Math.asinh (https://tc39.es/ecma262/#sec-math.asinh)
@@ -157,7 +157,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::asinh(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::asinh(n.as_number())))
     }
 
     /// Math.atan (https://tc39.es/ecma262/#sec-math.atan)
@@ -169,7 +169,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::atan(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::atan(n.as_number())))
     }
 
     /// Math.atanh (https://tc39.es/ecma262/#sec-math.atanh)
@@ -181,7 +181,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::atanh(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::atanh(n.as_number())))
     }
 
     /// Math.atan2 (https://tc39.es/ecma262/#sec-math.atan2)
@@ -197,7 +197,7 @@ impl MathObject {
         let x_arg = get_argument(cx, arguments, 1);
         let x = to_number(cx, x_arg)?;
 
-        Ok(Value::number(y.as_number().atan2(x.as_number())).to_handle(cx))
+        Ok(cx.number(y.as_number().atan2(x.as_number())))
     }
 
     /// Math.cbrt (https://tc39.es/ecma262/#sec-math.cbrt)
@@ -209,7 +209,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::cbrt(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::cbrt(n.as_number())))
     }
 
     /// Math.ceil (https://tc39.es/ecma262/#sec-math.ceil)
@@ -225,7 +225,7 @@ impl MathObject {
         if n.is_smi() {
             Ok(n)
         } else {
-            Ok(Value::number(f64::ceil(n.as_double())).to_handle(cx))
+            Ok(cx.number(f64::ceil(n.as_double())))
         }
     }
 
@@ -250,7 +250,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::cos(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::cos(n.as_number())))
     }
 
     /// Math.cosh (https://tc39.es/ecma262/#sec-math.cosh)
@@ -262,7 +262,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::cosh(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::cosh(n.as_number())))
     }
 
     /// Math.exp (https://tc39.es/ecma262/#sec-math.exp)
@@ -274,7 +274,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::exp(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::exp(n.as_number())))
     }
 
     /// Math.expm1 (https://tc39.es/ecma262/#sec-math.expm1)
@@ -286,7 +286,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::exp_m1(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::exp_m1(n.as_number())))
     }
 
     /// Math.floor (https://tc39.es/ecma262/#sec-math.floor)
@@ -302,7 +302,7 @@ impl MathObject {
         if n.is_smi() {
             Ok(n)
         } else {
-            Ok(Value::number(f64::floor(n.as_double())).to_handle(cx))
+            Ok(cx.number(f64::floor(n.as_double())))
         }
     }
 
@@ -315,7 +315,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number((n.as_number() as f32) as f64).to_handle(cx))
+        Ok(cx.number((n.as_number() as f32) as f64))
     }
 
     /// Math.hypot (https://tc39.es/ecma262/#sec-math.hypot)
@@ -360,7 +360,7 @@ impl MathObject {
             return Ok(sum.to_handle(cx));
         }
 
-        Ok(Value::number(f64::sqrt(sum.as_number())).to_handle(cx))
+        Ok(cx.number(f64::sqrt(sum.as_number())))
     }
 
     /// Math.imul (https://tc39.es/ecma262/#sec-math.imul)
@@ -390,7 +390,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::ln(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::ln(n.as_number())))
     }
 
     /// Math.log1p (https://tc39.es/ecma262/#sec-math.log1p)
@@ -402,7 +402,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::ln_1p(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::ln_1p(n.as_number())))
     }
 
     /// Math.log10 (https://tc39.es/ecma262/#sec-math.log10)
@@ -414,7 +414,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::log10(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::log10(n.as_number())))
     }
 
     /// Math.log2 (https://tc39.es/ecma262/#sec-math.log2)
@@ -426,7 +426,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::log2(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::log2(n.as_number())))
     }
 
     /// Math.max (https://tc39.es/ecma262/#sec-math.max)
@@ -521,7 +521,7 @@ impl MathObject {
         _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let n = rand::thread_rng().gen::<f64>();
-        Ok(Value::number(n).to_handle(cx))
+        Ok(cx.number(n))
     }
 
     /// Math.round (https://tc39.es/ecma262/#sec-math.round)
@@ -546,7 +546,7 @@ impl MathObject {
                 f64::ceil(n)
             };
 
-            Ok(Value::number(rounded).to_handle(cx))
+            Ok(cx.number(rounded))
         }
     }
 
@@ -591,7 +591,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::sin(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::sin(n.as_number())))
     }
 
     /// Math.sinh (https://tc39.es/ecma262/#sec-math.sinh)
@@ -603,7 +603,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::sinh(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::sinh(n.as_number())))
     }
 
     /// Math.sqrt (https://tc39.es/ecma262/#sec-math.sqrt)
@@ -615,7 +615,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::sqrt(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::sqrt(n.as_number())))
     }
 
     /// Math.tan (https://tc39.es/ecma262/#sec-math.tan)
@@ -627,7 +627,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::tan(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::tan(n.as_number())))
     }
 
     /// Math.tanh (https://tc39.es/ecma262/#sec-math.tanh)
@@ -639,7 +639,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
-        Ok(Value::number(f64::tanh(n.as_number())).to_handle(cx))
+        Ok(cx.number(f64::tanh(n.as_number())))
     }
 
     /// Math.trunc (https://tc39.es/ecma262/#sec-math.trunc)
@@ -655,7 +655,7 @@ impl MathObject {
         if n.is_smi() {
             Ok(n)
         } else {
-            Ok(Value::number(f64::trunc(n.as_double())).to_handle(cx))
+            Ok(cx.number(f64::trunc(n.as_double())))
         }
     }
 }

--- a/src/js/runtime/intrinsics/number_constructor.rs
+++ b/src/js/runtime/intrinsics/number_constructor.rs
@@ -104,28 +104,28 @@ impl NumberConstructor {
             realm.get_intrinsic(Intrinsic::NumberPrototype).into(),
         );
 
-        let epsilon_value = Value::number(f64::EPSILON).to_handle(cx);
+        let epsilon_value = cx.number(f64::EPSILON);
         func.intrinsic_frozen_property(cx, cx.names.epsilon(), epsilon_value);
 
-        let max_safe_integer_value = Value::number(MAX_SAFE_INTEGER_F64).to_handle(cx);
+        let max_safe_integer_value = cx.number(MAX_SAFE_INTEGER_F64);
         func.intrinsic_frozen_property(cx, cx.names.max_safe_integer(), max_safe_integer_value);
 
-        let max_value = Value::number(f64::MAX).to_handle(cx);
+        let max_value = cx.number(f64::MAX);
         func.intrinsic_frozen_property(cx, cx.names.max_value(), max_value);
 
-        let min_safe_integer_value = Value::number(MIN_SAFE_INTEGER_F64).to_handle(cx);
+        let min_safe_integer_value = cx.number(MIN_SAFE_INTEGER_F64);
         func.intrinsic_frozen_property(cx, cx.names.min_safe_integer(), min_safe_integer_value);
 
-        let min_value = Value::number(MIN_POSITIVE_SUBNORMAL_F64).to_handle(cx);
+        let min_value = cx.number(MIN_POSITIVE_SUBNORMAL_F64);
         func.intrinsic_frozen_property(cx, cx.names.min_value(), min_value);
 
         let nan_value = cx.nan();
         func.intrinsic_frozen_property(cx, cx.names.nan(), nan_value);
 
-        let neg_infinity_value = Value::number(f64::NEG_INFINITY).to_handle(cx);
+        let neg_infinity_value = cx.number(f64::NEG_INFINITY);
         func.intrinsic_frozen_property(cx, cx.names.negative_infinity(), neg_infinity_value);
 
-        let infinity_value = Value::number(f64::INFINITY).to_handle(cx);
+        let infinity_value = cx.number(f64::INFINITY);
         func.intrinsic_frozen_property(cx, cx.names.positive_infinity(), infinity_value);
 
         func.intrinsic_func(cx, cx.names.is_finite(), Self::is_finite, 1, realm);

--- a/src/js/runtime/intrinsics/number_constructor.rs
+++ b/src/js/runtime/intrinsics/number_constructor.rs
@@ -119,7 +119,7 @@ impl NumberConstructor {
         let min_value = Value::number(MIN_POSITIVE_SUBNORMAL_F64).to_handle(cx);
         func.intrinsic_frozen_property(cx, cx.names.min_value(), min_value);
 
-        let nan_value = Value::nan().to_handle(cx);
+        let nan_value = cx.nan();
         func.intrinsic_frozen_property(cx, cx.names.nan(), nan_value);
 
         let neg_infinity_value = Value::number(f64::NEG_INFINITY).to_handle(cx);

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -86,7 +86,7 @@ impl RegExpObject {
         Self::define_last_index_property(cx, object);
 
         // Initialize last index property
-        let zero_value = Value::from(0).to_handle(cx);
+        let zero_value = cx.zero();
         set(cx, object.into(), cx.names.last_index(), zero_value, true)?;
 
         Ok(object)
@@ -261,7 +261,7 @@ pub fn regexp_create(
     }
 
     // Initialize last index property
-    let zero_value = Value::from(0).to_handle(cx);
+    let zero_value = cx.zero();
     set(cx, regexp_object.into(), cx.names.last_index(), zero_value, true)?;
 
     Ok(regexp_object.as_value())

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -220,7 +220,7 @@ impl RegExpPrototype {
             return regexp_exec(cx, regexp_object, string_value);
         }
 
-        let zero_value = Value::from(0).to_handle(cx);
+        let zero_value = cx.zero();
         set(cx, regexp_object, cx.names.last_index(), zero_value, true)?;
 
         let result_array = array_create(cx, 0, None)?;
@@ -349,7 +349,7 @@ impl RegExpPrototype {
         }
 
         if is_global {
-            let zero_value = Value::from(0).to_handle(cx);
+            let zero_value = cx.zero();
             set(cx, regexp_object, cx.names.last_index(), zero_value, true)?;
         }
 
@@ -521,7 +521,7 @@ impl RegExpPrototype {
         // Save original last index, resetting to zero for search
         let previous_last_index = get(cx, regexp_object, cx.names.last_index())?;
         if !previous_last_index.is_positive_zero() {
-            let zero_value = Value::from(0).to_handle(cx);
+            let zero_value = cx.zero();
             set(cx, regexp_object, cx.names.last_index(), zero_value, true)?;
         }
 
@@ -535,7 +535,7 @@ impl RegExpPrototype {
         }
 
         if result.is_null() {
-            Ok(Value::from(-1).to_handle(cx))
+            Ok(cx.negative_one())
         } else {
             get(cx, result.as_object(), cx.names.index())
         }
@@ -864,7 +864,7 @@ fn regexp_builtin_exec(
     // last index under certain flags.
     if last_index > string_length as u64 {
         if is_global || is_sticky {
-            let zero_value = Value::from(0).to_handle(cx);
+            let zero_value = cx.zero();
             set(cx, regexp_object.into(), cx.names.last_index(), zero_value, true)?;
         }
 
@@ -878,7 +878,7 @@ fn regexp_builtin_exec(
     // Handle match failure, resetting last index under sticky flag
     if match_.is_none() {
         if is_global || is_sticky {
-            let zero_value = Value::from(0).to_handle(cx);
+            let zero_value = cx.zero();
             set(cx, regexp_object.into(), cx.names.last_index(), zero_value, true)?;
         }
 

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -181,7 +181,7 @@ impl StringPrototype {
         }
 
         let code_unit = string.code_unit_at(position as u32);
-        Ok(Value::smi(code_unit as i32).to_handle(cx))
+        Ok(cx.smi(code_unit as i32))
     }
 
     /// String.prototype.codePointAt (https://tc39.es/ecma262/#sec-string.prototype.codepointat)
@@ -202,7 +202,7 @@ impl StringPrototype {
         }
 
         let code_point = string.code_point_at(position as u32);
-        Ok(Value::smi(code_point as i32).to_handle(cx))
+        Ok(cx.smi(code_point as i32))
     }
 
     /// String.prototype.concat (https://tc39.es/ecma262/#sec-string.prototype.concat)
@@ -311,11 +311,11 @@ impl StringPrototype {
         let pos = pos.clamp(0.0, string.len() as f64) as u32;
 
         if pos > string.len() {
-            return Ok(Value::smi(-1).to_handle(cx));
+            return Ok(cx.smi(-1));
         }
 
         match string.find(search_string, pos) {
-            None => Ok(Value::smi(-1).to_handle(cx)),
+            None => Ok(cx.smi(-1)),
             Some(index) => Ok(Value::from(index).to_handle(cx)),
         }
     }
@@ -358,7 +358,7 @@ impl StringPrototype {
         let string_end = pos.clamp(0.0, string.len() as f64) as u32;
 
         match string.rfind(search_string, string_end) {
-            None => Ok(Value::smi(-1).to_handle(cx)),
+            None => Ok(cx.smi(-1)),
             Some(index) => Ok(Value::from(index).to_handle(cx)),
         }
     }
@@ -388,7 +388,7 @@ impl StringPrototype {
             Ordering::Greater => 1,
         };
 
-        Ok(Value::smi(comparison_number).to_handle(cx))
+        Ok(cx.smi(comparison_number))
     }
 
     /// String.prototype.match (https://tc39.es/ecma262/#sec-string.prototype.match)

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -177,7 +177,7 @@ impl StringPrototype {
         let position = to_integer_or_infinity(cx, position_arg)?;
 
         if position < 0.0 || position >= string.len() as f64 {
-            return Ok(Value::nan().to_handle(cx));
+            return Ok(cx.nan());
         }
 
         let code_unit = string.code_unit_at(position as u32);
@@ -311,11 +311,11 @@ impl StringPrototype {
         let pos = pos.clamp(0.0, string.len() as f64) as u32;
 
         if pos > string.len() {
-            return Ok(cx.smi(-1));
+            return Ok(cx.negative_one());
         }
 
         match string.find(search_string, pos) {
-            None => Ok(cx.smi(-1)),
+            None => Ok(cx.negative_one()),
             Some(index) => Ok(Value::from(index).to_handle(cx)),
         }
     }
@@ -358,7 +358,7 @@ impl StringPrototype {
         let string_end = pos.clamp(0.0, string.len() as f64) as u32;
 
         match string.rfind(search_string, string_end) {
-            None => Ok(cx.smi(-1)),
+            None => Ok(cx.negative_one()),
             Some(index) => Ok(Value::from(index).to_handle(cx)),
         }
     }

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -599,7 +599,7 @@ macro_rules! create_typed_array_constructor {
                     realm.get_intrinsic(Intrinsic::$prototype).into(),
                 );
 
-                let element_size_value = Value::smi(element_size!() as i32).to_handle(cx);
+                let element_size_value = cx.smi(element_size!() as i32);
                 func.intrinsic_frozen_property(
                     cx,
                     cx.names.bytes_per_element(),

--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -160,7 +160,7 @@ impl TypedArrayPrototype {
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
         if is_typed_array_out_of_bounds(&typed_array_record) {
-            return Ok(Value::smi(0).to_handle(cx));
+            return Ok(cx.smi(0));
         }
 
         let byte_length = typed_array_byte_length(&typed_array_record);
@@ -179,7 +179,7 @@ impl TypedArrayPrototype {
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
         if is_typed_array_out_of_bounds(&typed_array_record) {
-            return Ok(Value::smi(0).to_handle(cx));
+            return Ok(cx.smi(0));
         }
 
         Ok(Value::from(typed_array.byte_offset()).to_handle(cx))
@@ -546,7 +546,7 @@ impl TypedArrayPrototype {
 
         match find_result {
             Some((_, index_value)) => Ok(index_value),
-            None => Ok(Value::smi(-1).to_handle(cx)),
+            None => Ok(cx.smi(-1)),
         }
     }
 
@@ -606,7 +606,7 @@ impl TypedArrayPrototype {
 
         match find_result {
             Some((_, index_value)) => Ok(index_value),
-            None => Ok(Value::smi(-1).to_handle(cx)),
+            None => Ok(cx.smi(-1)),
         }
     }
 
@@ -710,7 +710,7 @@ impl TypedArrayPrototype {
         let length = typed_array_length(&typed_array_record) as u64;
 
         if length == 0 {
-            return Ok(Value::smi(-1).to_handle(cx));
+            return Ok(cx.smi(-1));
         }
 
         let search_element = get_argument(cx, arguments, 0);
@@ -718,7 +718,7 @@ impl TypedArrayPrototype {
         let n_arg = get_argument(cx, arguments, 1);
         let mut n = to_integer_or_infinity(cx, n_arg)?;
         if n == f64::INFINITY {
-            return Ok(Value::smi(-1).to_handle(cx));
+            return Ok(cx.smi(-1));
         } else if n == f64::NEG_INFINITY {
             n = 0.0;
         }
@@ -742,7 +742,7 @@ impl TypedArrayPrototype {
             }
         }
 
-        Ok(Value::smi(-1).to_handle(cx))
+        Ok(cx.smi(-1))
     }
 
     /// %TypedArray%.prototype.join (https://tc39.es/ecma262/#sec-%typedarray%.prototype.join)
@@ -814,7 +814,7 @@ impl TypedArrayPrototype {
         let length = typed_array_length(&typed_array_record) as u64;
 
         if length == 0 {
-            return Ok(Value::smi(-1).to_handle(cx));
+            return Ok(cx.smi(-1));
         }
 
         let search_element = get_argument(cx, arguments, 0);
@@ -823,7 +823,7 @@ impl TypedArrayPrototype {
             let start_arg = get_argument(cx, arguments, 1);
             let n = to_integer_or_infinity(cx, start_arg)?;
             if n == f64::NEG_INFINITY {
-                return Ok(Value::smi(-1).to_handle(cx));
+                return Ok(cx.smi(-1));
             }
 
             if n >= 0.0 {
@@ -832,7 +832,7 @@ impl TypedArrayPrototype {
                 let start_index = length as i64 + n as i64;
 
                 if start_index < 0 {
-                    return Ok(Value::smi(-1).to_handle(cx));
+                    return Ok(cx.smi(-1));
                 }
 
                 start_index as u64
@@ -854,7 +854,7 @@ impl TypedArrayPrototype {
             }
         }
 
-        Ok(Value::smi(-1).to_handle(cx))
+        Ok(cx.smi(-1))
     }
 
     /// get %TypedArray%.prototype.length (https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.length)
@@ -868,7 +868,7 @@ impl TypedArrayPrototype {
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
         if is_typed_array_out_of_bounds(&typed_array_record) {
-            return Ok(Value::smi(0).to_handle(cx));
+            return Ok(cx.smi(0));
         }
 
         let length = typed_array_length(&typed_array_record);
@@ -1679,8 +1679,7 @@ macro_rules! create_typed_array_prototype {
                 );
 
                 // Constructor property is added once TypedArrayConstructor has been created
-                let element_size_value =
-                    Value::smi(std::mem::size_of::<$element_type>() as i32).to_handle(cx);
+                let element_size_value = cx.smi(std::mem::size_of::<$element_type>() as i32);
                 object.intrinsic_frozen_property(
                     cx,
                     cx.names.bytes_per_element(),

--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -160,7 +160,7 @@ impl TypedArrayPrototype {
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
         if is_typed_array_out_of_bounds(&typed_array_record) {
-            return Ok(cx.smi(0));
+            return Ok(cx.zero());
         }
 
         let byte_length = typed_array_byte_length(&typed_array_record);
@@ -179,7 +179,7 @@ impl TypedArrayPrototype {
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
         if is_typed_array_out_of_bounds(&typed_array_record) {
-            return Ok(cx.smi(0));
+            return Ok(cx.zero());
         }
 
         Ok(Value::from(typed_array.byte_offset()).to_handle(cx))
@@ -546,7 +546,7 @@ impl TypedArrayPrototype {
 
         match find_result {
             Some((_, index_value)) => Ok(index_value),
-            None => Ok(cx.smi(-1)),
+            None => Ok(cx.negative_one()),
         }
     }
 
@@ -606,7 +606,7 @@ impl TypedArrayPrototype {
 
         match find_result {
             Some((_, index_value)) => Ok(index_value),
-            None => Ok(cx.smi(-1)),
+            None => Ok(cx.negative_one()),
         }
     }
 
@@ -710,7 +710,7 @@ impl TypedArrayPrototype {
         let length = typed_array_length(&typed_array_record) as u64;
 
         if length == 0 {
-            return Ok(cx.smi(-1));
+            return Ok(cx.negative_one());
         }
 
         let search_element = get_argument(cx, arguments, 0);
@@ -718,7 +718,7 @@ impl TypedArrayPrototype {
         let n_arg = get_argument(cx, arguments, 1);
         let mut n = to_integer_or_infinity(cx, n_arg)?;
         if n == f64::INFINITY {
-            return Ok(cx.smi(-1));
+            return Ok(cx.negative_one());
         } else if n == f64::NEG_INFINITY {
             n = 0.0;
         }
@@ -742,7 +742,7 @@ impl TypedArrayPrototype {
             }
         }
 
-        Ok(cx.smi(-1))
+        Ok(cx.negative_one())
     }
 
     /// %TypedArray%.prototype.join (https://tc39.es/ecma262/#sec-%typedarray%.prototype.join)
@@ -814,7 +814,7 @@ impl TypedArrayPrototype {
         let length = typed_array_length(&typed_array_record) as u64;
 
         if length == 0 {
-            return Ok(cx.smi(-1));
+            return Ok(cx.negative_one());
         }
 
         let search_element = get_argument(cx, arguments, 0);
@@ -823,7 +823,7 @@ impl TypedArrayPrototype {
             let start_arg = get_argument(cx, arguments, 1);
             let n = to_integer_or_infinity(cx, start_arg)?;
             if n == f64::NEG_INFINITY {
-                return Ok(cx.smi(-1));
+                return Ok(cx.negative_one());
             }
 
             if n >= 0.0 {
@@ -832,7 +832,7 @@ impl TypedArrayPrototype {
                 let start_index = length as i64 + n as i64;
 
                 if start_index < 0 {
-                    return Ok(cx.smi(-1));
+                    return Ok(cx.negative_one());
                 }
 
                 start_index as u64
@@ -854,7 +854,7 @@ impl TypedArrayPrototype {
             }
         }
 
-        Ok(cx.smi(-1))
+        Ok(cx.negative_one())
     }
 
     /// get %TypedArray%.prototype.length (https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.length)
@@ -868,7 +868,7 @@ impl TypedArrayPrototype {
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
         if is_typed_array_out_of_bounds(&typed_array_record) {
-            return Ok(cx.smi(0));
+            return Ok(cx.zero());
         }
 
         let length = typed_array_length(&typed_array_record);

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -486,7 +486,7 @@ impl Handle<ObjectValue> {
     }
 
     pub fn instrinsic_length_prop(&mut self, cx: Context, length: i32) {
-        let length_value = Value::smi(length).to_handle(cx);
+        let length_value = cx.smi(length);
         self.set_property(cx, cx.names.length(), Property::data(length_value, false, false, true))
     }
 

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -164,13 +164,13 @@ pub fn to_number(cx: Context, value_handle: Handle<Value>) -> EvalResult<Handle<
         }
     } else {
         match value.get_tag() {
-            NULL_TAG => Ok(cx.smi(0)),
-            UNDEFINED_TAG => Ok(Value::nan().to_handle(cx)),
+            NULL_TAG => Ok(cx.zero()),
+            UNDEFINED_TAG => Ok(cx.nan()),
             BOOL_TAG => {
                 if value.as_bool() {
-                    Ok(cx.smi(1))
+                    Ok(cx.one())
                 } else {
-                    Ok(cx.smi(0))
+                    Ok(cx.zero())
                 }
             }
             _ => unreachable!(),

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -164,13 +164,13 @@ pub fn to_number(cx: Context, value_handle: Handle<Value>) -> EvalResult<Handle<
         }
     } else {
         match value.get_tag() {
-            NULL_TAG => Ok(Value::smi(0).to_handle(cx)),
+            NULL_TAG => Ok(cx.smi(0)),
             UNDEFINED_TAG => Ok(Value::nan().to_handle(cx)),
             BOOL_TAG => {
                 if value.as_bool() {
-                    Ok(Value::smi(1).to_handle(cx))
+                    Ok(cx.smi(1))
                 } else {
-                    Ok(Value::smi(0).to_handle(cx))
+                    Ok(cx.smi(0))
                 }
             }
             _ => unreachable!(),


### PR DESCRIPTION
## Summary

Introduce the `Context::{smi, number, zero, one, negative_one, nan}` utilities to simply creation of number handles. The `Context::{smi, number}` functions will create the given value behind a handle, and `Context::{zero, one, negative_one, nan}` return a handle to the canonical value instead of allocating a new handle.