### PR TITLE
[runtime] Introduce ObjectValue safe downcasts for object subtypes

### DIFF
--- a/src/js/runtime/generator_object.rs
+++ b/src/js/runtime/generator_object.rs
@@ -203,17 +203,17 @@ fn generator_validate(
     cx: Context,
     generator: Handle<Value>,
 ) -> EvalResult<Handle<GeneratorObject>> {
-    if !generator.is_object() || !generator.as_object().is_generator() {
-        return type_error(cx, "expected generator");
+    if generator.is_object() {
+        if let Some(generator) = generator.as_object().as_generator() {
+            if generator.state == GeneratorState::Executing {
+                return type_error(cx, "generator is already executing");
+            }
+
+            return Ok(generator);
+        }
     }
 
-    let generator = generator.as_object().cast::<GeneratorObject>();
-
-    if generator.state == GeneratorState::Executing {
-        return type_error(cx, "generator is already executing");
-    }
-
-    Ok(generator)
+    type_error(cx, "expected generator")
 }
 
 /// GeneratorResume (https://tc39.es/ecma262/#sec-generatorresume)

--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -210,8 +210,8 @@ impl ArrayBufferPrototype {
         let new_object = construct(cx, constructor, &[new_length_value], None)?;
 
         // Check type of object returned from constructor
-        let mut new_array_buffer = if new_object.is_array_buffer() {
-            new_object.cast::<ArrayBufferObject>()
+        let mut new_array_buffer = if let Some(array_buffer) = new_object.as_array_buffer() {
+            array_buffer
         } else if new_object.is_shared_array_buffer() {
             return type_error(cx, "constructor cannot return SharedArrayBuffer");
         } else {
@@ -280,8 +280,8 @@ fn require_array_buffer(
 ) -> EvalResult<Handle<ArrayBufferObject>> {
     if value.is_object() {
         let object = value.as_object();
-        if object.is_array_buffer() {
-            return Ok(object.cast::<ArrayBufferObject>());
+        if let Some(array_buffer) = object.as_array_buffer() {
+            return Ok(array_buffer);
         }
     }
 

--- a/src/js/runtime/intrinsics/boolean_prototype.rs
+++ b/src/js/runtime/intrinsics/boolean_prototype.rs
@@ -56,8 +56,8 @@ fn this_boolean_value(cx: Context, value: Handle<Value>) -> EvalResult<bool> {
 
     if value.is_object() {
         let object_value = value.as_object();
-        if object_value.is_bool_object() {
-            return Ok(object_value.cast::<BooleanObject>().boolean_data());
+        if let Some(boolean_object) = object_value.as_boolean_object() {
+            return Ok(boolean_object.boolean_data());
         }
     }
 

--- a/src/js/runtime/intrinsics/data_view_prototype.rs
+++ b/src/js/runtime/intrinsics/data_view_prototype.rs
@@ -397,11 +397,11 @@ fn require_is_data_view(cx: Context, value: Handle<Value>) -> EvalResult<Handle<
     }
 
     let object = value.as_object();
-    if !object.is_data_view() {
-        return type_error(cx, "expected data view");
+    if let Some(data_view) = object.as_data_view() {
+        return Ok(data_view);
     }
 
-    Ok(object.cast::<DataViewObject>())
+    type_error(cx, "expected data view")
 }
 
 /// GetViewValue (https://tc39.es/ecma262/#sec-getviewvalue)

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -1618,12 +1618,10 @@ pub fn this_date_value(value: Handle<Value>) -> Option<f64> {
         return None;
     }
 
-    let object = value.as_object();
-    if !object.is_date_object() {
-        return None;
-    }
-
-    Some(object.cast::<DateObject>().date_value())
+    value
+        .as_object()
+        .as_date_object()
+        .map(|date| date.date_value())
 }
 
 #[inline]

--- a/src/js/runtime/intrinsics/finalization_registry_prototype.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_prototype.rs
@@ -120,10 +120,5 @@ fn this_finalization_registry_value(
         return None;
     }
 
-    let object = value.as_object();
-    if !object.is_finalization_registry_object() {
-        return None;
-    }
-
-    Some(object.cast::<FinalizationRegistryObject>())
+    value.as_object().as_finalization_registry_object()
 }

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -200,8 +200,8 @@ impl FunctionPrototype {
         }
 
         let this_object = this_value.as_object();
-        if this_object.is_closure() {
-            let function = this_object.cast::<Closure>().function();
+        if let Some(closure) = this_object.as_closure() {
+            let function = closure.function();
 
             // First check for if the closure is a bound function
             if BoundFunctionObject::is_bound_function(cx, this_object.get_()) {

--- a/src/js/runtime/intrinsics/json_object.rs
+++ b/src/js/runtime/intrinsics/json_object.rs
@@ -12,7 +12,6 @@ use crate::{
             error::{syntax_error, type_error},
             function::get_argument,
             get,
-            intrinsics::{bigint_constructor::BigIntObject, boolean_constructor::BooleanObject},
             object_value::ObjectValue,
             ordinary_object::ordinary_object_create,
             property::Property,
@@ -572,11 +571,10 @@ impl JSONSerializer {
                 value = to_number(cx, value)?;
             } else if value_object.is_string_object() {
                 value = to_string(cx, value)?.into();
-            } else if value_object.is_bool_object() {
-                let bool = value_object.cast::<BooleanObject>().boolean_data();
-                value = cx.bool(bool);
-            } else if value_object.is_bigint_object() {
-                value = value_object.cast::<BigIntObject>().bigint_data().into()
+            } else if let Some(boolean_object) = value_object.as_boolean_object() {
+                value = cx.bool(boolean_object.boolean_data());
+            } else if let Some(bigint_object) = value_object.as_bigint_object() {
+                value = bigint_object.bigint_data().into()
             }
         }
 

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -268,10 +268,5 @@ fn this_map_value(value: Handle<Value>) -> Option<Handle<MapObject>> {
         return None;
     }
 
-    let object = value.as_object();
-    if !object.is_map_object() {
-        return None;
-    }
-
-    Some(object.cast::<MapObject>())
+    value.as_object().as_map_object()
 }

--- a/src/js/runtime/intrinsics/number_prototype.rs
+++ b/src/js/runtime/intrinsics/number_prototype.rs
@@ -389,8 +389,8 @@ fn this_number_value(cx: Context, value_handle: Handle<Value>) -> EvalResult<Val
 
     if value.is_object() {
         let object_value = value.as_object();
-        if object_value.is_number_object() {
-            let number_f64 = object_value.cast::<NumberObject>().number_data();
+        if let Some(number_object) = object_value.as_number_object() {
+            let number_f64 = number_object.number_data();
             return Ok(Value::number(number_f64));
         }
     }

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -177,7 +177,7 @@ impl ObjectPrototype {
             "Function"
         } else if object.is_error() {
             "Error"
-        } else if object.is_bool_object() {
+        } else if object.is_boolean_object() {
             "Boolean"
         } else if object.is_number_object() {
             "Number"

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -175,11 +175,8 @@ impl RegExpConstructor {
             Some(new_target) => new_target,
         };
 
-        let regexp_source = if pattern_arg.is_object() && pattern_arg.as_object().is_regexp_object()
-        {
+        let regexp_source = if let Some(pattern_regexp_object) = as_regexp_object(pattern_arg) {
             // Construction from a regexp object
-            let pattern_regexp_object = pattern_arg.as_object().cast::<RegExpObject>();
-
             if flags_arg.is_undefined() {
                 RegExpSource::RegExpObject(pattern_regexp_object)
             } else {
@@ -206,6 +203,15 @@ impl RegExpConstructor {
         };
 
         regexp_create(cx, regexp_source, new_target)
+    }
+}
+
+#[inline]
+pub fn as_regexp_object(value: Handle<Value>) -> Option<Handle<RegExpObject>> {
+    if value.is_object() {
+        value.as_object().as_regexp_object()
+    } else {
+        None
     }
 }
 

--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -611,12 +611,7 @@ fn this_set_value(value: Handle<Value>) -> Option<Handle<SetObject>> {
         return None;
     }
 
-    let object = value.as_object();
-    if !object.is_set_object() {
-        return None;
-    }
-
-    Some(object.cast::<SetObject>())
+    value.as_object().as_set_object()
 }
 
 struct SetRecord {

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -42,7 +42,7 @@ use crate::{
     must,
 };
 
-use super::regexp_constructor::{FlagsSource, RegExpObject};
+use super::regexp_constructor::FlagsSource;
 
 pub struct StringPrototype;
 
@@ -433,8 +433,9 @@ impl StringPrototype {
         if !regexp_arg.is_nullish() {
             if is_regexp(cx, regexp_arg)? {
                 let regexp_object = regexp_arg.as_object();
-                let has_global_flag = if regexp_object.is_regexp_object() {
-                    regexp_object.cast::<RegExpObject>().flags().is_global()
+                let has_global_flag = if let Some(regexp_object) = regexp_object.as_regexp_object()
+                {
+                    regexp_object.flags().is_global()
                 } else {
                     let flags_string = get(cx, regexp_object, cx.names.flags())?;
                     require_object_coercible(cx, flags_string)?;
@@ -1213,8 +1214,8 @@ fn this_string_value(cx: Context, value: Handle<Value>) -> EvalResult<Handle<Val
 
     if value.is_object() {
         let object_value = value.as_object();
-        if object_value.is_string_object() {
-            return Ok(object_value.cast::<StringObject>().string_data().as_value());
+        if let Some(string_object) = object_value.as_string_object() {
+            return Ok(string_object.string_data().as_value());
         }
     }
 

--- a/src/js/runtime/intrinsics/symbol_prototype.rs
+++ b/src/js/runtime/intrinsics/symbol_prototype.rs
@@ -4,7 +4,7 @@ use crate::js::runtime::{
     value::SymbolValue, Context, Handle, Value,
 };
 
-use super::{intrinsics::Intrinsic, symbol_constructor::SymbolObject};
+use super::intrinsics::Intrinsic;
 
 pub struct SymbolPrototype;
 
@@ -101,8 +101,8 @@ fn this_symbol_value(cx: Context, value: Handle<Value>) -> EvalResult<Handle<Val
 
     if value.is_object() {
         let object_value = value.as_object();
-        if object_value.is_symbol_object() {
-            return Ok(object_value.cast::<SymbolObject>().symbol_data().into());
+        if let Some(symbol_object) = object_value.as_symbol_object() {
+            return Ok(symbol_object.symbol_data().into());
         }
     }
 

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -644,14 +644,14 @@ macro_rules! create_typed_array_constructor {
                         proto,
                         argument.as_typed_array(),
                     );
-                } else if argument.is_array_buffer() {
+                } else if let Some(argument) = argument.as_array_buffer() {
                     let byte_offset = get_argument(cx, arguments, 1);
                     let length = get_argument(cx, arguments, 2);
 
                     return Self::initialize_typed_array_from_array_buffer(
                         cx,
                         proto,
-                        argument.cast::<ArrayBufferObject>(),
+                        argument,
                         byte_offset,
                         length,
                     );

--- a/src/js/runtime/intrinsics/weak_map_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_map_prototype.rs
@@ -133,10 +133,5 @@ fn this_weak_map_value(value: Handle<Value>) -> Option<Handle<WeakMapObject>> {
         return None;
     }
 
-    let object = value.as_object();
-    if !object.is_weak_map_object() {
-        return None;
-    }
-
-    Some(object.cast::<WeakMapObject>())
+    value.as_object().as_weak_map_object()
 }

--- a/src/js/runtime/intrinsics/weak_ref_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_ref_prototype.rs
@@ -47,10 +47,5 @@ fn this_weak_ref_value(value: Handle<Value>) -> Option<Handle<WeakRefObject>> {
         return None;
     }
 
-    let object = value.as_object();
-    if !object.is_weak_ref_object() {
-        return None;
-    }
-
-    Some(object.cast::<WeakRefObject>())
+    value.as_object().as_weak_ref_object()
 }

--- a/src/js/runtime/intrinsics/weak_set_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_set_prototype.rs
@@ -105,10 +105,5 @@ fn this_weak_set_value(value: Handle<Value>) -> Option<Handle<WeakSetObject>> {
         return None;
     }
 
-    let object = value.as_object();
-    if !object.is_weak_set_object() {
-        return None;
-    }
-
-    Some(object.cast::<WeakSetObject>())
+    value.as_object().as_weak_set_object()
 }

--- a/src/js/runtime/object_descriptor.rs
+++ b/src/js/runtime/object_descriptor.rs
@@ -189,14 +189,17 @@ impl ObjectDescriptor {
         desc.to_handle()
     }
 
+    #[inline]
     pub const fn kind(&self) -> ObjectKind {
         self.kind
     }
 
+    #[inline]
     pub const fn vtable(&self) -> VirtualObjectVtable {
         self.vtable
     }
 
+    #[inline]
     pub fn is_object(&self) -> bool {
         self.flags.contains(DescFlags::IS_OBJECT)
     }

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -338,6 +338,14 @@ pub fn is_promise(value: Value) -> bool {
     value.is_object() && value.as_object().is_promise()
 }
 
+pub fn as_promise(value: Handle<Value>) -> Option<Handle<PromiseObject>> {
+    if is_promise(value.get()) {
+        Some(value.cast())
+    } else {
+        None
+    }
+}
+
 /// Coerce a value to an ordinary promise (aka the Promise constructor). An ordinary promise is
 /// returned as-is, otherwise value is wrapped in a resolved promise.
 ///
@@ -347,9 +355,7 @@ pub fn coerce_to_ordinary_promise(
     cx: Context,
     value: Handle<Value>,
 ) -> EvalResult<Handle<PromiseObject>> {
-    if is_promise(value.get()) {
-        let value = value.cast::<PromiseObject>();
-
+    if let Some(value) = as_promise(value) {
         let value_constructor = get(cx, value.into(), cx.names.constructor())?;
         let promise_constructor = cx.get_intrinsic_ptr(Intrinsic::PromiseConstructor);
         if value_constructor.is_object()

--- a/src/js/runtime/tasks.rs
+++ b/src/js/runtime/tasks.rs
@@ -6,9 +6,9 @@ use crate::js::runtime::{
 };
 
 use super::{
-    async_generator_object::{async_generator_resume, AsyncGeneratorObject},
+    async_generator_object::async_generator_resume,
     gc::{HandleScope, HeapVisitor},
-    generator_object::{GeneratorCompletionType, GeneratorObject},
+    generator_object::GeneratorCompletionType,
     object_value::ObjectValue,
     promise_object::{PromiseCapability, PromiseObject, PromiseReactionKind},
     Context, EvalResult, HeapPtr, Realm, Value,
@@ -176,12 +176,11 @@ impl AwaitResumeTask {
             PromiseReactionKind::Reject => GeneratorCompletionType::Throw,
         };
 
-        if generator.is_generator() {
-            let generator = generator.cast::<GeneratorObject>();
+        if let Some(generator) = generator.as_generator() {
             cx.vm()
                 .resume_generator(generator, completion_value, completion_type)?;
         } else {
-            let async_generator = generator.cast::<AsyncGeneratorObject>();
+            let async_generator = generator.as_async_generator().unwrap();
 
             // Must execute in the realm of the async generator since AsyncGeneratorResume may need
             // to drain the async queue when the VM stack is empty.

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -703,8 +703,7 @@ pub fn is_array(cx: Context, value: Handle<Value>) -> EvalResult<bool> {
         return Ok(true);
     }
 
-    if object_value.is_proxy() {
-        let proxy = object_value.cast::<ProxyObject>();
+    if let Some(proxy) = object_value.as_proxy() {
         if proxy.is_revoked() {
             return type_error(cx, "operation attempted on revoked proxy");
         }


### PR DESCRIPTION
## Summary

Introduce safe ObjectValue downcasts of the form `fn as_subtype(&self) -> Option<Handle<Subtype>>` for object subtypes. These are automatically generated using the `impl_subtype_casts` macro. Casts are generated for both `Handle<ObjectValue>` and `HeapPtr<ObjectValue>`, and `is_subtype` checks are generated for `ObjectValue`.

This lets us reduce the number of raw `cast::<Subtype>()` for objects in the codebase.