### PR TITLE
[runtime] Object subtypes now use a visit_object_pointers method during GC visit_pointers

### DIFF
--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -315,7 +315,7 @@ impl HeapObject for HeapPtr<MappedArgumentsObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.scope);
     }
 }
@@ -326,6 +326,6 @@ impl HeapObject for HeapPtr<UnmappedArgumentsObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -258,6 +258,6 @@ impl HeapObject for HeapPtr<ArrayObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -491,7 +491,7 @@ impl HeapObject for HeapPtr<AsyncGeneratorObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer_opt(&mut self.request_queue);
 
         if self.state.is_suspended() {

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -194,7 +194,7 @@ impl HeapObject for HeapPtr<Closure> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.function);
         visitor.visit_pointer(&mut self.scope);
     }

--- a/src/js/runtime/generator_object.rs
+++ b/src/js/runtime/generator_object.rs
@@ -296,7 +296,7 @@ impl HeapObject for HeapPtr<GeneratorObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
 
         if self.state.is_suspended() {
             let mut stack_frame = StackFrame::for_fp(self.current_fp().cast_mut());

--- a/src/js/runtime/intrinsics/array_buffer_constructor.rs
+++ b/src/js/runtime/intrinsics/array_buffer_constructor.rs
@@ -310,7 +310,7 @@ impl HeapObject for HeapPtr<ArrayBufferObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer_opt(&mut self.data);
     }
 }

--- a/src/js/runtime/intrinsics/array_iterator.rs
+++ b/src/js/runtime/intrinsics/array_iterator.rs
@@ -174,7 +174,7 @@ impl HeapObject for HeapPtr<ArrayIterator> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.array);
     }
 }

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
@@ -61,7 +61,7 @@ impl HeapObject for HeapPtr<AsyncFromSyncIterator> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.iterator);
         visitor.visit_value(&mut self.next_method);
     }

--- a/src/js/runtime/intrinsics/bigint_constructor.rs
+++ b/src/js/runtime/intrinsics/bigint_constructor.rs
@@ -182,7 +182,7 @@ impl HeapObject for HeapPtr<BigIntObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.bigint_data);
     }
 }

--- a/src/js/runtime/intrinsics/boolean_constructor.rs
+++ b/src/js/runtime/intrinsics/boolean_constructor.rs
@@ -128,6 +128,6 @@ impl HeapObject for HeapPtr<BooleanObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/data_view_constructor.rs
+++ b/src/js/runtime/intrinsics/data_view_constructor.rs
@@ -185,7 +185,7 @@ impl HeapObject for HeapPtr<DataViewObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.viewed_array_buffer);
     }
 }

--- a/src/js/runtime/intrinsics/date_object.rs
+++ b/src/js/runtime/intrinsics/date_object.rs
@@ -353,6 +353,6 @@ impl HeapObject for HeapPtr<DateObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl crate::js::runtime::gc::HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/error_constructor.rs
+++ b/src/js/runtime/intrinsics/error_constructor.rs
@@ -126,6 +126,6 @@ impl HeapObject for HeapPtr<ErrorObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/finalization_registry_object.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_object.rs
@@ -221,7 +221,7 @@ impl HeapObject for HeapPtr<FinalizationRegistryObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.cells);
         visitor.visit_pointer(&mut self.cleanup_callback);
 

--- a/src/js/runtime/intrinsics/map_iterator.rs
+++ b/src/js/runtime/intrinsics/map_iterator.rs
@@ -161,7 +161,7 @@ impl HeapObject for HeapPtr<MapIterator> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.map);
     }
 }

--- a/src/js/runtime/intrinsics/map_object.rs
+++ b/src/js/runtime/intrinsics/map_object.rs
@@ -86,7 +86,7 @@ impl HeapObject for HeapPtr<MapObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.map_data);
     }
 }

--- a/src/js/runtime/intrinsics/number_constructor.rs
+++ b/src/js/runtime/intrinsics/number_constructor.rs
@@ -233,6 +233,6 @@ impl HeapObject for HeapPtr<NumberObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -368,6 +368,6 @@ impl HeapObject for HeapPtr<ObjectPrototype> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -384,7 +384,7 @@ impl HeapObject for HeapPtr<RegExpObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.compiled_regexp);
     }
 }

--- a/src/js/runtime/intrinsics/regexp_string_iterator.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator.rs
@@ -153,7 +153,7 @@ impl HeapObject for HeapPtr<RegExpStringIterator> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.regexp_object);
         visitor.visit_pointer(&mut self.target_string);
     }

--- a/src/js/runtime/intrinsics/set_iterator.rs
+++ b/src/js/runtime/intrinsics/set_iterator.rs
@@ -151,7 +151,7 @@ impl HeapObject for HeapPtr<SetIterator> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.set);
     }
 }

--- a/src/js/runtime/intrinsics/set_object.rs
+++ b/src/js/runtime/intrinsics/set_object.rs
@@ -102,7 +102,7 @@ impl HeapObject for HeapPtr<SetObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.set_data);
     }
 }

--- a/src/js/runtime/intrinsics/string_iterator.rs
+++ b/src/js/runtime/intrinsics/string_iterator.rs
@@ -91,7 +91,7 @@ impl HeapObject for HeapPtr<StringIterator> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         self.iter.visit_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/symbol_constructor.rs
+++ b/src/js/runtime/intrinsics/symbol_constructor.rs
@@ -187,7 +187,7 @@ impl HeapObject for HeapPtr<SymbolObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.symbol_data);
     }
 }

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -944,7 +944,7 @@ macro_rules! create_typed_array_constructor {
             }
 
             fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-                self.cast::<ObjectValue>().visit_pointers(visitor);
+                self.visit_object_pointers(visitor);
                 visitor.visit_pointer(&mut self.viewed_array_buffer);
             }
         }

--- a/src/js/runtime/intrinsics/weak_map_object.rs
+++ b/src/js/runtime/intrinsics/weak_map_object.rs
@@ -100,7 +100,7 @@ impl HeapObject for HeapPtr<WeakMapObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.weak_map_data);
 
         // Intentionally do not visit next_weak_map

--- a/src/js/runtime/intrinsics/weak_ref_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_ref_constructor.rs
@@ -132,7 +132,7 @@ impl HeapObject for HeapPtr<WeakRefObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
 
         // Intentionally do not visit weak_ref_target and next_weak_ref
     }

--- a/src/js/runtime/intrinsics/weak_set_object.rs
+++ b/src/js/runtime/intrinsics/weak_set_object.rs
@@ -100,7 +100,7 @@ impl HeapObject for HeapPtr<WeakSetObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.weak_set_data);
 
         // Intentionally do not visit next_weak_set

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -239,7 +239,7 @@ impl HeapObject for HeapPtr<ModuleNamespaceObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.module);
     }
 }

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -145,6 +145,14 @@ macro_rules! extend_object {
                 value.cast::<$crate::js::runtime::object_value::ObjectValue>()
             }
         }
+
+        impl $(<$($generics),*>)? $crate::js::runtime::HeapPtr<$name $(<$($generics),*>)?> {
+            #[inline]
+            pub fn visit_object_pointers(&self, visitor: &mut impl $crate::js::runtime::gc::HeapVisitor) {
+                use $crate::js::runtime::gc::HeapObject;
+                self.as_object().visit_pointers(visitor);
+            }
+        }
     }
 }
 

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -1,4 +1,4 @@
-use crate::{extend_object, must};
+use crate::{extend_object_without_conversions, must};
 
 use super::{
     abstract_operations::{call_object, create_data_property, get, get_function_realm},
@@ -19,7 +19,7 @@ use super::{
 // from ObjectValue so that the same methods can appear on ObjectValue but perform dynamic dispatch.
 //
 // Should never be created. Only used to reference its vtable.
-extend_object! {
+extend_object_without_conversions! {
     pub struct OrdinaryObject {}
 }
 

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -571,7 +571,7 @@ impl HeapObject for HeapPtr<PromiseObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
 
         match &mut self.state {
             PromiseState::Pending { reactions, .. } => {

--- a/src/js/runtime/proxy_object.rs
+++ b/src/js/runtime/proxy_object.rs
@@ -763,7 +763,7 @@ impl HeapObject for HeapPtr<ProxyObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer_opt(&mut self.proxy_handler);
         visitor.visit_pointer_opt(&mut self.proxy_target);
     }

--- a/src/js/runtime/string_object.rs
+++ b/src/js/runtime/string_object.rs
@@ -197,7 +197,7 @@ impl HeapObject for HeapPtr<StringObject> {
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast::<ObjectValue>().visit_pointers(visitor);
+        self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.string_data);
     }
 }


### PR DESCRIPTION
## Summary

Implement a `visit_object_pointers` method on all ObjectValue subtypes which is used during `visit_pointers` instead of `self.cast::<ObjectValue>().visit_pointers`. This reduces the number of casts in the codebase