### PR TITLE
[runtime] Convert misc raw casts to known safe cast methods

### DIFF
--- a/src/js/runtime/abstract_operations.rs
+++ b/src/js/runtime/abstract_operations.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 
 use super::{
+    accessor::Accessor,
     array_object::create_array_from_list,
     bound_function_object::BoundFunctionObject,
     bytecode::function::Closure,
@@ -542,7 +543,7 @@ pub fn private_get(
         return Ok(property.value());
     }
 
-    let accessor = property.value().as_accessor();
+    let accessor = Accessor::from_value(property.value());
     match accessor.get {
         None => type_error(cx, "cannot access private field or method"),
         Some(getter) => {
@@ -571,7 +572,7 @@ pub fn private_set(
         type_error(cx, "cannot assign to private method")
     } else {
         // Property is an private accessor
-        let accessor = property.value().as_accessor();
+        let accessor = Accessor::from_value(property.value());
         match accessor.set {
             None => type_error(cx, "cannot set getter-only private property"),
             Some(setter) => {

--- a/src/js/runtime/accessor.rs
+++ b/src/js/runtime/accessor.rs
@@ -1,0 +1,51 @@
+use crate::{js::runtime::object_descriptor::ObjectKind, set_uninit};
+
+use super::{
+    gc::{HeapObject, HeapVisitor},
+    object_descriptor::ObjectDescriptor,
+    object_value::ObjectValue,
+    Context, Handle, HeapPtr, Value,
+};
+
+/// The value of an accessor property. May contain a getter and/or a setter.
+#[repr(C)]
+pub struct Accessor {
+    descriptor: HeapPtr<ObjectDescriptor>,
+    pub get: Option<HeapPtr<ObjectValue>>,
+    pub set: Option<HeapPtr<ObjectValue>>,
+}
+
+impl Accessor {
+    pub fn new(
+        cx: Context,
+        get: Option<Handle<ObjectValue>>,
+        set: Option<Handle<ObjectValue>>,
+    ) -> Handle<Accessor> {
+        let mut accessor = cx.alloc_uninit::<Accessor>();
+
+        set_uninit!(accessor.descriptor, cx.base_descriptors.get(ObjectKind::Accessor));
+        set_uninit!(accessor.get, get.map(|v| v.get_()));
+        set_uninit!(accessor.set, set.map(|v| v.get_()));
+
+        accessor.to_handle()
+    }
+
+    pub fn from_value(value: Handle<Value>) -> Handle<Accessor> {
+        debug_assert!(
+            value.is_pointer() && value.as_pointer().descriptor().kind() == ObjectKind::Accessor
+        );
+        value.cast::<Accessor>()
+    }
+}
+
+impl HeapObject for HeapPtr<Accessor> {
+    fn byte_size(&self) -> usize {
+        size_of::<Accessor>()
+    }
+
+    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut self.descriptor);
+        visitor.visit_pointer_opt(&mut self.get);
+        visitor.visit_pointer_opt(&mut self.set);
+    }
+}

--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -308,11 +308,13 @@ pub fn async_generator_validate(
     cx: Context,
     generator: Handle<Value>,
 ) -> EvalResult<Handle<AsyncGeneratorObject>> {
-    if !generator.is_object() || !generator.as_object().is_async_generator() {
-        return type_error(cx, "expected async generator");
+    if generator.is_object() {
+        if let Some(async_generator) = generator.as_object().as_async_generator() {
+            return Ok(async_generator);
+        }
     }
 
-    Ok(generator.as_object().cast::<AsyncGeneratorObject>())
+    type_error(cx, "expected async generator")
 }
 
 /// AsyncGeneratorResume (https://tc39.es/ecma262/#sec-asyncgeneratorresume)

--- a/src/js/runtime/bound_function_object.rs
+++ b/src/js/runtime/bound_function_object.rs
@@ -65,7 +65,7 @@ impl BoundFunctionObject {
             .private_element_find(cx, cx.well_known_symbols.bound_target().cast())
             .unwrap()
             .value()
-            .cast::<ObjectValue>()
+            .as_object()
     }
 
     fn set_target_function(
@@ -87,7 +87,7 @@ impl BoundFunctionObject {
     ) -> Option<Handle<ObjectValue>> {
         object
             .private_element_find(cx, cx.well_known_symbols.bound_target().cast())
-            .map(|p| p.value().cast::<ObjectValue>())
+            .map(|p| p.value().as_object())
     }
 
     pub fn is_bound_function(cx: Context, object: HeapPtr<ObjectValue>) -> bool {

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -39,7 +39,6 @@ use crate::js::{
             SourceTextModule,
         },
         object_descriptor::ObjectKind,
-        object_value::ObjectValue,
         regexp::compiler::compile_regexp,
         scope::Scope,
         scope_names::{ScopeFlags, ScopeNameFlags, ScopeNames},
@@ -487,7 +486,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
         );
 
         // Place the module in the first slot of its module scope
-        module_scope.set_slot(0, module.cast::<ObjectValue>().get_().into());
+        module_scope.set_heap_item_slot(0, module.get_().as_heap_item());
 
         module
     }
@@ -517,7 +516,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
                 if let VMLocation::ModuleScope { index, .. } = binding.vm_location().unwrap() {
                     // All exported value are boxed, which will eventually be linked to import
                     let boxed_value = BoxedValue::new(self.cx, init_value);
-                    module_scope.set_slot(index, boxed_value.cast::<ObjectValue>().into());
+                    module_scope.set_heap_item_slot(index, boxed_value.as_heap_item());
                 } else {
                     unreachable!("expected module scope location")
                 }

--- a/src/js/runtime/class_names.rs
+++ b/src/js/runtime/class_names.rs
@@ -225,7 +225,7 @@ pub fn new_class(
         cx.vm().store_to_scope_at_depth(
             home_object.scope_index as usize,
             home_object.parent_depth as usize,
-            constructor.cast::<ObjectValue>().get_().into(),
+            constructor.as_object().get_().into(),
         );
     }
 

--- a/src/js/runtime/gc/garbage_collector.rs
+++ b/src/js/runtime/gc/garbage_collector.rs
@@ -8,7 +8,6 @@ use crate::js::runtime::{
         weak_ref_constructor::WeakRefObject, weak_set_object::WeakSetObject,
     },
     object_descriptor::{ObjectDescriptor, ObjectKind},
-    object_value::ObjectValue,
     string_value::FlatString,
     Context, Value,
 };
@@ -267,7 +266,7 @@ impl GarbageCollector {
 
                 // Target is known to be live if it has already moved (and left a forwarding pointer)
                 if let Some(forwarding_ptr) = decode_forwarding_pointer(target_descriptor) {
-                    weak_ref.set_weak_ref_target(forwarding_ptr.cast::<ObjectValue>().into());
+                    weak_ref.set_weak_ref_target(Value::heap_item(forwarding_ptr));
                 } else {
                     // Otherwise target was garbage collected so reset target to undefined
                     weak_ref.set_weak_ref_target(Value::undefined());
@@ -295,7 +294,7 @@ impl GarbageCollector {
 
                     // Value is known to be live if it has already moved (and left a forwarding pointer)
                     if let Some(forwarding_ptr) = decode_forwarding_pointer(weak_ref_descriptor) {
-                        *weak_ref_value = forwarding_ptr.cast::<ObjectValue>().into();
+                        *weak_ref_value = Value::heap_item(forwarding_ptr);
                     } else {
                         // Otherwise value was garbage collected so remove value from set.
                         // It is safe to remove during iteration for a BsHashSet.
@@ -353,7 +352,7 @@ impl GarbageCollector {
                     // pointer. Visit the value associated with the key since we now know it is
                     // live. Also update key to point to to-space so we can tell it is visited.
                     if let Some(forwarding_ptr) = decode_forwarding_pointer(weak_key_descriptor) {
-                        *weak_key_value = forwarding_ptr.cast::<ObjectValue>().into();
+                        *weak_key_value = Value::heap_item(forwarding_ptr);
                         found_new_live_value = true;
                         self.visit_value(value);
                     }
@@ -407,7 +406,7 @@ impl GarbageCollector {
                     // know it is live. Also update target to point to to-space so we can tell it
                     // is visited.
                     if let Some(forwarding_ptr) = decode_forwarding_pointer(target_descriptor) {
-                        cell.target = forwarding_ptr.cast::<ObjectValue>().into();
+                        cell.target = Value::heap_item(forwarding_ptr);
 
                         if let Some(ref mut unregister_token) = cell.unregister_token {
                             found_new_live_unregister_token = true;

--- a/src/js/runtime/gc/handle.rs
+++ b/src/js/runtime/gc/handle.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::js::runtime::{
     object_value::ObjectValue,
     string_value::StringValue,
-    value::{AccessorValue, BigIntValue, SymbolValue},
+    value::{BigIntValue, SymbolValue},
     Context, Value,
 };
 
@@ -366,11 +366,6 @@ impl Handle<Value> {
 
     #[inline]
     pub fn as_bigint(&self) -> Handle<BigIntValue> {
-        self.cast()
-    }
-
-    #[inline]
-    pub fn as_accessor(&self) -> Handle<AccessorValue> {
         self.cast()
     }
 }

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -1,4 +1,5 @@
 use crate::js::runtime::{
+    accessor::Accessor,
     arguments_object::{MappedArgumentsObject, UnmappedArgumentsObject},
     array_object::ArrayObject,
     array_properties::{DenseArrayProperties, SparseArrayProperties},
@@ -65,7 +66,7 @@ use crate::js::runtime::{
     source_file::SourceFile,
     string_object::StringObject,
     string_value::StringValue,
-    value::{AccessorValue, BigIntValue, SymbolValue},
+    value::{BigIntValue, SymbolValue},
     Realm,
 };
 
@@ -139,7 +140,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::String => self.cast::<StringValue>().byte_size(),
             ObjectKind::Symbol => self.cast::<SymbolValue>().byte_size(),
             ObjectKind::BigInt => self.cast::<BigIntValue>().byte_size(),
-            ObjectKind::Accessor => self.cast::<AccessorValue>().byte_size(),
+            ObjectKind::Accessor => self.cast::<Accessor>().byte_size(),
             ObjectKind::Promise => self.cast::<PromiseObject>().byte_size(),
             ObjectKind::PromiseReaction => self.cast::<PromiseReaction>().byte_size(),
             ObjectKind::PromiseCapability => self.cast::<PromiseCapability>().byte_size(),
@@ -247,7 +248,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::String => self.cast::<StringValue>().visit_pointers(visitor),
             ObjectKind::Symbol => self.cast::<SymbolValue>().visit_pointers(visitor),
             ObjectKind::BigInt => self.cast::<BigIntValue>().visit_pointers(visitor),
-            ObjectKind::Accessor => self.cast::<AccessorValue>().visit_pointers(visitor),
+            ObjectKind::Accessor => self.cast::<Accessor>().visit_pointers(visitor),
             ObjectKind::Promise => self.cast::<PromiseObject>().visit_pointers(visitor),
             ObjectKind::PromiseReaction => self.cast::<PromiseReaction>().visit_pointers(visitor),
             ObjectKind::PromiseCapability => {

--- a/src/js/runtime/gc/heap_object.rs
+++ b/src/js/runtime/gc/heap_object.rs
@@ -19,6 +19,16 @@ pub trait IsHeapObject {}
 
 impl<T> IsHeapObject for T where HeapPtr<T>: HeapObject {}
 
+impl<T> HeapPtr<T>
+where
+    HeapPtr<T>: HeapObject,
+{
+    #[inline]
+    pub fn as_heap_item(&self) -> HeapPtr<HeapItem> {
+        self.cast()
+    }
+}
+
 pub trait HeapVisitor {
     fn visit(&mut self, ptr: &mut HeapPtr<HeapItem>);
 

--- a/src/js/runtime/intrinsics/intrinsics.rs
+++ b/src/js/runtime/intrinsics/intrinsics.rs
@@ -232,7 +232,7 @@ impl Intrinsics {
         macro_rules! register_existing_intrinsic {
             ($intrinsic_name:ident, $expr:expr) => {
                 realm.intrinsics.intrinsics.as_mut_slice()[Intrinsic::$intrinsic_name as usize] =
-                    ($expr).cast::<ObjectValue>().get_();
+                    ($expr).as_object().get_();
             };
         }
 
@@ -486,7 +486,7 @@ pub fn throw_type_error(
 
 /// %ThrowTypeError% (https://tc39.es/ecma262/#sec-%throwtypeerror%)
 fn create_throw_type_error_intrinsic(cx: Context, realm: Handle<Realm>) -> Handle<Value> {
-    let throw_type_error_func = BuiltinFunction::create_builtin_function_without_properties(
+    let mut throw_type_error_func = BuiltinFunction::create_builtin_function_without_properties(
         cx,
         throw_type_error,
         /* name */ None,
@@ -510,9 +510,7 @@ fn create_throw_type_error_intrinsic(cx: Context, realm: Handle<Realm>) -> Handl
     let name_desc = PropertyDescriptor::data(name, false, false, false);
     must!(define_property_or_throw(cx, throw_type_error_func, cx.names.name(), name_desc,));
 
-    must!(throw_type_error_func
-        .cast::<ObjectValue>()
-        .prevent_extensions(cx));
+    must!(throw_type_error_func.prevent_extensions(cx));
 
     throw_type_error_func.into()
 }

--- a/src/js/runtime/mod.rs
+++ b/src/js/runtime/mod.rs
@@ -1,4 +1,5 @@
 pub mod abstract_operations;
+mod accessor;
 mod arguments_object;
 mod array_object;
 mod array_properties;

--- a/src/js/runtime/module/linker.rs
+++ b/src/js/runtime/module/linker.rs
@@ -1,7 +1,6 @@
 use crate::js::runtime::{
     boxed_value::BoxedValue, error::syntax_error, gc::HandleScope,
-    module::source_text_module::ModuleState, object_value::ObjectValue, Context, EvalResult,
-    Handle,
+    module::source_text_module::ModuleState, Context, EvalResult, Handle,
 };
 
 use super::source_text_module::{
@@ -160,7 +159,7 @@ fn initialize_environment(cx: Context, module: Handle<SourceTextModule>) -> Eval
                     } => {
                         module
                             .module_scope_ptr()
-                            .set_slot(entry.slot_index, boxed_value.cast::<ObjectValue>().into());
+                            .set_heap_item_slot(entry.slot_index, boxed_value.as_heap_item());
                     }
                     // Namespace object may be stored as a module or scope value
                     ResolveExportResult::Resolved {
@@ -175,17 +174,16 @@ fn initialize_environment(cx: Context, module: Handle<SourceTextModule>) -> Eval
                         // all other exports, which are actual bindings whose BoxedValue is created
                         // when creating the the module scope).
                         let boxed_value = BoxedValue::new(cx, namespace_object.into());
-                        let stored_value = boxed_value.cast::<ObjectValue>().into();
                         module
                             .module_scope_ptr()
-                            .set_slot(entry.slot_index, stored_value);
+                            .set_heap_item_slot(entry.slot_index, boxed_value.as_heap_item());
                     }
                     _ => return syntax_error(cx, "could not resolve module specifier"),
                 }
             } else {
                 // Namespace object may be stored as a module or scope value
                 let namespace_object = imported_module.get_namespace_object(cx);
-                let namespace_object = namespace_object.cast::<ObjectValue>().into();
+                let namespace_object = namespace_object.as_value();
                 let slot_index = entry.slot_index;
 
                 if entry.is_exported {

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -7,7 +7,7 @@ use crate::{
         error::reference_error,
         gc::{HeapObject, HeapVisitor},
         object_descriptor::ObjectKind,
-        object_value::{ObjectValue, VirtualObject},
+        object_value::VirtualObject,
         ordinary_object::{
             object_create_with_optional_proto, ordinary_define_own_property, ordinary_delete,
             ordinary_get, ordinary_get_own_property, ordinary_has_property,
@@ -45,7 +45,7 @@ impl ModuleNamespaceObject {
         // Mark as non-extensible. This satisifes:
         // - [[IsExtensible]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-isextensible)
         // - [[PreventExtensions]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-preventextensions)
-        object.cast::<ObjectValue>().set_is_extensible_field(false);
+        object.as_object().set_is_extensible_field(false);
 
         set_uninit!(object.module, module.get_());
 

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -607,11 +607,11 @@ impl Handle<SourceTextModule> {
                 if let ResolveExportResult::Resolved { name, module } = result {
                     match name {
                         ResolveExportName::Local { boxed_value, .. } => {
-                            boxed_value_or_module_handle.replace(boxed_value.cast::<HeapItem>());
+                            boxed_value_or_module_handle.replace(boxed_value.as_heap_item());
                             self.insert_export(cx, key_handle, boxed_value_or_module_handle);
                         }
                         ResolveExportName::Namespace => {
-                            boxed_value_or_module_handle.replace(module.cast::<HeapItem>());
+                            boxed_value_or_module_handle.replace(module.as_heap_item());
                             self.insert_export(cx, key_handle, boxed_value_or_module_handle);
                         }
                     }

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -8,6 +8,7 @@ use std::{
 use crate::set_uninit;
 
 use super::{
+    accessor::Accessor,
     array_object::ArrayObject,
     array_properties::ArrayProperties,
     async_generator_object::AsyncGeneratorObject,
@@ -36,7 +37,7 @@ use super::{
     proxy_object::ProxyObject,
     string_object::StringObject,
     type_utilities::is_callable_object,
-    value::{AccessorValue, SymbolValue, Value},
+    value::{SymbolValue, Value},
     Context, Realm,
 };
 
@@ -94,6 +95,12 @@ macro_rules! extend_object_without_conversions {
             #[inline]
             pub fn as_object(&self) -> $crate::js::runtime::HeapPtr<$crate::js::runtime::object_value::ObjectValue> {
                 self.cast()
+            }
+
+            #[allow(dead_code)]
+            #[inline]
+            pub fn as_value(&self) -> $crate::js::runtime::Value {
+                self.as_object().into()
             }
         }
 
@@ -433,7 +440,7 @@ impl Handle<ObjectValue> {
         realm: Handle<Realm>,
     ) {
         let getter = BuiltinFunction::create(cx, func, 0, name, realm, None, Some("get"));
-        let accessor_value = AccessorValue::new(cx, Some(getter), None);
+        let accessor_value = Accessor::new(cx, Some(getter), None);
         self.set_property(cx, name, Property::accessor(accessor_value.into(), false, true));
     }
 
@@ -447,7 +454,7 @@ impl Handle<ObjectValue> {
     ) {
         let getter = BuiltinFunction::create(cx, getter, 0, name, realm, None, Some("get"));
         let setter = BuiltinFunction::create(cx, setter, 1, name, realm, None, Some("set"));
-        let accessor_value = AccessorValue::new(cx, Some(getter), Some(setter));
+        let accessor_value = Accessor::new(cx, Some(getter), Some(setter));
         self.set_property(cx, name, Property::accessor(accessor_value.into(), false, true));
     }
 

--- a/src/js/runtime/property.rs
+++ b/src/js/runtime/property.rs
@@ -1,9 +1,10 @@
 use bitflags::bitflags;
 
 use super::{
+    accessor::Accessor,
     gc::{Handle, HeapVisitor},
     object_value::ObjectValue,
-    value::{AccessorValue, Value},
+    value::Value,
     Context,
 };
 
@@ -99,7 +100,7 @@ impl Property {
     }
 
     pub fn private_getter(cx: Context, getter: Handle<ObjectValue>) -> Property {
-        let accessor_value = AccessorValue::new(cx, Some(getter), None);
+        let accessor_value = Accessor::new(cx, Some(getter), None);
         Property {
             value: accessor_value.into(),
             flags: PropertyFlags::IS_PRIVATE_ACCESSOR,
@@ -107,14 +108,14 @@ impl Property {
     }
 
     pub fn private_setter(cx: Context, setter: Handle<ObjectValue>) -> Property {
-        let accessor_value = AccessorValue::new(cx, None, Some(setter));
+        let accessor_value = Accessor::new(cx, None, Some(setter));
         Property {
             value: accessor_value.into(),
             flags: PropertyFlags::IS_PRIVATE_ACCESSOR,
         }
     }
 
-    pub fn private_accessor(accessor: Handle<AccessorValue>) -> Property {
+    pub fn private_accessor(accessor: Handle<Accessor>) -> Property {
         Property {
             value: accessor.into(),
             flags: PropertyFlags::IS_PRIVATE_ACCESSOR,

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -225,7 +225,7 @@ impl Handle<Realm> {
         for i in 0..scope_names.len() {
             if i == 0 {
                 // The first global scope slot is always the realm
-                global_scope.set_slot(0, self.get_().cast::<ObjectValue>().into());
+                global_scope.set_heap_item_slot(0, self.get_().as_heap_item());
             } else if scope_names
                 .get_slot_name(i)
                 .ptr_eq(&cx.names.this.as_string().as_flat())

--- a/src/js/runtime/scope.rs
+++ b/src/js/runtime/scope.rs
@@ -5,7 +5,7 @@ use super::{
     boxed_value::BoxedValue,
     collections::InlineArray,
     error::{err_assign_constant, err_cannot_set_property},
-    gc::{HeapObject, HeapVisitor},
+    gc::{HeapItem, HeapObject, HeapVisitor},
     get,
     module::source_text_module::SourceTextModule,
     object_descriptor::ObjectDescriptor,
@@ -153,6 +153,11 @@ impl Scope {
         );
 
         value.as_pointer().cast::<BoxedValue>()
+    }
+
+    /// Set the boxed value at the given slot index of a module scope.
+    pub fn set_heap_item_slot(&mut self, index: usize, heap_item: HeapPtr<HeapItem>) {
+        self.set_slot(index, Value::heap_item(heap_item));
     }
 
     /// Return the realm stored in this global scope.


### PR DESCRIPTION
## Summary

Convert a variety of raw `cast::<T>()` calls to safer, explicitly enumerated cast methods. In particular:
- Convert `cast::<ObjectValue>()` to `as_object()` for object subtypes
- Convert `cast::<HeapItem>()` to the new `as_heap_item` for heap items
- Introduce `Value::from_heap` to create a value from a heap item
- Move `Accessor` out of the values module and treat it as a standard heap item 