### PR TITLE
[runtime] Use deref operator instead of custom `get()` and `get_()` for handles

### DIFF
--- a/src/js/runtime/accessor.rs
+++ b/src/js/runtime/accessor.rs
@@ -24,8 +24,8 @@ impl Accessor {
         let mut accessor = cx.alloc_uninit::<Accessor>();
 
         set_uninit!(accessor.descriptor, cx.base_descriptors.get(ObjectKind::Accessor));
-        set_uninit!(accessor.get, get.map(|v| v.get_()));
-        set_uninit!(accessor.set, set.map(|v| v.get_()));
+        set_uninit!(accessor.get, get.map(|v| *v));
+        set_uninit!(accessor.set, set.map(|v| *v));
 
         accessor.to_handle()
     }

--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -82,7 +82,7 @@ impl MappedArgumentsObject {
             Intrinsic::ObjectPrototype,
         );
 
-        set_uninit!(object.scope, scope.get_());
+        set_uninit!(object.scope, *scope);
 
         // An parameter is mapped if it has not been shadowed, which we know due to the special
         // shadowed scope slot name.
@@ -90,7 +90,7 @@ impl MappedArgumentsObject {
 
         object.mapped_parameters.init_with_uninit(num_parameters);
         for i in 0..num_parameters {
-            let is_mapped = !scope_names.get_slot_name(i).ptr_eq(&shadowed_name.get_());
+            let is_mapped = !scope_names.get_slot_name(i).ptr_eq(&*shadowed_name);
             object.mapped_parameters.as_mut_slice()[i] = is_mapped;
         }
 
@@ -163,7 +163,7 @@ impl MappedArgumentsObject {
     }
 
     fn set_mapped_argument(&mut self, index: usize, value: Handle<Value>) {
-        self.scope.set_slot(index, value.get());
+        self.scope.set_slot(index, *value);
     }
 }
 

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -163,7 +163,7 @@ pub fn array_species_create(
 
         if !this_realm_ptr.ptr_eq(&constructor_realm)
             && same_object_value(
-                constructor.as_object().get_(),
+                *constructor.as_object(),
                 constructor_realm.get_intrinsic_ptr(Intrinsic::ArrayConstructor),
             )
         {

--- a/src/js/runtime/array_properties.rs
+++ b/src/js/runtime/array_properties.rs
@@ -300,7 +300,7 @@ impl ArrayProperties {
 
                 Self::set_property(cx, object, array_index, property);
             } else {
-                dense_properties.set(array_index, property.value().get());
+                dense_properties.set(array_index, *property.value());
             }
         } else {
             let mut sparse_properties = array_properties.as_sparse();

--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -117,7 +117,7 @@ impl AsyncGeneratorObject {
         let mut generator = cx.alloc_uninit_with_size::<AsyncGeneratorObject>(size);
 
         let descriptor = cx.base_descriptors.get(ObjectKind::AsyncGenerator);
-        object_ordinary_init(cx, generator.into(), descriptor, Some(prototype.get_()));
+        object_ordinary_init(cx, generator.into(), descriptor, Some(*prototype));
 
         set_uninit!(generator.state, AsyncGeneratorState::SuspendedStart);
         set_uninit!(generator.pc_to_resume_offset, pc_to_resume_offset);
@@ -263,8 +263,8 @@ impl AsyncGeneratorRequest {
         let mut request = cx.alloc_uninit::<AsyncGeneratorRequest>();
 
         set_uninit!(request.descriptor, cx.base_descriptors.get(ObjectKind::AsyncGeneratorRequest));
-        set_uninit!(request.capability, capability.get_());
-        set_uninit!(request.completion_value, completion_value.get());
+        set_uninit!(request.capability, *capability);
+        set_uninit!(request.completion_value, *completion_value);
         set_uninit!(request.completion_type, completion_type);
         set_uninit!(request.next, None);
 

--- a/src/js/runtime/boxed_value.rs
+++ b/src/js/runtime/boxed_value.rs
@@ -18,7 +18,7 @@ impl BoxedValue {
         let mut scope = cx.alloc_uninit::<BoxedValue>();
 
         set_uninit!(scope.descriptor, cx.base_descriptors.get(ObjectKind::BoxedValue));
-        set_uninit!(scope.value, value.get());
+        set_uninit!(scope.value, *value);
 
         scope
     }

--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -472,7 +472,7 @@ macro_rules! builtin_symbols {
                 $(
                     self.well_known_symbols.$rust_name = {
                         let description = self.alloc_string($description).as_string();
-                        PropertyKey::symbol(SymbolValue::new(*self, Some(description), /* is_private */ false)).get()
+                        *PropertyKey::symbol(SymbolValue::new(*self, Some(description), /* is_private */ false))
                     };
                 )*
             }

--- a/src/js/runtime/bytecode/constant_table.rs
+++ b/src/js/runtime/bytecode/constant_table.rs
@@ -34,7 +34,7 @@ impl ConstantTable {
         // Copy constants into inline constants array
         object.constants.init_with_uninit(constants.len());
         for (i, constant) in constants.iter().enumerate() {
-            set_uninit!(object.constants.as_mut_slice()[i], constant.get());
+            set_uninit!(object.constants.as_mut_slice()[i], **constant);
         }
 
         // Copy metadata into metadata section

--- a/src/js/runtime/bytecode/constant_table_builder.rs
+++ b/src/js/runtime/bytecode/constant_table_builder.rs
@@ -53,7 +53,7 @@ impl PartialEq for ConstantTableEntry {
         match (self, other) {
             // Strings must be interned, so we can check pointer equality
             (ConstantTableEntry::String(lhs), ConstantTableEntry::String(rhs)) => {
-                lhs.get_().ptr_eq(&rhs.get_())
+                lhs.ptr_eq(&**rhs)
             }
             // Heap objects are not deduplicated, so compare the index
             (

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -48,8 +48,8 @@ impl Closure {
         let mut object =
             object_create::<Closure>(cx, ObjectKind::Closure, Intrinsic::FunctionPrototype);
 
-        set_uninit!(object.function, function.get_());
-        set_uninit!(object.scope, scope.get_());
+        set_uninit!(object.function, *function);
+        set_uninit!(object.scope, *scope);
 
         let closure = object.to_handle();
         Self::init_common_properties(cx, closure, function, cx.current_realm());
@@ -65,8 +65,8 @@ impl Closure {
     ) -> Handle<Closure> {
         let mut object = object_create_with_proto::<Closure>(cx, ObjectKind::Closure, prototype);
 
-        set_uninit!(object.function, function.get_());
-        set_uninit!(object.scope, scope.get_());
+        set_uninit!(object.function, *function);
+        set_uninit!(object.scope, *scope);
 
         let closure = object.to_handle();
         Self::init_common_properties(cx, closure, function, cx.current_realm());
@@ -83,8 +83,8 @@ impl Closure {
         let proto = realm.get_intrinsic(Intrinsic::FunctionPrototype);
         let mut object = object_create_with_proto::<Closure>(cx, ObjectKind::Closure, proto);
 
-        set_uninit!(object.function, function.get_());
-        set_uninit!(object.scope, scope.get_());
+        set_uninit!(object.function, *function);
+        set_uninit!(object.scope, *scope);
 
         let closure = object.to_handle();
         Self::init_common_properties(cx, closure, function, realm);
@@ -100,8 +100,8 @@ impl Closure {
     ) -> Handle<Closure> {
         let mut object = object_create_with_proto::<Closure>(cx, ObjectKind::Closure, prototype);
 
-        set_uninit!(object.function, function.get_());
-        set_uninit!(object.scope, scope.get_());
+        set_uninit!(object.function, *function);
+        set_uninit!(object.scope, *scope);
 
         // Does not need to the `name` and `length` properties as these will be set by caller
         object.to_handle()
@@ -271,9 +271,9 @@ impl BytecodeFunction {
         let mut object = cx.alloc_uninit_with_size::<BytecodeFunction>(size);
 
         set_uninit!(object.descriptor, cx.base_descriptors.get(ObjectKind::BytecodeFunction));
-        set_uninit!(object.constant_table, constant_table.map(|c| c.get_()));
-        set_uninit!(object.exception_handlers, exception_handlers.map(|h| h.get_()));
-        set_uninit!(object.realm, realm.get_());
+        set_uninit!(object.constant_table, constant_table.map(|c| *c));
+        set_uninit!(object.exception_handlers, exception_handlers.map(|h| *h));
+        set_uninit!(object.realm, *realm);
         set_uninit!(object.num_registers, num_registers);
         set_uninit!(object.num_parameters, num_parameters);
         set_uninit!(object.function_length, function_length);
@@ -284,8 +284,8 @@ impl BytecodeFunction {
         set_uninit!(object.is_async, is_async);
         set_uninit!(object.new_target_index, new_target_index);
         set_uninit!(object.generator_index, generator_index);
-        set_uninit!(object.name, name.map(|n| n.get_()));
-        set_uninit!(object.source_file, source_file.map(|f| f.get_()));
+        set_uninit!(object.name, name.map(|n| *n));
+        set_uninit!(object.source_file, source_file.map(|f| *f));
         set_uninit!(object.source_range, source_range);
         set_uninit!(object.rust_runtime_function_id, None);
         object.bytecode.init_from_slice(&bytecode);
@@ -308,7 +308,7 @@ impl BytecodeFunction {
         set_uninit!(object.descriptor, cx.base_descriptors.get(ObjectKind::BytecodeFunction));
         set_uninit!(object.constant_table, None);
         set_uninit!(object.exception_handlers, None);
-        set_uninit!(object.realm, realm.get_());
+        set_uninit!(object.realm, *realm);
         set_uninit!(object.num_registers, 0);
         set_uninit!(object.num_parameters, 0);
         set_uninit!(object.function_length, 0);
@@ -319,7 +319,7 @@ impl BytecodeFunction {
         set_uninit!(object.is_async, false);
         set_uninit!(object.new_target_index, None);
         set_uninit!(object.generator_index, None);
-        set_uninit!(object.name, name.map(|n| n.get_()));
+        set_uninit!(object.name, name.map(|n| *n));
         set_uninit!(object.source_file, None);
         set_uninit!(object.source_range, 0..0);
         set_uninit!(object.rust_runtime_function_id, Some(function_id));

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -131,7 +131,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
         if self.all_functions.is_some() {
             FunctionVecField(&mut self.all_functions)
                 .maybe_grow_for_push(self.cx)
-                .push_without_growing(function.get_());
+                .push_without_growing(*function);
         }
     }
 
@@ -486,7 +486,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
         );
 
         // Place the module in the first slot of its module scope
-        module_scope.set_heap_item_slot(0, module.get_().as_heap_item());
+        module_scope.set_heap_item_slot(0, module.as_heap_item());
 
         module
     }
@@ -848,7 +848,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
                 let mut parent_constant_table = parent_function.constant_table_ptr().unwrap();
                 parent_constant_table.set_constant(
                     constant_index as usize,
-                    emit_result.bytecode_function.cast::<Value>().get(),
+                    Value::heap_item(emit_result.bytecode_function.as_heap_item()),
                 );
             }
             // Patch exported function into the module scope
@@ -867,7 +867,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
 
                 // And place inside boxed value in the module scope
                 let mut boxed_value = module_scope.get_module_slot(slot_index);
-                boxed_value.set(closure.get_().into());
+                boxed_value.set(*closure.as_value());
             }
         }
 
@@ -9265,7 +9265,7 @@ impl<'a> BsVecField<HeapPtr<BytecodeFunction>> for FunctionVecField<'a> {
     }
 
     fn get(&self) -> HeapPtr<FunctionVec> {
-        self.0.as_ref().unwrap().get_()
+        **self.0.as_ref().unwrap()
     }
 
     fn set(&mut self, vec: HeapPtr<FunctionVec>) {

--- a/src/js/runtime/class_names.rs
+++ b/src/js/runtime/class_names.rs
@@ -140,7 +140,7 @@ impl Method {
     #[inline]
     fn to_heap(&self) -> HeapMethod {
         HeapMethod {
-            name: self.name.map(|n| n.get_()),
+            name: self.name.map(|n| *n),
             is_static: self.is_static,
             is_getter: self.is_getter,
             is_setter: self.is_setter,
@@ -216,7 +216,7 @@ pub fn new_class(
         cx.vm().store_to_scope_at_depth(
             home_object.scope_index as usize,
             home_object.parent_depth as usize,
-            prototype.get_().into(),
+            *prototype.as_value(),
         );
     }
 
@@ -225,7 +225,7 @@ pub fn new_class(
         cx.vm().store_to_scope_at_depth(
             home_object.scope_index as usize,
             home_object.parent_depth as usize,
-            constructor.as_object().get_().into(),
+            *constructor.as_value(),
         );
     }
 

--- a/src/js/runtime/eval/expression.rs
+++ b/src/js/runtime/eval/expression.rs
@@ -567,7 +567,7 @@ pub fn eval_instanceof_expression(
     let instance_of_handler = get_method(cx, target, has_instance_key)?;
     if let Some(instance_of_handler) = instance_of_handler {
         let result = call_object(cx, instance_of_handler, target, &[value])?;
-        return Ok(to_boolean(result.get()));
+        return Ok(to_boolean(*result));
     }
 
     let target_object = target.as_object();

--- a/src/js/runtime/for_in_iterator.rs
+++ b/src/js/runtime/for_in_iterator.rs
@@ -42,12 +42,12 @@ impl ForInIterator {
         let mut iterator = cx.alloc_uninit_with_size::<ForInIterator>(size);
 
         set_uninit!(iterator.descriptor, cx.base_descriptors.get(ObjectKind::ForInIterator));
-        set_uninit!(iterator.object, object.get_());
+        set_uninit!(iterator.object, *object);
         set_uninit!(iterator.index, 0);
 
         iterator.keys.init_with_uninit(keys.len());
         for (i, key) in keys.iter().enumerate() {
-            set_uninit!(iterator.keys.as_mut_slice()[i], key.get_());
+            set_uninit!(iterator.keys.as_mut_slice()[i], **key);
         }
 
         iterator
@@ -123,7 +123,7 @@ impl Handle<ForInIterator> {
 
             // Check if property was deleted, otherwise skip it
             if object.has_property(cx, property_key)? {
-                return Ok(Value::string(key.get_()));
+                return Ok(*key.as_value());
             }
         }
     }

--- a/src/js/runtime/gc/handle.rs
+++ b/src/js/runtime/gc/handle.rs
@@ -337,12 +337,6 @@ impl HandleContext {
 }
 
 impl Handle<Value> {
-    /// Get the value stored behind the handle.
-    #[inline]
-    pub fn get(&self) -> Value {
-        unsafe { self.ptr.as_ptr().cast::<Value>().read() }
-    }
-
     #[inline]
     pub fn from_fixed_non_heap_ptr(value_ref: &Value) -> Handle<Value> {
         let ptr = unsafe { NonNull::new_unchecked(value_ref as *const Value as *mut Value) };
@@ -367,14 +361,6 @@ impl Handle<Value> {
     #[inline]
     pub fn as_bigint(&self) -> Handle<BigIntValue> {
         self.cast()
-    }
-}
-
-impl<T: IsHeapObject> Handle<T> {
-    /// Get the heap pointer stored behind the handle.
-    #[inline]
-    pub fn get_(&self) -> HeapPtr<T> {
-        unsafe { self.ptr.as_ptr().cast::<HeapPtr<T>>().read() }
     }
 }
 
@@ -429,14 +415,14 @@ impl Escapable for u32 {
 impl Escapable for Handle<Value> {
     #[inline]
     fn escape(&self, cx: Context) -> Self {
-        self.get().to_handle(cx)
+        (**self).to_handle(cx)
     }
 }
 
 impl<T: IsHeapObject> Escapable for Handle<T> {
     #[inline]
     fn escape(&self, _: Context) -> Self {
-        self.get_().to_handle()
+        (**self).to_handle()
     }
 }
 

--- a/src/js/runtime/gc/heap_trait_object.rs
+++ b/src/js/runtime/gc/heap_trait_object.rs
@@ -56,13 +56,13 @@ macro_rules! heap_trait_object {
         impl $stack_object {
             #[allow(dead_code)]
             pub fn ptr_eq(&self, other: &Self) -> bool {
-                self.data.get_().ptr_eq(&other.data.get_())
+                (*self.data).ptr_eq(&*other.data)
             }
 
             #[allow(dead_code)]
             #[inline]
             pub fn to_heap(self) -> $heap_object {
-                $heap_object { data: self.data.get_(), vtable: self.vtable }
+                $heap_object { data: *self.data, vtable: self.vtable }
             }
 
             #[allow(dead_code)]

--- a/src/js/runtime/generator_object.rs
+++ b/src/js/runtime/generator_object.rs
@@ -113,7 +113,7 @@ impl GeneratorObject {
         let mut generator = cx.alloc_uninit_with_size::<GeneratorObject>(size);
 
         let descriptor = cx.base_descriptors.get(ObjectKind::Generator);
-        object_ordinary_init(cx, generator.into(), descriptor, prototype.map(|p| p.get_()));
+        object_ordinary_init(cx, generator.into(), descriptor, prototype.map(|p| *p));
 
         set_uninit!(generator.state, GeneratorState::SuspendedStart);
         set_uninit!(generator.pc_to_resume_offset, pc_to_resume_offset);

--- a/src/js/runtime/global_names.rs
+++ b/src/js/runtime/global_names.rs
@@ -44,13 +44,13 @@ impl GlobalNames {
         let mut global_names = cx.alloc_uninit_with_size::<GlobalNames>(size);
 
         set_uninit!(global_names.descriptor, cx.base_descriptors.get(ObjectKind::GlobalNames));
-        set_uninit!(global_names.scope_names, scope_names.get_());
+        set_uninit!(global_names.scope_names, *scope_names);
         global_names.num_functions = funcs.len();
 
         // Place function names first in the names array
         global_names.names.init_with_uninit(num_names);
         for (i, name) in funcs.iter().chain(vars.iter()).enumerate() {
-            global_names.names.set_unchecked(i, name.get_());
+            global_names.names.set_unchecked(i, **name);
         }
 
         global_names.to_handle()
@@ -146,17 +146,11 @@ fn global_declaration_instantiation(
 
         if i < global_names.num_functions {
             if !can_declare_global_function(cx, global_object, name_key)? {
-                return type_error(
-                    cx,
-                    &format!("cannot declare global function {}", name_handle.get_()),
-                );
+                return type_error(cx, &format!("cannot declare global function {}", *name_handle));
             }
         } else {
             if !can_declare_global_var(cx, global_object, name_key)? {
-                return type_error(
-                    cx,
-                    &format!("cannot declare global var {}", name_handle.get_()),
-                );
+                return type_error(cx, &format!("cannot declare global var {}", *name_handle));
             }
         }
     }

--- a/src/js/runtime/interned_strings.rs
+++ b/src/js/runtime/interned_strings.rs
@@ -71,9 +71,9 @@ impl InternedStrings {
                 cx.interned_strings
                     .strings_field()
                     .maybe_grow_for_insertion(cx)
-                    .insert_without_growing(string.get_());
+                    .insert_without_growing(*string);
 
-                string.get_()
+                *string
             }
         }
     }
@@ -88,7 +88,7 @@ impl InternedStrings {
                 cx.interned_strings
                     .str_cache_field()
                     .maybe_grow_for_insertion(cx)
-                    .insert_without_growing(Wtf8String::from_str(str), interned_string.get_());
+                    .insert_without_growing(Wtf8String::from_str(str), *interned_string);
 
                 interned_string.as_string()
             }
@@ -105,7 +105,7 @@ impl InternedStrings {
                 cx.interned_strings
                     .str_cache_field()
                     .maybe_grow_for_insertion(cx)
-                    .insert_without_growing(str.clone(), interned_string.get_());
+                    .insert_without_growing(str.clone(), *interned_string);
 
                 interned_string.as_string()
             }

--- a/src/js/runtime/intrinsics/array_buffer_constructor.rs
+++ b/src/js/runtime/intrinsics/array_buffer_constructor.rs
@@ -83,7 +83,7 @@ impl ArrayBufferObject {
 
         // Initialize data block to all zeros
         object.data = if let Some(data) = data {
-            Some(data.get_())
+            Some(*data)
         } else {
             Some(BsArray::<u8>::new(cx, ObjectKind::ByteArray, byte_length, 0))
         };
@@ -225,7 +225,7 @@ pub fn array_buffer_copy_and_detach(
         to_index(cx, new_length)?
     };
 
-    throw_if_detached(cx, array_buffer.get_())?;
+    throw_if_detached(cx, *array_buffer)?;
 
     // Can only remain auto-resizable if ArrayBuffer was already resizable and we are not forced
     // to fix the length.

--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -122,7 +122,7 @@ impl ArrayBufferPrototype {
         let new_length_arg = get_argument(cx, arguments, 0);
         let new_byte_length = to_index(cx, new_length_arg)?;
 
-        throw_if_detached(cx, array_buffer.get_())?;
+        throw_if_detached(cx, *array_buffer)?;
 
         if new_byte_length > max_byte_length {
             return range_error(cx, "new length exceeds max byte length");
@@ -166,7 +166,7 @@ impl ArrayBufferPrototype {
     ) -> EvalResult<Handle<Value>> {
         let mut array_buffer = require_array_buffer(cx, this_value, "slice")?;
 
-        throw_if_detached(cx, array_buffer.get_())?;
+        throw_if_detached(cx, *array_buffer)?;
 
         let length = array_buffer.byte_length() as u64;
 
@@ -218,7 +218,7 @@ impl ArrayBufferPrototype {
             return type_error(cx, "expected array buffer");
         };
 
-        throw_if_detached(cx, new_array_buffer.get_())?;
+        throw_if_detached(cx, *new_array_buffer)?;
 
         if new_array_buffer.ptr_eq(&array_buffer) {
             return type_error(cx, "constructor cannot return same array buffer");
@@ -227,7 +227,7 @@ impl ArrayBufferPrototype {
         }
 
         // Original array buffer may have become detached during previous calls
-        throw_if_detached(cx, array_buffer.get_())?;
+        throw_if_detached(cx, *array_buffer)?;
 
         // Copy data from original array buffer to new array buffer
         unsafe {

--- a/src/js/runtime/intrinsics/array_iterator.rs
+++ b/src/js/runtime/intrinsics/array_iterator.rs
@@ -66,7 +66,7 @@ impl ArrayIterator {
             Self::get_array_like_length
         };
 
-        set_uninit!(object.array, array.get_());
+        set_uninit!(object.array, *array);
         set_uninit!(object.is_done, false);
         set_uninit!(object.kind, kind);
         set_uninit!(object.current_index, 0);

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -165,7 +165,7 @@ impl ArrayPrototype {
             get(cx, object.as_object(), cx.well_known_symbols.is_concat_spreadable())?;
 
         if !is_spreadable.is_undefined() {
-            return Ok(to_boolean(is_spreadable.get()));
+            return Ok(to_boolean(*is_spreadable));
         }
 
         is_array(cx, object)
@@ -366,7 +366,7 @@ impl ArrayPrototype {
                 let arguments = [value, index_value, object.into()];
 
                 let test_result = call_object(cx, callback_function, this_arg, &arguments)?;
-                if !to_boolean(test_result.get()) {
+                if !to_boolean(*test_result) {
                     return Ok(cx.bool(false));
                 }
             }
@@ -463,7 +463,7 @@ impl ArrayPrototype {
 
                 let is_selected = call_object(cx, callback_function, this_arg, &arguments)?;
 
-                if to_boolean(is_selected.get()) {
+                if to_boolean(*is_selected) {
                     // Reuse index_key handle as it is never referenced again
                     let mut result_index_key = index_key;
 
@@ -1361,7 +1361,7 @@ impl ArrayPrototype {
                 let arguments = [value, index_value, object.into()];
 
                 let test_result = call_object(cx, callback_function, this_arg, &arguments)?;
-                if to_boolean(test_result.get()) {
+                if to_boolean(*test_result) {
                     return Ok(cx.bool(true));
                 }
             }
@@ -1858,7 +1858,7 @@ pub fn find_via_predicate(
         let arguments = [value, index_value, object.into()];
 
         let test_result = call_object(cx, predicate, this_arg, &arguments)?;
-        if to_boolean(test_result.get()) {
+        if to_boolean(*test_result) {
             return Ok(Some((value, index_value)));
         }
     }

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
@@ -40,8 +40,8 @@ impl AsyncFromSyncIterator {
         );
 
         set_uninit!(object.descriptor, cx.base_descriptors.get(ObjectKind::AsyncFromSyncIterator));
-        set_uninit!(object.iterator, iterator.iterator.get_());
-        set_uninit!(object.next_method, iterator.next_method.get());
+        set_uninit!(object.iterator, *iterator.iterator);
+        set_uninit!(object.next_method, *iterator.next_method);
 
         object.to_handle()
     }

--- a/src/js/runtime/intrinsics/bigint_constructor.rs
+++ b/src/js/runtime/intrinsics/bigint_constructor.rs
@@ -39,7 +39,7 @@ impl BigIntObject {
         let mut object =
             object_create::<BigIntObject>(cx, ObjectKind::BigIntObject, Intrinsic::BigIntPrototype);
 
-        set_uninit!(object.bigint_data, bigint_data.get_());
+        set_uninit!(object.bigint_data, *bigint_data);
 
         object.to_handle()
     }
@@ -90,7 +90,7 @@ impl BigIntConstructor {
         let primitive = to_primitive(cx, value, ToPrimitivePreferredType::Number)?;
 
         if primitive.is_number() {
-            if !is_integral_number(primitive.get()) {
+            if !is_integral_number(*primitive) {
                 return range_error(cx, "number is not an integer");
             }
 

--- a/src/js/runtime/intrinsics/boolean_constructor.rs
+++ b/src/js/runtime/intrinsics/boolean_constructor.rs
@@ -111,7 +111,7 @@ impl BooleanConstructor {
         arguments: &[Handle<Value>],
         new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        let bool_value = to_boolean(get_argument(cx, arguments, 0).get());
+        let bool_value = to_boolean(*get_argument(cx, arguments, 0));
 
         match new_target {
             None => Ok(cx.bool(bool_value)),

--- a/src/js/runtime/intrinsics/data_view_constructor.rs
+++ b/src/js/runtime/intrinsics/data_view_constructor.rs
@@ -45,7 +45,7 @@ impl DataViewObject {
             Intrinsic::DataViewPrototype,
         )?;
 
-        let viewed_array_buffer = viewed_array_buffer.get_();
+        let viewed_array_buffer = *viewed_array_buffer;
 
         object.viewed_array_buffer = viewed_array_buffer;
         object.byte_length = byte_length;
@@ -122,7 +122,7 @@ impl DataViewConstructor {
         let offset_arg = get_argument(cx, arguments, 1);
         let offset = to_index(cx, offset_arg)?;
 
-        throw_if_detached(cx, buffer_object.get_())?;
+        throw_if_detached(cx, *buffer_object)?;
 
         let buffer_byte_length = buffer_object.byte_length();
         if offset > buffer_byte_length {
@@ -161,7 +161,7 @@ impl DataViewConstructor {
         )?;
 
         // Be sure to check for array buffer detachment since constructor may invoke user code
-        throw_if_detached(cx, buffer_object.get_())?;
+        throw_if_detached(cx, *buffer_object)?;
 
         // Also check if underlying buffer was resized during construction and redo bounds checks
         let buffer_byte_length = buffer_object.byte_length();

--- a/src/js/runtime/intrinsics/data_view_prototype.rs
+++ b/src/js/runtime/intrinsics/data_view_prototype.rs
@@ -417,7 +417,7 @@ fn get_view_value<T>(
 
     let get_index_arg = get_argument(cx, arguments, 0);
     let get_index = to_index(cx, get_index_arg)?;
-    let is_little_endian = to_boolean(get_argument(cx, arguments, 1).get());
+    let is_little_endian = to_boolean(*get_argument(cx, arguments, 1));
 
     let data_view_record = make_data_view_with_buffer_witness_record(data_view);
     if is_view_out_of_bounds(&data_view_record) {
@@ -470,7 +470,7 @@ fn set_view_value<T>(
 
     let get_index_arg = get_argument(cx, arguments, 0);
     let get_index = to_index(cx, get_index_arg)?;
-    let is_little_endian = to_boolean(get_argument(cx, arguments, 2).get());
+    let is_little_endian = to_boolean(*get_argument(cx, arguments, 2));
 
     let value_arg = get_argument(cx, arguments, 1);
     let value = if content_type == ContentType::BigInt {

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -1502,15 +1502,15 @@ impl DatePrototype {
         let hint = get_argument(cx, arguments, 0);
         if hint.is_string() {
             let hint = hint.as_string().flatten();
-            if hint.get_() == cx.names.default.as_string().as_flat()
-                || hint.get_() == cx.names.string_.as_string().as_flat()
+            if *hint == cx.names.default.as_string().as_flat()
+                || *hint == cx.names.string_.as_string().as_flat()
             {
                 return ordinary_to_primitive(
                     cx,
                     this_value.as_object(),
                     ToPrimitivePreferredType::String,
                 );
-            } else if hint.get_() == cx.names.number_.as_string().as_flat() {
+            } else if *hint == cx.names.number_.as_string().as_flat() {
                 return ordinary_to_primitive(
                     cx,
                     this_value.as_object(),

--- a/src/js/runtime/intrinsics/finalization_registry_object.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_object.rs
@@ -45,8 +45,8 @@ impl FinalizationRegistryObject {
             Intrinsic::FinalizationRegistryPrototype,
         )?;
 
-        set_uninit!(object.cells, cells.get_());
-        set_uninit!(object.cleanup_callback, cleanup_callback.get_());
+        set_uninit!(object.cells, *cells);
+        set_uninit!(object.cleanup_callback, *cleanup_callback);
 
         Ok(object.to_handle())
     }
@@ -158,7 +158,7 @@ impl FinalizationRegistryCells {
         // Save old cells pointer behind handle across allcation
         let old_cells = old_cells.to_handle();
         let mut new_cells = FinalizationRegistryCells::new(cx, new_capacity);
-        let old_cells = old_cells.get_();
+        let old_cells = *old_cells;
 
         // Copy over occupied cells to new array
         let mut new_cells_index = 0;

--- a/src/js/runtime/intrinsics/finalization_registry_prototype.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_prototype.rs
@@ -52,7 +52,7 @@ impl FinalizationRegistryPrototype {
         let held_value = get_argument(cx, arguments, 1);
         let unregister_token = get_argument(cx, arguments, 2);
 
-        if !can_be_held_weakly(cx, target.get()) {
+        if !can_be_held_weakly(cx, *target) {
             return type_error(cx, "FinalizationRegistry targets must be objects or symbols");
         }
 
@@ -63,7 +63,7 @@ impl FinalizationRegistryPrototype {
             );
         }
 
-        let unregister_token = if can_be_held_weakly(cx, unregister_token.get()) {
+        let unregister_token = if can_be_held_weakly(cx, *unregister_token) {
             Some(unregister_token)
         } else if unregister_token.is_undefined() {
             None
@@ -76,9 +76,9 @@ impl FinalizationRegistryPrototype {
 
         FinalizationRegistryCells::maybe_grow_for_insertion(cx, registry_object)
             .insert_without_growing(FinalizationRegistryCell {
-                target: target.get(),
-                held_value: held_value.get(),
-                unregister_token: unregister_token.map(|t| t.get()),
+                target: *target,
+                held_value: *held_value,
+                unregister_token: unregister_token.map(|t| *t),
             });
 
         Ok(cx.undefined())
@@ -100,14 +100,14 @@ impl FinalizationRegistryPrototype {
 
         let unregister_token = get_argument(cx, arguments, 0);
 
-        if !can_be_held_weakly(cx, unregister_token.get()) {
+        if !can_be_held_weakly(cx, *unregister_token) {
             return type_error(
                 cx,
                 "FinalizationRegistry unregister tokens must be objects or symbols",
             );
         }
 
-        let did_remove = registry_object.cells().remove(unregister_token.get());
+        let did_remove = registry_object.cells().remove(*unregister_token);
 
         Ok(cx.bool(did_remove))
     }

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -47,7 +47,7 @@ impl FunctionPrototype {
 
         // Initialize all fields of the prototype objec
         let descriptor_ptr = cx.base_descriptors.get(ObjectKind::Closure);
-        object_ordinary_init(cx, object.get_(), descriptor_ptr, Some(object_proto_ptr));
+        object_ordinary_init(cx, *object, descriptor_ptr, Some(object_proto_ptr));
 
         // The prototype object is a function which accepts any arguments and returns undefined
         // when invoked.
@@ -62,7 +62,7 @@ impl FunctionPrototype {
 
         object
             .cast::<Closure>()
-            .init_extra_fields(function.get_(), scope.get_());
+            .init_extra_fields(*function, *scope);
 
         object.instrinsic_length_prop(cx, 0);
         object.intrinsic_name_prop(cx, "");
@@ -204,7 +204,7 @@ impl FunctionPrototype {
             let function = closure.function();
 
             // First check for if the closure is a bound function
-            if BoundFunctionObject::is_bound_function(cx, this_object.get_()) {
+            if BoundFunctionObject::is_bound_function(cx, *this_object) {
                 return Ok(cx.alloc_string("function () { [native code] }").as_value());
             }
 

--- a/src/js/runtime/intrinsics/intrinsics.rs
+++ b/src/js/runtime/intrinsics/intrinsics.rs
@@ -232,7 +232,7 @@ impl Intrinsics {
         macro_rules! register_existing_intrinsic {
             ($intrinsic_name:ident, $expr:expr) => {
                 realm.intrinsics.intrinsics.as_mut_slice()[Intrinsic::$intrinsic_name as usize] =
-                    ($expr).as_object().get_();
+                    *($expr).as_object();
             };
         }
 

--- a/src/js/runtime/intrinsics/json_object.rs
+++ b/src/js/runtime/intrinsics/json_object.rs
@@ -649,7 +649,7 @@ impl JSONSerializer {
     }
 
     fn check_for_cycle(&mut self, cx: Context, value: Handle<ObjectValue>) -> EvalResult<()> {
-        let value_ptr = value.get_();
+        let value_ptr = *value;
         let has_cycle = self
             .stack
             .iter()

--- a/src/js/runtime/intrinsics/map_iterator.rs
+++ b/src/js/runtime/intrinsics/map_iterator.rs
@@ -69,7 +69,7 @@ impl MapIterator {
 
     fn store_iter(&mut self, iter: GcSafeEntriesIter<ValueCollectionKey, Value>) {
         let (map, next_entry_index) = iter.to_parts();
-        self.map = map.get_();
+        self.map = *map;
         self.next_entry_index = next_entry_index;
     }
 }

--- a/src/js/runtime/intrinsics/map_object.rs
+++ b/src/js/runtime/intrinsics/map_object.rs
@@ -40,7 +40,7 @@ impl MapObject {
             Intrinsic::MapPrototype,
         )?;
 
-        set_uninit!(object.map_data, map_data.get_());
+        set_uninit!(object.map_data, *map_data);
 
         Ok(object.to_handle())
     }
@@ -60,7 +60,7 @@ impl Handle<MapObject> {
 
         self.map_data_field()
             .maybe_grow_for_insertion(cx)
-            .insert_without_growing(key_handle.get(), value.get())
+            .insert_without_growing(key_handle.get(), *value)
     }
 }
 

--- a/src/js/runtime/intrinsics/math_object.rs
+++ b/src/js/runtime/intrinsics/math_object.rs
@@ -330,7 +330,7 @@ impl MathObject {
         let mut has_nan: bool = false;
 
         for arg in arguments {
-            let n = to_number(cx, *arg)?.get();
+            let n = *to_number(cx, *arg)?;
 
             if has_infinity {
                 continue;
@@ -440,7 +440,7 @@ impl MathObject {
         let mut found_nan = false;
 
         for arg in arguments {
-            let n = to_number(cx, *arg)?.get();
+            let n = *to_number(cx, *arg)?;
 
             if found_nan || n.is_nan() {
                 if !found_nan {
@@ -474,7 +474,7 @@ impl MathObject {
         let mut found_nan = false;
 
         for arg in arguments {
-            let n = to_number(cx, *arg)?.get();
+            let n = *to_number(cx, *arg)?;
 
             if found_nan || n.is_nan() {
                 if !found_nan {
@@ -558,7 +558,7 @@ impl MathObject {
         _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
-        let n = to_number(cx, argument)?.get();
+        let n = *to_number(cx, argument)?;
 
         if n.is_smi() {
             let n_smi = n.as_smi();

--- a/src/js/runtime/intrinsics/number_constructor.rs
+++ b/src/js/runtime/intrinsics/number_constructor.rs
@@ -193,7 +193,7 @@ impl NumberConstructor {
         _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
-        Ok(cx.bool(is_integral_number(value.get())))
+        Ok(cx.bool(is_integral_number(*value)))
     }
 
     /// Number.isNaN (https://tc39.es/ecma262/#sec-number.isnan)
@@ -219,7 +219,7 @@ impl NumberConstructor {
         _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
-        if !is_integral_number(value.get()) {
+        if !is_integral_number(*value) {
             return Ok(cx.bool(false));
         }
 

--- a/src/js/runtime/intrinsics/number_prototype.rs
+++ b/src/js/runtime/intrinsics/number_prototype.rs
@@ -382,7 +382,7 @@ const RADIX_TO_PRECISION: [u8; 37] = [
 ];
 
 fn this_number_value(cx: Context, value_handle: Handle<Value>) -> EvalResult<Value> {
-    let value = value_handle.get();
+    let value = *value_handle;
     if value.is_number() {
         return Ok(value);
     }

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -39,7 +39,7 @@ impl ObjectPrototype {
         let mut object = object.as_object();
 
         let descriptor = cx.base_descriptors.get(ObjectKind::ObjectPrototype);
-        object_ordinary_init(cx, object.get_(), descriptor, None);
+        object_ordinary_init(cx, *object, descriptor, None);
 
         // Constructor property is added once ObjectConstructor has been created
         object.intrinsic_func(cx, cx.names.has_own_property(), Self::has_own_property, 1, realm);

--- a/src/js/runtime/intrinsics/promise_constructor.rs
+++ b/src/js/runtime/intrinsics/promise_constructor.rs
@@ -838,7 +838,7 @@ pub fn reject_builtin_function(
 
     // Rejecting an already settled promise has no effect
     if promise.is_pending() {
-        promise.reject(cx, resolution.get());
+        promise.reject(cx, *resolution);
     }
 
     Ok(cx.undefined())

--- a/src/js/runtime/intrinsics/promise_prototype.rs
+++ b/src/js/runtime/intrinsics/promise_prototype.rs
@@ -234,7 +234,7 @@ impl PromisePrototype {
         arguments: &[Handle<Value>],
         _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        if !is_promise(this_value.get()) {
+        if !is_promise(*this_value) {
             return type_error(cx, "Promise.prototype.then called on non-promise");
         }
         let promise = this_value.as_object().cast::<PromiseObject>();

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -79,7 +79,7 @@ impl RegExpObject {
             Intrinsic::RegExpPrototype
         ));
 
-        set_uninit!(object.compiled_regexp, compiled_regexp.get_());
+        set_uninit!(object.compiled_regexp, *compiled_regexp);
 
         let object = object.to_handle();
 
@@ -262,7 +262,7 @@ pub fn regexp_create(
 
             let compiled_regexp = compile_regexp(cx, &regexp, source);
 
-            regexp_object.compiled_regexp = compiled_regexp.get_();
+            regexp_object.compiled_regexp = *compiled_regexp;
         }
     }
 

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -118,42 +118,42 @@ impl RegExpPrototype {
         let mut flags_string = String::new();
 
         let has_indices_value = get(cx, this_object, cx.names.has_indices())?;
-        if to_boolean(has_indices_value.get()) {
+        if to_boolean(*has_indices_value) {
             flags_string.push('d');
         }
 
         let global_value = get(cx, this_object, cx.names.global())?;
-        if to_boolean(global_value.get()) {
+        if to_boolean(*global_value) {
             flags_string.push('g');
         }
 
         let ignore_case_value = get(cx, this_object, cx.names.ignore_case())?;
-        if to_boolean(ignore_case_value.get()) {
+        if to_boolean(*ignore_case_value) {
             flags_string.push('i');
         }
 
         let multiline_value = get(cx, this_object, cx.names.multiline())?;
-        if to_boolean(multiline_value.get()) {
+        if to_boolean(*multiline_value) {
             flags_string.push('m');
         }
 
         let dot_all_value = get(cx, this_object, cx.names.dot_all())?;
-        if to_boolean(dot_all_value.get()) {
+        if to_boolean(*dot_all_value) {
             flags_string.push('s');
         }
 
         let unicode_value = get(cx, this_object, cx.names.unicode())?;
-        if to_boolean(unicode_value.get()) {
+        if to_boolean(*unicode_value) {
             flags_string.push('u');
         }
 
         let unicode_sets_value = get(cx, this_object, cx.names.unicode_sets())?;
-        if to_boolean(unicode_sets_value.get()) {
+        if to_boolean(*unicode_sets_value) {
             flags_string.push('v');
         }
 
         let sticky_value = get(cx, this_object, cx.names.sticky())?;
-        if to_boolean(sticky_value.get()) {
+        if to_boolean(*sticky_value) {
             flags_string.push('y');
         }
 
@@ -555,7 +555,7 @@ impl RegExpPrototype {
             if let Some(regexp_object) = this_object.as_regexp_object() {
                 return Ok(regexp_object.escaped_pattern_source().as_value());
             } else if same_object_value(
-                this_object.get_(),
+                *this_object,
                 cx.get_intrinsic_ptr(Intrinsic::RegExpPrototype),
             ) {
                 return Ok(cx.alloc_string("(?:)").as_value());
@@ -799,10 +799,8 @@ fn regexp_has_flag(
         if let Some(regexp_object) = this_object.as_regexp_object() {
             let has_flag = regexp_object.flags().contains(flag);
             return Ok(cx.bool(has_flag));
-        } else if same_object_value(
-            this_object.get_(),
-            cx.get_intrinsic_ptr(Intrinsic::RegExpPrototype),
-        ) {
+        } else if same_object_value(*this_object, cx.get_intrinsic_ptr(Intrinsic::RegExpPrototype))
+        {
             return Ok(cx.undefined());
         }
     }

--- a/src/js/runtime/intrinsics/regexp_string_iterator.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator.rs
@@ -50,8 +50,8 @@ impl RegExpStringIterator {
             Intrinsic::RegExpStringIteratorPrototype,
         );
 
-        set_uninit!(object.regexp_object, regexp_object.get_());
-        set_uninit!(object.target_string, target_string.get_());
+        set_uninit!(object.regexp_object, *regexp_object);
+        set_uninit!(object.target_string, *target_string);
         set_uninit!(object.is_global, is_global);
         set_uninit!(object.is_unicode, is_unicode);
         set_uninit!(object.is_done, false);

--- a/src/js/runtime/intrinsics/set_iterator.rs
+++ b/src/js/runtime/intrinsics/set_iterator.rs
@@ -65,7 +65,7 @@ impl SetIterator {
 
     fn store_iter(&mut self, iter: GcSafeEntriesIter<ValueCollectionKey, ()>) {
         let (set, next_entry_index) = iter.to_parts();
-        self.set = set.get_();
+        self.set = *set;
         self.next_entry_index = next_entry_index;
     }
 }

--- a/src/js/runtime/intrinsics/set_object.rs
+++ b/src/js/runtime/intrinsics/set_object.rs
@@ -39,7 +39,7 @@ impl SetObject {
             Intrinsic::SetPrototype,
         )?;
 
-        set_uninit!(object.set_data, set_data.get_());
+        set_uninit!(object.set_data, *set_data);
 
         Ok(object.to_handle())
     }
@@ -49,7 +49,7 @@ impl SetObject {
         let mut object =
             object_create::<SetObject>(cx, ObjectKind::SetObject, Intrinsic::SetPrototype);
 
-        set_uninit!(object.set_data, set_data.get_());
+        set_uninit!(object.set_data, *set_data);
 
         object.to_handle()
     }

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -484,7 +484,7 @@ impl StringPrototype {
         let form = if form_arg.is_undefined() {
             NormalizationForm::NFC
         } else {
-            let form_string = to_string(cx, form_arg)?.flatten().get_();
+            let form_string = *to_string(cx, form_arg)?.flatten();
             if form_string == cx.names.nfc.as_string().as_flat() {
                 NormalizationForm::NFC
             } else if form_string == cx.names.nfd.as_string().as_flat() {
@@ -1315,7 +1315,7 @@ fn normalize_string<I: Iterator<Item = char>>(
     string: Handle<StringValue>,
     f: impl Fn(CharIterator) -> I,
 ) -> Handle<StringValue> {
-    let parts = to_valid_string_parts(string.flatten().get_());
+    let parts = to_valid_string_parts(*string.flatten());
 
     let mut normalized_string = Wtf8String::new();
 

--- a/src/js/runtime/intrinsics/symbol_constructor.rs
+++ b/src/js/runtime/intrinsics/symbol_constructor.rs
@@ -35,7 +35,7 @@ impl SymbolObject {
         let mut object =
             object_create::<SymbolObject>(cx, ObjectKind::SymbolObject, Intrinsic::SymbolPrototype);
 
-        set_uninit!(object.symbol_data, symbol_data.get_());
+        set_uninit!(object.symbol_data, *symbol_data);
 
         object.to_handle()
     }
@@ -145,7 +145,7 @@ impl SymbolConstructor {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let string_key = to_string(cx, argument)?.flatten();
-        if let Some(symbol_value) = cx.global_symbol_registry().get(&string_key.get_()) {
+        if let Some(symbol_value) = cx.global_symbol_registry().get(&string_key) {
             return Ok(symbol_value.to_handle().into());
         }
 
@@ -153,7 +153,7 @@ impl SymbolConstructor {
             SymbolValue::new(cx, Some(string_key.as_string()), /* is_private */ false);
         cx.global_symbol_registry_field()
             .maybe_grow_for_insertion(cx)
-            .insert_without_growing(string_key.get_(), new_symbol.get_());
+            .insert_without_growing(*string_key, *new_symbol);
 
         Ok(new_symbol.into())
     }
@@ -169,7 +169,7 @@ impl SymbolConstructor {
         if !symbol_value.is_symbol() {
             return type_error(cx, "expected symbol value");
         }
-        let symbol_value = symbol_value.as_symbol().get_();
+        let symbol_value = *symbol_value.as_symbol();
 
         for (string, symbol) in cx.global_symbol_registry().iter_gc_unsafe() {
             if symbol.ptr_eq(&symbol_value) {

--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -360,7 +360,7 @@ impl TypedArrayPrototype {
             let arguments = [value, index_value, object.into()];
 
             let test_result = call_object(cx, callback_function, this_arg, &arguments)?;
-            if !to_boolean(test_result.get()) {
+            if !to_boolean(*test_result) {
                 return Ok(cx.bool(false));
             }
         }
@@ -471,7 +471,7 @@ impl TypedArrayPrototype {
 
             let is_selected = call_object(cx, callback_function, this_arg, &arguments)?;
 
-            if to_boolean(is_selected.get()) {
+            if to_boolean(*is_selected) {
                 kept_values.push(value)
             }
         }
@@ -1120,7 +1120,7 @@ impl TypedArrayPrototype {
         }
 
         let source_byte_index =
-            if same_object_value(source_buffer.get_().into(), target_buffer.get_().into()) {
+            if same_object_value(*source_buffer.as_object(), *target_buffer.as_object()) {
                 let source_byte_length = typed_array_byte_length(&source_record);
                 source_buffer =
                     clone_array_buffer(cx, source_buffer, source_byte_offset, source_byte_length)?;
@@ -1145,7 +1145,7 @@ impl TypedArrayPrototype {
                 while to_byte_index < limit {
                     // Convert between types. May allocate but does not invoke user code.
                     let element_value =
-                        source.read_element_value(cx, source_buffer.get_(), from_byte_index);
+                        source.read_element_value(cx, *source_buffer, from_byte_index);
 
                     target.write_element_value(cx, to_byte_index, element_value)?;
 
@@ -1338,7 +1338,7 @@ impl TypedArrayPrototype {
             let arguments = [value, index_value, object.into()];
 
             let test_result = call_object(cx, callback_function, this_arg, &arguments)?;
-            if to_boolean(test_result.get()) {
+            if to_boolean(*test_result) {
                 return Ok(cx.bool(true));
             }
         }

--- a/src/js/runtime/intrinsics/weak_map_object.rs
+++ b/src/js/runtime/intrinsics/weak_map_object.rs
@@ -45,7 +45,7 @@ impl WeakMapObject {
             Intrinsic::WeakMapPrototype,
         )?;
 
-        set_uninit!(object.weak_map_data, weak_map_data.get_());
+        set_uninit!(object.weak_map_data, *weak_map_data);
 
         Ok(object.to_handle())
     }
@@ -73,7 +73,7 @@ impl Handle<WeakMapObject> {
 
         self.weak_map_data_field()
             .maybe_grow_for_insertion(cx)
-            .insert_without_growing(key_handle.get(), value.get())
+            .insert_without_growing(key_handle.get(), *value)
     }
 }
 

--- a/src/js/runtime/intrinsics/weak_map_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_map_prototype.rs
@@ -118,7 +118,7 @@ impl WeakMapPrototype {
         let key = get_argument(cx, arguments, 0);
         let value = get_argument(cx, arguments, 1);
 
-        if !can_be_held_weakly(cx, key.get()) {
+        if !can_be_held_weakly(cx, *key) {
             return type_error(cx, "WeakMap keys must be objects or symbols");
         }
 

--- a/src/js/runtime/intrinsics/weak_ref_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_ref_constructor.rs
@@ -43,7 +43,7 @@ impl WeakRefObject {
             Intrinsic::WeakRefPrototype,
         )?;
 
-        set_uninit!(object.weak_ref_target, value.get());
+        set_uninit!(object.weak_ref_target, *value);
 
         Ok(object.to_handle())
     }
@@ -102,7 +102,7 @@ impl WeakRefConstructor {
         };
 
         let target_value = get_argument(cx, arguments, 0);
-        if !can_be_held_weakly(cx, target_value.get()) {
+        if !can_be_held_weakly(cx, *target_value) {
             return type_error(cx, "WeakRef only holds objects and symbols");
         }
 

--- a/src/js/runtime/intrinsics/weak_set_object.rs
+++ b/src/js/runtime/intrinsics/weak_set_object.rs
@@ -45,7 +45,7 @@ impl WeakSetObject {
             Intrinsic::WeakSetPrototype,
         )?;
 
-        set_uninit!(object.weak_set_data, weak_set_data.get_());
+        set_uninit!(object.weak_set_data, *weak_set_data);
 
         Ok(object.to_handle())
     }

--- a/src/js/runtime/intrinsics/weak_set_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_set_prototype.rs
@@ -44,7 +44,7 @@ impl WeakSetPrototype {
         };
 
         let value = get_argument(cx, arguments, 0);
-        if !can_be_held_weakly(cx, value.get()) {
+        if !can_be_held_weakly(cx, *value) {
             return type_error(cx, "WeakSet only holds objects and symbols");
         }
 

--- a/src/js/runtime/iterator.rs
+++ b/src/js/runtime/iterator.rs
@@ -88,9 +88,9 @@ pub fn iterator_next(
     value: Option<Handle<Value>>,
 ) -> EvalResult<Handle<ObjectValue>> {
     let result = if let Some(value) = value {
-        call(cx, next_method, iterator.into(), &[value])?
+        call(cx, next_method, iterator.as_value(), &[value])?
     } else {
-        call(cx, next_method, iterator.into(), &[])?
+        call(cx, next_method, iterator.as_value(), &[])?
     };
 
     if !result.is_object() {
@@ -103,7 +103,7 @@ pub fn iterator_next(
 /// IteratorComplete (https://tc39.es/ecma262/#sec-iteratorcomplete)
 pub fn iterator_complete(cx: Context, iter_result: Handle<ObjectValue>) -> EvalResult<bool> {
     let is_done = get(cx, iter_result, cx.names.done())?;
-    Ok(to_boolean(is_done.get()))
+    Ok(to_boolean(*is_done))
 }
 
 /// IteratorValue (https://tc39.es/ecma262/#sec-iteratorvalue)

--- a/src/js/runtime/module/linker.rs
+++ b/src/js/runtime/module/linker.rs
@@ -115,7 +115,7 @@ impl GraphLinker {
                 let mut required_module = self.stack.pop().unwrap();
                 required_module.set_state(ModuleState::Linked);
 
-                if required_module.ptr_eq(&module.get_()) {
+                if required_module.ptr_eq(&module) {
                     break;
                 }
             }
@@ -143,12 +143,11 @@ fn initialize_environment(cx: Context, module: Handle<SourceTextModule>) -> Eval
             let entry = ImportEntry::from_heap(heap_entry);
 
             let mut imported_module = module
-                .get_imported_module(entry.module_request.get_())
+                .get_imported_module(*entry.module_request)
                 .to_handle();
 
             if let Some(import_name) = entry.import_name {
-                let resolution =
-                    imported_module.resolve_export(cx, import_name.get_(), &mut vec![]);
+                let resolution = imported_module.resolve_export(cx, *import_name, &mut vec![]);
 
                 match resolution {
                     // Regular imports are linked to their corresponding export by referencing

--- a/src/js/runtime/module/loader.rs
+++ b/src/js/runtime/module/loader.rs
@@ -96,9 +96,9 @@ impl GraphLoader {
         module_result: EvalResult<Handle<SourceTextModule>>,
     ) {
         if let Ok(module) = module_result {
-            let module_index = referrer.lookup_specifier_index(specifier.get_()).unwrap();
+            let module_index = referrer.lookup_specifier_index(*specifier).unwrap();
             if !referrer.has_loaded_module_at(module_index) {
-                referrer.set_loaded_module_at(module_index, module.get_());
+                referrer.set_loaded_module_at(module_index, *module);
             }
         }
 
@@ -208,7 +208,7 @@ pub fn host_load_imported_module(
     };
 
     // Cache the module
-    cx.modules.insert(new_module_path_string, module.get_());
+    cx.modules.insert(new_module_path_string, *module);
 
     Ok(module)
 }

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -47,7 +47,7 @@ impl ModuleNamespaceObject {
         // - [[PreventExtensions]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-preventextensions)
         object.as_object().set_is_extensible_field(false);
 
-        set_uninit!(object.module, module.get_());
+        set_uninit!(object.module, *module);
 
         let object = object.to_handle();
 
@@ -59,7 +59,7 @@ impl ModuleNamespaceObject {
             Property::data(cx.names.module().as_string().into(), false, false, false),
         );
 
-        object.get_()
+        *object
     }
 }
 
@@ -109,7 +109,7 @@ impl VirtualObject for Handle<ModuleNamespaceObject> {
             return Ok(ordinary_get_own_property(cx, (*self).into(), key));
         }
 
-        match self.lookup_export(cx, key.get())? {
+        match self.lookup_export(cx, *key)? {
             None => Ok(None),
             Some(value) => {
                 let value = value.to_handle(cx);
@@ -158,7 +158,7 @@ impl VirtualObject for Handle<ModuleNamespaceObject> {
             return ordinary_has_property(cx, (*self).into(), key);
         }
 
-        Ok(self.module.exports_ptr().contains_key(&key.get()))
+        Ok(self.module.exports_ptr().contains_key(&key))
     }
 
     /// [[Get]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-get-p-receiver)
@@ -172,7 +172,7 @@ impl VirtualObject for Handle<ModuleNamespaceObject> {
             return ordinary_get(cx, (*self).into(), key, receiver);
         }
 
-        match self.lookup_export(cx, key.get())? {
+        match self.lookup_export(cx, *key)? {
             None => Ok(cx.undefined()),
             Some(value) => Ok(value.to_handle(cx)),
         }
@@ -195,7 +195,7 @@ impl VirtualObject for Handle<ModuleNamespaceObject> {
             return ordinary_delete(cx, (*self).into(), key);
         }
 
-        Ok(!self.module.exports_ptr().contains_key(&key.get()))
+        Ok(!self.module.exports_ptr().contains_key(&key))
     }
 
     /// [[OwnPropertyKeys]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-ownpropertykeys)

--- a/src/js/runtime/object_descriptor.rs
+++ b/src/js/runtime/object_descriptor.rs
@@ -181,7 +181,7 @@ impl ObjectDescriptor {
     {
         let mut desc = cx.alloc_uninit::<ObjectDescriptor>();
 
-        set_uninit!(desc.descriptor, descriptor.get_());
+        set_uninit!(desc.descriptor, *descriptor);
         set_uninit!(desc.vtable, extract_object_vtable::<Handle<T>>());
         set_uninit!(desc.kind, kind);
         set_uninit!(desc.flags, flags);
@@ -232,14 +232,14 @@ impl BaseDescriptors {
             ObjectKind::Descriptor,
             DescFlags::empty(),
         );
-        descriptor.descriptor = descriptor.get_();
-        descriptors[ObjectKind::Descriptor as usize] = descriptor.get_();
+        descriptor.descriptor = *descriptor;
+        descriptors[ObjectKind::Descriptor as usize] = *descriptor;
 
         macro_rules! register_descriptor {
             ($object_kind:expr, $object_ty:ty, $flags:expr) => {
                 let desc =
                     ObjectDescriptor::new::<$object_ty>(cx, descriptor, $object_kind, $flags);
-                descriptors[$object_kind as usize] = desc.get_();
+                descriptors[$object_kind as usize] = *desc;
             };
         }
 

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -55,7 +55,7 @@ impl Handle<ObjectValue> {
         cx: Context,
         new_prototype: Option<Handle<ObjectValue>>,
     ) -> EvalResult<bool> {
-        if same_opt_object_value(self.prototype(), new_prototype.map(|p| p.get_())) {
+        if same_opt_object_value(self.prototype(), new_prototype.map(|p| *p)) {
             return Ok(true);
         }
 
@@ -88,7 +88,7 @@ impl Handle<ObjectValue> {
             }
         }
 
-        self.set_prototype(new_prototype.map(|p| p.get_()));
+        self.set_prototype(new_prototype.map(|p| *p));
 
         Ok(true)
     }
@@ -370,11 +370,11 @@ pub fn validate_and_apply_property_descriptor(
                 let mut accessor_value = Accessor::from_value(property.value());
 
                 if desc.has_get {
-                    accessor_value.get = desc.get.map(|x| x.get_());
+                    accessor_value.get = desc.get.map(|x| *x);
                 }
 
                 if desc.has_set {
-                    accessor_value.set = desc.set.map(|x| x.get_());
+                    accessor_value.set = desc.set.map(|x| *x);
                 }
             }
 
@@ -617,7 +617,7 @@ where
     let object = cx.alloc_uninit::<T>();
 
     let descriptor = cx.base_descriptors.get(descriptor_kind);
-    object_ordinary_init(cx, object.into(), descriptor, Some(proto.get_()));
+    object_ordinary_init(cx, object.into(), descriptor, Some(*proto));
 
     object
 }
@@ -633,7 +633,7 @@ where
     let object = cx.alloc_uninit::<T>();
 
     let descriptor = cx.base_descriptors.get(descriptor_kind);
-    let proto = proto.map(|p| p.get_());
+    let proto = proto.map(|p| *p);
     object_ordinary_init(cx, object.into(), descriptor, proto);
 
     object
@@ -670,7 +670,7 @@ where
     let object = cx.alloc_uninit::<T>();
 
     let descriptor = cx.base_descriptors.get(descriptor_kind);
-    object_ordinary_init(cx, object.into(), descriptor, Some(proto.get_()));
+    object_ordinary_init(cx, object.into(), descriptor, Some(*proto));
 
     Ok(object)
 }

--- a/src/js/runtime/property.rs
+++ b/src/js/runtime/property.rs
@@ -183,7 +183,7 @@ impl Property {
     }
 
     pub fn to_heap(&self) -> HeapProperty {
-        HeapProperty { value: self.value.get(), flags: self.flags }
+        HeapProperty { value: *self.value, flags: self.flags }
     }
 
     pub fn from_heap(cx: Context, heap_property: &HeapProperty) -> Property {

--- a/src/js/runtime/property_descriptor.rs
+++ b/src/js/runtime/property_descriptor.rs
@@ -275,12 +275,12 @@ pub fn to_property_descriptor(cx: Context, value: Handle<Value>) -> EvalResult<P
 
     if has_property(cx, object, cx.names.enumerable())? {
         let enumerable = get(cx, object, cx.names.enumerable())?;
-        desc.is_enumerable = Some(to_boolean(enumerable.get()));
+        desc.is_enumerable = Some(to_boolean(*enumerable));
     }
 
     if has_property(cx, object, cx.names.configurable())? {
         let configurable = get(cx, object, cx.names.configurable())?;
-        desc.is_configurable = Some(to_boolean(configurable.get()));
+        desc.is_configurable = Some(to_boolean(*configurable));
     }
 
     if has_property(cx, object, cx.names.value())? {
@@ -289,7 +289,7 @@ pub fn to_property_descriptor(cx: Context, value: Handle<Value>) -> EvalResult<P
 
     if has_property(cx, object, cx.names.writable())? {
         let writable = get(cx, object, cx.names.writable())?;
-        desc.is_writable = Some(to_boolean(writable.get()));
+        desc.is_writable = Some(to_boolean(*writable));
     }
 
     if has_property(cx, object, cx.names.get())? {

--- a/src/js/runtime/proxy_object.rs
+++ b/src/js/runtime/proxy_object.rs
@@ -44,8 +44,8 @@ impl ProxyObject {
         let mut object =
             object_create::<ProxyObject>(cx, ObjectKind::Proxy, Intrinsic::ObjectPrototype);
 
-        set_uninit!(object.proxy_handler, Some(proxy_handler.get_()));
-        set_uninit!(object.proxy_target, Some(proxy_target.get_()));
+        set_uninit!(object.proxy_handler, Some(*proxy_handler));
+        set_uninit!(object.proxy_target, Some(*proxy_target));
         set_uninit!(object.is_callable, is_callable);
         set_uninit!(object.is_constructor, is_constructor);
 
@@ -184,7 +184,7 @@ impl VirtualObject for Handle<ProxyObject> {
         let trap_arguments = [target.into(), key.to_value(cx), desc_value.into()];
         let trap_result = call_object(cx, trap.unwrap(), handler, &trap_arguments)?;
 
-        if !to_boolean(trap_result.get()) {
+        if !to_boolean(*trap_result) {
             return Ok(false);
         }
 
@@ -263,7 +263,7 @@ impl VirtualObject for Handle<ProxyObject> {
 
         let trap_arguments = [target.into(), key.to_value(cx)];
         let trap_result = call_object(cx, trap.unwrap(), handler, &trap_arguments)?;
-        let trap_result = to_boolean(trap_result.get());
+        let trap_result = to_boolean(*trap_result);
 
         if !trap_result {
             let target_desc = target.get_own_property(cx, key)?;
@@ -355,7 +355,7 @@ impl VirtualObject for Handle<ProxyObject> {
         let trap_arguments = [target.into(), key.to_value(cx), value, receiver];
         let trap_result = call_object(cx, trap.unwrap(), handler, &trap_arguments)?;
 
-        if !to_boolean(trap_result.get()) {
+        if !to_boolean(*trap_result) {
             return Ok(false);
         }
 
@@ -395,7 +395,7 @@ impl VirtualObject for Handle<ProxyObject> {
         let trap_arguments = [target.into(), key.to_value(cx)];
         let trap_result = call_object(cx, trap.unwrap(), handler, &trap_arguments)?;
 
-        if !to_boolean(trap_result.get()) {
+        if !to_boolean(*trap_result) {
             return Ok(false);
         }
 
@@ -658,7 +658,7 @@ impl ProxyObject {
         let trap_arguments = [target.into(), proto_value];
         let trap_result = call_object(cx, trap.unwrap(), handler, &trap_arguments)?;
 
-        if !to_boolean(trap_result.get()) {
+        if !to_boolean(*trap_result) {
             return Ok(false);
         }
 
@@ -693,7 +693,7 @@ impl ProxyObject {
         }
 
         let trap_result = call_object(cx, trap.unwrap(), handler, &[target.into()])?;
-        let trap_result = to_boolean(trap_result.get());
+        let trap_result = to_boolean(*trap_result);
 
         let target_result = is_extensible_(cx, target)?;
 
@@ -722,7 +722,7 @@ impl ProxyObject {
         }
 
         let trap_result = call_object(cx, trap.unwrap(), handler, &[target.into()])?;
-        let trap_result = to_boolean(trap_result.get());
+        let trap_result = to_boolean(*trap_result);
 
         if trap_result && is_extensible_(cx, target)? {
             return type_error(cx, "proxy can't report an extensible object as non-extensible");

--- a/src/js/runtime/regexp/compiled_regexp.rs
+++ b/src/js/runtime/regexp/compiled_regexp.rs
@@ -72,7 +72,7 @@ impl CompiledRegExpObject {
         let mut object = cx.alloc_uninit_with_size::<CompiledRegExpObject>(size);
 
         set_uninit!(object.descriptor, cx.base_descriptors.get(ObjectKind::CompiledRegExpObject));
-        set_uninit!(object.escaped_pattern_source, escaped_pattern_source.get_());
+        set_uninit!(object.escaped_pattern_source, *escaped_pattern_source);
         set_uninit!(object.flags, regexp.flags);
         set_uninit!(object.has_named_capture_groups, has_named_capture_groups);
         set_uninit!(
@@ -88,7 +88,7 @@ impl CompiledRegExpObject {
         // Initialize capture group strings
         let capture_group_ptrs = capture_group_handles
             .into_iter()
-            .map(|capture_group| capture_group.map(|name_string| name_string.get_()))
+            .map(|capture_group| capture_group.map(|name_string| *name_string))
             .collect::<Vec<_>>();
         object
             .capture_groups_as_slice_mut()

--- a/src/js/runtime/regexp/matcher.rs
+++ b/src/js/runtime/regexp/matcher.rs
@@ -730,7 +730,7 @@ pub fn run_matcher(
     // May allocate, after this point no more allocations can occur
     let flat_string = target_string.flatten();
 
-    let regexp = regexp.get_();
+    let regexp = *regexp;
 
     if regexp.flags.is_case_insensitive() {
         return run_case_insensitive_matcher(regexp, flat_string, start_index);

--- a/src/js/runtime/scope_names.rs
+++ b/src/js/runtime/scope_names.rs
@@ -68,7 +68,7 @@ impl ScopeNames {
         // Copy names into inline names array
         scope_names.names.init_with_uninit(names.len());
         for (i, name) in names.iter().enumerate() {
-            scope_names.names.set_unchecked(i, name.get_());
+            scope_names.names.set_unchecked(i, **name);
         }
 
         // Copy name flags into name flags section

--- a/src/js/runtime/source_file.rs
+++ b/src/js/runtime/source_file.rs
@@ -45,8 +45,8 @@ impl SourceFile {
 
         set_uninit!(scope.descriptor, cx.base_descriptors.get(ObjectKind::SourceFile));
         set_uninit!(scope.line_offsets, None);
-        set_uninit!(scope.path, path.get_());
-        set_uninit!(scope.display_name, display_name.map(|n| n.get_()));
+        set_uninit!(scope.path, *path);
+        set_uninit!(scope.display_name, display_name.map(|n| *n));
 
         scope.contents.init_from_slice(source.contents.as_bytes());
 

--- a/src/js/runtime/string_object.rs
+++ b/src/js/runtime/string_object.rs
@@ -47,7 +47,7 @@ impl StringObject {
         let mut object =
             object_create::<StringObject>(cx, ObjectKind::StringObject, Intrinsic::StringPrototype);
 
-        let string_data = string_data_handle.get_();
+        let string_data = *string_data_handle;
         let string_length = string_data.len();
 
         set_uninit!(object.string_data, string_data);
@@ -71,7 +71,7 @@ impl StringObject {
             Intrinsic::StringPrototype,
         )?;
 
-        let string_data = string_data_handle.get_();
+        let string_data = *string_data_handle;
         let string_length = string_data.len();
 
         set_uninit!(object.string_data, string_data);
@@ -91,7 +91,7 @@ impl StringObject {
         let mut object =
             object_create_with_proto::<StringObject>(cx, ObjectKind::StringObject, proto);
 
-        let string_data = string_data_handle.get_();
+        let string_data = *string_data_handle;
         let string_length = string_data.len();
 
         set_uninit!(object.string_data, string_data);

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -142,7 +142,7 @@ pub fn to_numeric(cx: Context, value: Handle<Value>) -> EvalResult<Handle<Value>
 /// ToNumber (https://tc39.es/ecma262/#sec-tonumber)
 pub fn to_number(cx: Context, value_handle: Handle<Value>) -> EvalResult<Handle<Value>> {
     // Safe since value is never referenced after allocation
-    let value = value_handle.get();
+    let value = *value_handle;
 
     // Fast path
     if value.is_number() {
@@ -189,7 +189,7 @@ fn string_to_number(value: Handle<StringValue>) -> Value {
 /// ToIntegerOrInfinity (https://tc39.es/ecma262/#sec-tointegerorinfinity)
 pub fn to_integer_or_infinity(cx: Context, value: Handle<Value>) -> EvalResult<f64> {
     let number_handle = to_number(cx, value)?;
-    let number = number_handle.get();
+    let number = *number_handle;
 
     Ok(to_integer_or_infinity_f64(number.as_number()))
 }
@@ -215,7 +215,7 @@ pub fn to_integer_or_infinity_f64(number_f64: f64) -> f64 {
 /// ToInt32 (https://tc39.es/ecma262/#sec-toint32)
 pub fn to_int32(cx: Context, value_handle: Handle<Value>) -> EvalResult<i32> {
     // Fast pass if the value is a smi
-    let value = value_handle.get();
+    let value = *value_handle;
     if value.is_smi() {
         return Ok(value.as_smi());
     }
@@ -249,7 +249,7 @@ pub fn to_int32(cx: Context, value_handle: Handle<Value>) -> EvalResult<i32> {
 /// ToUint32 (https://tc39.es/ecma262/#sec-touint32)
 pub fn to_uint32(cx: Context, value_handle: Handle<Value>) -> EvalResult<u32> {
     // Fast pass if the value is a non-negative smi
-    let value = value_handle.get();
+    let value = *value_handle;
     if value.is_smi() {
         let i32_value = value.as_smi();
         if i32_value >= 0 {
@@ -281,7 +281,7 @@ pub fn to_uint32(cx: Context, value_handle: Handle<Value>) -> EvalResult<u32> {
 /// ToInt16 (https://tc39.es/ecma262/#sec-toint16)
 pub fn to_int16(cx: Context, value_handle: Handle<Value>) -> EvalResult<i16> {
     // Fast path if the value is a smi
-    let value = value_handle.get();
+    let value = *value_handle;
     if value.is_smi() {
         return Ok(value.as_smi() as i16);
     }
@@ -315,7 +315,7 @@ pub fn to_int16(cx: Context, value_handle: Handle<Value>) -> EvalResult<i16> {
 /// ToUint16 (https://tc39.es/ecma262/#sec-touint16)
 pub fn to_uint16(cx: Context, value_handle: Handle<Value>) -> EvalResult<u16> {
     // Fast path if the value is a non-negative smi
-    let value = value_handle.get();
+    let value = *value_handle;
     if value.is_smi() {
         let i32_value = value.as_smi();
         if i32_value >= 0 {
@@ -347,7 +347,7 @@ pub fn to_uint16(cx: Context, value_handle: Handle<Value>) -> EvalResult<u16> {
 /// ToInt8 (https://tc39.es/ecma262/#sec-toint8)
 pub fn to_int8(cx: Context, value_handle: Handle<Value>) -> EvalResult<i8> {
     // Fast path if the value is a smi
-    let value = value_handle.get();
+    let value = *value_handle;
     if value.is_smi() {
         return Ok(value.as_smi() as i8);
     }
@@ -381,7 +381,7 @@ pub fn to_int8(cx: Context, value_handle: Handle<Value>) -> EvalResult<i8> {
 /// ToUint8 (https://tc39.es/ecma262/#sec-touint8)
 pub fn to_uint8(cx: Context, value_handle: Handle<Value>) -> EvalResult<u8> {
     // Fast path if the value is a non-negative smi
-    let value = value_handle.get();
+    let value = *value_handle;
     if value.is_smi() {
         let i32_value = value.as_smi();
         if i32_value >= 0 {
@@ -413,7 +413,7 @@ pub fn to_uint8(cx: Context, value_handle: Handle<Value>) -> EvalResult<u8> {
 /// ToUint8Clamp (https://tc39.es/ecma262/#sec-touint8clamp)
 pub fn to_uint8_clamp(cx: Context, value_handle: Handle<Value>) -> EvalResult<u8> {
     // Fast path if the value is a smi
-    let value = value_handle.get();
+    let value = *value_handle;
     if value.is_smi() {
         let i32_value = value.as_smi();
 
@@ -458,7 +458,7 @@ pub fn to_uint8_clamp(cx: Context, value_handle: Handle<Value>) -> EvalResult<u8
 /// ToBigInt (https://tc39.es/ecma262/#sec-tobigint)
 pub fn to_bigint(cx: Context, value: Handle<Value>) -> EvalResult<Handle<BigIntValue>> {
     let primitive_handle = to_primitive(cx, value, ToPrimitivePreferredType::Number)?;
-    let primitive = primitive_handle.get();
+    let primitive = *primitive_handle;
 
     if primitive.is_pointer() {
         match primitive.as_pointer().descriptor().kind() {
@@ -514,7 +514,7 @@ pub fn to_big_uint64(cx: Context, value: Handle<Value>) -> EvalResult<BigInt> {
 /// ToString (https://tc39.es/ecma262/#sec-tostring)
 pub fn to_string(mut cx: Context, value_handle: Handle<Value>) -> EvalResult<Handle<StringValue>> {
     // Safe since value is never referenced after allocation
-    let value = value_handle.get();
+    let value = *value_handle;
 
     // Fast path
     if value.is_string() {
@@ -559,7 +559,7 @@ pub fn to_string(mut cx: Context, value_handle: Handle<Value>) -> EvalResult<Han
 /// ToObject (https://tc39.es/ecma262/#sec-toobject)
 pub fn to_object(cx: Context, value_handle: Handle<Value>) -> EvalResult<Handle<ObjectValue>> {
     // Safe since pointer value is never referenced after allocation
-    let value = value_handle.get();
+    let value = *value_handle;
 
     if value.is_pointer() {
         // Fast path
@@ -627,7 +627,7 @@ pub fn canonical_numeric_string_index_string(
         // If string representations are equal, must be canonical numeric index
         let number_string = must!(to_string(cx, number_value));
         if key_string.eq(&number_string) {
-            if !is_integral_number(number_value.get()) {
+            if !is_integral_number(*number_value) {
                 return Some(None);
             }
 
@@ -642,8 +642,7 @@ pub fn canonical_numeric_string_index_string(
             }
 
             Some(Some(number as u32))
-        } else if key_string
-            .get_()
+        } else if (*key_string)
             .as_flat()
             .eq(&cx.names.negative_zero.as_string().as_flat())
         {
@@ -659,7 +658,7 @@ pub fn canonical_numeric_string_index_string(
 
 /// ToIndex (https://tc39.es/ecma262/#sec-toindex)
 pub fn to_index(cx: Context, value_handle: Handle<Value>) -> EvalResult<usize> {
-    let value = value_handle.get();
+    let value = *value_handle;
     if value.is_smi() {
         let smi = value.as_smi();
         if smi < 0 {
@@ -779,7 +778,7 @@ pub fn is_regexp(cx: Context, value: Handle<Value>) -> EvalResult<bool> {
     let matcher = get(cx, object, match_key)?;
 
     if !matcher.is_undefined() {
-        return Ok(to_boolean(matcher.get()));
+        return Ok(to_boolean(*matcher));
     }
 
     Ok(object.is_regexp_object())
@@ -815,8 +814,8 @@ pub fn same_value(v1_handle: Handle<Value>, v2_handle: Handle<Value>) -> bool {
 
 /// SameValueZero (https://tc39.es/ecma262/#sec-samevaluezero)
 pub fn same_value_zero(v1_handle: Handle<Value>, v2_handle: Handle<Value>) -> bool {
-    let v1 = v1_handle.get();
-    let v2 = v2_handle.get();
+    let v1 = *v1_handle;
+    let v2 = *v2_handle;
 
     // Same as same_value, but treats differently signed zeros as equal
     if v1.is_number() {
@@ -858,8 +857,8 @@ pub fn same_value_zero_non_allocating(v1: Value, v2: Value) -> bool {
 /// Also includes BigInt handling
 #[inline]
 fn same_value_non_numeric(v1_handle: Handle<Value>, v2_handle: Handle<Value>) -> bool {
-    let v1 = v1_handle.get();
-    let v2 = v2_handle.get();
+    let v1 = *v1_handle;
+    let v2 = *v2_handle;
 
     // Fast path, if values have same bits they are always equal
     if v1.as_raw_bits() == v2.as_raw_bits() {
@@ -930,7 +929,7 @@ pub fn to_property_key(
     cx: Context,
     value_handle: Handle<Value>,
 ) -> EvalResult<Handle<PropertyKey>> {
-    let value = value_handle.get();
+    let value = *value_handle;
     if value.is_smi() {
         let smi_value = value.as_smi();
         if smi_value >= 0 {
@@ -960,8 +959,8 @@ pub fn is_less_than(
 ) -> EvalResult<Value> {
     // Safe since allocation can only occur during to_numeric, and direct values are not held
     // across the to_numeric calls.
-    let x = x_handle.get();
-    let y = y_handle.get();
+    let x = *x_handle;
+    let y = *y_handle;
 
     if x.is_pointer() && y.is_pointer() {
         let x_kind = x.as_pointer().descriptor().kind();
@@ -1002,8 +1001,8 @@ pub fn is_less_than(
     let num_x_handle = to_numeric(cx, x_handle)?;
     let num_y_handle = to_numeric(cx, y_handle)?;
 
-    let num_x = num_x_handle.get();
-    let num_y = num_y_handle.get();
+    let num_x = *num_x_handle;
+    let num_y = *num_y_handle;
 
     let x_is_bigint = num_x.is_bigint();
     let y_is_bigint = num_y.is_bigint();
@@ -1095,8 +1094,8 @@ pub fn is_loosely_equal(
 ) -> EvalResult<bool> {
     // Safe since allocation can only occur during to_number, to_primitive, and recursive calls to
     // is_loosely_equal, and direct values are not held across these calls.
-    let v1 = v1_handle.get();
-    let v2 = v2_handle.get();
+    let v1 = *v1_handle;
+    let v2 = *v2_handle;
 
     // If values have the same type, then use (inlined) is_strictly_equal.
     //
@@ -1280,8 +1279,8 @@ pub fn is_loosely_equal(
 
 /// IsStrictlyEqual (https://tc39.es/ecma262/#sec-isstrictlyequal)
 pub fn is_strictly_equal(v1_handle: Handle<Value>, v2_handle: Handle<Value>) -> bool {
-    let v1 = v1_handle.get();
-    let v2 = v2_handle.get();
+    let v1 = *v1_handle;
+    let v2 = *v2_handle;
 
     if v1.is_number() {
         if v2.is_number() {
@@ -1302,7 +1301,7 @@ pub fn same_object_value(value1: HeapPtr<ObjectValue>, value2: HeapPtr<ObjectVal
 
 #[inline]
 pub fn same_object_value_handles(value1: Handle<ObjectValue>, value2: Handle<ObjectValue>) -> bool {
-    value1.get_().ptr_eq(&value2.get_())
+    same_object_value(*value1, *value2)
 }
 
 /// Specialization of SameValue for optional objects, checks object identity
@@ -1325,7 +1324,7 @@ pub fn same_opt_object_value_handles(
 ) -> bool {
     match (value1, value2) {
         (None, None) => true,
-        (Some(value1), Some(value2)) => value1.get_().ptr_eq(&value2.get_()),
+        (Some(value1), Some(value2)) => same_object_value_handles(value1, value2),
         _ => false,
     }
 }

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -576,7 +576,7 @@ impl SymbolValue {
         let mut symbol = cx.alloc_uninit::<SymbolValue>();
 
         set_uninit!(symbol.descriptor, cx.base_descriptors.get(ObjectKind::Symbol));
-        set_uninit!(symbol.description, description.map(|desc| desc.get_()));
+        set_uninit!(symbol.description, description.map(|desc| *desc));
         set_uninit!(symbol.hash_code, rand::thread_rng().gen::<u32>());
         set_uninit!(symbol.is_private, is_private);
 
@@ -632,14 +632,14 @@ impl Eq for HeapPtr<SymbolValue> {}
 impl hash::Hash for Handle<SymbolValue> {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.get_().hash(state)
+        (**self).hash(state)
     }
 }
 
 impl PartialEq for Handle<SymbolValue> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.get_().eq(&other.get_())
+        (**self).eq(&**other)
     }
 }
 
@@ -743,10 +743,10 @@ impl ValueCollectionKey {
     pub fn from(value: Handle<Value>) -> Self {
         if value.is_string() {
             let flat_string = value.as_string().flatten();
-            return ValueCollectionKey(flat_string.as_string().get_().into());
+            return ValueCollectionKey(*flat_string.as_value());
         }
 
-        ValueCollectionKey(value.get())
+        ValueCollectionKey(*value)
     }
 
     pub fn get(&self) -> Value {
@@ -826,6 +826,6 @@ impl ValueCollectionKeyHandle {
     }
 
     pub fn get(&self) -> ValueCollectionKey {
-        ValueCollectionKey(self.0.get())
+        ValueCollectionKey(*self.0)
     }
 }


### PR DESCRIPTION
## Summary

Handles have a `get()` or `_get()` method which returns in the inner value or heap item respectively. However handles already implement the Deref trait so we can instead use the standard rust deref operator `*`.

Convert all usages of `get() and `_get()` to the deref operator in the interest of standardizing on common rust patterns.