### PR TITLE
[runtime] AsyncFromSyncIterator closes the underlying iterator before rejecting

### DIFF
--- a/src/js/runtime/intrinsics/promise_constructor.rs
+++ b/src/js/runtime/intrinsics/promise_constructor.rs
@@ -125,7 +125,7 @@ impl PromiseConstructor {
 
         if completion.is_err() {
             if !iterator.is_done {
-                completion = iterator_close(cx, &iterator, completion);
+                completion = iterator_close(cx, iterator.iterator, completion);
             }
 
             if_abrupt_reject_promise!(cx, completion, capability);

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -203,6 +203,7 @@ rust_runtime_functions!(
     ArrayPrototype::unshift,
     ArrayPrototype::values,
     ArrayPrototype::with,
+    async_from_sync_iterator_prototype::async_from_sync_iterator_continuation_on_reject,
     async_from_sync_iterator_prototype::create_continuing_iter_result_object,
     async_from_sync_iterator_prototype::create_done_iter_result_object,
     AsyncFromSyncIteratorPrototype::next,

--- a/src/js/runtime/intrinsics/weak_set_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_set_constructor.rs
@@ -74,7 +74,7 @@ impl WeakSetConstructor {
                         call_object(cx, adder.as_object(), weak_set.into(), &[next_value]);
 
                     if add_result.is_err() {
-                        return iterator_close(cx, &iterator, add_result);
+                        return iterator_close(cx, iterator.iterator, add_result);
                     }
                 }
             }

--- a/src/js/runtime/iterator.rs
+++ b/src/js/runtime/iterator.rs
@@ -126,13 +126,13 @@ pub fn iterator_step(cx: Context, iterator: &Iterator) -> EvalResult<Option<Hand
 /// IteratorClose (https://tc39.es/ecma262/#sec-iteratorclose)
 pub fn iterator_close(
     cx: Context,
-    iterator: &Iterator,
+    iterator: Handle<ObjectValue>,
     completion: EvalResult<Handle<Value>>,
 ) -> EvalResult<Handle<Value>> {
-    let inner_result = get_method(cx, iterator.iterator.into(), cx.names.return_());
+    let inner_result = get_method(cx, iterator.into(), cx.names.return_());
     let inner_result = match inner_result {
         Ok(None) => return completion,
-        Ok(Some(return_)) => call_object(cx, return_, iterator.iterator.into(), &[]),
+        Ok(Some(return_)) => call_object(cx, return_, iterator.into(), &[]),
         Err(thrown_value) => Err(thrown_value),
     };
 
@@ -227,7 +227,7 @@ pub fn iter_iterator_values<
                 let completion = f(cx, value);
 
                 if let Some(completion) = completion {
-                    return iterator_close(cx, &iterator, completion);
+                    return iterator_close(cx, iterator.iterator, completion);
                 }
             }
         }
@@ -254,7 +254,7 @@ pub fn iter_iterator_method_values<
                 let completion = f(cx, value);
 
                 if let Some(completion) = completion {
-                    return iterator_close(cx, &iterator, completion);
+                    return iterator_close(cx, iterator.iterator, completion);
                 }
             }
         }


### PR DESCRIPTION
## Summary

In https://github.com/tc39/ecma262/pull/2600 AsyncFromSyncIterator was changed to close the underlying sync iterator before rejecting in some cases.

In addition if in `AsyncFromSyncIterator.prototype.throw` the underlying sync iterator does not have a `throw` method, threw a new TypeError.

## Tests

Fixes all failing AsyncFromSyncIteratorPrototype test262 tests.