### PR TITLE
[parser] Parse "for await (async of" as the start of a for-of statement

### DIFF
--- a/tests/js_parser/statement/for_each.exp
+++ b/tests/js_parser/statement/for_each.exp
@@ -1,6 +1,6 @@
 {
   type: "Program",
-  loc: "1:0-18:25",
+  loc: "1:0-19:25",
   body: [
     {
       type: "ForOfStatement",
@@ -170,7 +170,7 @@
     },
     {
       type: "FunctionDeclaration",
-      loc: "13:0-15:1",
+      loc: "13:0-16:1",
       id: {
         type: "Identifier",
         loc: "13:15-13:18",
@@ -179,7 +179,7 @@
       params: [],
       body: {
         type: "Block",
-        loc: "13:21-15:1",
+        loc: "13:21-16:1",
         body: [
           {
             type: "ForOfStatement",
@@ -201,6 +201,26 @@
             },
             await: true,
           },
+          {
+            type: "ForOfStatement",
+            loc: "15:2-15:27",
+            left: {
+              type: "Identifier",
+              loc: "15:13-15:18",
+              name: "async",
+            },
+            right: {
+              type: "Identifier",
+              loc: "15:22-15:23",
+              name: "b",
+            },
+            body: {
+              type: "Block",
+              loc: "15:25-15:27",
+              body: [],
+            },
+            await: true,
+          },
         ],
       },
       async: true,
@@ -209,18 +229,18 @@
     },
     {
       type: "ForInStatement",
-      loc: "18:0-18:25",
+      loc: "19:0-19:25",
       left: {
         type: "VariableDeclaration",
-        loc: "18:5-18:10",
+        loc: "19:5-19:10",
         kind: "var",
         declarations: [
           {
             type: "VariableDeclarator",
-            loc: "18:9-18:10",
+            loc: "19:9-19:10",
             id: {
               type: "Identifier",
-              loc: "18:9-18:10",
+              loc: "19:9-19:10",
               name: "a",
             },
             init: null,
@@ -229,28 +249,28 @@
       },
       right: {
         type: "SequenceExpression",
-        loc: "18:14-18:21",
+        loc: "19:14-19:21",
         expressions: [
           {
             type: "Literal",
-            loc: "18:14-18:15",
+            loc: "19:14-19:15",
             value: 1,
           },
           {
             type: "Literal",
-            loc: "18:17-18:18",
+            loc: "19:17-19:18",
             value: 2,
           },
           {
             type: "Literal",
-            loc: "18:20-18:21",
+            loc: "19:20-19:21",
             value: 3,
           },
         ],
       },
       body: {
         type: "Block",
-        loc: "18:23-18:25",
+        loc: "19:23-19:25",
         body: [],
       },
     },

--- a/tests/js_parser/statement/for_each.js
+++ b/tests/js_parser/statement/for_each.js
@@ -12,6 +12,7 @@ for (a in b) {}
 
 async function foo() {
   for await (a of b) {}
+  for await (async of b) {}
 }
 
 // Sequence expression allowed in for-in


### PR DESCRIPTION
## Summary

We should allow parsing for-await-of statements that begin with "for await (async of". This requires a special case, otherwise the "async of" will be interpreted as the start of an async arrow function and a backtrack will be forced to try parsing as an async arrow function.

## Tests

- Added a parser snapshot test for this case.
- Fixes test262 `language/statements/for-await-of/head-lhs-async.js`