### PR TITLE
[regexp] Parse RegExps without named capture groups, then reparase if a named capture group was encountered

### DIFF
--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -107,6 +107,8 @@ pub enum ParseError {
     InvalidQuantifierBounds,
     NonQuantifiableAssertion,
     InvalidUnicodeProperty,
+    // RegExp parsing marker error to signal a named capture group was encountered
+    NamedCaptureGroupEncountered,
 }
 
 #[derive(Debug)]
@@ -431,6 +433,9 @@ impl fmt::Display for ParseError {
             }
             ParseError::InvalidUnicodeProperty => {
                 write!(f, "Invalid unicode property in regular expression")
+            }
+            ParseError::NamedCaptureGroupEncountered => {
+                panic!("Marker error should have been caught")
             }
         }
     }

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -2907,8 +2907,9 @@ impl<'a> Parser<'a> {
 
             // Start position of pattern is offset by one to account for the leading `/`
             let pattern_start_pos = start_pos + 1;
-            let lexer_stream = Utf8LexerStream::new(pattern_start_pos, source, pattern.as_bytes());
-            let regexp = p(RegExpParser::parse_regexp(lexer_stream, flags)?);
+            let create_lexer_stream =
+                || Utf8LexerStream::new(pattern_start_pos, source.clone(), pattern.as_bytes());
+            let regexp = p(RegExpParser::parse_regexp(&create_lexer_stream, flags)?);
 
             Ok(RegExpLiteral { loc, raw, pattern, flags: flags_string, regexp })
         } else {

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -2,6 +2,10 @@
   // Tests that are known to fail but should count against test262 progress.
   "known_failures": {
     "tests": [
+      // Test includes annex-B features (tests contain RegExp identity escape for characters in
+      // the ID_Continue Unicode class).
+      "built-ins/String/prototype/split/separator-regexp.js",
+
       // Incorrect tests due to changed base/property evaluation order
       // https://github.com/tc39/test262/issues/3407
       "language/expressions/assignment/target-member-computed-reference-null.js",


### PR DESCRIPTION
## Summary

Fixes RegExp parsing to happen in two attempts. The first attempt assumes there are no named capture groups, meaning named backreferences are parsed as identity escapes and named capture groups cause an error which signals a named capture group was encountered.

If named capture groups were encountered in the first pass, try parsing again but this time including named backreferences.

## Tests

Fixes part of test262 `built-ins/String/prototype/split/separator-regexp.js`.

But unfortunately this exposed another error later in the test that appears to be due to the inclusion of an annex-B feature. This test includes RegExps with identity escapes for code points in the ID_Continue Unicode class. Mark it as ignored for now with a note.