### PR TITLE
[parser] Introduce Annex B flag and gated RegExp named capture group reparsing behind Annex B

### DIFF
--- a/src/js/common/options.rs
+++ b/src/js/common/options.rs
@@ -22,6 +22,10 @@ pub struct Args {
     #[arg(short, long, default_value_t = false)]
     pub module: bool,
 
+    /// Enable Annex B extensions
+    #[arg(long, default_value_t = false)]
+    pub annex_b: bool,
+
     /// Expose global gc methods
     #[arg(long, default_value_t = false)]
     pub expose_gc: bool,
@@ -36,6 +40,8 @@ pub struct Args {
 
 /// Options passed throughout the program.
 pub struct Options {
+    /// Whether Annex B extensions are enabled
+    pub annex_b: bool,
     /// Print each AST to the console
     pub print_ast: bool,
     /// Print the bytecode to the console
@@ -50,6 +56,7 @@ impl Options {
     /// Create a new options struct from the command line arguments.
     pub fn new_from_args(args: &Args) -> Self {
         Self {
+            annex_b: args.annex_b,
             print_ast: args.print_ast,
             print_bytecode: args.print_bytecode,
             print_regexp_bytecode: args.print_regexp_bytecode,
@@ -69,6 +76,7 @@ impl Default for Options {
     /// Create a new options struct with default values.
     fn default() -> Self {
         Self {
+            annex_b: false,
             print_ast: false,
             print_bytecode: false,
             print_regexp_bytecode: false,

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 
 use bitflags::bitflags;
 
+use crate::js::common::options::Options;
 use crate::js::common::wtf_8::Wtf8String;
 
 use super::ast::*;
@@ -98,6 +99,8 @@ struct Parser<'a> {
     scope_builder: ScopeTree,
     /// The program kind that is currently being parsed - script vs module.
     program_kind: ProgramKind,
+    /// Options set for the compiler
+    options: Rc<Options>,
 }
 
 /// A save point for the parser, can be used to restore the parser to a particular position.
@@ -2909,7 +2912,8 @@ impl<'a> Parser<'a> {
             let pattern_start_pos = start_pos + 1;
             let create_lexer_stream =
                 || Utf8LexerStream::new(pattern_start_pos, source.clone(), pattern.as_bytes());
-            let regexp = p(RegExpParser::parse_regexp(&create_lexer_stream, flags)?);
+            let regexp =
+                p(RegExpParser::parse_regexp(&create_lexer_stream, flags, self.options.as_ref())?);
 
             Ok(RegExpLiteral { loc, raw, pattern, flags: flags_string, regexp })
         } else {

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -100,7 +100,7 @@ struct Parser<'a> {
     /// The program kind that is currently being parsed - script vs module.
     program_kind: ProgramKind,
     /// Options set for the compiler
-    options: Rc<Options>,
+    options: &'a Options,
 }
 
 /// A save point for the parser, can be used to restore the parser to a particular position.
@@ -124,7 +124,7 @@ fn swap_and_save<T: Copy>(reference: &mut T, new_value: T) -> T {
 
 impl<'a> Parser<'a> {
     // Must prime parser by calling advance before using.
-    fn new(lexer: Lexer<'a>, scope_builder: ScopeTree) -> Parser<'a> {
+    fn new(lexer: Lexer<'a>, scope_builder: ScopeTree, options: &'a Options) -> Parser<'a> {
         Parser {
             lexer,
             token: Token::Eof,
@@ -136,6 +136,7 @@ impl<'a> Parser<'a> {
             allow_in: true,
             scope_builder,
             program_kind: ProgramKind::Script,
+            options,
         }
     }
 
@@ -2912,8 +2913,7 @@ impl<'a> Parser<'a> {
             let pattern_start_pos = start_pos + 1;
             let create_lexer_stream =
                 || Utf8LexerStream::new(pattern_start_pos, source.clone(), pattern.as_bytes());
-            let regexp =
-                p(RegExpParser::parse_regexp(&create_lexer_stream, flags, self.options.as_ref())?);
+            let regexp = p(RegExpParser::parse_regexp(&create_lexer_stream, flags, self.options)?);
 
             Ok(RegExpLiteral { loc, raw, pattern, flags: flags_string, regexp })
         } else {
@@ -4650,10 +4650,10 @@ pub struct ParseFunctionResult {
     pub source: Rc<Source>,
 }
 
-pub fn parse_script(source: &Rc<Source>) -> ParseResult<ParseProgramResult> {
+pub fn parse_script(source: &Rc<Source>, options: &Options) -> ParseResult<ParseProgramResult> {
     // Create and prime parser
     let lexer = Lexer::new(source);
-    let mut parser = Parser::new(lexer, ScopeTree::new_global());
+    let mut parser = Parser::new(lexer, ScopeTree::new_global(), options);
 
     let initial_state = parser.save();
     parser.advance()?;
@@ -4661,10 +4661,10 @@ pub fn parse_script(source: &Rc<Source>) -> ParseResult<ParseProgramResult> {
     parser.parse_script(initial_state)
 }
 
-pub fn parse_module(source: &Rc<Source>) -> ParseResult<ParseProgramResult> {
+pub fn parse_module(source: &Rc<Source>, options: &Options) -> ParseResult<ParseProgramResult> {
     // Create and prime parser
     let lexer = Lexer::new(source);
-    let mut parser = Parser::new(lexer, ScopeTree::new_module());
+    let mut parser = Parser::new(lexer, ScopeTree::new_module(), options);
     parser.advance()?;
 
     parser.parse_module()
@@ -4672,12 +4672,13 @@ pub fn parse_module(source: &Rc<Source>) -> ParseResult<ParseProgramResult> {
 
 pub fn parse_script_for_eval(
     source: &Rc<Source>,
+    options: &Options,
     is_direct: bool,
     inherit_strict_mode: bool,
 ) -> ParseResult<ParseProgramResult> {
     // Create and prime parser
     let lexer = Lexer::new(source);
-    let mut parser = Parser::new(lexer, ScopeTree::new_eval(is_direct));
+    let mut parser = Parser::new(lexer, ScopeTree::new_eval(is_direct), options);
 
     // Inherit strict mode from context
     parser.set_in_strict_mode(inherit_strict_mode);
@@ -4690,12 +4691,13 @@ pub fn parse_script_for_eval(
 
 pub fn parse_function_params_for_function_constructor(
     source: &Rc<Source>,
+    options: &Options,
     is_async: bool,
     is_generator: bool,
 ) -> ParseResult<()> {
     // Create and prime parser
     let lexer = Lexer::new(source);
-    let mut parser = Parser::new(lexer, ScopeTree::new_global());
+    let mut parser = Parser::new(lexer, ScopeTree::new_global(), options);
 
     parser.allow_await = is_async;
     parser.allow_yield = is_generator;
@@ -4710,12 +4712,13 @@ pub fn parse_function_params_for_function_constructor(
 
 pub fn parse_function_body_for_function_constructor(
     source: &Rc<Source>,
+    options: &Options,
     is_async: bool,
     is_generator: bool,
 ) -> ParseResult<()> {
     // Create and prime parser
     let lexer = Lexer::new(source);
-    let mut parser = Parser::new(lexer, ScopeTree::new_global());
+    let mut parser = Parser::new(lexer, ScopeTree::new_global(), options);
 
     parser.allow_await = is_async;
     parser.allow_yield = is_generator;
@@ -4731,10 +4734,11 @@ pub fn parse_function_body_for_function_constructor(
 
 pub fn parse_function_for_function_constructor(
     source: &Rc<Source>,
+    options: &Options,
 ) -> ParseResult<ParseFunctionResult> {
     // Create and prime parser
     let lexer = Lexer::new(source);
-    let mut parser = Parser::new(lexer, ScopeTree::new_global());
+    let mut parser = Parser::new(lexer, ScopeTree::new_global(), options);
     parser.advance()?;
 
     let func_node = parser.parse_function_declaration(FunctionContext::TOPLEVEL)?;

--- a/src/js/parser/regexp_parser.rs
+++ b/src/js/parser/regexp_parser.rs
@@ -197,7 +197,7 @@ impl<T: LexerStream> RegExpParser<T> {
         // First try to parse without named capture groups. Only reparse if a named capture group
         // was encountered.
         let lexer_stream = create_lexer_stream();
-        let parser;
+        let mut parser;
 
         let disjunction = if !options.annex_b {
             // Always parse with named capture groups if Annex B is not enabled
@@ -438,7 +438,7 @@ impl<T: LexerStream> RegExpParser<T> {
                         }
                     }
                     // Named backreferences. Can only parse when we are in parse named capture
-                    // groups mode (i.e. when reparsing because we saw a named capture group).
+                    // groups mode.
                     'k' if self.parse_named_capture_groups => {
                         self.advance2();
 
@@ -682,8 +682,8 @@ impl<T: LexerStream> RegExpParser<T> {
                             let disjunction = self.parse_disjunction()?;
                             self.expect(')')?;
 
-                            // The first parse assumes there are no named capture groups. Throw a
-                            // marker error to signal that a named capture group was encountered.
+                            // In Annex B the first parse assumes there are no named capture groups.
+                            // Throw a marker error to signal that a named capture group was found.
                             if !self.parse_named_capture_groups {
                                 return self
                                     .error(self.pos(), ParseError::NamedCaptureGroupEncountered);

--- a/src/js/runtime/eval/create_dynamic_function.rs
+++ b/src/js/runtime/eval/create_dynamic_function.rs
@@ -109,9 +109,12 @@ pub fn create_dynamic_function(
         Ok(source) => Rc::new(source),
         Err(err) => return syntax_parse_error(cx, &err),
     };
-    if let Err(err) =
-        parse_function_params_for_function_constructor(&params_source, is_async, is_generator)
-    {
+    if let Err(err) = parse_function_params_for_function_constructor(
+        &params_source,
+        cx.options.as_ref(),
+        is_async,
+        is_generator,
+    ) {
         return syntax_parse_error(cx, &err);
     }
 
@@ -119,9 +122,12 @@ pub fn create_dynamic_function(
         Ok(source) => Rc::new(source),
         Err(err) => return syntax_parse_error(cx, &err),
     };
-    if let Err(err) =
-        parse_function_body_for_function_constructor(&body_source, is_async, is_generator)
-    {
+    if let Err(err) = parse_function_body_for_function_constructor(
+        &body_source,
+        cx.options.as_ref(),
+        is_async,
+        is_generator,
+    ) {
         return syntax_parse_error(cx, &err);
     }
 
@@ -130,10 +136,11 @@ pub fn create_dynamic_function(
         Ok(source) => Rc::new(source),
         Err(err) => return syntax_parse_error(cx, &err),
     };
-    let mut parse_result = match parse_function_for_function_constructor(&full_source) {
-        Ok(parse_result) => parse_result,
-        Err(err) => return syntax_parse_error(cx, &err),
-    };
+    let mut parse_result =
+        match parse_function_for_function_constructor(&full_source, cx.options.as_ref()) {
+            Ok(parse_result) => parse_result,
+            Err(err) => return syntax_parse_error(cx, &err),
+        };
 
     if let Err(errs) =
         analyze_function_for_function_constructor(&mut parse_result, full_source.clone())

--- a/src/js/runtime/eval/eval.rs
+++ b/src/js/runtime/eval/eval.rs
@@ -50,7 +50,8 @@ pub fn perform_eval(
         Err(error) => return syntax_parse_error(cx, &error),
     };
 
-    let parse_result = parse_script_for_eval(&source, is_direct, is_strict_caller);
+    let parse_result =
+        parse_script_for_eval(&source, cx.options.as_ref(), is_direct, is_strict_caller);
     let mut parse_result = match parse_result {
         Ok(parse_result) => parse_result,
         Err(error) => return syntax_parse_error(cx, &error),

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -314,7 +314,7 @@ fn parse_pattern(
         create_lexer_stream: &dyn Fn() -> T,
         flags: RegExpFlags,
     ) -> EvalResult<RegExp> {
-        match RegExpParser::parse_regexp(create_lexer_stream, flags) {
+        match RegExpParser::parse_regexp(create_lexer_stream, flags, cx.options.as_ref()) {
             Ok(regexp) => Ok(regexp),
             Err(error) => syntax_parse_error(cx, &error),
         }

--- a/src/js/runtime/module/loader.rs
+++ b/src/js/runtime/module/loader.rs
@@ -181,7 +181,7 @@ pub fn host_load_imported_module(
     }
 
     // Parse the file at the given path, returning AST
-    let mut parse_result = match parse_file_at_path(new_module_path.as_path()) {
+    let mut parse_result = match parse_file_at_path(cx, new_module_path.as_path()) {
         Ok(parse_result) => parse_result,
         Err(error) => return syntax_parse_error(cx, &error),
     };
@@ -213,7 +213,7 @@ pub fn host_load_imported_module(
     Ok(module)
 }
 
-fn parse_file_at_path(path: &Path) -> ParseResult<ParseProgramResult> {
+fn parse_file_at_path(cx: Context, path: &Path) -> ParseResult<ParseProgramResult> {
     let source = Rc::new(Source::new_from_file(path.to_str().unwrap())?);
-    parse_module(&source)
+    parse_module(&source, cx.options.as_ref())
 }

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -158,7 +158,7 @@ impl Test262Object {
             Err(error) => return syntax_parse_error(cx, &error),
         };
 
-        let parse_result = parse_script(&source);
+        let parse_result = parse_script(&source, cx.options.as_ref());
         let mut parse_result = match parse_result {
             Ok(parse_result) => parse_result,
             Err(error) => return syntax_parse_error(cx, &error),

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,9 +48,9 @@ fn evaluate_file(
 ) -> Result<(), Box<dyn Error>> {
     let source = Rc::new(js::parser::source::Source::new_from_file(file)?);
     let mut parse_result = if args.module {
-        js::parser::parse_module(&source)?
+        js::parser::parse_module(&source, cx.options.as_ref())?
     } else {
-        js::parser::parse_script(&source)?
+        js::parser::parse_script(&source, cx.options.as_ref())?
     };
 
     js::parser::analyze::analyze(&mut parse_result)?;


### PR DESCRIPTION
## Summary

In https://github.com/Hans-Halverson/brimstone/pull/75 we accidentally included an Annex B feature where RegExps are parsed twice, the first time assuming there are no named capture groups.

Let's introduce a CLI flag `--annex-b` which gates whether to include Annex B features. This flag must be passed down into all parser entrypoints via the compiler options.

## Tests

- Fixes test262 `built-ins/RegExp/named-groups/unicode-references.js`