### PR TITLE
[runtime] Fix bug around Accessor creation in debug mode in ValidateAndApplyPropertyDescriptor

### DIFF
--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -367,13 +367,13 @@ pub fn validate_and_apply_property_descriptor(
                     property.set_value(value);
                 }
             } else {
-                let mut accessor_value = Accessor::from_value(property.value());
-
                 if desc.has_get {
+                    let mut accessor_value = Accessor::from_value(property.value());
                     accessor_value.get = desc.get.map(|x| *x);
                 }
 
                 if desc.has_set {
+                    let mut accessor_value = Accessor::from_value(property.value());
                     accessor_value.set = desc.set.map(|x| *x);
                 }
             }


### PR DESCRIPTION
## Summary

A newly introduced `debug_assert` added in https://github.com/Hans-Halverson/brimstone/pull/70 is being hit within ValidateAndApplyPropertyDescriptor. Fix this by moving `Accessor::from_value` to after we known the property descriptor is actually an accessor.

## Tests

- Fixes all test262 tests for implemented features running in debug mode