### PR TITLE
[ci] Add cache for rust builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
+
       - name: Check formatting
         run: cargo fmt -- --check
 
@@ -25,6 +27,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
+
       - name: Run tests
         run: cargo test
 
@@ -34,6 +38,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
       
       - name: Checkout test262 repo
         run: ./tests/test262/install_test262.sh
@@ -50,6 +56,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
       
       - name: Checkout test262 repo
         run: ./tests/test262/install_test262.sh
@@ -66,6 +74,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
       
       - name: Checkout test262 repo
         run: ./tests/test262/install_test262.sh


### PR DESCRIPTION
## Summary

Use https://github.com/Swatinem/rust-cache to add a cache for rust builds in CI. Each job has a separate cache, and only dependencies are cached.