### PR TITLE
[regexp] Do not keep captures from 0-length matches of optional quantifiers

### DIFF
--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -8,8 +8,7 @@
       //
       ////////////////////////////////////////
 
-      // Bug regarding capture groups in lookaheads
-      "built-ins/RegExp/lookahead-quantifier-match-groups.js",
+      // None!
 
       ////////////////////////////////////////
       //


### PR DESCRIPTION
## Summary

We should not be keeping captures when a quantifier that allows 0 repititions has a 0-length match. We detect if this case is possible and emit a sequence of instructions at the end of the quantifier which check progress, and if no progress has been made we clear all captures in the quantifier.

We also now correctly propagate capture info out of a lookaround node.

This is the last known bug (that we plan on fixing) in the test262 tests for all implemented features!

## Tests

- Fixes test262 `built-ins/RegExp/lookahead-quantifier-match-groups.js`