### PR TITLE
[bytecode] Refactor bytecode instruction macro to allow for easier extension

### DIFF
--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -30,12 +30,36 @@ pub trait Instruction: fmt::Display {
     fn byte_length(&self) -> usize;
 }
 
+/// Generate bytecode instructions using a custom DSL.
+///
+/// Instructions are defined using the following syntax:
+///
+/// // The short instruction name
+/// InstructionName {
+///
+///   // The full instruction name in camel case
+///   camel_case: InstructionNameInstruction,
+///
+///   // The full instruction name in snake case
+///   snake_case: instruction_name_instruction,
+///
+///   // The operands of the instruction in the form `[operand_index] operand_name: operand_type`
+///   operands: {
+///     [0] operand_name_1: OperandType1,
+///     [1] operand_name_2: OperandType2,
+///     ...
+///   }
+/// }
 macro_rules! define_instructions {
     ($(
-        $(#[$($attrs:tt)*])* $short_name:ident ($instr_name_camel:ident, $instr_name_snake:ident) {
-            $([$operand_idx:expr] $operand_name:ident: $operand_type:ident,)*
-        })
-    *) => {
+        $(#[$($attrs:tt)*])* $short_name:ident {
+            camel_case: $instr_name_camel:ident,
+            snake_case: $instr_name_snake:ident,
+            operands: {
+                $([$operand_idx:expr] $operand_name:ident: $operand_type:ident,)*
+            }
+        }
+    )*) => {
         $(
             $(#[$($attrs)*])*
             #[repr(C)]
@@ -215,124 +239,200 @@ macro_rules! define_instructions {
 
 define_instructions!(
     /// Prefix denoting that the next instruction is wide.
-    WidePrefix (WidePrefixInstruction, wide_prefix_instruction) {}
+    WidePrefix {
+        camel_case: WidePrefixInstruction,
+        snake_case: wide_prefix_instruction,
+        operands: {}
+    }
 
     /// Prefix denoting that the next instruction is extra wide.
-    ExtraWidePrefix (ExtraWidePrefixInstruction, extra_wide_prefix_instruction) {}
+    ExtraWidePrefix {
+        camel_case: ExtraWidePrefixInstruction,
+        snake_case: extra_wide_prefix_instruction,
+        operands: {}
+    }
 
     /// Copy a value between registers.
-    Mov (MovInstruction, mov_instruction) {
-        [0] dest: Register,
-        [1] src: Register,
+    Mov {
+        camel_case: MovInstruction,
+        snake_case: mov_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] src: Register,
+        }
     }
 
     /// Load an immediate into a register.
-    LoadImmediate (LoadImmediateInstruction, load_immediate_instruction) {
-        [0] dest: Register,
-        [1] immediate: SInt,
+    LoadImmediate {
+        camel_case: LoadImmediateInstruction,
+        snake_case: load_immediate_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] immediate: SInt,
+        }
     }
 
     /// Load a constant from the constant table into a register.
-    LoadConstant (LoadConstantInstruction, load_constant_instruction) {
-        [0] dest: Register,
-        [1] constant_index: ConstantIndex,
+    LoadConstant {
+        camel_case: LoadConstantInstruction,
+        snake_case: load_constant_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] constant_index: ConstantIndex,
+        }
     }
 
     /// Load the value `undefined` into a register.
-    LoadUndefined (LoadUndefinedInstruction, load_undefined_instruction) {
-        [0] dest: Register,
+    LoadUndefined {
+        camel_case: LoadUndefinedInstruction,
+        snake_case: load_undefined_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Load the value `null` into a register.
-    LoadNull (LoadNullInstruction, load_null_instruction) {
-        [0] dest: Register,
+    LoadNull {
+        camel_case: LoadNullInstruction,
+        snake_case: load_null_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Load the empty value into a register.
-    LoadEmpty (LoadEmptyInstruction, load_empty_instruction) {
-        [0] dest: Register,
+    LoadEmpty {
+        camel_case: LoadEmptyInstruction,
+        snake_case: load_empty_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Load the value `true` into a register.
-    LoadTrue (LoadTrueInstruction, load_true_instruction) {
-        [0] dest: Register,
+    LoadTrue {
+        camel_case: LoadTrueInstruction,
+        snake_case: load_true_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Load the value `false` into a register.
-    LoadFalse (LoadFalseInstruction, load_false_instruction) {
-        [0] dest: Register,
+    LoadFalse {
+        camel_case: LoadFalseInstruction,
+        snake_case: load_false_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Load a global variable into a register, erroring if the global does not exist. The global
     /// variable's name is stored in the constant table.
-    LoadGlobal (LoadGlobalInstruction, load_global_instruction) {
-        [0] dest: Register,
-        [1] constant_index: ConstantIndex,
+    LoadGlobal {
+        camel_case: LoadGlobalInstruction,
+        snake_case: load_global_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] constant_index: ConstantIndex,
+        }
     }
 
     /// Load a global variable into a register, loading undefined if the global does not exist. The
     /// global variable's name is stored in the constant table.
-    LoadGlobalOrUnresolved (LoadGlobalOrUnresolvedInstruction, load_global_or_unresolved_instruction) {
-        [0] dest: Register,
-        [1] constant_index: ConstantIndex,
+    LoadGlobalOrUnresolved {
+        camel_case: LoadGlobalOrUnresolvedInstruction,
+        snake_case: load_global_or_unresolved_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] constant_index: ConstantIndex,
+        }
     }
 
     /// Store a register into a global variable. The global variable's name is stored in the
     /// constant table.
-    StoreGlobal (StoreGlobalInstruction, store_global_instruction) {
-        [0] value: Register,
-        [1] constant_index: ConstantIndex,
+    StoreGlobal {
+        camel_case: StoreGlobalInstruction,
+        snake_case: store_global_instruction,
+        operands: {
+            [0] value: Register,
+            [1] constant_index: ConstantIndex,
+        }
     }
 
     /// Load a variable with the given name into dest, erroring if the name could not be resolved.
     /// Dynamically look up the variable by name in the scope chain. The name is stored in the
     /// constant table.
-    LoadDynamic (LoadDynamicInstruction, load_dynamic_instruction) {
-        [0] dest: Register,
-        [1] name_index: ConstantIndex,
+    LoadDynamic {
+        camel_case: LoadDynamicInstruction,
+        snake_case: load_dynamic_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] name_index: ConstantIndex,
+        }
     }
 
     /// Load a variable with the given name into dest, loading undefiend if the name could not be
     /// resolved. Dynamically look up the variable by name in the scope chain. The name is stored in
     /// the constant table.
-    LoadDynamicOrUnresolved (LoadDynamicOrUnresolvedInstruction, load_dynamic_or_unresolved_instruction) {
-        [0] dest: Register,
-        [1] name_index: ConstantIndex,
+    LoadDynamicOrUnresolved {
+        camel_case: LoadDynamicOrUnresolvedInstruction,
+        snake_case: load_dynamic_or_unresolved_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] name_index: ConstantIndex,
+        }
     }
 
     /// Store a value into a variable. Dynamically look up the variable by name in the scope chain.
     /// The name is stored in the constant table.
-    StoreDynamic (StoreDynamicInstruction, store_dynamic_instruction) {
-        [0] value: Register,
-        [1] name_index: ConstantIndex,
+    StoreDynamic {
+        camel_case: StoreDynamicInstruction,
+        snake_case: store_dynamic_instruction,
+        operands: {
+            [0] value: Register,
+            [1] name_index: ConstantIndex,
+        }
     }
 
     /// Call a function. Arguments are passed in contiguous sequence of registers starting at argv,
     /// of length argc. The receiver is undefined.
-    Call (CallInstruction, call_instruction) {
-        [0] dest: Register,
-        [1] function: Register,
-        [2] argv: Register,
-        [3] argc: UInt,
+    Call {
+        camel_case: CallInstruction,
+        snake_case: call_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] function: Register,
+            [2] argv: Register,
+            [3] argc: UInt,
+        }
     }
 
     /// Call a function, specifying the receiver to be used. All other arguments are passed in a
     /// contiguous sequence of registers starting at argv, of length argc.
-    CallWithReceiver (CallWithReceiverInstruction, call_with_receiver_instruction) {
-        [0] dest: Register,
-        [1] function: Register,
-        [2] receiver: Register,
-        [3] argv: Register,
-        [4] argc: UInt,
+    CallWithReceiver {
+        camel_case: CallWithReceiverInstruction,
+        snake_case: call_with_receiver_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] function: Register,
+            [2] receiver: Register,
+            [3] argv: Register,
+            [4] argc: UInt,
+        }
     }
 
     /// Call a function with a variable number of arguments, specifying the receiver to be used. All
     /// other arguments are passed in an array.
-    CallVarargs (CallVarargsInstruction, call_varargs_instruction) {
-        [0] dest: Register,
-        [1] function: Register,
-        [2] receiver: Register,
-        [3] args: Register,
+    CallVarargs {
+        camel_case: CallVarargsInstruction,
+        snake_case: call_varargs_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] function: Register,
+            [2] receiver: Register,
+            [3] args: Register,
+        }
     }
 
     /// Call a function which may be a direct eval. If this is a direct eval then perform the direct
@@ -340,12 +440,16 @@ define_instructions!(
     ///
     /// Arguments are passed in contiguous sequence of registers starting at argv, of length argc.
     /// The receiver is undefined.
-    CallMaybeEval (CallMaybeEvalInstruction, call_maybe_eval_instruction) {
-        [0] dest: Register,
-        [1] function: Register,
-        [2] argv: Register,
-        [3] argc: UInt,
-        [4] flags: UInt,
+    CallMaybeEval {
+        camel_case: CallMaybeEvalInstruction,
+        snake_case: call_maybe_eval_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] function: Register,
+            [2] argv: Register,
+            [3] argc: UInt,
+            [4] flags: UInt,
+        }
     }
 
     /// Call a function with variable number of arguments, where the function may be a direct eval.
@@ -353,434 +457,686 @@ define_instructions!(
     /// instruction.
     ///
     /// The receiver is undefined. All other arguments are passed in an array.
-    CallMaybeEvalVarargs (CallMaybeEvalVarargsInstruction, call_maybe_eval_varargs_instruction) {
-        [0] dest: Register,
-        [1] function: Register,
-        [2] args: Register,
-        [3] flags: UInt,
+    CallMaybeEvalVarargs {
+        camel_case: CallMaybeEvalVarargsInstruction,
+        snake_case: call_maybe_eval_varargs_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] function: Register,
+            [2] args: Register,
+            [3] flags: UInt,
+        }
     }
 
     /// Call a constructor. Arguments are passed in contiguous sequence of registers starting at
     /// argv, of length argc. The new target is passed in its own register.
-    Construct (ConstructInstruction, construct_instruction) {
-        [0] dest: Register,
-        [1] function: Register,
-        [2] new_target: Register,
-        [3] argv: Register,
-        [4] argc: UInt,
+    Construct {
+        camel_case: ConstructInstruction,
+        snake_case: construct_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] function: Register,
+            [2] new_target: Register,
+            [3] argv: Register,
+            [4] argc: UInt,
+        }
     }
 
     /// Call a constructor with a variable number of arguments, where arguments are passed in an
     /// array. The new target is passed in its own register.
-    ConstructVarargs (ConstructVarargsInstruction, construct_varargs_instruction) {
-        [0] dest: Register,
-        [1] function: Register,
-        [2] new_target: Register,
-        [3] args: Register,
+    ConstructVarargs {
+        camel_case: ConstructVarargsInstruction,
+        snake_case: construct_varargs_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] function: Register,
+            [2] new_target: Register,
+            [3] args: Register,
+        }
     }
 
     /// Call the super constructor in a default derived constructor, storing the result in `this`.
-    DefaultSuperCall (DefaultSuperCallInstruction, default_super_call_instruction) {}
+    DefaultSuperCall {
+        camel_case: DefaultSuperCallInstruction,
+        snake_case: default_super_call_instruction,
+        operands: {}
+    }
 
     /// Return from a function, producing a value.
-    Ret (RetInstruction, ret_instruction) {
-        [0] return_value: Register,
+    Ret {
+        camel_case: RetInstruction,
+        snake_case: ret_instruction,
+        operands: {
+            [0] return_value: Register,
+        }
     }
 
     /// Add two values together, storing the result in dest.
-    Add (AddInstruction, add_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    Add {
+        camel_case: AddInstruction,
+        snake_case: add_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Subtract one value from another, storing the result in dest.
-    Sub (SubInstruction, sub_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    Sub {
+        camel_case: SubInstruction,
+        snake_case: sub_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Multiply one value with another, storing the result in dest.
-    Mul (MulInstruction, mul_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    Mul {
+        camel_case: MulInstruction,
+        snake_case: mul_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Divide one value with another, storing the result in dest.
-    Div (DivInstruction, div_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    Div {
+        camel_case: DivInstruction,
+        snake_case: div_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Find the remainder from dividing the left value with the right value, storing the result in
     /// dest.
-    Rem (RemInstruction, rem_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    Rem {
+        camel_case: RemInstruction,
+        snake_case: rem_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Raise the left value to the power of the right value, storing the result in dest.
-    Exp (ExpInstruction, exp_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    Exp {
+        camel_case: ExpInstruction,
+        snake_case: exp_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Bitwise and the two operands, storing the result in dest.
-    BitAnd (BitAndInstruction, bit_and_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    BitAnd {
+        camel_case: BitAndInstruction,
+        snake_case: bit_and_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Bitwise or the two operands, storing the result in dest.
-    BitOr (BitOrInstruction, bit_or_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    BitOr {
+        camel_case: BitOrInstruction,
+        snake_case: bit_or_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Bitwise xor the two operands, storing the result in dest.
-    BitXor (BitXorInstruction, bit_xor_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    BitXor {
+        camel_case: BitXorInstruction,
+        snake_case: bit_xor_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Shift the left operand left by the right operand, storing the result in dest.
-    ShiftLeft (ShiftLeftInstruction, shift_left_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    ShiftLeft {
+        camel_case: ShiftLeftInstruction,
+        snake_case: shift_left_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Shift the left operand right by the right operand, storing the result in dest. Extends the
     /// highest bit of the left operand, preserving the sign of the left operand.
-    ShiftRightArithmetic (ShiftRightArithmeticInstruction, shift_right_arithmetic_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    ShiftRightArithmetic {
+        camel_case: ShiftRightArithmeticInstruction,
+        snake_case: shift_right_arithmetic_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Shift the left operand right by the right operand, storing the result in dest. New bits are
     /// filled with zeroes.
-    ShiftRightLogical (ShiftRightLogicalInstruction, shift_right_logical_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    ShiftRightLogical {
+        camel_case: ShiftRightLogicalInstruction,
+        snake_case: shift_right_logical_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Test if the two operands are loosely equal to each other (`==`), storing the result in dest.
-    LooseEqual (LooseEqualInstruction, loose_equal_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    LooseEqual {
+        camel_case: LooseEqualInstruction,
+        snake_case: loose_equal_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Test if the two operands are loosely not equal to each other (`!=`), storing the result in
     /// dest.
-    LooseNotEqual (LooseNotEqualInstruction, loose_not_equal_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    LooseNotEqual {
+        camel_case: LooseNotEqualInstruction,
+        snake_case: loose_not_equal_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Test if the two operands are strictly equal to each other (`===`), storing the result in
     /// dest.
-    StrictEqual (StrictEqualInstruction, strict_equal_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    StrictEqual {
+        camel_case: StrictEqualInstruction,
+        snake_case: strict_equal_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Test if the two operands are strictly not equal to each other (`!==`), storing the result in
     /// dest.
-    StrictNotEqual (StrictNotEqualInstruction, strict_not_equal_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    StrictNotEqual {
+        camel_case: StrictNotEqualInstruction,
+        snake_case: strict_not_equal_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Test if the left operand is less than the right operand, storing the result in dest.
-    LessThan (LessThanInstruction, less_than_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    LessThan {
+        camel_case: LessThanInstruction,
+        snake_case: less_than_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Test if the left operand is less than or equal to the right operand, storing the result in
     /// dest.
-    LessThanOrEqual (LessThanOrEqualInstruction, less_than_or_equal_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    LessThanOrEqual {
+        camel_case: LessThanOrEqualInstruction,
+        snake_case: less_than_or_equal_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Test if the left operand is greater than the right operand, storing the result in dest.
-    GreaterThan (GreaterThanInstruction, greater_than_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    GreaterThan {
+        camel_case: GreaterThanInstruction,
+        snake_case: greater_than_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Test if the left operand is greater than or equal to the right operand, storing the result
     /// in dest.
-    GreaterThanOrEqual (GreaterThanOrEqualInstruction, greater_than_or_equal_instruction) {
-        [0] dest: Register,
-        [1] left: Register,
-        [2] right: Register,
+    GreaterThanOrEqual {
+        camel_case: GreaterThanOrEqualInstruction,
+        snake_case: greater_than_or_equal_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: Register,
+        }
     }
 
     /// Negate a value with number conversion `-ToNumber(value)`, storing the result in dest.
-    Neg (NegInstruction, neg_instruction) {
-        [0] dest: Register,
-        [1] value: Register,
+    Neg {
+        camel_case: NegInstruction,
+        snake_case: neg_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] value: Register,
+        }
     }
 
     /// Increment a register, storing the result in that same register. Assumes the value is numeric
     /// and does not perform conversion, so caller must ensure that the value is a number or BigInt.
-    Inc (IncInstruction, inc_instruction) {
-        [0] dest: Register,
+    Inc {
+        camel_case: IncInstruction,
+        snake_case: inc_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Decrement a register, storing the result in that same register. Assumes the value is numeric
     /// and does not perform conversion, so caller must ensure that the value is a number or BigInt.
-    Dec (DecInstruction, dec_instruction) {
-        [0] dest: Register,
+    Dec {
+        camel_case: DecInstruction,
+        snake_case: dec_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Logical not of a value with boolean conversion `!ToBoolean(value)`, storing the result in
     /// dest.
-    LogNot (LogNotInstruction, log_not_instruction) {
-        [0] dest: Register,
-        [1] value: Register,
+    LogNot {
+        camel_case: LogNotInstruction,
+        snake_case: log_not_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] value: Register,
+        }
     }
 
     /// Bitwise not of a value with integer conversion `~ToNumeric(value)`, storing the result in
     /// dest.
-    BitNot (BitNotInstruction, bit_not_instruction) {
-        [0] dest: Register,
-        [1] value: Register,
+    BitNot {
+        camel_case: BitNotInstruction,
+        snake_case: bit_not_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] value: Register,
+        }
     }
 
     /// Find the type of a value as a string, storing the result in dest.
-    TypeOf (TypeOfInstruction, type_of_instruction) {
-        [0] dest: Register,
-        [1] value: Register,
+    TypeOf {
+        camel_case: TypeOfInstruction,
+        snake_case: type_of_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] value: Register,
+        }
     }
 
     /// Evaluate an `in` expression, storing the result in dest.
-    In (InInstruction, in_instruction) {
-        [0] dest: Register,
-        [1] object: Register,
-        [2] key: Register,
+    In {
+        camel_case: InInstruction,
+        snake_case: in_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] object: Register,
+            [2] key: Register,
+        }
     }
 
     /// Evaluate an `instanceof` expression, storing the result in dest.
-    InstanceOf (InstanceOfInstruction, instance_of_instruction) {
-        [0] dest: Register,
-        [1] object: Register,
-        [2] constructor: Register,
+    InstanceOf {
+        camel_case: InstanceOfInstruction,
+        snake_case: instance_of_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] object: Register,
+            [2] constructor: Register,
+        }
     }
 
     /// Apply the ToNumber abstract operation to a value, storing the result in dest.
-    ToNumber (ToNumberInstruction, to_number_instruction) {
-        [0] dest: Register,
-        [1] value: Register,
+    ToNumber {
+        camel_case: ToNumberInstruction,
+        snake_case: to_number_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] value: Register,
+        }
     }
 
     /// Apply the ToNumber abstract operation to a value, storing the result in dest.
-    ToNumeric (ToNumericInstruction, to_numeric_instruction) {
-        [0] dest: Register,
-        [1] value: Register,
+    ToNumeric {
+        camel_case: ToNumericInstruction,
+        snake_case: to_numeric_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] value: Register,
+        }
     }
 
     /// Apply the ToString abstract operation to a value, storing the result in dest.
-    ToString (ToStringInstruction, to_string_instruction) {
-        [0] dest: Register,
-        [1] value: Register,
+    ToString {
+        camel_case: ToStringInstruction,
+        snake_case: to_string_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] value: Register,
+        }
     }
 
     /// Apply the ToPropertyKey abstract operation to a value, storing the result in dest.
-    ToPropertyKey (ToPropertyKeyInstruction, to_property_key_instruction) {
-        [0] dest: Register,
-        [1] value: Register,
+    ToPropertyKey {
+        camel_case: ToPropertyKeyInstruction,
+        snake_case: to_property_key_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] value: Register,
+        }
     }
 
     /// Apply the ToObject abstract operation to a value, storing the result in dest.
-    ToObject (ToObjectInstruction, to_object_instruction) {
-        [0] dest: Register,
-        [1] value: Register,
+    ToObject {
+        camel_case: ToObjectInstruction,
+        snake_case: to_object_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] value: Register,
+        }
     }
 
     /// Unconditionally jump to the given instruction, specified inline as a byte offset from the
     /// start of the current instruction.
-    Jump (JumpInstruction, jump_instruction) {
-        [0] offset: SInt,
+    Jump {
+        camel_case: JumpInstruction,
+        snake_case: jump_instruction,
+        operands: {
+            [0] offset: SInt,
+        }
     }
 
     /// Unconditionally jump to the given instruction, specified as an index into the constant table
     /// which holds the byte offset from the start of the current instruction.
-    JumpConstant (JumpConstantInstruction, jump_constant_instruction) {
-        [0] constant_index: ConstantIndex,
+    JumpConstant {
+        camel_case: JumpConstantInstruction,
+        snake_case: jump_constant_instruction,
+        operands: {
+            [0] constant_index: ConstantIndex,
+        }
     }
 
     /// Conditionally jump to the given instruction if the condition is true, using an inline
     /// offset. Does not convert its operand to a boolean first, only checks for `false ``exactly.
-    JumpTrue (JumpTrueInstruction, jump_true_instruction) {
-        [0] condition: Register,
-        [1] offset: SInt,
+    JumpTrue {
+        camel_case: JumpTrueInstruction,
+        snake_case: jump_true_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] offset: SInt,
+        }
     }
 
     /// Conditionally jump to the given instruction if the condition is true, with offset stored
     /// in the constant table. Does not convert its operand to a boolean first, only checks for
     /// `false` exactly.
-    JumpTrueConstant (JumpTrueConstantInstruction, jump_true_constant_instruction) {
-        [0] condition: Register,
-        [1] constant_index: ConstantIndex,
+    JumpTrueConstant {
+        camel_case: JumpTrueConstantInstruction,
+        snake_case: jump_true_constant_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] constant_index: ConstantIndex,
+        }
     }
 
     /// Conditionally jump to the given instruction if ToBoolean(condition) is true, using an
     /// inline ofset.
-    JumpToBooleanTrue (JumpToBooleanTrueInstruction, jump_to_boolean_true_instruction) {
-        [0] condition: Register,
-        [1] offset: SInt,
+    JumpToBooleanTrue {
+        camel_case: JumpToBooleanTrueInstruction,
+        snake_case: jump_to_boolean_true_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] offset: SInt,
+        }
     }
 
     /// Conditionally jump to the given instruction if ToBoolean(condition) is true, with offset
     /// stored in the constant table.
-    JumpToBooleanTrueConstant (JumpToBooleanTrueConstantInstruction, jump_to_boolean_true_constant_instruction) {
-        [0] condition: Register,
-        [1] constant_index: ConstantIndex,
+    JumpToBooleanTrueConstant {
+        camel_case: JumpToBooleanTrueConstantInstruction,
+        snake_case: jump_to_boolean_true_constant_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] constant_index: ConstantIndex,
+        }
     }
 
     /// Conditionally jump to the given instruction if the condition is false, using an inline
     /// offset. Does not convert its operand to a boolean first, only checks for `false ``exactly.
-    JumpFalse (JumpFalseInstruction, jump_false_instruction) {
-        [0] condition: Register,
-        [1] offset: SInt,
+    JumpFalse {
+        camel_case: JumpFalseInstruction,
+        snake_case: jump_false_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] offset: SInt,
+        }
     }
 
     /// Conditionally jump to the given instruction if the condition is false, with offset stored
     /// in the constant table. Does not convert its operand to a boolean first, only checks for
     /// `false` exactly.
-    JumpFalseConstant (JumpFalseConstantInstruction, jump_false_constant_instruction) {
-        [0] condition: Register,
-        [1] constant_index: ConstantIndex,
+    JumpFalseConstant {
+        camel_case: JumpFalseConstantInstruction,
+        snake_case: jump_false_constant_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] constant_index: ConstantIndex,
+        }
     }
 
     /// Conditionally jump to the given instruction if ToBoolean(condition) is false, using an
     /// inline ofset.
-    JumpToBooleanFalse (JumpToBooleanFalseInstruction, jump_to_boolean_false_instruction) {
-        [0] condition: Register,
-        [1] offset: SInt,
+    JumpToBooleanFalse {
+        camel_case: JumpToBooleanFalseInstruction,
+        snake_case: jump_to_boolean_false_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] offset: SInt,
+        }
     }
 
     /// Conditionally jump to the given instruction if ToBoolean(condition) is false, with offset
     /// stored in the constant table.
-    JumpToBooleanFalseConstant (JumpToBooleanFalseConstantInstruction, jump_to_boolean_false_constant_instruction) {
-        [0] condition: Register,
-        [1] constant_index: ConstantIndex,
+    JumpToBooleanFalseConstant {
+        camel_case: JumpToBooleanFalseConstantInstruction,
+        snake_case: jump_to_boolean_false_constant_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] constant_index: ConstantIndex,
+        }
     }
 
     /// Conditionally jump to the given instruction if the condition is not undefined, using an
     /// inline offset.
-    JumpNotUndefined (JumpNotUndefinedInstruction, jump_not_undefined_instruction) {
-        [0] condition: Register,
-        [1] offset: SInt,
+    JumpNotUndefined {
+        camel_case: JumpNotUndefinedInstruction,
+        snake_case: jump_not_undefined_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] offset: SInt,
+        }
     }
 
     /// Conditionally jump to the given instruction if the condition is not undefined, with offset
     /// stored in the constant table.
-    JumpNotUndefinedConstant (JumpNotUndefinedConstantInstruction, jump_not_undefined_constant_instruction) {
-        [0] condition: Register,
-        [1] constant_index: ConstantIndex,
+    JumpNotUndefinedConstant {
+        camel_case: JumpNotUndefinedConstantInstruction,
+        snake_case: jump_not_undefined_constant_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] constant_index: ConstantIndex,
+        }
     }
 
     /// Conditionally jump to the given instruction if the condition is nullish, using an inline
     /// offset.
-    JumpNullish (JumpNullishInstruction, jump_nullish_instruction) {
-        [0] condition: Register,
-        [1] offset: SInt,
+    JumpNullish {
+        camel_case: JumpNullishInstruction,
+        snake_case: jump_nullish_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] offset: SInt,
+        }
     }
 
     /// Conditionally jump to the given instruction if the condition is nullish, with offset stored
     /// in the constant table.
-    JumpNullishConstant (JumpNullishConstantInstruction, jump_nullish_constant_instruction) {
-        [0] condition: Register,
-        [1] constant_index: ConstantIndex,
+    JumpNullishConstant {
+        camel_case: JumpNullishConstantInstruction,
+        snake_case: jump_nullish_constant_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] constant_index: ConstantIndex,
+        }
     }
 
     /// Conditionally jump to the given instruction if the condition is not nullish, using an inline
     /// offset.
-    JumpNotNullish (JumpNotNullishInstruction, jump_not_nullish_instruction) {
-        [0] condition: Register,
-        [1] offset: SInt,
+    JumpNotNullish {
+        camel_case: JumpNotNullishInstruction,
+        snake_case: jump_not_nullish_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] offset: SInt,
+        }
     }
 
     /// Conditionally jump to the given instruction if the condition is not nullish, with offset
     /// stored in the constant table.
-    JumpNotNullishConstant (JumpNotNullishConstantInstruction, jump_not_nullish_constant_instruction) {
-        [0] condition: Register,
-        [1] constant_index: ConstantIndex,
+    JumpNotNullishConstant {
+        camel_case: JumpNotNullishConstantInstruction,
+        snake_case: jump_not_nullish_constant_instruction,
+        operands: {
+            [0] condition: Register,
+            [1] constant_index: ConstantIndex,
+        }
     }
 
     /// Create a new closure from the function at the given index in the constant table.
-    NewClosure (NewClosureInstruction, new_closure_instruction) {
-        [0] dest: Register,
-        [1] function_index: ConstantIndex,
+    NewClosure {
+        camel_case: NewClosureInstruction,
+        snake_case: new_closure_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] function_index: ConstantIndex,
+        }
     }
 
     /// Create a new closure from the async function at the given index in the constant table.
-    NewAsyncClosure (NewAsyncClosureInstruction, new_async_closure_instruction) {
-        [0] dest: Register,
-        [1] function_index: ConstantIndex,
+    NewAsyncClosure {
+        camel_case: NewAsyncClosureInstruction,
+        snake_case: new_async_closure_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] function_index: ConstantIndex,
+        }
     }
 
     /// Create a new generator closure from the function at the given index in the constant table.
-    NewGenerator (NewGeneratorInstruction, new_generator_instruction) {
-        [0] dest: Register,
-        [1] function_index: ConstantIndex,
+    NewGenerator {
+        camel_case: NewGeneratorInstruction,
+        snake_case: new_generator_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] function_index: ConstantIndex,
+        }
     }
 
     /// Create a new async generator closure from the function at the given index in the constant
     /// table.
-    NewAsyncGenerator (NewAsyncGeneratorInstruction, new_async_generator_instruction) {
-        [0] dest: Register,
-        [1] function_index: ConstantIndex,
+    NewAsyncGenerator {
+        camel_case: NewAsyncGeneratorInstruction,
+        snake_case: new_async_generator_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] function_index: ConstantIndex,
+        }
     }
 
     /// Create a new empty object stored in dest.
-    NewObject (NewObjectInstruction, new_object_instruction) {
-        [0] dest: Register,
+    NewObject {
+        camel_case: NewObjectInstruction,
+        snake_case: new_object_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Create a new empty array stored in dest.
-    NewArray (NewArrayInstruction, new_array_instruction) {
-        [0] dest: Register,
+    NewArray {
+        camel_case: NewArrayInstruction,
+        snake_case: new_array_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Create a new RegExp object from the compiled RegExp at the given index in the constant
     /// table.
-    NewRegExp (NewRegExpInstruction, new_regexp_instruction) {
-        [0] dest: Register,
-        [1] regexp_index: ConstantIndex,
+    NewRegExp {
+        camel_case: NewRegExpInstruction,
+        snake_case: new_regexp_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] regexp_index: ConstantIndex,
+        }
     }
 
     /// Create a new mapped arguments object for the current function, and store in dest.
-    NewMappedArguments (NewMappedArgumentsInstruction, new_mapped_arguments_instruction) {
-        [0] dest: Register,
+    NewMappedArguments {
+        camel_case: NewMappedArgumentsInstruction,
+        snake_case: new_mapped_arguments_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Create a new unmapped arguments object for the current function, and store in dest.
     ///
     /// Copies the current function's arguments (up to argc) to the new arguments object.
-    NewUnmappedArguments (NewUnmappedArgumentsInstruction, new_unmapped_arguments_instruction) {
-        [0] dest: Register,
+    NewUnmappedArguments {
+        camel_case: NewUnmappedArgumentsInstruction,
+        snake_case: new_unmapped_arguments_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Create a new class given the constructor, methods, and static class names object. The
@@ -791,154 +1147,230 @@ define_instructions!(
     /// - The super class is passed in a register. Empty is passed if there is no super class.
     /// - The class's methods (and computed property keys) are passed in a contiguous sequence of
     ///   registers starting at `methods`. The length of the sequence is in the class names object.
-    NewClass (NewClassInstruction, new_class_instruction) {
-        [0] dest: Register,
-        [1] class_names_index: ConstantIndex,
-        [2] constructor_function_index: ConstantIndex,
-        [3] super_class: Register,
-        [4] methods: Register,
+    NewClass {
+        camel_case: NewClassInstruction,
+        snake_case: new_class_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] class_names_index: ConstantIndex,
+            [2] constructor_function_index: ConstantIndex,
+            [3] super_class: Register,
+            [4] methods: Register,
+        }
     }
 
     /// Create a new accessor value from the getter and setter functions. The result is stored in
     /// dest. Getter and setter operands must both be closures.
-    NewAccessor (NewAccessorInstruction, new_accessor_instruction) {
-        [0] dest: Register,
-        [1] getter: Register,
-        [2] setter: Register,
+    NewAccessor {
+        camel_case: NewAccessorInstruction,
+        snake_case: new_accessor_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] getter: Register,
+            [2] setter: Register,
+        }
     }
 
     /// Create a new private symbol and store in dest. The private symbol has the name stored at the
     /// given index in the constant table. Name is not prefixed with "#".
-    NewPrivateSymbol (NewPrivateSymbolInstruction, new_private_symbol_instruction) {
-        [0] dest: Register,
-        [1] name_index: ConstantIndex,
+    NewPrivateSymbol {
+        camel_case: NewPrivateSymbolInstruction,
+        snake_case: new_private_symbol_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] name_index: ConstantIndex,
+        }
     }
 
     /// Get a property from an object, storing the result in dest. The property key may be any
     /// value.
-    GetProperty (GetPropertyInstruction, get_property_instruction) {
-        [0] dest: Register,
-        [1] object: Register,
-        [2] key: Register,
+    GetProperty {
+        camel_case: GetPropertyInstruction,
+        snake_case: get_property_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] object: Register,
+            [2] key: Register,
+        }
     }
 
     /// Set a property on an object to the given value. The property key may be any value.
-    SetProperty (SetPropertyInstruction, set_property_instruction) {
-        [0] object: Register,
-        [1] key: Register,
-        [2] value: Register,
+    SetProperty {
+        camel_case: SetPropertyInstruction,
+        snake_case: set_property_instruction,
+        operands: {
+            [0] object: Register,
+            [1] key: Register,
+            [2] value: Register,
+        }
     }
 
     /// Define a property on an object with the given value. The property key may be any value.
-    DefineProperty (DefinePropertyInstruction, define_property_instruction) {
-        [0] object: Register,
-        [1] key: Register,
-        [2] value: Register,
-        [3] flags: UInt,
+    DefineProperty {
+        camel_case: DefinePropertyInstruction,
+        snake_case: define_property_instruction,
+        operands: {
+            [0] object: Register,
+            [1] key: Register,
+            [2] value: Register,
+            [3] flags: UInt,
+        }
     }
 
     /// Get a named property from an object, storing the result in dest. The name must be a string
     /// literal in the constant table.
-    GetNamedProperty (GetNamedPropertyInstruction, get_named_property_instruction) {
-        [0] dest: Register,
-        [1] object: Register,
-        [2] name_constant_index: ConstantIndex,
+    GetNamedProperty {
+        camel_case: GetNamedPropertyInstruction,
+        snake_case: get_named_property_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] object: Register,
+            [2] name_constant_index: ConstantIndex,
+        }
     }
 
     /// Set a named property on an object to the given value. The name must be a string literal in
     /// the constant table.
-    SetNamedProperty (SetNamedPropertyInstruction, set_named_property_instruction) {
-        [0] object: Register,
-        [1] name_constant_index: ConstantIndex,
-        [2] value: Register,
+    SetNamedProperty {
+        camel_case: SetNamedPropertyInstruction,
+        snake_case: set_named_property_instruction,
+        operands: {
+            [0] object: Register,
+            [1] name_constant_index: ConstantIndex,
+            [2] value: Register,
+        }
     }
 
     /// Define a named property on an object with the given value. The name must be a string literal
     /// in the constant table.
-    DefineNamedProperty (DefineNamedPropertyInstruction, define_named_property_instruction) {
-        [0] object: Register,
-        [1] name_constant_index: ConstantIndex,
-        [2] value: Register,
+    DefineNamedProperty {
+        camel_case: DefineNamedPropertyInstruction,
+        snake_case: define_named_property_instruction,
+        operands: {
+            [0] object: Register,
+            [1] name_constant_index: ConstantIndex,
+            [2] value: Register,
+        }
     }
 
     /// Get a super property from an object, storing the result in dest. The property key may be any
     /// value. Takes both the home object and receiver of the enclosing method.
-    GetSuperProperty (GetSuperPropertyInstruction, get_super_property_instruction) {
-        [0] dest: Register,
-        [1] home_object: Register,
-        [2] receiver: Register,
-        [3] key: Register,
+    GetSuperProperty {
+        camel_case: GetSuperPropertyInstruction,
+        snake_case: get_super_property_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] home_object: Register,
+            [2] receiver: Register,
+            [3] key: Register,
+        }
     }
 
     /// Get a named super property, storing the result in dest. The name must be a string literal
     /// in the constant table. Takes both the home object and receiver of the enclosing method.
-    GetNamedSuperProperty (GetNamedSuperPropertyInstruction, get_named_super_property_instruction) {
-        [0] dest: Register,
-        [1] home_object: Register,
-        [2] receiver: Register,
-        [3] name_constant_index: ConstantIndex,
+    GetNamedSuperProperty {
+        camel_case: GetNamedSuperPropertyInstruction,
+        snake_case: get_named_super_property_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] home_object: Register,
+            [2] receiver: Register,
+            [3] name_constant_index: ConstantIndex,
+        }
     }
 
     /// Set a super property on an object to the given value. The property key may be any value.
     /// Takes both the home object and receiver of the enclosing method.
-    SetSuperProperty (SetSuperPropertyInstruction, set_super_property_instruction) {
-        [0] home_object: Register,
-        [1] receiver: Register,
-        [2] key: Register,
-        [3] value: Register,
+    SetSuperProperty {
+        camel_case: SetSuperPropertyInstruction,
+        snake_case: set_super_property_instruction,
+        operands: {
+            [0] home_object: Register,
+            [1] receiver: Register,
+            [2] key: Register,
+            [3] value: Register,
+        }
     }
 
     /// Delete the property with the given key from an object. The property key may be any value
     /// and will be converted to a property key with ToPropertyKey.
-    DeleteProperty (DeletePropertyInstruction, delete_property_instruction) {
-        [0] dest: Register,
-        [1] object: Register,
-        [2] key: Register,
+    DeleteProperty {
+        camel_case: DeletePropertyInstruction,
+        snake_case: delete_property_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] object: Register,
+            [2] key: Register,
+        }
     }
 
     /// The `delete` operator when applied to an identifier. The name of the binding is stored in
     /// the constant table, and the result according to the `delete` operator is placed in dest.
-    DeleteBinding (DeleteBindingInstruction, delete_binding_instruction) {
-        [0] dest: Register,
-        [1] name_constant_index: ConstantIndex,
+    DeleteBinding {
+        camel_case: DeleteBindingInstruction,
+        snake_case: delete_binding_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] name_constant_index: ConstantIndex,
+        }
     }
 
     /// Get a private property from an object, storing the result in dest. The key must be a private
     /// symbol.
-    GetPrivateProperty (GetPrivatePropertyInstruction, get_private_property_instruction) {
-        [0] dest: Register,
-        [1] object: Register,
-        [2] key: Register,
+    GetPrivateProperty {
+        camel_case: GetPrivatePropertyInstruction,
+        snake_case: get_private_property_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] object: Register,
+            [2] key: Register,
+        }
     }
 
     /// Set a private property on an object to the given value. The key must be a private symbol.
-    SetPrivateProperty (SetPrivatePropertyInstruction, set_private_property_instruction) {
-        [0] object: Register,
-        [1] key: Register,
-        [2] value: Register,
+    SetPrivateProperty {
+        camel_case: SetPrivatePropertyInstruction,
+        snake_case: set_private_property_instruction,
+        operands: {
+            [0] object: Register,
+            [1] key: Register,
+            [2] value: Register,
+        }
     }
 
     /// Define a private property on an object with the given value. The key must be a private
     /// symbol.
-    DefinePrivateProperty (DefinePrivatePropertyInstruction, define_private_property_instruction) {
-        [0] object: Register,
-        [1] key: Register,
-        [2] value: Register,
-        [3] flags: UInt,
+    DefinePrivateProperty {
+        camel_case: DefinePrivatePropertyInstruction,
+        snake_case: define_private_property_instruction,
+        operands: {
+            [0] object: Register,
+            [1] key: Register,
+            [2] value: Register,
+            [3] flags: UInt,
+        }
     }
 
     /// Set a property on an array literal to the given value.
-    SetArrayProperty (SetArrayPropertyInstruction, set_array_property_instruction) {
-        [0] array: Register,
-        [1] index: Register,
-        [2] value: Register,
+    SetArrayProperty {
+        camel_case: SetArrayPropertyInstruction,
+        snake_case: set_array_property_instruction,
+        operands: {
+            [0] array: Register,
+            [1] index: Register,
+            [2] value: Register,
+        }
     }
 
     /// Set the prototype of an object to the given value. Assumes the object value is an object.
     /// Does nothing if the new prototype is not an object or null.
-    SetPrototypeOf (SetPrototypeOfInstruction, set_prototype_of_instruction) {
-        [0] object: Register,
-        [1] prototype: Register,
+    SetPrototypeOf {
+        camel_case: SetPrototypeOfInstruction,
+        snake_case: set_prototype_of_instruction,
+        operands: {
+            [0] object: Register,
+            [1] prototype: Register,
+        }
     }
 
     /// Copy the data properties from a source object to a destination object. Destination must be
@@ -946,28 +1378,40 @@ define_instructions!(
     ///
     /// Property keys to exclude are passed in a contiguous sequence of registers starting at
     /// `argv`, of length `argc`. Caller must ensure that all values are property keys.
-    CopyDataProperties (CopyDataPropertiesInstruction, copy_data_properties) {
-        [0] dest: Register,
-        [1] source: Register,
-        [2] argv: Register,
-        [3] argc: UInt,
+    CopyDataProperties {
+        camel_case: CopyDataPropertiesInstruction,
+        snake_case: copy_data_properties,
+        operands: {
+            [0] dest: Register,
+            [1] source: Register,
+            [2] argv: Register,
+            [3] argc: UInt,
+    }
     }
 
     /// Lookup a method with the given name on a value, storing the result in dest. If there is no
     /// property with the given name the result is undefined. If there is a property but it is not
     /// nullish and not callable then error.
-    GetMethod (GetMethodInstruction, get_method_instruction) {
-        [0] dest: Register,
-        [1] object: Register,
-        [2] name: ConstantIndex,
+    GetMethod {
+        camel_case: GetMethodInstruction,
+        snake_case: get_method_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] object: Register,
+            [2] name: ConstantIndex,
+        }
     }
 
     /// Create a new lexical scope and push it to the stack, becoming the current scope. The old
     /// current scope becomes the parent scope.
     ///
     /// The scope names to use are at the given index in the constant table.
-    PushLexicalScope (PushLexicalScopeInstruction, push_lexical_scope_instruction) {
-        [0] scope_names_index: ConstantIndex,
+    PushLexicalScope {
+        camel_case: PushLexicalScopeInstruction,
+        snake_case: push_lexical_scope_instruction,
+        operands: {
+            [0] scope_names_index: ConstantIndex,
+        }
     }
 
     /// Create a new function scope and push it to the stack, becoming the current scope. The old
@@ -976,8 +1420,12 @@ define_instructions!(
     /// A function scope is treated as a var scope when looking up the containing var scope.
     ///
     /// The scope names to use are at the given index in the constant table.
-    PushFunctionScope (PushFunctionScopeInstruction, push_function_scope_instruction) {
-        [0] scope_names_index: ConstantIndex,
+    PushFunctionScope {
+        camel_case: PushFunctionScopeInstruction,
+        snake_case: push_function_scope_instruction,
+        operands: {
+            [0] scope_names_index: ConstantIndex,
+        }
     }
 
     /// Create a new with scope for the given object and push it to the stack, becoming the current
@@ -986,65 +1434,105 @@ define_instructions!(
     /// Any value may be passed as the object. It will be converted to an object with ToObject.
     ///
     /// The scope names to use are at the given index in the constant table.
-    PushWithScope (PushWithScopeInstruction, push_with_scope_instruction) {
-        [0] object: Register,
-        [1] scope_names_index: ConstantIndex,
+    PushWithScope {
+        camel_case: PushWithScopeInstruction,
+        snake_case: push_with_scope_instruction,
+        operands: {
+            [0] object: Register,
+            [1] scope_names_index: ConstantIndex,
+        }
     }
 
     /// Pop a scope off the stack, replacing it with its parent scope.
-    PopScope (PopScopeInstruction, pop_scope_instruction) {}
+    PopScope {
+        camel_case: PopScopeInstruction,
+        snake_case: pop_scope_instruction,
+        operands: {}
+    }
 
     /// Duplicate the current scope and replace the current scope with the duplicate.
-    DupScope (DupScopeInstruction, dup_scope_instruction) {}
+    DupScope {
+        camel_case: DupScopeInstruction,
+        snake_case: dup_scope_instruction,
+        operands: {}
+    }
 
     /// Load the value at `scope_index` from a scope and store in dest. The scope is found at
     /// `parent_depth` levels up the scope chain. A `parent_depth` of 0 refers to the current scope.
-    LoadFromScope (LoadFromScopeInstruction, load_from_scope_instruction) {
-        [0] dest: Register,
-        [1] scope_index: UInt,
-        [2] parent_depth: UInt,
+    LoadFromScope {
+        camel_case: LoadFromScopeInstruction,
+        snake_case: load_from_scope_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] scope_index: UInt,
+            [2] parent_depth: UInt,
+        }
     }
 
     /// Store the `value` into a scope at `scope_index`. The scope is found at `parent_depth`
     /// levels up the scope chain. A `parent_depth` of 0 refers to the current scope.
-    StoreToScope (StoreToScopeInstruction, store_to_scope_instruction) {
-        [0] value: Register,
-        [1] scope_index: UInt,
-        [2] parent_depth: UInt,
+    StoreToScope {
+        camel_case: StoreToScopeInstruction,
+        snake_case: store_to_scope_instruction,
+        operands: {
+            [0] value: Register,
+            [1] scope_index: UInt,
+            [2] parent_depth: UInt,
+        }
     }
 
     /// Load the value at `scope_index` from a module scope and store in dest. The scope is found at
     /// `parent_depth` levels up the scope chain. A `parent_depth` of 0 refers to the current scope.
-    LoadFromModule (LoadFromModuleInstruction, load_from_module_instruction) {
-        [0] dest: Register,
-        [1] scope_index: UInt,
-        [2] parent_depth: UInt,
+    LoadFromModule {
+        camel_case: LoadFromModuleInstruction,
+        snake_case: load_from_module_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] scope_index: UInt,
+            [2] parent_depth: UInt,
+        }
     }
 
     /// Store the `value` into a module scope at `scope_index`. The scope is found at `parent_depth`
     /// levels up the scope chain. A `parent_depth` of 0 refers to the current scope.
-    StoreToModule (StoreToModuleInstruction, store_to_module_instruction) {
-        [0] value: Register,
-        [1] scope_index: UInt,
-        [2] parent_depth: UInt,
+    StoreToModule {
+        camel_case: StoreToModuleInstruction,
+        snake_case: store_to_module_instruction,
+        operands: {
+            [0] value: Register,
+            [1] scope_index: UInt,
+            [2] parent_depth: UInt,
+        }
     }
 
     /// Throw an error.
-    Throw(ThrowInstruction, throw_instruction) {
-        [0] error: Register,
+    Throw {
+        camel_case: ThrowInstruction,
+        snake_case: throw_instruction,
+        operands: {
+            [0] error: Register,
+        }
     }
 
     /// Create a rest parameter for the current function and store in dest.
-    RestParameter(RestParameterInstruction, rest_parameter_instruction) {
-        [0] dest: Register,
+    RestParameter {
+        camel_case: RestParameterInstruction,
+        snake_case: rest_parameter_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Get the super constructor of a derived constructor, storing the result in dest.
     ///
     /// Errors if the super constructor is not a constructor.
-    GetSuperConstructor (GetSuperConstructorInstruction, get_super_constructor_instruction) {
-        [0] dest: Register,
-        [1] derived_constructor: Register,
+    GetSuperConstructor {
+        camel_case: GetSuperConstructorInstruction,
+        snake_case: get_super_constructor_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] derived_constructor: Register,
+        }
     }
 
     /// Check if a binding is being accessed in the Temporal Dead Zone (TDZ), meaning the time
@@ -1052,110 +1540,178 @@ define_instructions!(
     ///
     /// A value in the TDZ is represented by the empty value. A constant index for the name of the
     /// binding is provided as the second operand.
-    CheckTdz(CheckTdzInstruction, check_tdz_instruction) {
-        [0] value: Register,
-        [1] name_constant_index: ConstantIndex,
+    CheckTdz {
+        camel_case: CheckTdzInstruction,
+        snake_case: check_tdz_instruction,
+        operands: {
+            [0] value: Register,
+            [1] name_constant_index: ConstantIndex,
+        }
     }
 
     /// Check whether a `this` value is initialized, throwing a ReferenceError if it is not.
-    CheckThisInitialized(CheckThisInitializedInstruction, check_this_initialized_instruction) {
-        [0] value: Register,
+    CheckThisInitialized {
+        camel_case: CheckThisInitializedInstruction,
+        snake_case: check_this_initialized_instruction,
+        operands: {
+            [0] value: Register,
+        }
     }
 
     /// Check whether a `this` value is initialized, meaning super() has already been called.
-    CheckSuperAlreadyCalled(CheckSuperAlreadyCalledInstruction, check_super_already_called_instruction) {
-        [0] value: Register,
+    CheckSuperAlreadyCalled {
+        camel_case: CheckSuperAlreadyCalledInstruction,
+        snake_case: check_super_already_called_instruction,
+        operands: {
+            [0] value: Register,
+        }
     }
 
     /// Check whether a value is valid as the return value of an iterator, throwing an error if not.
-    CheckIteratorResultObject(CheckIteratorResultObjectInstruction, check_iterator_result_object_instruction) {
-        [0] value: Register,
+    CheckIteratorResultObject {
+        camel_case: CheckIteratorResultObjectInstruction,
+        snake_case: check_iterator_result_object_instruction,
+        operands: {
+            [0] value: Register,
+        }
     }
 
     /// Throw a TypeError for attempting to assign an already initialized const binding.
-    ErrorConst(ErrorConstInstruction, error_const_instruction) {
-        [0] name_constant_index: ConstantIndex,
+    ErrorConst {
+        camel_case: ErrorConstInstruction,
+        snake_case: error_const_instruction,
+        operands: {
+            [0] name_constant_index: ConstantIndex,
+        }
     }
 
     /// Throw a ReferenceError for attempting to delete a super property.
-    ErrorDeleteSuperProperty (ErrorDeleteSuperPropertyInstruction, error_delete_super_property_instruction) {}
+    ErrorDeleteSuperProperty {
+        camel_case: ErrorDeleteSuperPropertyInstruction,
+        snake_case: error_delete_super_property_instruction,
+        operands: {}
+    }
 
     /// Throw a TypeError for a throw completion in a yield* where the iterator does not have a
     /// throw method.
-    ErrorIteratorNoThrowMethod (ErrorIteratorNoThrowMethodInstruction, error_iterator_no_throw_method_instruction) {}
+    ErrorIteratorNoThrowMethod {
+        camel_case: ErrorIteratorNoThrowMethodInstruction,
+        snake_case: error_iterator_no_throw_method_instruction,
+        operands: {}
+    }
 
     /// Create a new for-in iterator for the given object, storing in dest. Gathers all the iterable
     /// keys of the object and its prototype chain, storing them in the iterator. Expects that the
     /// object value is not nullish, all other values will be coerced with ToObject.
-    NewForInIterator (NewForInIteratorInstruction, new_for_in_iterator_instruction) {
-        [0] dest: Register,
-        [1] object: Register,
+    NewForInIterator {
+        camel_case: NewForInIteratorInstruction,
+        snake_case: new_for_in_iterator_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] object: Register,
+        }
     }
 
     /// Call the `next` method on a for-in iterator, storing the result in dest. Returns either the
     /// next string key or undefined if there are no more keys.
-    ForInNext(ForInNextInstruction, for_in_next_instruction) {
-        [0] dest: Register,
-        [1] iterator: Register,
+    ForInNext {
+        camel_case: ForInNextInstruction,
+        snake_case: for_in_next_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] iterator: Register,
+        }
     }
 
     /// Get the iterator for a given iterable, storing the iterator and its next method in
     /// registers.
-    GetIterator(GetIteratorInstruction, get_iterator_instruction) {
-        [0] iterator: Register,
-        [1] next_method: Register,
-        [2] iterable: Register,
+    GetIterator {
+        camel_case: GetIteratorInstruction,
+        snake_case: get_iterator_instruction,
+        operands: {
+            [0] iterator: Register,
+            [1] next_method: Register,
+            [2] iterable: Register,
+        }
     }
 
     /// Get the async iterator for a given iterable, storing the iterator and its next method in
     /// registers.
-    GetAsyncIterator(GetAsyncIteratorInstruction, get_async_iterator_instruction) {
-        [0] iterator: Register,
-        [1] next_method: Register,
-        [2] iterable: Register,
+    GetAsyncIterator {
+        camel_case: GetAsyncIteratorInstruction,
+        snake_case: get_async_iterator_instruction,
+        operands: {
+            [0] iterator: Register,
+            [1] next_method: Register,
+            [2] iterable: Register,
+        }
     }
 
     /// Call the `next` method on an iterator, storing the returned value and boolean `is_done` flag
     /// in registers.
-    IteratorNext(IteratorNextInstruction, iterator_next_instruction) {
-        [0] value: Register,
-        [1] is_done: Register,
-        [2] iterator: Register,
-        [3] next_method: Register,
+    IteratorNext {
+        camel_case: IteratorNextInstruction,
+        snake_case: iterator_next_instruction,
+        operands: {
+            [0] value: Register,
+            [1] is_done: Register,
+            [2] iterator: Register,
+            [3] next_method: Register,
+        }
     }
 
     /// Unpack an iterator result object, storing the returned value and boolean `is_done` flag in
     /// registers. Errors if the iterator result is not an object.
-    IteratorUnpackResult(IteratorUnpackResultInstruction, iterator_unpack_result_instruction) {
-        [0] value: Register,
-        [1] is_done: Register,
-        [2] iterator_result: Register,
+    IteratorUnpackResult {
+        camel_case: IteratorUnpackResultInstruction,
+        snake_case: iterator_unpack_result_instruction,
+        operands: {
+            [0] value: Register,
+            [1] is_done: Register,
+            [2] iterator_result: Register,
+        }
     }
 
     /// Close an iterator, calling its `return` method if it exists.
-    IteratorClose(IteratorCloseInstruction, iterator_close_instruction) {
-        [0] iterator: Register,
+    IteratorClose {
+        camel_case: IteratorCloseInstruction,
+        snake_case: iterator_close_instruction,
+        operands: {
+            [0] iterator: Register,
+        }
     }
 
     /// The portion of AsyncIteratorClose before the await. Closes an async iterator, calling its
     /// `return` method if it exists. Stores whether the return method exists, and if so also stores
     /// the return result in a register.
-    AsyncIteratorCloseStart(AsyncIteratorCloseStartInstruction, async_iterator_close_start_instruction) {
-        [0] return_result: Register,
-        [1] has_return_method: Register,
-        [2] iterator: Register,
+    AsyncIteratorCloseStart {
+        camel_case: AsyncIteratorCloseStartInstruction,
+        snake_case: async_iterator_close_start_instruction,
+        operands: {
+            [0] return_result: Register,
+            [1] has_return_method: Register,
+            [2] iterator: Register,
+        }
     }
 
     /// The portion of AsyncIteratorClose after the await, taking the intermediate value from
     /// AsyncIteratorCloseStart.
-    AsyncIteratorCloseFinish(AsyncIteratorCloseFinishInstruction, async_iterator_close_finish_instruction) {
-        [0] return_result: Register,
+    AsyncIteratorCloseFinish {
+        camel_case: AsyncIteratorCloseFinishInstruction,
+        snake_case: async_iterator_close_finish_instruction,
+        operands: {
+            [0] return_result: Register,
+        }
     }
 
     /// Create a generator in the current function. Suspends the current function and returns the
     /// generator to the caller. Also stores the generator to the provided register.
-    GeneratorStart(GeneratorStartInstruction, generator_start_instruction) {
-        [0] generator: Register,
+    GeneratorStart {
+        camel_case: GeneratorStartInstruction,
+        snake_case: generator_start_instruction,
+        operands: {
+            [0] generator: Register,
+        }
     }
 
     /// Yield a value from the current function, returning the value to the caller. Takes the
@@ -1164,16 +1720,24 @@ define_instructions!(
     /// The completion passed into GeneratorResume when the generator resumes will be stored in the
     /// a pair of registers holding the completion value and completion type. The completion type
     /// is true for normal completions, undefined for returns, and null for throws.
-    Yield(YieldInstruction, yield_instruction) {
-        [0] completion_value_dest: Register,
-        [1] completion_type_dest: Register,
-        [2] generator: Register,
-        [3] yield_value: Register,
+    Yield {
+        camel_case: YieldInstruction,
+        snake_case: yield_instruction,
+        operands: {
+            [0] completion_value_dest: Register,
+            [1] completion_type_dest: Register,
+            [2] generator: Register,
+            [3] yield_value: Register,
+        }
     }
 
     /// Create a new promise object at the start of an async function and store it in dest.
-    NewPromise(NewPromiseInstruction, new_promise_instruction) {
-        [0] dest: Register,
+    NewPromise {
+        camel_case: NewPromiseInstruction,
+        snake_case: new_promise_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Await a promise passed as an argument, suspend the current async function until the promise
@@ -1187,34 +1751,54 @@ define_instructions!(
     ///
     /// For async generators the generator is passed in place of the return promise, and empty will
     /// be returned to signal that the async generator has suspended.
-    Await(AwaitInstruction, await_instruction) {
-        [0] completion_value_dest: Register,
-        [1] completion_type_dest: Register,
-        [2] return_promise_or_generator: Register,
-        [3] argument_promise: Register,
+    Await {
+        camel_case: AwaitInstruction,
+        snake_case: await_instruction,
+        operands: {
+            [0] completion_value_dest: Register,
+            [1] completion_type_dest: Register,
+            [2] return_promise_or_generator: Register,
+            [3] argument_promise: Register,
+        }
     }
 
     /// Resolve a promise with a value.
-    ResolvePromise(ResolvePromiseInstruction, resolve_promise_instruction) {
-        [0] promise: Register,
-        [1] value: Register,
+    ResolvePromise {
+        camel_case: ResolvePromiseInstruction,
+        snake_case: resolve_promise_instruction,
+        operands: {
+            [0] promise: Register,
+            [1] value: Register,
+        }
     }
 
     /// Reject a promise with a value.
-    RejectPromise(RejectPromiseInstruction, reject_promise_instruction) {
-        [0] promise: Register,
-        [1] value: Register,
+    RejectPromise {
+        camel_case: RejectPromiseInstruction,
+        snake_case: reject_promise_instruction,
+        operands: {
+            [0] promise: Register,
+            [1] value: Register,
+        }
     }
 
     /// Load the `import.meta` object into dest.
-    ImportMeta(ImportMetaInstruction, import_meta_instruction) {
-        [0] dest: Register,
+    ImportMeta {
+        camel_case: ImportMetaInstruction,
+        snake_case: import_meta_instruction,
+        operands: {
+            [0] dest: Register,
+        }
     }
 
     /// Import the module with the given specifier, storing the result of the import into dest.
-    DynamicImport(DynamicImportInstruction, dynamic_import_instruction) {
-        [0] dest: Register,
-        [1] specifier: Register,
+    DynamicImport {
+        camel_case: DynamicImportInstruction,
+        snake_case: dynamic_import_instruction,
+        operands: {
+            [0] dest: Register,
+            [1] specifier: Register,
+        }
     }
 );
 


### PR DESCRIPTION
## Summary

We have a rust macro which is used to define all bytecode instructions via a custom DSL. Change the syntax used in this macro to make adding additional properties easier. We now use key-value pairs to define each property of the instruction.

No functionality is changed in this PR.