### PR TITLE
[bytecode] Bytecode source maps for basic load, store, and call instructions

### DIFF
--- a/src/js/parser/loc.rs
+++ b/src/js/parser/loc.rs
@@ -18,6 +18,9 @@ impl Loc {
 
 pub const EMPTY_LOC: Loc = Loc { start: 0, end: 0 };
 
+/// Pos to use as a sentinel value when a Pos is not available.
+pub const NO_POS: Pos = usize::MAX;
+
 /// Calculate the byte offsets of the start of each line.
 pub fn calculate_line_offsets(source: &[u8]) -> Vec<u32> {
     let mut line_offsets = vec![0];

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -30,6 +30,17 @@ pub trait Instruction: fmt::Display {
     fn byte_length(&self) -> usize;
 }
 
+/// A utility macro for optionally including a term in a macro expansion.
+///
+/// All this does is return the second argument. But if the first argument is set to an optional
+/// macro variable while inside a $( ... )? block, the second argument will be written instead.
+#[allow(unused)]
+macro_rules! if_set {
+    ($x:tt, $y:tt) => {
+        $y
+    };
+}
+
 /// Generate bytecode instructions using a custom DSL.
 ///
 /// Instructions are defined using the following syntax:
@@ -43,6 +54,10 @@ pub trait Instruction: fmt::Display {
 ///   // The full instruction name in snake case
 ///   snake_case: instruction_name_instruction,
 ///
+///   // (Optional) Marks that this instruction can throw an error. Source code positions are only
+///   // recorded in the source map for instructions that can throw.
+///   can_throw: true,
+///
 ///   // The operands of the instruction in the form `[operand_index] operand_name: operand_type`
 ///   operands: {
 ///     [0] operand_name_1: OperandType1,
@@ -55,12 +70,18 @@ macro_rules! define_instructions {
         $(#[$($attrs:tt)*])* $short_name:ident {
             camel_case: $instr_name_camel:ident,
             snake_case: $instr_name_snake:ident,
+            $(can_throw: $can_throw:ident,)?
             operands: {
                 $([$operand_idx:expr] $operand_name:ident: $operand_type:ident,)*
             }
         }
     )*) => {
         $(
+            // Statically verify that only "true" can be passed to the "can_throw" property
+            $(
+                const _: () = assert!($can_throw, "Only 'true' is allowed for the 'can_throw' property");
+            )?
+
             $(#[$($attrs)*])*
             #[repr(C)]
             pub struct $instr_name_camel<W: Width>([W::UInt; count!($($operand_name)*)]);
@@ -85,10 +106,18 @@ macro_rules! define_instructions {
                 const BYTE_LENGTH: usize = Self::NUM_OPERANDS * W::NUM_BYTES;
 
                 /// Write the instruction into the given bytecode stream.
-                pub fn write(writer: &mut BytecodeWriter, $($operand_name: $operand_type<W>,)*) {
+                pub fn write(
+                    writer: &mut BytecodeWriter,
+                    $($operand_name: $operand_type<W>,)*
+                    $(if_set!($can_throw, pos): usize, )?
+                ) {
+                    // Write instruction to bytecode buffer
                     writer.write_width_prefix(W::ENUM);
                     writer.write_opcode(Self::OPCODE);
                     $(writer.write_operand($operand_name);)*
+
+                    // Write a source map entry if this instruction can throw
+                    $(if_set!($can_throw, writer).write_source_map_entry(pos);)?
                 }
             }
 
@@ -172,6 +201,7 @@ macro_rules! define_instructions {
                 pub fn $instr_name_snake(
                     &mut self,
                     $($operand_name: $operand_type<ExtraWide>,)*
+                    $(if_set!($can_throw, pos): usize,)?
                 ) {
                     // Calculate the width needed to fit all operands
                     let mut width = WidthEnum::Narrow;
@@ -182,14 +212,17 @@ macro_rules! define_instructions {
                         WidthEnum::Narrow => $instr_name_camel::<Narrow>::write(
                             self,
                             $($operand_name.to_narrow(),)*
+                            $(if_set!($can_throw, pos),)?
                         ),
                         WidthEnum::Wide => $instr_name_camel::<Wide>::write(
                             self,
                             $($operand_name.to_wide(),)*
+                            $(if_set!($can_throw, pos),)?
                         ),
                         WidthEnum::ExtraWide => $instr_name_camel::<ExtraWide>::write(
                             self,
                             $($operand_name,)*
+                            $(if_set!($can_throw, pos),)?
                         ),
                     }
                 }

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -34,7 +34,6 @@ pub trait Instruction: fmt::Display {
 ///
 /// All this does is return the second argument. But if the first argument is set to an optional
 /// macro variable while inside a $( ... )? block, the second argument will be written instead.
-#[allow(unused)]
 macro_rules! if_set {
     ($x:tt, $y:tt) => {
         $y
@@ -365,6 +364,7 @@ define_instructions!(
     LoadGlobal {
         camel_case: LoadGlobalInstruction,
         snake_case: load_global_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] constant_index: ConstantIndex,
@@ -376,6 +376,7 @@ define_instructions!(
     LoadGlobalOrUnresolved {
         camel_case: LoadGlobalOrUnresolvedInstruction,
         snake_case: load_global_or_unresolved_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] constant_index: ConstantIndex,
@@ -387,6 +388,7 @@ define_instructions!(
     StoreGlobal {
         camel_case: StoreGlobalInstruction,
         snake_case: store_global_instruction,
+        can_throw: true,
         operands: {
             [0] value: Register,
             [1] constant_index: ConstantIndex,
@@ -399,6 +401,7 @@ define_instructions!(
     LoadDynamic {
         camel_case: LoadDynamicInstruction,
         snake_case: load_dynamic_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] name_index: ConstantIndex,
@@ -411,6 +414,7 @@ define_instructions!(
     LoadDynamicOrUnresolved {
         camel_case: LoadDynamicOrUnresolvedInstruction,
         snake_case: load_dynamic_or_unresolved_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] name_index: ConstantIndex,
@@ -422,6 +426,7 @@ define_instructions!(
     StoreDynamic {
         camel_case: StoreDynamicInstruction,
         snake_case: store_dynamic_instruction,
+        can_throw: true,
         operands: {
             [0] value: Register,
             [1] name_index: ConstantIndex,
@@ -433,6 +438,7 @@ define_instructions!(
     Call {
         camel_case: CallInstruction,
         snake_case: call_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] function: Register,
@@ -506,6 +512,7 @@ define_instructions!(
     Construct {
         camel_case: ConstructInstruction,
         snake_case: construct_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] function: Register,
@@ -1519,6 +1526,7 @@ define_instructions!(
     LoadFromModule {
         camel_case: LoadFromModuleInstruction,
         snake_case: load_from_module_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] scope_index: UInt,

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -1026,7 +1026,7 @@ impl VM {
                             dispatch_or_throw!(LoadFromModuleInstruction, execute_load_from_module)
                         }
                         OpCode::StoreToModule => {
-                            dispatch_or_throw!(StoreToModuleInstruction, execute_store_to_module)
+                            dispatch!(StoreToModuleInstruction, execute_store_to_module)
                         }
                         OpCode::Throw => execute_throw!(get_instr),
                         OpCode::RestParameter => {
@@ -3905,10 +3905,7 @@ impl VM {
     }
 
     #[inline]
-    fn execute_store_to_module<W: Width>(
-        &mut self,
-        instr: &StoreToModuleInstruction<W>,
-    ) -> EvalResult<()> {
+    fn execute_store_to_module<W: Width>(&mut self, instr: &StoreToModuleInstruction<W>) {
         let scope_index = instr.scope_index().value().to_usize();
         let parent_depth = instr.parent_depth().value().to_usize();
         let value = self.read_register(instr.value());
@@ -3918,8 +3915,6 @@ impl VM {
         let mut boxed_value = self.load_from_module_scope_at_depth(scope_index, parent_depth);
 
         boxed_value.set(value);
-
-        Ok(())
     }
 
     #[inline]

--- a/src/js/runtime/bytecode/writer.rs
+++ b/src/js/runtime/bytecode/writer.rs
@@ -1,6 +1,9 @@
 use std::ops::Range;
 
-use crate::js::{common::varint::encode_varint, parser::loc::Pos};
+use crate::js::{
+    common::varint::encode_varint,
+    parser::loc::{Pos, NO_POS},
+};
 
 use super::{
     instruction::{
@@ -22,7 +25,7 @@ pub struct BytecodeWriter {
 
 impl BytecodeWriter {
     pub fn new() -> Self {
-        Self { bytes: vec![], source_map: vec![], last_pos: 0 }
+        Self { bytes: vec![], source_map: vec![], last_pos: NO_POS }
     }
 
     pub fn finish(self) -> (Vec<u8>, Vec<u8>) {
@@ -110,10 +113,9 @@ impl BytecodeWriter {
     /// source position.
     ///
     /// Should be called after writing the instruction that corresponds to the source position.
-    #[allow(unused)]
     pub fn write_source_map_entry(&mut self, source_position: Pos) {
         // No need to write runs of the same source position
-        if source_position == self.last_pos {
+        if source_position == NO_POS || source_position == self.last_pos {
             return;
         } else {
             self.last_pos = source_position;

--- a/src/js/runtime/source_file.rs
+++ b/src/js/runtime/source_file.rs
@@ -107,5 +107,6 @@ impl HeapObject for HeapPtr<SourceFile> {
         visitor.visit_pointer(&mut self.descriptor);
         visitor.visit_pointer(&mut self.path);
         visitor.visit_pointer_opt(&mut self.display_name);
+        visitor.visit_pointer_opt(&mut self.line_offsets);
     }
 }

--- a/tests/js_error/error_types/eval.exp
+++ b/tests/js_error/error_types/eval.exp
@@ -1,2 +1,2 @@
 Error: This is an error
-  at <global> (tests/js_error/error_types/eval.js)
+  at <global> (tests/js_error/error_types/eval.js:1:7)

--- a/tests/js_error/source_locations/expression/call/basic.exp
+++ b/tests/js_error/source_locations/expression/call/basic.exp
@@ -1,0 +1,5 @@
+Error: This is an error
+  at baz (tests/js_error/source_locations/expression/call/basic.js:10:9)
+  at bar (tests/js_error/source_locations/expression/call/basic.js:6:3)
+  at foo (tests/js_error/source_locations/expression/call/basic.js:2:3)
+  at <global> (tests/js_error/source_locations/expression/call/basic.js:13:1)

--- a/tests/js_error/source_locations/expression/call/basic.js
+++ b/tests/js_error/source_locations/expression/call/basic.js
@@ -1,0 +1,13 @@
+function foo() {
+  bar();
+}
+
+function bar() {
+  baz();
+}
+
+function baz() {
+  throw new Error('This is an error');
+}
+
+foo();

--- a/tests/js_error/source_locations/expression/construct/basic.exp
+++ b/tests/js_error/source_locations/expression/construct/basic.exp
@@ -1,0 +1,3 @@
+Error: 
+  at foo (tests/js_error/source_locations/expression/construct/basic.js:2:9)
+  at <global> (tests/js_error/source_locations/expression/construct/basic.js:5:2)

--- a/tests/js_error/source_locations/expression/construct/basic.js
+++ b/tests/js_error/source_locations/expression/construct/basic.js
@@ -1,0 +1,5 @@
+function foo() {
+  throw new Error()
+}
+
+(new foo());

--- a/tests/js_error/source_locations/expression/super_call/basic.exp
+++ b/tests/js_error/source_locations/expression/super_call/basic.exp
@@ -1,0 +1,4 @@
+Error: 
+  at A (tests/js_error/source_locations/expression/super_call/basic.js:3:11)
+  at B (tests/js_error/source_locations/expression/super_call/basic.js:9:5)
+  at <global> (tests/js_error/source_locations/expression/super_call/basic.js:13:1)

--- a/tests/js_error/source_locations/expression/super_call/basic.js
+++ b/tests/js_error/source_locations/expression/super_call/basic.js
@@ -1,0 +1,13 @@
+class A {
+  constructor() {
+    throw new Error();
+  }
+}
+
+class B extends A {
+  constructor() {
+    super();
+  }
+}
+
+new B();

--- a/tests/js_error/source_locations/expression/template/tagged_template_throws.exp
+++ b/tests/js_error/source_locations/expression/template/tagged_template_throws.exp
@@ -1,0 +1,3 @@
+Error: 
+  at foo (tests/js_error/source_locations/expression/template/tagged_template_throws.js:2:9)
+  at <global> (tests/js_error/source_locations/expression/template/tagged_template_throws.js:5:1)

--- a/tests/js_error/source_locations/expression/template/tagged_template_throws.js
+++ b/tests/js_error/source_locations/expression/template/tagged_template_throws.js
@@ -1,0 +1,5 @@
+function foo() {
+  throw new Error()
+}
+
+foo`test`;

--- a/tests/js_error/source_locations/expression/typeof/load_dynamic_throws.exp
+++ b/tests/js_error/source_locations/expression/typeof/load_dynamic_throws.exp
@@ -1,0 +1,4 @@
+Error: Error on get
+  at get (tests/js_error/source_locations/expression/typeof/load_dynamic_throws.js:3:11)
+  at <eval> (<eval>:1:8)
+  at <global> (tests/js_error/source_locations/expression/typeof/load_dynamic_throws.js:7:1)

--- a/tests/js_error/source_locations/expression/typeof/load_dynamic_throws.js
+++ b/tests/js_error/source_locations/expression/typeof/load_dynamic_throws.js
@@ -1,0 +1,7 @@
+Object.defineProperty(globalThis, 'x', {
+  get() {
+    throw new Error('Error on get');
+  }
+});
+
+eval('typeof x');

--- a/tests/js_error/source_locations/expression/typeof/load_global_throws.exp
+++ b/tests/js_error/source_locations/expression/typeof/load_global_throws.exp
@@ -1,0 +1,3 @@
+Error: Error on get
+  at get (tests/js_error/source_locations/expression/typeof/load_global_throws.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/typeof/load_global_throws.js:7:8)

--- a/tests/js_error/source_locations/expression/typeof/load_global_throws.js
+++ b/tests/js_error/source_locations/expression/typeof/load_global_throws.js
@@ -1,0 +1,7 @@
+Object.defineProperty(globalThis, 'x', {
+  get() {
+    throw new Error('Error on get');
+  }
+});
+
+typeof x;

--- a/tests/js_error/source_locations/loads/load_dynamic_unresolved.exp
+++ b/tests/js_error/source_locations/loads/load_dynamic_unresolved.exp
@@ -1,0 +1,4 @@
+ReferenceError: x is not defined
+  at <eval> (<eval>:1:1)
+  at test (tests/js_error/source_locations/loads/load_dynamic_unresolved.js:2:3)
+  at <global> (tests/js_error/source_locations/loads/load_dynamic_unresolved.js:5:1)

--- a/tests/js_error/source_locations/loads/load_dynamic_unresolved.js
+++ b/tests/js_error/source_locations/loads/load_dynamic_unresolved.js
@@ -1,0 +1,5 @@
+function test() {
+  eval("x");
+}
+
+test();

--- a/tests/js_error/source_locations/loads/load_from_module_uninitialized.exp
+++ b/tests/js_error/source_locations/loads/load_from_module_uninitialized.exp
@@ -1,0 +1,4 @@
+ReferenceError: module value is not initialized
+  at <module> (tests/js_error/source_locations/loads/load_from_module_uninitialized.js:1:1)
+  at <anonymous> (<native>)
+  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/loads/load_from_module_uninitialized.js
+++ b/tests/js_error/source_locations/loads/load_from_module_uninitialized.js
@@ -1,0 +1,3 @@
+x = 2;
+
+export let x = 1;

--- a/tests/js_error/source_locations/loads/load_global_unresolved.exp
+++ b/tests/js_error/source_locations/loads/load_global_unresolved.exp
@@ -1,0 +1,3 @@
+ReferenceError: x is not defined
+  at test (tests/js_error/source_locations/loads/load_global_unresolved.js:3:3)
+  at <global> (tests/js_error/source_locations/loads/load_global_unresolved.js:6:1)

--- a/tests/js_error/source_locations/loads/load_global_unresolved.js
+++ b/tests/js_error/source_locations/loads/load_global_unresolved.js
@@ -1,0 +1,6 @@
+function test() {
+  // Load from unresolved identifier
+  x;
+}
+
+test();

--- a/tests/js_error/source_locations/stores/store_dynamic_unresolved.exp
+++ b/tests/js_error/source_locations/stores/store_dynamic_unresolved.exp
@@ -1,0 +1,4 @@
+ReferenceError: x is not defined
+  at <eval> (<eval>:1:1)
+  at test (tests/js_error/source_locations/stores/store_dynamic_unresolved.js:4:3)
+  at <global> (tests/js_error/source_locations/stores/store_dynamic_unresolved.js:7:1)

--- a/tests/js_error/source_locations/stores/store_dynamic_unresolved.js
+++ b/tests/js_error/source_locations/stores/store_dynamic_unresolved.js
@@ -1,0 +1,7 @@
+"use strict";
+
+function test() {
+  eval("x = 1");
+}
+
+test();

--- a/tests/js_error/source_locations/stores/store_global_unresolved.exp
+++ b/tests/js_error/source_locations/stores/store_global_unresolved.exp
@@ -1,0 +1,3 @@
+ReferenceError: x is not defined
+  at test (tests/js_error/source_locations/stores/store_global_unresolved.js:5:3)
+  at <global> (tests/js_error/source_locations/stores/store_global_unresolved.js:8:1)

--- a/tests/js_error/source_locations/stores/store_global_unresolved.js
+++ b/tests/js_error/source_locations/stores/store_global_unresolved.js
@@ -1,0 +1,8 @@
+"use strict";
+
+function test() {
+  // Store to unresolved identifier (in strict mode)
+  x = 1;
+}
+
+test();


### PR DESCRIPTION
## Summary

Start implementing bytecode source maps for a handful of simple instructions (loads, stores, and calls). Start off by implementing a new "can_throw" property in the bytecode DSL, which when set requires an additional source position argument when writing the instruction. This allows us to create bytecode source map entires for every bytecode instruction that can throw.

We then add can_throw to the following instructions, threading through source position information during bytecode generation:
- LoadGlobal
- LoadGlobalOrUnresolved
- StoreGlobal
- LoadDynamic
- LoadDynamicOrUnresolved
- StoreDynamic
- Call
- Construct
- LoadFromModule 

## Tests

Added error snapshot tests for all instructions with source maps, verifying that source maps are being created and applied correctly.