### PR TITLE
[bytecode] Source locations for all call instructions

### DIFF
--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -648,6 +648,9 @@ pub struct ForEachStatement {
     pub body: P<Statement>,
     pub is_await: bool,
 
+    /// Source position of start of the `in` or `of` keyword.
+    pub in_of_pos: Pos,
+
     /// Block scope node that contains the for statement variable declarations and the body.
     pub scope: AstPtr<AstScopeNode>,
 }

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -1248,6 +1248,7 @@ impl<'a> Parser<'a> {
                     _,
                     Expression::Binary(BinaryExpression {
                         operator: BinaryOperator::In,
+                        operator_pos,
                         left,
                         right,
                         ..
@@ -1267,6 +1268,7 @@ impl<'a> Parser<'a> {
                         right: right.into_outer(),
                         body,
                         is_await: false,
+                        in_of_pos: operator_pos,
                         scope,
                     })
                 }
@@ -1328,6 +1330,9 @@ impl<'a> Parser<'a> {
             _ => unreachable!(),
         };
 
+        // Save the source location of the `in` or `of` keyword
+        let in_of_pos = self.loc.start;
+
         self.advance()?;
 
         let right = match kind {
@@ -1356,6 +1361,7 @@ impl<'a> Parser<'a> {
             right,
             body,
             is_await,
+            in_of_pos,
             scope,
         }))
     }

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -3367,7 +3367,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             match args {
                 CallArgs::Varargs { args, receiver } => {
                     self.writer
-                        .call_varargs_instruction(dest, callee, receiver, args);
+                        .call_varargs_instruction(dest, callee, receiver, args, call_pos);
                 }
                 CallArgs::Normal { argv, argc } => {
                     self.writer.call_with_receiver_instruction(
@@ -3396,7 +3396,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     // receiver.
                     self.writer.load_undefined_instruction(receiver);
                     self.writer
-                        .call_varargs_instruction(dest, callee, receiver, args);
+                        .call_varargs_instruction(dest, callee, receiver, args, call_pos);
                 }
                 CallArgs::Normal { argv, argc } => {
                     self.writer
@@ -3688,21 +3688,16 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         // new.target is set to the callee
         let new_target = callee;
+        let new_pos = expr.loc.start;
 
         match args {
             CallArgs::Normal { argv, argc } => {
-                self.writer.construct_instruction(
-                    dest,
-                    callee,
-                    new_target,
-                    argv,
-                    argc,
-                    expr.loc.start,
-                );
+                self.writer
+                    .construct_instruction(dest, callee, new_target, argv, argc, new_pos);
             }
             CallArgs::Varargs { args, .. } => {
                 self.writer
-                    .construct_varargs_instruction(dest, callee, new_target, args);
+                    .construct_varargs_instruction(dest, callee, new_target, args, new_pos);
             }
         }
 
@@ -5408,6 +5403,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     super_constructor,
                     new_target,
                     args,
+                    super_pos,
                 );
             }
             CallArgs::Normal { argv, argc } => {

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -1901,7 +1901,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
     fn generate_default_constructor(mut self, class_pos: Pos) -> EmitResult<EmitFunctionResult> {
         // Call super constructor if necessary
         if self.is_derived_constructor() {
-            self.writer.default_super_call_instruction();
+            self.writer.default_super_call_instruction(class_pos);
         }
 
         // Initialize fields if any exist, defined onto the `this` value

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -717,6 +717,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
                 source_range,
             } = func_node
             {
+                let class_pos = source_range.start;
                 let generator = BytecodeFunctionGenerator::new_for_default_constructor(
                     self.cx,
                     self.scope_tree,
@@ -729,7 +730,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
                     /* is_base_constructor */ is_base,
                 )?;
 
-                emit_result = generator.generate_default_constructor()?;
+                emit_result = generator.generate_default_constructor(class_pos)?;
             } else if let PendingFunctionNode::ClassFieldsInitializer {
                 scope: init_func_scope,
                 fields,
@@ -1612,7 +1613,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
     fn generate(mut self, func: &ast::Function) -> EmitResult<EmitFunctionResult> {
         // Base constructors initialize class fields immediately
         if !self.is_derived_constructor() {
-            self.gen_initialize_class_fields(Register::this())?;
+            self.gen_initialize_class_fields(Register::this(), func.loc.start)?;
         }
 
         // Async functions reserve a register for the promise object
@@ -1897,14 +1898,14 @@ impl<'a> BytecodeFunctionGenerator<'a> {
     }
 
     /// Generate the bytecode for a default constructor.
-    fn generate_default_constructor(mut self) -> EmitResult<EmitFunctionResult> {
+    fn generate_default_constructor(mut self, class_pos: Pos) -> EmitResult<EmitFunctionResult> {
         // Call super constructor if necessary
         if self.is_derived_constructor() {
             self.writer.default_super_call_instruction();
         }
 
         // Initialize fields if any exist, defined onto the `this` value
-        self.gen_initialize_class_fields(Register::this())?;
+        self.gen_initialize_class_fields(Register::this(), class_pos)?;
 
         // Return undefined for a base constructor and `this` for a derived constructor. No default
         // constructor scope is needed since it is only needed if `this` is captured.
@@ -3357,6 +3358,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             self.register_allocator.release(this_value);
         }
 
+        let call_pos = expr.loc.start;
+
         // Generate the call itself, optionally with receiver
         let dest = self.allocate_destination(dest)?;
 
@@ -3367,8 +3370,9 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                         .call_varargs_instruction(dest, callee, receiver, args);
                 }
                 CallArgs::Normal { argv, argc } => {
-                    self.writer
-                        .call_with_receiver_instruction(dest, callee, this_value, argv, argc);
+                    self.writer.call_with_receiver_instruction(
+                        dest, callee, this_value, argv, argc, call_pos,
+                    );
                 }
             }
         } else if is_maybe_direct_eval {
@@ -3396,7 +3400,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 }
                 CallArgs::Normal { argv, argc } => {
                     self.writer
-                        .call_instruction(dest, callee, argv, argc, expr.loc.start);
+                        .call_instruction(dest, callee, argv, argc, call_pos);
                 }
             }
         }
@@ -3484,15 +3488,17 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             self.register_allocator.release(this_value);
         }
 
+        let call_pos = expr.loc.start;
+
         // Generate the call itself, optionally with receiver
         let dest = self.allocate_destination(dest)?;
 
         if let Some(this_value) = this_value {
             self.writer
-                .call_with_receiver_instruction(dest, callee, this_value, argv, argc);
+                .call_with_receiver_instruction(dest, callee, this_value, argv, argc, call_pos);
         } else {
             self.writer
-                .call_instruction(dest, callee, argv, argc, expr.loc.start);
+                .call_instruction(dest, callee, argv, argc, call_pos);
         }
 
         Ok(dest)
@@ -4917,8 +4923,10 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             yield_value
         };
 
+        let pos = expr.loc.start;
+
         if expr.is_delegate {
-            self.gen_yield_star(yield_value, dest)
+            self.gen_yield_star(yield_value, pos, dest)
         } else if self.is_async() {
             self.gen_async_yield(yield_value, dest)
         } else {
@@ -5023,7 +5031,12 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         Ok(completion_value)
     }
 
-    fn gen_yield_star(&mut self, argument: GenRegister, dest: ExprDest) -> EmitResult<GenRegister> {
+    fn gen_yield_star(
+        &mut self,
+        argument: GenRegister,
+        pos: Pos,
+        dest: ExprDest,
+    ) -> EmitResult<GenRegister> {
         self.register_allocator.release(argument);
 
         let dest = self.allocate_destination(dest)?;
@@ -5071,6 +5084,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             iterator,
             completion_value,
             UInt::new(1),
+            pos,
         );
 
         if self.is_async() {
@@ -5122,6 +5136,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             iterator,
             completion_value,
             UInt::new(1),
+            pos,
         );
         self.register_allocator.release(return_method);
 
@@ -5179,6 +5194,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             iterator,
             completion_value,
             UInt::new(1),
+            pos,
         );
         self.register_allocator.release(throw_method);
 
@@ -5353,6 +5369,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         super_call: &ast::SuperCallExpression,
         dest: ExprDest,
     ) -> EmitResult<GenRegister> {
+        let super_pos = super_call.loc.start;
+
         // Super calls implicitly use the surrounding derived constructor, so load it to register
         let derived_constructor = self.gen_load_internal_binding(
             super_call.constructor_scope,
@@ -5399,7 +5417,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     new_target,
                     argv,
                     argc,
-                    super_call.loc.start,
+                    super_pos,
                 );
             }
         }
@@ -5433,14 +5451,14 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         // Derived constructors initialize fields after the super call
         if self.is_derived_constructor() {
-            self.gen_initialize_class_fields(call_result)?;
+            self.gen_initialize_class_fields(call_result, super_pos)?;
         }
 
         Ok(call_result)
     }
 
     /// Initialize class fields in a constructor, defined onto the `this` value.
-    fn gen_initialize_class_fields(&mut self, this_reg: GenRegister) -> EmitResult<()> {
+    fn gen_initialize_class_fields(&mut self, this_reg: GenRegister, pos: Pos) -> EmitResult<()> {
         let initializer = std::mem::replace(&mut self.class_fields, ClassFieldsInitializer::none());
 
         // Check if a class fields initializer is needed
@@ -5468,6 +5486,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             this_reg,
             /* dummy value */ fields_init_value,
             UInt::new(0),
+            pos,
         );
 
         self.register_allocator.release(fields_init_value);
@@ -6352,6 +6371,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         let store_flags = StoreFlags::INITIALIZATION;
         let mut constructor_dest = dest;
 
+        let class_pos = class.loc.start;
+
         if let Some(id) = class.id.as_ref() {
             if matches!(kind, GenClassKind::Declaration) {
                 constructor_dest = self.expr_dest_for_id(id, store_flags);
@@ -6640,6 +6661,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 constructor_reg,
                 /* dummy value */ static_init_value,
                 UInt::new(0),
+                class_pos,
             );
 
             self.register_allocator.release(static_init_value);
@@ -7494,6 +7516,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 // Dummy argv since no args are provided
                 iterator,
                 UInt::new(0),
+                stmt.in_of_pos,
             );
 
             let awaited_result = self.gen_await(iterator_result, ExprDest::Any)?;

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -3382,11 +3382,11 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             match args {
                 CallArgs::Varargs { args, .. } => {
                     self.writer
-                        .call_maybe_eval_varargs_instruction(dest, callee, args, flags);
+                        .call_maybe_eval_varargs_instruction(dest, callee, args, flags, call_pos);
                 }
                 CallArgs::Normal { argv, argc } => {
                     self.writer
-                        .call_maybe_eval_instruction(dest, callee, argv, argc, flags);
+                        .call_maybe_eval_instruction(dest, callee, argv, argc, flags, call_pos);
                 }
             }
         } else {

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -467,6 +467,7 @@ define_instructions!(
     CallVarargs {
         camel_case: CallVarargsInstruction,
         snake_case: call_varargs_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] function: Register,
@@ -528,6 +529,7 @@ define_instructions!(
     ConstructVarargs {
         camel_case: ConstructVarargsInstruction,
         snake_case: construct_varargs_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] function: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -452,6 +452,7 @@ define_instructions!(
     CallWithReceiver {
         camel_case: CallWithReceiverInstruction,
         snake_case: call_with_receiver_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] function: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -544,6 +544,7 @@ define_instructions!(
     DefaultSuperCall {
         camel_case: DefaultSuperCallInstruction,
         snake_case: default_super_call_instruction,
+        can_throw: true,
         operands: {}
     }
 

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -484,6 +484,7 @@ define_instructions!(
     CallMaybeEval {
         camel_case: CallMaybeEvalInstruction,
         snake_case: call_maybe_eval_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] function: Register,
@@ -501,6 +502,7 @@ define_instructions!(
     CallMaybeEvalVarargs {
         camel_case: CallMaybeEvalVarargsInstruction,
         snake_case: call_maybe_eval_varargs_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] function: Register,

--- a/tests/js_error/source_locations/class/fields/init_call_derived_constructor.exp
+++ b/tests/js_error/source_locations/class/fields/init_call_derived_constructor.exp
@@ -1,0 +1,4 @@
+TypeError: BigInt cannot be converted to number
+  at fieldsInitializer (tests/js_error/source_locations/class/fields/init_call_derived_constructor.js:4:13)
+  at C (tests/js_error/source_locations/class/fields/init_call_derived_constructor.js:8:5)
+  at <global> (tests/js_error/source_locations/class/fields/init_call_derived_constructor.js:12:1)

--- a/tests/js_error/source_locations/class/fields/init_call_derived_constructor.js
+++ b/tests/js_error/source_locations/class/fields/init_call_derived_constructor.js
@@ -1,0 +1,12 @@
+class B {}
+
+class C extends B {
+  field = 1 + 2n;
+
+  constructor() {
+    // Field init call for derived constructor is placed at the super call expression
+    super()
+  }
+}
+
+new C();

--- a/tests/js_error/source_locations/class/fields/init_call_no_constructor.exp
+++ b/tests/js_error/source_locations/class/fields/init_call_no_constructor.exp
@@ -1,0 +1,4 @@
+TypeError: BigInt cannot be converted to number
+  at fieldsInitializer (tests/js_error/source_locations/class/fields/init_call_no_constructor.js:3:13)
+  at C (tests/js_error/source_locations/class/fields/init_call_no_constructor.js:2:1)
+  at <global> (tests/js_error/source_locations/class/fields/init_call_no_constructor.js:6:1)

--- a/tests/js_error/source_locations/class/fields/init_call_no_constructor.js
+++ b/tests/js_error/source_locations/class/fields/init_call_no_constructor.js
@@ -1,0 +1,6 @@
+// No constructor, so source location for fields init call is the start of the class
+class C {
+  field = 1 + 2n;
+}
+
+new C();

--- a/tests/js_error/source_locations/class/fields/init_call_with_constructor.exp
+++ b/tests/js_error/source_locations/class/fields/init_call_with_constructor.exp
@@ -1,0 +1,4 @@
+TypeError: BigInt cannot be converted to number
+  at fieldsInitializer (tests/js_error/source_locations/class/fields/init_call_with_constructor.js:3:13)
+  at C (tests/js_error/source_locations/class/fields/init_call_with_constructor.js:5:3)
+  at <global> (tests/js_error/source_locations/class/fields/init_call_with_constructor.js:8:1)

--- a/tests/js_error/source_locations/class/fields/init_call_with_constructor.js
+++ b/tests/js_error/source_locations/class/fields/init_call_with_constructor.js
@@ -1,0 +1,8 @@
+// Constructor, so source location for fields init call is the start of the constructor
+class C {
+  field = 1 + 2n;
+
+  constructor() {}
+}
+
+new C();

--- a/tests/js_error/source_locations/class/static_initializer/call.exp
+++ b/tests/js_error/source_locations/class/static_initializer/call.exp
@@ -1,0 +1,3 @@
+Error: 
+  at staticInitializer (tests/js_error/source_locations/class/static_initializer/call.js:4:11)
+  at <global> (tests/js_error/source_locations/class/static_initializer/call.js:2:1)

--- a/tests/js_error/source_locations/class/static_initializer/call.js
+++ b/tests/js_error/source_locations/class/static_initializer/call.js
@@ -1,0 +1,6 @@
+// Source location for where static initializer was called is start of class
+class C {
+  static {
+    throw new Error();
+  }
+}

--- a/tests/js_error/source_locations/expression/call/call_maybe_eval.exp
+++ b/tests/js_error/source_locations/expression/call/call_maybe_eval.exp
@@ -1,0 +1,3 @@
+Error: 
+  at eval (tests/js_error/source_locations/expression/call/call_maybe_eval.js:2:9)
+  at <global> (tests/js_error/source_locations/expression/call/call_maybe_eval.js:5:1)

--- a/tests/js_error/source_locations/expression/call/call_maybe_eval.js
+++ b/tests/js_error/source_locations/expression/call/call_maybe_eval.js
@@ -1,0 +1,5 @@
+function eval() {
+  throw new Error();
+}
+
+eval();

--- a/tests/js_error/source_locations/expression/call/call_maybe_eval_varargs.exp
+++ b/tests/js_error/source_locations/expression/call/call_maybe_eval_varargs.exp
@@ -1,0 +1,3 @@
+Error: 
+  at eval (tests/js_error/source_locations/expression/call/call_maybe_eval_varargs.js:2:9)
+  at <global> (tests/js_error/source_locations/expression/call/call_maybe_eval_varargs.js:5:1)

--- a/tests/js_error/source_locations/expression/call/call_maybe_eval_varargs.js
+++ b/tests/js_error/source_locations/expression/call/call_maybe_eval_varargs.js
@@ -1,0 +1,5 @@
+function eval() {
+  throw new Error();
+}
+
+eval(...[]);

--- a/tests/js_error/source_locations/expression/call/call_varargs.exp
+++ b/tests/js_error/source_locations/expression/call/call_varargs.exp
@@ -1,0 +1,3 @@
+Error: 
+  at foo (tests/js_error/source_locations/expression/call/call_varargs.js:2:9)
+  at <global> (tests/js_error/source_locations/expression/call/call_varargs.js:5:1)

--- a/tests/js_error/source_locations/expression/call/call_varargs.js
+++ b/tests/js_error/source_locations/expression/call/call_varargs.js
@@ -1,0 +1,5 @@
+function foo() {
+  throw new Error();
+}
+
+foo(1, ...[]);

--- a/tests/js_error/source_locations/expression/call/call_with_receiver.exp
+++ b/tests/js_error/source_locations/expression/call/call_with_receiver.exp
@@ -1,0 +1,3 @@
+Error: 
+  at method (tests/js_error/source_locations/expression/call/call_with_receiver.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/call/call_with_receiver.js:7:1)

--- a/tests/js_error/source_locations/expression/call/call_with_receiver.js
+++ b/tests/js_error/source_locations/expression/call/call_with_receiver.js
@@ -1,0 +1,7 @@
+var o = {
+  method() {
+    throw new Error();
+  }
+};
+
+o.method();

--- a/tests/js_error/source_locations/expression/construct/construct_varargs.exp
+++ b/tests/js_error/source_locations/expression/construct/construct_varargs.exp
@@ -1,0 +1,3 @@
+Error: 
+  at foo (tests/js_error/source_locations/expression/construct/construct_varargs.js:2:9)
+  at <global> (tests/js_error/source_locations/expression/construct/construct_varargs.js:5:2)

--- a/tests/js_error/source_locations/expression/construct/construct_varargs.js
+++ b/tests/js_error/source_locations/expression/construct/construct_varargs.js
@@ -1,0 +1,5 @@
+function foo() {
+  throw new Error();
+}
+
+(new foo(1, ...[]));

--- a/tests/js_error/source_locations/expression/super_call/construct_varargs.exp
+++ b/tests/js_error/source_locations/expression/super_call/construct_varargs.exp
@@ -1,0 +1,4 @@
+Error: 
+  at A (tests/js_error/source_locations/expression/super_call/construct_varargs.js:3:11)
+  at B (tests/js_error/source_locations/expression/super_call/construct_varargs.js:9:5)
+  at <global> (tests/js_error/source_locations/expression/super_call/construct_varargs.js:13:1)

--- a/tests/js_error/source_locations/expression/super_call/construct_varargs.js
+++ b/tests/js_error/source_locations/expression/super_call/construct_varargs.js
@@ -1,0 +1,13 @@
+class A {
+  constructor() {
+    throw new Error();
+  }
+}
+
+class B extends A {
+  constructor() {
+    super(1, ...[]);
+  }
+}
+
+new B();

--- a/tests/js_error/source_locations/expression/super_call/default_super_call.exp
+++ b/tests/js_error/source_locations/expression/super_call/default_super_call.exp
@@ -1,0 +1,4 @@
+Error: 
+  at B (tests/js_error/source_locations/expression/super_call/default_super_call.js:3:11)
+  at C (tests/js_error/source_locations/expression/super_call/default_super_call.js:7:1)
+  at <global> (tests/js_error/source_locations/expression/super_call/default_super_call.js:10:1)

--- a/tests/js_error/source_locations/expression/super_call/default_super_call.js
+++ b/tests/js_error/source_locations/expression/super_call/default_super_call.js
@@ -1,0 +1,10 @@
+class B {
+  constructor() {
+    throw new Error()
+  }
+}
+
+class C extends B {}
+
+// Default derived constructor error points to start of the class
+new C();

--- a/tests/js_error/source_locations/expression/template/tagged_template_call_with_receiver.exp
+++ b/tests/js_error/source_locations/expression/template/tagged_template_call_with_receiver.exp
@@ -1,0 +1,3 @@
+Error: 
+  at foo (tests/js_error/source_locations/expression/template/tagged_template_call_with_receiver.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/template/tagged_template_call_with_receiver.js:7:1)

--- a/tests/js_error/source_locations/expression/template/tagged_template_call_with_receiver.js
+++ b/tests/js_error/source_locations/expression/template/tagged_template_call_with_receiver.js
@@ -1,0 +1,7 @@
+var o = {
+  foo() {
+    throw new Error();
+  }
+};
+
+o.foo`test`;

--- a/tests/js_error/source_locations/expression/yield_star/next_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/next_throws.exp
@@ -1,0 +1,5 @@
+Error: next
+  at next (tests/js_error/source_locations/expression/yield_star/next_throws.js:5:15)
+  at generator (tests/js_error/source_locations/expression/yield_star/next_throws.js:12:3)
+  at next (<native>)
+  at <global> (tests/js_error/source_locations/expression/yield_star/next_throws.js:16:1)

--- a/tests/js_error/source_locations/expression/yield_star/next_throws.js
+++ b/tests/js_error/source_locations/expression/yield_star/next_throws.js
@@ -1,0 +1,16 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        throw new Error('next');
+      }
+    };
+  }
+}
+
+function *generator() {
+  yield* iterable;
+}
+
+let iter = generator();
+iter.next();

--- a/tests/js_error/source_locations/expression/yield_star/return_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/return_throws.exp
@@ -1,0 +1,5 @@
+Error: return
+  at return (tests/js_error/source_locations/expression/yield_star/return_throws.js:8:15)
+  at generator (tests/js_error/source_locations/expression/yield_star/return_throws.js:15:3)
+  at return (<native>)
+  at <global> (tests/js_error/source_locations/expression/yield_star/return_throws.js:20:1)

--- a/tests/js_error/source_locations/expression/yield_star/return_throws.js
+++ b/tests/js_error/source_locations/expression/yield_star/return_throws.js
@@ -1,0 +1,20 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      return() {
+        throw new Error('return');
+      }
+    };
+  }
+}
+
+function *generator() {
+  yield* iterable;
+}
+
+let iter = generator();
+iter.next();
+iter.return();

--- a/tests/js_error/source_locations/expression/yield_star/throw_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/throw_throws.exp
@@ -1,0 +1,5 @@
+Error: throw
+  at throw (tests/js_error/source_locations/expression/yield_star/throw_throws.js:8:15)
+  at generator (tests/js_error/source_locations/expression/yield_star/throw_throws.js:15:3)
+  at throw (<native>)
+  at <global> (tests/js_error/source_locations/expression/yield_star/throw_throws.js:20:1)

--- a/tests/js_error/source_locations/expression/yield_star/throw_throws.js
+++ b/tests/js_error/source_locations/expression/yield_star/throw_throws.js
@@ -1,0 +1,20 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      throw() {
+        throw new Error('throw');
+      }
+    };
+  }
+}
+
+function *generator() {
+  yield* iterable;
+}
+
+let iter = generator();
+iter.next();
+iter.throw();

--- a/tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.exp
@@ -1,0 +1,7 @@
+Error: 
+  at next (tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.js:5:15)
+  at next (<native>)
+  at foo (tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.js:13:20)
+  at <module> (tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.js:16:7)
+  at <anonymous> (<native>)
+  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.js
+++ b/tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.js
@@ -1,0 +1,16 @@
+var iter = {
+  [Symbol.iterator]: function() {
+    return {
+      next() {
+        throw new Error()
+      }
+    }
+  }
+}
+
+async function foo() {
+  // Error occurs in `next` and points to the `of`
+  for await (var x of iter) {}
+}
+
+await foo();


### PR DESCRIPTION
## Summary

Write entries to the BytecodeSourceMap for each call instruction. The source position reported for errors in the call instruction is the start of the corresponding call expression.

Future improvement: for calls after a member expression we should try to report the location of the member itself, not the start of the call expression.

## Tests

Added error snapshot tests for all call instructions, verifying that reported source position is correct.