### PR TITLE
[bytecode] Source positions for 

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -7922,7 +7922,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         let vm_scope_id = with_scope.vm_scope_id().unwrap();
         let scope_names_index = self.gen_scope_names(with_scope, ScopeFlags::empty())?;
         self.writer
-            .push_with_scope_instruction(object, scope_names_index);
+            .push_with_scope_instruction(object, scope_names_index, stmt.loc.start);
         self.push_scope_stack_node(vm_scope_id);
 
         self.register_allocator.release(object);

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -6646,6 +6646,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             ConstantIndex::new(constructor_index),
             super_class,
             first_argument_reg,
+            class_pos,
         );
 
         // Initialize the class itself in the body scope if necessary.

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -3851,8 +3851,13 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             if let ast::PropertyKind::Spread(_) = property.kind {
                 let property_pos = property.loc.start;
                 let source = self.gen_expression(&property.key)?;
-                self.writer
-                    .copy_data_properties(object, source, source, UInt::new(0), property_pos);
+                self.writer.copy_data_properties(
+                    object,
+                    source,
+                    source,
+                    UInt::new(0),
+                    property_pos,
+                );
                 self.register_allocator.release(source);
                 continue;
             }
@@ -5118,7 +5123,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         // method if it exists.
         let return_method = self.register_allocator.allocate()?;
         self.writer
-            .get_method_instruction(return_method, iterator, return_constant_index);
+            .get_method_instruction(return_method, iterator, return_constant_index, pos);
 
         // If return method does not exist then return the (awaited) completion value
         let has_return_method_block = self.new_block();
@@ -5174,7 +5179,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         // Extract the throw method from the iterator if one exists
         let throw_method = self.register_allocator.allocate()?;
         self.writer
-            .get_method_instruction(throw_method, iterator, throw_constant_index);
+            .get_method_instruction(throw_method, iterator, throw_constant_index, pos);
 
         // If throw method does not exist then close the iterator and throw an error
         let has_throw_method_block = self.new_block();
@@ -6027,8 +6032,13 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             // Create a new object and copy all data properties, except for the property keys saved
             // to the stack.
             self.writer.new_object_instruction(rest_element);
-            self.writer
-                .copy_data_properties(rest_element, object_value, argv, argc, rest_element_pos);
+            self.writer.copy_data_properties(
+                rest_element,
+                object_value,
+                argv,
+                argc,
+                rest_element_pos,
+            );
 
             self.gen_store_to_reference(reference, rest_element, store_flags)?;
             self.register_allocator.release(rest_element);

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1513,6 +1513,7 @@ define_instructions!(
     PushWithScope {
         camel_case: PushWithScopeInstruction,
         snake_case: push_with_scope_instruction,
+        can_throw: true,
         operands: {
             [0] object: Register,
             [1] scope_names_index: ConstantIndex,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1455,12 +1455,13 @@ define_instructions!(
     CopyDataProperties {
         camel_case: CopyDataPropertiesInstruction,
         snake_case: copy_data_properties,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] source: Register,
             [2] argv: Register,
             [3] argc: UInt,
-    }
+        }
     }
 
     /// Lookup a method with the given name on a value, storing the result in dest. If there is no

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1470,6 +1470,7 @@ define_instructions!(
     GetMethod {
         camel_case: GetMethodInstruction,
         snake_case: get_method_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] object: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1223,6 +1223,7 @@ define_instructions!(
     NewClass {
         camel_case: NewClassInstruction,
         snake_case: new_class_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] class_names_index: ConstantIndex,

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -889,18 +889,15 @@ impl VM {
                             dispatch!(NewAsyncClosureInstruction, execute_new_async_closure)
                         }
                         OpCode::NewGenerator => {
-                            dispatch_or_throw!(NewGeneratorInstruction, execute_new_generator)
+                            dispatch!(NewGeneratorInstruction, execute_new_generator)
                         }
                         OpCode::NewAsyncGenerator => {
-                            dispatch_or_throw!(
-                                NewAsyncGeneratorInstruction,
-                                execute_new_async_generator
-                            )
+                            dispatch!(NewAsyncGeneratorInstruction, execute_new_async_generator)
                         }
                         OpCode::NewObject => dispatch!(NewObjectInstruction, execute_new_object),
                         OpCode::NewArray => dispatch!(NewArrayInstruction, execute_new_array),
                         OpCode::NewRegExp => {
-                            dispatch_or_throw!(NewRegExpInstruction, execute_new_regexp)
+                            dispatch!(NewRegExpInstruction, execute_new_regexp)
                         }
                         OpCode::NewMappedArguments => {
                             dispatch!(NewMappedArgumentsInstruction, execute_new_mapped_arguments)
@@ -3092,10 +3089,7 @@ impl VM {
     }
 
     #[inline]
-    fn execute_new_generator<W: Width>(
-        &mut self,
-        instr: &NewGeneratorInstruction<W>,
-    ) -> EvalResult<()> {
+    fn execute_new_generator<W: Width>(&mut self, instr: &NewGeneratorInstruction<W>) {
         let func = self.get_constant(instr.function_index());
         let func = func.to_handle(self.cx()).cast::<BytecodeFunction>();
 
@@ -3108,18 +3102,13 @@ impl VM {
             .get_intrinsic(Intrinsic::GeneratorFunctionPrototype);
         let closure = Closure::new_with_proto(self.cx(), func, scope, func_proto);
 
-        GeneratorPrototype::install_on_generator_function(self.cx(), closure)?;
+        must!(GeneratorPrototype::install_on_generator_function(self.cx(), closure));
 
         self.write_register(dest, *closure.as_value());
-
-        Ok(())
     }
 
     #[inline]
-    fn execute_new_async_generator<W: Width>(
-        &mut self,
-        instr: &NewAsyncGeneratorInstruction<W>,
-    ) -> EvalResult<()> {
+    fn execute_new_async_generator<W: Width>(&mut self, instr: &NewAsyncGeneratorInstruction<W>) {
         let func = self.get_constant(instr.function_index());
         let func = func.to_handle(self.cx()).cast::<BytecodeFunction>();
 
@@ -3132,11 +3121,9 @@ impl VM {
             .get_intrinsic(Intrinsic::AsyncGeneratorFunctionPrototype);
         let closure = Closure::new_with_proto(self.cx(), func, scope, func_proto);
 
-        AsyncGeneratorPrototype::install_on_async_generator_function(self.cx(), closure)?;
+        must!(AsyncGeneratorPrototype::install_on_async_generator_function(self.cx(), closure));
 
         self.write_register(dest, *closure.as_value());
-
-        Ok(())
     }
 
     #[inline]
@@ -3160,7 +3147,7 @@ impl VM {
     }
 
     #[inline]
-    fn execute_new_regexp<W: Width>(&mut self, instr: &NewRegExpInstruction<W>) -> EvalResult<()> {
+    fn execute_new_regexp<W: Width>(&mut self, instr: &NewRegExpInstruction<W>) {
         let compiled_regexp = self.get_constant(instr.regexp_index());
         let compiled_regexp = compiled_regexp
             .to_handle(self.cx())
@@ -3169,11 +3156,9 @@ impl VM {
         let dest = instr.dest();
 
         // Allocates
-        let regexp = RegExpObject::new_from_compiled_regexp(self.cx(), compiled_regexp)?;
+        let regexp = RegExpObject::new_from_compiled_regexp(self.cx(), compiled_regexp);
 
         self.write_register(dest, *regexp.as_value());
-
-        Ok(())
     }
 
     #[inline]

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -1030,10 +1030,7 @@ impl VM {
                             dispatch!(RestParameterInstruction, execute_rest_parameter)
                         }
                         OpCode::GetSuperConstructor => {
-                            dispatch_or_throw!(
-                                GetSuperConstructorInstruction,
-                                execute_get_super_constructor
-                            )
+                            dispatch!(GetSuperConstructorInstruction, execute_get_super_constructor)
                         }
                         OpCode::CheckTdz => {
                             dispatch_or_throw!(CheckTdzInstruction, execute_check_tdz)
@@ -3940,7 +3937,7 @@ impl VM {
     fn execute_get_super_constructor<W: Width>(
         &mut self,
         instr: &GetSuperConstructorInstruction<W>,
-    ) -> EvalResult<()> {
+    ) {
         let derived_constructor = self
             .read_register_to_handle(instr.derived_constructor())
             .as_object();
@@ -3955,8 +3952,6 @@ impl VM {
             .unwrap_or(Value::null());
 
         self.write_register(dest, super_constructor);
-
-        Ok(())
     }
 
     #[inline]

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -70,7 +70,7 @@ impl RegExpObject {
     pub fn new_from_compiled_regexp(
         cx: Context,
         compiled_regexp: Handle<CompiledRegExpObject>,
-    ) -> EvalResult<Handle<RegExpObject>> {
+    ) -> Handle<RegExpObject> {
         let regexp_constructor = cx.get_intrinsic(Intrinsic::RegExpConstructor);
         let mut object = must!(object_create_from_constructor::<RegExpObject>(
             cx,
@@ -87,9 +87,9 @@ impl RegExpObject {
 
         // Initialize last index property
         let zero_value = cx.zero();
-        set(cx, object.into(), cx.names.last_index(), zero_value, true)?;
+        must!(set(cx, object.into(), cx.names.last_index(), zero_value, true));
 
-        Ok(object)
+        object
     }
 
     fn define_last_index_property(cx: Context, regexp_object: Handle<RegExpObject>) {

--- a/tests/js_error/source_locations/class/new_class.exp
+++ b/tests/js_error/source_locations/class/new_class.exp
@@ -1,0 +1,2 @@
+TypeError: super class must be a constructor
+  at <global> (tests/js_error/source_locations/class/new_class.js:1:2)

--- a/tests/js_error/source_locations/class/new_class.js
+++ b/tests/js_error/source_locations/class/new_class.js
@@ -1,0 +1,1 @@
+(class C extends 1 {})

--- a/tests/js_error/source_locations/destructure/object/copy_data_properties_throws.exp
+++ b/tests/js_error/source_locations/destructure/object/copy_data_properties_throws.exp
@@ -1,0 +1,3 @@
+Error: 
+  at getOwnPropertyDescriptor (tests/js_error/source_locations/destructure/object/copy_data_properties_throws.js:3:11)
+  at <global> (tests/js_error/source_locations/destructure/object/copy_data_properties_throws.js:10:7)

--- a/tests/js_error/source_locations/destructure/object/copy_data_properties_throws.js
+++ b/tests/js_error/source_locations/destructure/object/copy_data_properties_throws.js
@@ -1,0 +1,10 @@
+var proxy = new Proxy({}, {
+  getOwnPropertyDescriptor() {
+    throw new Error()
+  },
+  ownKeys() {
+    return ['a']
+  }
+});
+
+var { ...x } = proxy;

--- a/tests/js_error/source_locations/expression/object/literal_copy_data_properties.exp
+++ b/tests/js_error/source_locations/expression/object/literal_copy_data_properties.exp
@@ -1,0 +1,3 @@
+Error: 
+  at getOwnPropertyDescriptor (tests/js_error/source_locations/expression/object/literal_copy_data_properties.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/object/literal_copy_data_properties.js:10:4)

--- a/tests/js_error/source_locations/expression/object/literal_copy_data_properties.js
+++ b/tests/js_error/source_locations/expression/object/literal_copy_data_properties.js
@@ -1,0 +1,10 @@
+var proxy = new Proxy({}, {
+  getOwnPropertyDescriptor() {
+    throw new Error()
+  },
+  ownKeys() {
+    return ['a']
+  }
+});
+
+({ ...proxy });

--- a/tests/js_error/source_locations/expression/yield_star/return_get_method_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/return_get_method_throws.exp
@@ -1,0 +1,5 @@
+Error: get return
+  at get return (tests/js_error/source_locations/expression/yield_star/return_get_method_throws.js:8:15)
+  at generator (tests/js_error/source_locations/expression/yield_star/return_get_method_throws.js:15:3)
+  at return (<native>)
+  at <global> (tests/js_error/source_locations/expression/yield_star/return_get_method_throws.js:20:1)

--- a/tests/js_error/source_locations/expression/yield_star/return_get_method_throws.js
+++ b/tests/js_error/source_locations/expression/yield_star/return_get_method_throws.js
@@ -1,0 +1,20 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      get return() {
+        throw new Error('get return');
+      }
+    };
+  }
+}
+
+function *generator() {
+  yield* iterable;
+}
+
+let iter = generator();
+iter.next();
+iter.return();

--- a/tests/js_error/source_locations/expression/yield_star/throw_get_method_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/throw_get_method_throws.exp
@@ -1,0 +1,5 @@
+Error: get throw
+  at get throw (tests/js_error/source_locations/expression/yield_star/throw_get_method_throws.js:8:15)
+  at generator (tests/js_error/source_locations/expression/yield_star/throw_get_method_throws.js:15:3)
+  at throw (<native>)
+  at <global> (tests/js_error/source_locations/expression/yield_star/throw_get_method_throws.js:20:1)

--- a/tests/js_error/source_locations/expression/yield_star/throw_get_method_throws.js
+++ b/tests/js_error/source_locations/expression/yield_star/throw_get_method_throws.js
@@ -1,0 +1,20 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      get throw() {
+        throw new Error('get throw');
+      }
+    };
+  }
+}
+
+function *generator() {
+  yield* iterable;
+}
+
+let iter = generator();
+iter.next();
+iter.throw();

--- a/tests/js_error/source_locations/statement/with/push_with_scope_throws.exp
+++ b/tests/js_error/source_locations/statement/with/push_with_scope_throws.exp
@@ -1,0 +1,2 @@
+TypeError: null has no properties
+  at <global> (tests/js_error/source_locations/statement/with/push_with_scope_throws.js:2:1)

--- a/tests/js_error/source_locations/statement/with/push_with_scope_throws.js
+++ b/tests/js_error/source_locations/statement/with/push_with_scope_throws.js
@@ -1,0 +1,2 @@
+// Errors point to start of with statement
+with (null) {}


### PR DESCRIPTION
## Summary

Write entries to the BytecodeSourceMap for an assortment of bytecode instructions. We now write source map entries for:

- NewClass
- CopyDataProperties
- GetMethod
- PushWithScope

The following instructions are marked non-throwing in the VM: NewGenerator, NewAsyncGenerator, NewRegExp, and GetSuperConstruct. These instructions already could not throw in practice, so let's enforce this in the VM implementation signatures.

## Tests

Added error snapshot tests for all implemented instructions, verifying that reported source position is correct.