### PR TITLE
[bytecode] Source positions for iterator instructions

### DIFF
--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -1160,7 +1160,7 @@ pub struct ArrayExpression {
 pub enum ArrayElement {
     Expression(Expression),
     Spread(SpreadElement),
-    Hole,
+    Hole(Pos),
 }
 
 pub struct SpreadElement {
@@ -1373,7 +1373,7 @@ impl Pattern {
                     match element {
                         ArrayPatternElement::Pattern(pattern) => pattern.iter_patterns(f),
                         ArrayPatternElement::Rest(rest) => rest.argument.iter_patterns(f),
-                        ArrayPatternElement::Hole => {}
+                        ArrayPatternElement::Hole(_) => {}
                     }
                 }
             }
@@ -1399,6 +1399,22 @@ impl Pattern {
             Pattern::Member(_) | Pattern::SuperMember(_) => Ok(()),
         }
     }
+
+    pub fn loc(&self) -> Loc {
+        match self {
+            Pattern::Id(patt) => patt.loc,
+            Pattern::Array(patt) => patt.loc,
+            Pattern::Object(patt) => patt.loc,
+            Pattern::Assign(patt) => patt.loc,
+            Pattern::Member(expr) => expr.loc,
+            Pattern::SuperMember(expr) => expr.loc,
+        }
+    }
+
+    /// The source position of the start of the pattern.
+    pub fn pos(&self) -> Pos {
+        self.loc().start
+    }
 }
 
 pub struct ArrayPattern {
@@ -1409,7 +1425,7 @@ pub struct ArrayPattern {
 pub enum ArrayPatternElement {
     Pattern(Pattern),
     Rest(RestElement),
-    Hole,
+    Hole(Pos),
 }
 
 impl ArrayPattern {
@@ -1423,7 +1439,7 @@ impl ArrayPattern {
                 ArrayPatternElement::Rest(RestElement { argument, .. }) => {
                     argument.iter_bound_names(f)?
                 }
-                ArrayPatternElement::Hole => {}
+                ArrayPatternElement::Hole(_) => {}
             }
         }
 

--- a/src/js/parser/ast_visitor.rs
+++ b/src/js/parser/ast_visitor.rs
@@ -704,7 +704,7 @@ pub fn default_visit_array_expression<V: AstVisitor>(visitor: &mut V, expr: &mut
         match element {
             ArrayElement::Expression(expr) => visitor.visit_expression(expr),
             ArrayElement::Spread(spread) => visitor.visit_spread_element(spread),
-            ArrayElement::Hole => {}
+            ArrayElement::Hole(_) => {}
         }
     }
 }
@@ -792,7 +792,7 @@ pub fn default_visit_array_pattern<V: AstVisitor>(visitor: &mut V, patt: &mut Ar
         match element {
             ArrayPatternElement::Pattern(pattern) => visitor.visit_pattern(pattern),
             ArrayPatternElement::Rest(rest) => visitor.visit_rest_element(rest),
-            ArrayPatternElement::Hole => {}
+            ArrayPatternElement::Hole(_) => {}
         }
     }
 }

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -3020,8 +3020,9 @@ impl<'a> Parser<'a> {
         while self.token != Token::RightBracket {
             match self.token {
                 Token::Comma => {
+                    let hole_pos = self.current_start_pos();
                     self.advance()?;
-                    elements.push(ArrayElement::Hole);
+                    elements.push(ArrayElement::Hole(hole_pos));
                     continue;
                 }
                 Token::Spread => {
@@ -3930,8 +3931,9 @@ impl<'a> Parser<'a> {
         while self.token != Token::RightBracket {
             match self.token {
                 Token::Comma => {
+                    let hole_pos = self.current_start_pos();
                     self.advance()?;
-                    elements.push(ArrayPatternElement::Hole);
+                    elements.push(ArrayPatternElement::Hole(hole_pos));
                 }
                 Token::Spread => {
                     let rest_element = self.parse_rest_element(binding_kind)?;
@@ -4587,7 +4589,7 @@ impl<'a> Parser<'a> {
                     let pattern = self.reparse_expression_as_maybe_assignment_pattern(expr)?;
                     ArrayPatternElement::Pattern(pattern)
                 }
-                ArrayElement::Hole => ArrayPatternElement::Hole,
+                ArrayElement::Hole(pos) => ArrayPatternElement::Hole(pos),
                 ArrayElement::Spread(spread) => {
                     // Trailing commas (or properties after) are not allowed on rest element
                     if spread.has_trailing_comma {

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -801,7 +801,7 @@ impl<'a> Printer<'a> {
         match element {
             ArrayElement::Expression(expr) => self.print_expression(expr),
             ArrayElement::Spread(spread) => self.print_spread_element(spread),
-            ArrayElement::Hole => self.print_null(),
+            ArrayElement::Hole(_) => self.print_null(),
         }
     }
 
@@ -985,7 +985,7 @@ impl<'a> Printer<'a> {
         match element {
             ArrayPatternElement::Pattern(pattern) => self.print_pattern(pattern),
             ArrayPatternElement::Rest(rest) => self.print_rest_element(rest),
-            ArrayPatternElement::Hole => self.print_null(),
+            ArrayPatternElement::Hole(_) => self.print_null(),
         }
     }
 

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -7590,7 +7590,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             self.register_allocator.release(awaited_result);
 
             self.writer
-                .iterator_unpack_result_instruction(value, is_done, awaited_result);
+                .iterator_unpack_result_instruction(value, is_done, awaited_result, of_pos);
         } else {
             // Synchronous for-of can use a combined IteratorNext instruction
             self.writer

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -5205,7 +5205,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         if self.is_async() {
             self.gen_async_iterator_close(iterator)?;
         } else {
-            self.writer.iterator_close_instruction(iterator);
+            self.writer.iterator_close_instruction(iterator, pos);
         }
 
         self.writer.error_iterator_no_throw_method_instruction(pos);
@@ -6240,7 +6240,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             // need to be swallowed.
             //
             // Iterator is only closed if we are not done, which is enforced by the JumpTrue above.
-            self.writer.iterator_close_instruction(iterator);
+            self.writer
+                .iterator_close_instruction(iterator, pattern_pos);
 
             // Exit the finally scope and release all of its registers
             let finally_scope = self.pop_finally_scope();
@@ -6281,7 +6282,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             // already done.
             self.write_jump_true_instruction(is_done, finally_footer_block)?;
             let (mut close_handler, _) = self.gen_in_exception_handler(|this| {
-                this.writer.iterator_close_instruction(iterator);
+                this.writer
+                    .iterator_close_instruction(iterator, pattern_pos);
                 Ok(())
             })?;
 
@@ -7653,7 +7655,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 if stmt.is_await {
                     this.gen_async_iterator_close(iterator)
                 } else {
-                    this.writer.iterator_close_instruction(iterator);
+                    this.writer.iterator_close_instruction(iterator, of_pos);
                     Ok(())
                 }
             })?;

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -7743,6 +7743,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         let for_scope = stmt.scope.as_ref();
         self.gen_scope_start(for_scope, None)?;
 
+        let in_pos = stmt.in_of_pos;
         let right_pos = stmt.right.pos();
 
         // Entire for-in statement is skipped if right hand side is nullish
@@ -7771,7 +7772,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         // Iteration starts by calling the for-in iterator's `next` method
         let next_result = self.gen_for_each_next_result_dest(stmt, store_flags)?;
-        self.writer.for_in_next_instruction(next_result, iterator);
+        self.writer
+            .for_in_next_instruction(next_result, iterator, in_pos);
 
         // An undefined result from `next` means there are no more keys, jump out of the loop
         self.write_jump_nullish_instruction(next_result, loop_end_block)?;

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -5064,7 +5064,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         if self.is_async() {
             self.writer
-                .get_async_iterator_instruction(iterator, next_method, argument);
+                .get_async_iterator_instruction(iterator, next_method, argument, pos);
         } else {
             self.writer
                 .get_iterator_instruction(iterator, next_method, argument, pos);
@@ -7535,7 +7535,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         if stmt.is_await {
             self.writer
-                .get_async_iterator_instruction(iterator, next_method, iterable);
+                .get_async_iterator_instruction(iterator, next_method, iterable, right_pos);
         } else {
             self.writer
                 .get_iterator_instruction(iterator, next_method, iterable, right_pos);

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -7743,6 +7743,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         let for_scope = stmt.scope.as_ref();
         self.gen_scope_start(for_scope, None)?;
 
+        let right_pos = stmt.right.pos();
+
         // Entire for-in statement is skipped if right hand side is nullish
         let object = self.gen_outer_expression(&stmt.right)?;
         self.write_jump_nullish_instruction(object, loop_end_block)?;
@@ -7751,7 +7753,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         self.register_allocator.release(object);
         let iterator = self.register_allocator.allocate()?;
         self.writer
-            .new_for_in_iterator_instruction(iterator, object);
+            .new_for_in_iterator_instruction(iterator, object, right_pos);
 
         // End of scope for evaluating the right hand side
         self.gen_scope_end(for_scope);

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1740,6 +1740,7 @@ define_instructions!(
     IteratorNext {
         camel_case: IteratorNextInstruction,
         snake_case: iterator_next_instruction,
+        can_throw: true,
         operands: {
             [0] value: Register,
             [1] is_done: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1702,6 +1702,7 @@ define_instructions!(
     ForInNext {
         camel_case: ForInNextInstruction,
         snake_case: for_in_next_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] iterator: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1714,6 +1714,7 @@ define_instructions!(
     GetIterator {
         camel_case: GetIteratorInstruction,
         snake_case: get_iterator_instruction,
+        can_throw: true,
         operands: {
             [0] iterator: Register,
             [1] next_method: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1727,6 +1727,7 @@ define_instructions!(
     GetAsyncIterator {
         camel_case: GetAsyncIteratorInstruction,
         snake_case: get_async_iterator_instruction,
+        can_throw: true,
         operands: {
             [0] iterator: Register,
             [1] next_method: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1778,6 +1778,7 @@ define_instructions!(
     AsyncIteratorCloseStart {
         camel_case: AsyncIteratorCloseStartInstruction,
         snake_case: async_iterator_close_start_instruction,
+        can_throw: true,
         operands: {
             [0] return_result: Register,
             [1] has_return_method: Register,
@@ -1790,6 +1791,7 @@ define_instructions!(
     AsyncIteratorCloseFinish {
         camel_case: AsyncIteratorCloseFinishInstruction,
         snake_case: async_iterator_close_finish_instruction,
+        can_throw: true,
         operands: {
             [0] return_result: Register,
         }

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1690,6 +1690,7 @@ define_instructions!(
     NewForInIterator {
         camel_case: NewForInIteratorInstruction,
         snake_case: new_for_in_iterator_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] object: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1754,6 +1754,7 @@ define_instructions!(
     IteratorUnpackResult {
         camel_case: IteratorUnpackResultInstruction,
         snake_case: iterator_unpack_result_instruction,
+        can_throw: true,
         operands: {
             [0] value: Register,
             [1] is_done: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1766,6 +1766,7 @@ define_instructions!(
     IteratorClose {
         camel_case: IteratorCloseInstruction,
         snake_case: iterator_close_instruction,
+        can_throw: true,
         operands: {
             [0] iterator: Register,
         }

--- a/tests/js_error/source_locations/destructure/array/element_iterator_next.exp
+++ b/tests/js_error/source_locations/destructure/array/element_iterator_next.exp
@@ -1,0 +1,3 @@
+Error: 
+  at next (tests/js_error/source_locations/destructure/array/element_iterator_next.js:8:17)
+  at <global> (tests/js_error/source_locations/destructure/array/element_iterator_next.js:19:9)

--- a/tests/js_error/source_locations/destructure/array/element_iterator_next.js
+++ b/tests/js_error/source_locations/destructure/array/element_iterator_next.js
@@ -1,0 +1,19 @@
+var numNextCalls = 0;
+
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        if (numNextCalls >= 1) {
+          throw new Error();
+        }
+
+        numNextCalls++;
+
+        return { value: 1, done: false };
+      }
+    }
+  }
+}
+
+var [a, b, c] = iterable;

--- a/tests/js_error/source_locations/destructure/array/get_iterator.exp
+++ b/tests/js_error/source_locations/destructure/array/get_iterator.exp
@@ -1,0 +1,3 @@
+Error: 
+  at <anonymous> (tests/js_error/source_locations/destructure/array/get_iterator.js:3:11)
+  at <global> (tests/js_error/source_locations/destructure/array/get_iterator.js:7:5)

--- a/tests/js_error/source_locations/destructure/array/get_iterator.js
+++ b/tests/js_error/source_locations/destructure/array/get_iterator.js
@@ -1,0 +1,7 @@
+var iterable = {
+  [Symbol.iterator]() {
+    throw new Error();
+  }
+};
+
+var [] = iterable;

--- a/tests/js_error/source_locations/destructure/array/hole_iterator_next.exp
+++ b/tests/js_error/source_locations/destructure/array/hole_iterator_next.exp
@@ -1,0 +1,3 @@
+Error: 
+  at next (tests/js_error/source_locations/destructure/array/hole_iterator_next.js:8:17)
+  at <global> (tests/js_error/source_locations/destructure/array/hole_iterator_next.js:19:9)

--- a/tests/js_error/source_locations/destructure/array/hole_iterator_next.js
+++ b/tests/js_error/source_locations/destructure/array/hole_iterator_next.js
@@ -1,0 +1,19 @@
+var numNextCalls = 0;
+
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        if (numNextCalls >= 1) {
+          throw new Error();
+        }
+
+        numNextCalls++;
+
+        return { value: 1, done: false };
+      }
+    }
+  }
+}
+
+var [a, , c] = iterable;

--- a/tests/js_error/source_locations/destructure/array/iterator_close_empty.exp
+++ b/tests/js_error/source_locations/destructure/array/iterator_close_empty.exp
@@ -1,0 +1,3 @@
+Error: 
+  at get return (tests/js_error/source_locations/destructure/array/iterator_close_empty.js:8:15)
+  at <global> (tests/js_error/source_locations/destructure/array/iterator_close_empty.js:14:5)

--- a/tests/js_error/source_locations/destructure/array/iterator_close_empty.js
+++ b/tests/js_error/source_locations/destructure/array/iterator_close_empty.js
@@ -1,0 +1,14 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      get return() {
+        throw new Error();
+      }
+    }
+  }
+};
+
+var [] = iterable;

--- a/tests/js_error/source_locations/destructure/array/iterator_close_non_empty.exp
+++ b/tests/js_error/source_locations/destructure/array/iterator_close_non_empty.exp
@@ -1,0 +1,3 @@
+Error: 
+  at get return (tests/js_error/source_locations/destructure/array/iterator_close_non_empty.js:8:15)
+  at <global> (tests/js_error/source_locations/destructure/array/iterator_close_non_empty.js:14:5)

--- a/tests/js_error/source_locations/destructure/array/iterator_close_non_empty.js
+++ b/tests/js_error/source_locations/destructure/array/iterator_close_non_empty.js
@@ -1,0 +1,14 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      get return() {
+        throw new Error();
+      }
+    }
+  }
+};
+
+var [x] = iterable;

--- a/tests/js_error/source_locations/destructure/array/rest_iterator_next.exp
+++ b/tests/js_error/source_locations/destructure/array/rest_iterator_next.exp
@@ -1,0 +1,3 @@
+Error: 
+  at next (tests/js_error/source_locations/destructure/array/rest_iterator_next.js:5:15)
+  at <global> (tests/js_error/source_locations/destructure/array/rest_iterator_next.js:11:6)

--- a/tests/js_error/source_locations/destructure/array/rest_iterator_next.js
+++ b/tests/js_error/source_locations/destructure/array/rest_iterator_next.js
@@ -1,0 +1,11 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        throw new Error();
+      }
+    }
+  }
+};
+
+var [...rest] = iterable;

--- a/tests/js_error/source_locations/expression/array/spread_get_iterator.exp
+++ b/tests/js_error/source_locations/expression/array/spread_get_iterator.exp
@@ -1,0 +1,3 @@
+Error: 
+  at <anonymous> (tests/js_error/source_locations/expression/array/spread_get_iterator.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/array/spread_get_iterator.js:7:2)

--- a/tests/js_error/source_locations/expression/array/spread_get_iterator.js
+++ b/tests/js_error/source_locations/expression/array/spread_get_iterator.js
@@ -1,0 +1,7 @@
+var iterable = {
+  [Symbol.iterator]() {
+    throw new Error();
+  }
+};
+
+[...iterable];

--- a/tests/js_error/source_locations/expression/array/spread_iterator_next.exp
+++ b/tests/js_error/source_locations/expression/array/spread_iterator_next.exp
@@ -1,0 +1,3 @@
+Error: 
+  at next (tests/js_error/source_locations/expression/array/spread_iterator_next.js:5:15)
+  at <global> (tests/js_error/source_locations/expression/array/spread_iterator_next.js:11:2)

--- a/tests/js_error/source_locations/expression/array/spread_iterator_next.js
+++ b/tests/js_error/source_locations/expression/array/spread_iterator_next.js
@@ -1,0 +1,11 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        throw new Error();
+      }
+    }
+  }
+};
+
+[...iterable]

--- a/tests/js_error/source_locations/expression/yield_star/async_iterator_close_finish_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/async_iterator_close_finish_throws_module.exp
@@ -1,0 +1,3 @@
+TypeError: iterator's return method must return an object
+  at generator (tests/js_error/source_locations/expression/yield_star/async_iterator_close_finish_throws_module.js:15:3)
+  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/async_iterator_close_finish_throws_module.js
+++ b/tests/js_error/source_locations/expression/yield_star/async_iterator_close_finish_throws_module.js
@@ -1,0 +1,20 @@
+var iterable = {
+  [Symbol.asyncIterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      return() {
+        return 1;
+      }
+    }
+  }
+};
+
+async function *generator() {
+  yield* iterable;
+}
+
+var iter = generator();
+await iter.next();
+await iter.throw();

--- a/tests/js_error/source_locations/expression/yield_star/async_iterator_close_start_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/async_iterator_close_start_throws_module.exp
@@ -1,0 +1,5 @@
+Error: 
+  at get return (tests/js_error/source_locations/expression/yield_star/async_iterator_close_start_throws_module.js:8:15)
+  at generator (tests/js_error/source_locations/expression/yield_star/async_iterator_close_start_throws_module.js:15:3)
+  at throw (<native>)
+  at <module> (tests/js_error/source_locations/expression/yield_star/async_iterator_close_start_throws_module.js:20:7)

--- a/tests/js_error/source_locations/expression/yield_star/async_iterator_close_start_throws_module.js
+++ b/tests/js_error/source_locations/expression/yield_star/async_iterator_close_start_throws_module.js
@@ -1,0 +1,20 @@
+var iterable = {
+  [Symbol.asyncIterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      get return() {
+        throw new Error();
+      }
+    }
+  }
+};
+
+async function *generator() {
+  yield* iterable;
+}
+
+var iter = generator();
+await iter.next();
+await iter.throw();

--- a/tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.exp
@@ -1,0 +1,7 @@
+Error: 
+  at <anonymous> (tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.js:3:11)
+  at generator (tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.js:8:3)
+  at next (<native>)
+  at <module> (tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.js:12:7)
+  at <anonymous> (<native>)
+  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.js
+++ b/tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.js
@@ -1,0 +1,12 @@
+var iterable = {
+  [Symbol.iterator]() {
+    throw new Error();
+  }
+}
+
+async function *generator() {
+  yield* iterable;
+}
+
+let iter = generator();
+await iter.next();

--- a/tests/js_error/source_locations/expression/yield_star/get_iterator_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/get_iterator_throws.exp
@@ -1,0 +1,5 @@
+Error: 
+  at <anonymous> (tests/js_error/source_locations/expression/yield_star/get_iterator_throws.js:3:11)
+  at generator (tests/js_error/source_locations/expression/yield_star/get_iterator_throws.js:8:3)
+  at next (<native>)
+  at <global> (tests/js_error/source_locations/expression/yield_star/get_iterator_throws.js:12:1)

--- a/tests/js_error/source_locations/expression/yield_star/get_iterator_throws.js
+++ b/tests/js_error/source_locations/expression/yield_star/get_iterator_throws.js
@@ -1,0 +1,12 @@
+var iterable = {
+  [Symbol.iterator]() {
+    throw new Error();
+  }
+}
+
+function *generator() {
+  yield* iterable;
+}
+
+let iter = generator();
+iter.next();

--- a/tests/js_error/source_locations/expression/yield_star/iterator_close_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/iterator_close_throws.exp
@@ -1,0 +1,5 @@
+Error: 
+  at get return (tests/js_error/source_locations/expression/yield_star/iterator_close_throws.js:8:15)
+  at generator (tests/js_error/source_locations/expression/yield_star/iterator_close_throws.js:15:3)
+  at throw (<native>)
+  at <global> (tests/js_error/source_locations/expression/yield_star/iterator_close_throws.js:20:1)

--- a/tests/js_error/source_locations/expression/yield_star/iterator_close_throws.js
+++ b/tests/js_error/source_locations/expression/yield_star/iterator_close_throws.js
@@ -1,0 +1,20 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      get return() {
+        throw new Error();
+      }
+    }
+  }
+};
+
+function *generator() {
+  yield* iterable;
+}
+
+var iter = generator();
+iter.next();
+iter.throw();

--- a/tests/js_error/source_locations/statement/for_await/async_iterator_close_finish_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/async_iterator_close_finish_module.exp
@@ -1,0 +1,3 @@
+TypeError: return method must return an object
+  at return (<native>)
+  at foo (tests/js_error/source_locations/statement/for_await/async_iterator_close_finish_module.js:15:20)

--- a/tests/js_error/source_locations/statement/for_await/async_iterator_close_finish_module.js
+++ b/tests/js_error/source_locations/statement/for_await/async_iterator_close_finish_module.js
@@ -1,0 +1,20 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      return() {
+        return 1;
+      }
+    }
+  }
+};
+
+async function foo() {
+  for await (var x of iterable) {
+    break;
+  }
+}
+
+await foo();

--- a/tests/js_error/source_locations/statement/for_await/async_iterator_close_start_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/async_iterator_close_start_module.exp
@@ -1,0 +1,4 @@
+Error: 
+  at get return (tests/js_error/source_locations/statement/for_await/async_iterator_close_start_module.js:8:15)
+  at return (<native>)
+  at foo (tests/js_error/source_locations/statement/for_await/async_iterator_close_start_module.js:15:20)

--- a/tests/js_error/source_locations/statement/for_await/async_iterator_close_start_module.js
+++ b/tests/js_error/source_locations/statement/for_await/async_iterator_close_start_module.js
@@ -1,0 +1,20 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      get return() {
+        throw new Error();
+      }
+    }
+  }
+};
+
+async function foo() {
+  for await (var x of iterable) {
+    break;
+  }
+}
+
+await foo();

--- a/tests/js_error/source_locations/statement/for_await/get_async_iterator_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/get_async_iterator_module.exp
@@ -1,0 +1,6 @@
+Error: 
+  at <anonymous> (tests/js_error/source_locations/statement/for_await/get_async_iterator_module.js:3:11)
+  at foo (tests/js_error/source_locations/statement/for_await/get_async_iterator_module.js:8:23)
+  at <module> (tests/js_error/source_locations/statement/for_await/get_async_iterator_module.js:11:7)
+  at <anonymous> (<native>)
+  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/statement/for_await/get_async_iterator_module.js
+++ b/tests/js_error/source_locations/statement/for_await/get_async_iterator_module.js
@@ -1,0 +1,11 @@
+var iterable = {
+  [Symbol.iterator]: function() {
+    throw new Error();
+  }
+}
+
+async function foo() {
+  for await (var x of iterable) {}
+}
+
+await foo();

--- a/tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.exp
@@ -1,0 +1,6 @@
+TypeError: iterator's next method must return an object
+  at next (<native>)
+  at foo (tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.js:12:20)
+  at <module> (tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.js:15:7)
+  at <anonymous> (<native>)
+  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.js
+++ b/tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.js
@@ -1,0 +1,15 @@
+var iter = {
+  [Symbol.iterator]: function() {
+    return {
+      next() {
+        return 1;
+      }
+    }
+  }
+}
+
+async function foo() {
+  for await (var x of iter) {}
+}
+
+await foo();

--- a/tests/js_error/source_locations/statement/for_in/for_in_next.exp
+++ b/tests/js_error/source_locations/statement/for_in/for_in_next.exp
@@ -1,0 +1,3 @@
+Error: 
+  at has (tests/js_error/source_locations/statement/for_in/for_in_next.js:7:13)
+  at <global> (tests/js_error/source_locations/statement/for_in/for_in_next.js:12:12)

--- a/tests/js_error/source_locations/statement/for_in/for_in_next.js
+++ b/tests/js_error/source_locations/statement/for_in/for_in_next.js
@@ -1,0 +1,12 @@
+var numHasCalls = 0;
+
+var iter = new Proxy(
+  { key: 1 },
+  {
+    has() {
+      throw new Error()
+    }
+  }
+);
+
+for (var x in iter) {}

--- a/tests/js_error/source_locations/statement/for_in/new_for_in_iterator.exp
+++ b/tests/js_error/source_locations/statement/for_in/new_for_in_iterator.exp
@@ -1,0 +1,3 @@
+Error: 
+  at ownKeys (tests/js_error/source_locations/statement/for_in/new_for_in_iterator.js:3:11)
+  at <global> (tests/js_error/source_locations/statement/for_in/new_for_in_iterator.js:7:15)

--- a/tests/js_error/source_locations/statement/for_in/new_for_in_iterator.js
+++ b/tests/js_error/source_locations/statement/for_in/new_for_in_iterator.js
@@ -1,0 +1,7 @@
+var poisoned = new Proxy({}, {
+  ownKeys() {
+    throw new Error()
+  }
+});
+
+for (var x in poisoned) {}

--- a/tests/js_error/source_locations/statement/for_of/get_iterator.exp
+++ b/tests/js_error/source_locations/statement/for_of/get_iterator.exp
@@ -1,0 +1,3 @@
+Error: 
+  at <anonymous> (tests/js_error/source_locations/statement/for_of/get_iterator.js:3:11)
+  at <global> (tests/js_error/source_locations/statement/for_of/get_iterator.js:7:15)

--- a/tests/js_error/source_locations/statement/for_of/get_iterator.js
+++ b/tests/js_error/source_locations/statement/for_of/get_iterator.js
@@ -1,0 +1,7 @@
+var iterable = {
+  [Symbol.iterator]() {
+    throw new Error();
+  }
+}
+
+for (var x of iterable) {}

--- a/tests/js_error/source_locations/statement/for_of/iterator_close.exp
+++ b/tests/js_error/source_locations/statement/for_of/iterator_close.exp
@@ -1,0 +1,3 @@
+Error: 
+  at get return (tests/js_error/source_locations/statement/for_of/iterator_close.js:8:15)
+  at <global> (tests/js_error/source_locations/statement/for_of/iterator_close.js:14:12)

--- a/tests/js_error/source_locations/statement/for_of/iterator_close.js
+++ b/tests/js_error/source_locations/statement/for_of/iterator_close.js
@@ -1,0 +1,16 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      get return() {
+        throw new Error();
+      }
+    }
+  }
+};
+
+for (var x of iterable) {
+  break;
+}

--- a/tests/js_error/source_locations/statement/for_of/iterator_next.exp
+++ b/tests/js_error/source_locations/statement/for_of/iterator_next.exp
@@ -1,0 +1,3 @@
+Error: 
+  at next (tests/js_error/source_locations/statement/for_of/iterator_next.js:5:15)
+  at <global> (tests/js_error/source_locations/statement/for_of/iterator_next.js:11:12)

--- a/tests/js_error/source_locations/statement/for_of/iterator_next.js
+++ b/tests/js_error/source_locations/statement/for_of/iterator_next.js
@@ -1,0 +1,11 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        throw new Error();
+      }
+    }
+  }
+};
+
+for (var x of iterable) {}


### PR DESCRIPTION
## Summary

Write entries to the BytecodeSourceMap for all iterator instructions. We now write source map entries for:

- NewForInIterator
- ForInNext
- GetIterator
- GetAsyncIterator
- IteratorNext
- IteratorUnpackResult
- IteratorClose
- AsyncIteratorCloseStart
- AsyncIteratorCloseFinish

## Tests

Added error snapshot tests for all implemented instructions, verifying that reported source position is correct.