### PR TITLE
[bytecode] Source positions for property instructions

### DIFF
--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -1070,6 +1070,9 @@ pub struct MemberExpression {
     pub is_computed: bool,
     pub is_optional: bool,
     pub is_private: bool,
+
+    /// Source position of the `.` or `[` token
+    pub operator_pos: Pos,
 }
 
 pub struct ChainExpression {
@@ -1239,10 +1242,19 @@ pub struct SuperMemberExpression {
     /// super expression, or tagged as unresolved dynamic if the scope could not be statically
     /// determined.
     pub home_object_scope: TaggedResolvedScope,
+
+    /// Source position of the `.` or `[` token
+    pub operator_pos: Pos,
 }
 
 impl SuperMemberExpression {
-    pub fn new(loc: Loc, super_: Loc, property: P<Expression>, is_computed: bool) -> Self {
+    pub fn new(
+        loc: Loc,
+        super_: Loc,
+        operator_pos: Pos,
+        property: P<Expression>,
+        is_computed: bool,
+    ) -> Self {
         Self {
             loc,
             super_,
@@ -1251,6 +1263,7 @@ impl SuperMemberExpression {
             is_static: false,
             this_scope: None,
             home_object_scope: TaggedResolvedScope::unresolved_global(),
+            operator_pos,
         }
     }
 

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -4147,7 +4147,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
             let dest = self.allocate_destination(dest)?;
             self.writer
-                .get_private_property_instruction(dest, object, key);
+                .get_private_property_instruction(dest, object, key, operator_pos);
 
             Ok(dest)
         } else {
@@ -4447,9 +4447,12 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                                 operator_pos,
                             )
                         }
-                        Property::Private(key) => self
-                            .writer
-                            .get_private_property_instruction(temp, object, key),
+                        Property::Private(key) => self.writer.get_private_property_instruction(
+                            temp,
+                            object,
+                            key,
+                            operator_pos,
+                        ),
                         Property::Super { key, this_value } => {
                             self.writer.get_super_property_instruction(
                                 temp,
@@ -4667,7 +4670,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 } else if member.is_private {
                     let key = self.gen_load_private_symbol(member.property.to_id())?;
                     self.writer
-                        .get_private_property_instruction(temp, object, key);
+                        .get_private_property_instruction(temp, object, key, operator_pos);
 
                     Property::Private(key)
                 } else {
@@ -5434,6 +5437,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 home_object,
                 receiver,
                 name_constant_index,
+                operand_pos,
             );
 
             Ok(dest)

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -3046,7 +3046,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 self.register_allocator.release(object);
                 let dest = self.allocate_destination(dest)?;
 
-                self.writer.delete_property_instruction(dest, object, key);
+                self.writer
+                    .delete_property_instruction(dest, object, key, delete_pos);
 
                 Ok(dest)
             }
@@ -3083,7 +3084,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 let dest = self.allocate_destination(dest)?;
 
                 // Write the delete property instruction
-                self.writer.delete_property_instruction(dest, object, key);
+                self.writer
+                    .delete_property_instruction(dest, object, key, delete_pos);
                 self.write_jump_instruction(join_block)?;
 
                 // If object is nullish (or short circuits), then entire delete will evaluate to
@@ -3117,7 +3119,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
                 let name_constant_index = self.add_string_constant(&id.name)?;
                 self.writer
-                    .delete_binding_instruction(dest, name_constant_index);
+                    .delete_binding_instruction(dest, name_constant_index, delete_pos);
 
                 Ok(dest)
             }

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -4450,9 +4450,15 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                         Property::Private(key) => self
                             .writer
                             .get_private_property_instruction(temp, object, key),
-                        Property::Super { key, this_value } => self
-                            .writer
-                            .get_super_property_instruction(temp, object, this_value, key),
+                        Property::Super { key, this_value } => {
+                            self.writer.get_super_property_instruction(
+                                temp,
+                                object,
+                                this_value,
+                                key,
+                                operator_pos,
+                            )
+                        }
                     }
 
                     if !expr.operator.is_logical() {
@@ -5391,6 +5397,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         dest: ExprDest,
         release_receiver: bool,
     ) -> EmitResult<GenRegister> {
+        let operand_pos = expr.operator_pos;
+
         if expr.is_computed {
             let key = self.gen_expression(&expr.property)?;
 
@@ -5401,8 +5409,13 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             }
 
             let dest = self.allocate_destination(dest)?;
-            self.writer
-                .get_super_property_instruction(dest, home_object, receiver, key);
+            self.writer.get_super_property_instruction(
+                dest,
+                home_object,
+                receiver,
+                key,
+                operand_pos,
+            );
 
             Ok(dest)
         } else {

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -4510,8 +4510,13 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                         self.register_allocator.release(key);
                     }
                     Property::Super { key, this_value } => {
-                        self.writer
-                            .set_super_property_instruction(object, this_value, key, temp);
+                        self.writer.set_super_property_instruction(
+                            object,
+                            this_value,
+                            key,
+                            temp,
+                            member_operator_pos,
+                        );
                         self.register_allocator.release(key);
                         self.register_allocator.release(this_value);
                     }
@@ -4748,6 +4753,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                         this_value,
                         key,
                         modified_temp,
+                        member_operator_pos,
                     );
                     self.register_allocator.release(key);
                     self.register_allocator.release(this_value);
@@ -5943,6 +5949,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             home_object,
             this_value,
             property,
+            operator_pos: member.operator_pos,
         }))
     }
 
@@ -6000,12 +6007,13 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
                 Ok(())
             }
-            ReferenceKind::SuperProperty { home_object, this_value, property } => {
+            ReferenceKind::SuperProperty { home_object, this_value, property, operator_pos } => {
                 self.writer.set_super_property_instruction(
                     *home_object,
                     *this_value,
                     *property,
                     value,
+                    *operator_pos,
                 );
 
                 self.register_allocator.release(*property);
@@ -9231,6 +9239,7 @@ enum ReferenceKind<'a> {
         home_object: GenRegister,
         this_value: GenRegister,
         property: GenRegister,
+        operator_pos: Pos,
     },
     ArrayPattern(&'a ast::ArrayPattern),
     ObjectPattern(&'a ast::ObjectPattern),

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1297,6 +1297,7 @@ define_instructions!(
     GetNamedProperty {
         camel_case: GetNamedPropertyInstruction,
         snake_case: get_named_property_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] object: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1348,6 +1348,7 @@ define_instructions!(
     GetNamedSuperProperty {
         camel_case: GetNamedSuperPropertyInstruction,
         snake_case: get_named_super_property_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] home_object: Register,
@@ -1397,6 +1398,7 @@ define_instructions!(
     GetPrivateProperty {
         camel_case: GetPrivatePropertyInstruction,
         snake_case: get_private_property_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] object: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1273,6 +1273,7 @@ define_instructions!(
     SetProperty {
         camel_case: SetPropertyInstruction,
         snake_case: set_property_instruction,
+        can_throw: true,
         operands: {
             [0] object: Register,
             [1] key: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1311,6 +1311,7 @@ define_instructions!(
     SetNamedProperty {
         camel_case: SetNamedPropertyInstruction,
         snake_case: set_named_property_instruction,
+        can_throw: true,
         operands: {
             [0] object: Register,
             [1] name_constant_index: ConstantIndex,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1413,6 +1413,7 @@ define_instructions!(
     SetPrivateProperty {
         camel_case: SetPrivatePropertyInstruction,
         snake_case: set_private_property_instruction,
+        can_throw: true,
         operands: {
             [0] object: Register,
             [1] key: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1364,6 +1364,7 @@ define_instructions!(
     SetSuperProperty {
         camel_case: SetSuperPropertyInstruction,
         snake_case: set_super_property_instruction,
+        can_throw: true,
         operands: {
             [0] home_object: Register,
             [1] receiver: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1285,6 +1285,7 @@ define_instructions!(
     DefineProperty {
         camel_case: DefinePropertyInstruction,
         snake_case: define_property_instruction,
+        can_throw: true,
         operands: {
             [0] object: Register,
             [1] key: Register,
@@ -1324,6 +1325,7 @@ define_instructions!(
     DefineNamedProperty {
         camel_case: DefineNamedPropertyInstruction,
         snake_case: define_named_property_instruction,
+        can_throw: true,
         operands: {
             [0] object: Register,
             [1] name_constant_index: ConstantIndex,
@@ -1426,6 +1428,7 @@ define_instructions!(
     DefinePrivateProperty {
         camel_case: DefinePrivatePropertyInstruction,
         snake_case: define_private_property_instruction,
+        can_throw: true,
         operands: {
             [0] object: Register,
             [1] key: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1380,6 +1380,7 @@ define_instructions!(
     DeleteProperty {
         camel_case: DeletePropertyInstruction,
         snake_case: delete_property_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] object: Register,
@@ -1392,6 +1393,7 @@ define_instructions!(
     DeleteBinding {
         camel_case: DeleteBindingInstruction,
         snake_case: delete_binding_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] name_constant_index: ConstantIndex,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1334,6 +1334,7 @@ define_instructions!(
     GetSuperProperty {
         camel_case: GetSuperPropertyInstruction,
         snake_case: get_super_property_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] home_object: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1261,6 +1261,7 @@ define_instructions!(
     GetProperty {
         camel_case: GetPropertyInstruction,
         snake_case: get_property_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] object: Register,

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -3646,7 +3646,7 @@ impl VM {
             Property::private_setter(self.cx(), value.as_object())
         };
 
-        object.property_property_add(self.cx(), key, property)
+        object.private_property_add(self.cx(), key, property)
     }
 
     #[inline]

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -389,7 +389,7 @@ impl Handle<ObjectValue> {
 
     /// PrivateFieldAdd (https://tc39.es/ecma262/#sec-privatefieldadd)
     /// PrivateMethodOrAccessorAdd (https://tc39.es/ecma262/#sec-privatemethodoraccessoradd)
-    pub fn property_property_add(
+    pub fn private_property_add(
         &mut self,
         cx: Context,
         private_name: Handle<SymbolValue>,

--- a/src/js/runtime/scope.rs
+++ b/src/js/runtime/scope.rs
@@ -1,7 +1,7 @@
 use crate::{field_offset, js::runtime::object_descriptor::ObjectKind, set_uninit};
 
 use super::{
-    abstract_operations::{has_own_property, has_property},
+    abstract_operations::has_property,
     boxed_value::BoxedValue,
     collections::InlineArray,
     error::{err_assign_constant, err_cannot_set_property},
@@ -350,7 +350,7 @@ impl Handle<Scope> {
                 let key = name.cast::<PropertyKey>();
 
                 // If the property is found, delete it
-                if has_own_property(cx, object_handle, key)? {
+                if has_property(cx, object_handle, key)? {
                     return object_handle.delete(cx, key);
                 }
             }

--- a/tests/js_error/source_locations/destructure/member/set_named_property.exp
+++ b/tests/js_error/source_locations/destructure/member/set_named_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at set foo (tests/js_error/source_locations/destructure/member/set_named_property.js:3:11)
+  at <global> (tests/js_error/source_locations/destructure/member/set_named_property.js:7:10)

--- a/tests/js_error/source_locations/destructure/member/set_named_property.js
+++ b/tests/js_error/source_locations/destructure/member/set_named_property.js
@@ -4,4 +4,4 @@ var obj = {
   }
 };
 
-({ x: obj['fo' + 'o'] } = { x: 1 });
+({ x: obj.foo } = { x: 1 });

--- a/tests/js_error/source_locations/destructure/member/set_private_property.exp
+++ b/tests/js_error/source_locations/destructure/member/set_private_property.exp
@@ -1,0 +1,4 @@
+Error: 
+  at set #foo (tests/js_error/source_locations/destructure/member/set_private_property.js:3:11)
+  at test (tests/js_error/source_locations/destructure/member/set_private_property.js:7:15)
+  at <global> (tests/js_error/source_locations/destructure/member/set_private_property.js:12:1)

--- a/tests/js_error/source_locations/destructure/member/set_private_property.js
+++ b/tests/js_error/source_locations/destructure/member/set_private_property.js
@@ -1,0 +1,12 @@
+class C {
+  set #foo(_) {
+    throw new Error()
+  }
+
+  test() {
+    ({ x: this.#foo } = { x: 1 });
+  }
+}
+
+var c = new C();
+c.test();

--- a/tests/js_error/source_locations/destructure/member/set_property.exp
+++ b/tests/js_error/source_locations/destructure/member/set_property.exp
@@ -1,3 +1,3 @@
 Error: 
   at set foo (tests/js_error/source_locations/destructure/member/set_property.js:3:11)
-  at <global> (tests/js_error/source_locations/destructure/member/set_property.js:7:4)
+  at <global> (tests/js_error/source_locations/destructure/member/set_property.js:7:10)

--- a/tests/js_error/source_locations/destructure/member/set_property.exp
+++ b/tests/js_error/source_locations/destructure/member/set_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at set foo (tests/js_error/source_locations/destructure/member/set_property.js:3:11)
+  at <global> (tests/js_error/source_locations/destructure/member/set_property.js:7:4)

--- a/tests/js_error/source_locations/destructure/member/set_property.js
+++ b/tests/js_error/source_locations/destructure/member/set_property.js
@@ -1,0 +1,7 @@
+var obj = {
+  set foo(_) {
+    throw new Error();
+  }
+};
+
+({ x: obj.foo } = { x: 1 });

--- a/tests/js_error/source_locations/destructure/member/set_super_property.exp
+++ b/tests/js_error/source_locations/destructure/member/set_super_property.exp
@@ -1,0 +1,4 @@
+Error: 
+  at set foo (tests/js_error/source_locations/destructure/member/set_super_property.js:3:11)
+  at test (tests/js_error/source_locations/destructure/member/set_super_property.js:9:16)
+  at <global> (tests/js_error/source_locations/destructure/member/set_super_property.js:14:1)

--- a/tests/js_error/source_locations/destructure/member/set_super_property.js
+++ b/tests/js_error/source_locations/destructure/member/set_super_property.js
@@ -1,0 +1,14 @@
+class B {
+  set foo(_) {
+    throw new Error()
+  }
+}
+
+class C extends B {
+  test() {
+    ({ x: super.foo } = { x: 1 });
+  }
+}
+
+var c = new C();
+c.test();

--- a/tests/js_error/source_locations/destructure/object/get_named_property.exp
+++ b/tests/js_error/source_locations/destructure/object/get_named_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at get foo (tests/js_error/source_locations/destructure/object/get_named_property.js:3:11)
+  at <global> (tests/js_error/source_locations/destructure/object/get_named_property.js:7:7)

--- a/tests/js_error/source_locations/destructure/object/get_named_property.js
+++ b/tests/js_error/source_locations/destructure/object/get_named_property.js
@@ -1,0 +1,7 @@
+var obj = {
+  get foo() {
+    throw new Error();
+  }
+};
+
+var { foo: x } = obj;

--- a/tests/js_error/source_locations/destructure/object/get_property.exp
+++ b/tests/js_error/source_locations/destructure/object/get_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at get foo (tests/js_error/source_locations/destructure/object/get_property.js:3:11)
+  at <global> (tests/js_error/source_locations/destructure/object/get_property.js:7:7)

--- a/tests/js_error/source_locations/destructure/object/get_property.js
+++ b/tests/js_error/source_locations/destructure/object/get_property.js
@@ -1,0 +1,7 @@
+var obj = {
+  get foo() {
+    throw new Error();
+  }
+};
+
+var { ['fo' + 'o']: x } = obj;

--- a/tests/js_error/source_locations/expression/assign/set_named_property.exp
+++ b/tests/js_error/source_locations/expression/assign/set_named_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at set foo (tests/js_error/source_locations/expression/assign/set_named_property.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/assign/set_named_property.js:7:4)

--- a/tests/js_error/source_locations/expression/assign/set_named_property.js
+++ b/tests/js_error/source_locations/expression/assign/set_named_property.js
@@ -4,4 +4,4 @@ var obj = {
   }
 };
 
-({ x: obj['fo' + 'o'] } = { x: 1 });
+obj.foo = 1;

--- a/tests/js_error/source_locations/expression/assign/set_private_property.exp
+++ b/tests/js_error/source_locations/expression/assign/set_private_property.exp
@@ -1,0 +1,4 @@
+Error: 
+  at set #foo (tests/js_error/source_locations/expression/assign/set_private_property.js:3:11)
+  at test (tests/js_error/source_locations/expression/assign/set_private_property.js:7:9)
+  at <global> (tests/js_error/source_locations/expression/assign/set_private_property.js:12:1)

--- a/tests/js_error/source_locations/expression/assign/set_private_property.js
+++ b/tests/js_error/source_locations/expression/assign/set_private_property.js
@@ -1,0 +1,12 @@
+class C {
+  set #foo(_) {
+    throw new Error()
+  }
+
+  test() {
+    this.#foo = 2;
+  }
+}
+
+var c = new C();
+c.test();

--- a/tests/js_error/source_locations/expression/assign/set_property.exp
+++ b/tests/js_error/source_locations/expression/assign/set_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at set foo (tests/js_error/source_locations/expression/assign/set_property.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/assign/set_property.js:7:4)

--- a/tests/js_error/source_locations/expression/assign/set_property.js
+++ b/tests/js_error/source_locations/expression/assign/set_property.js
@@ -1,0 +1,7 @@
+var obj = {
+  set foo(_) {
+    throw new Error();
+  }
+};
+
+obj['fo' + 'o'] = 1;

--- a/tests/js_error/source_locations/expression/assign/set_super_property.exp
+++ b/tests/js_error/source_locations/expression/assign/set_super_property.exp
@@ -1,0 +1,4 @@
+Error: 
+  at set foo (tests/js_error/source_locations/expression/assign/set_super_property.js:3:11)
+  at test (tests/js_error/source_locations/expression/assign/set_super_property.js:9:10)
+  at <global> (tests/js_error/source_locations/expression/assign/set_super_property.js:14:1)

--- a/tests/js_error/source_locations/expression/assign/set_super_property.js
+++ b/tests/js_error/source_locations/expression/assign/set_super_property.js
@@ -1,0 +1,14 @@
+class B {
+  set foo(_) {
+    throw new Error()
+  }
+}
+
+class C extends B {
+  test() {
+    super.foo = 2;
+  }
+}
+
+var c = new C();
+c.test();

--- a/tests/js_error/source_locations/expression/assign_op/get_named_property.exp
+++ b/tests/js_error/source_locations/expression/assign_op/get_named_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at get foo (tests/js_error/source_locations/expression/assign_op/get_named_property.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/assign_op/get_named_property.js:7:4)

--- a/tests/js_error/source_locations/expression/assign_op/get_named_property.js
+++ b/tests/js_error/source_locations/expression/assign_op/get_named_property.js
@@ -1,0 +1,7 @@
+var obj = {
+  get foo() {
+    throw new Error();
+  }
+};
+
+obj.foo += 1;

--- a/tests/js_error/source_locations/expression/assign_op/get_private_property.exp
+++ b/tests/js_error/source_locations/expression/assign_op/get_private_property.exp
@@ -1,0 +1,4 @@
+Error: 
+  at get #foo (tests/js_error/source_locations/expression/assign_op/get_private_property.js:3:11)
+  at test (tests/js_error/source_locations/expression/assign_op/get_private_property.js:7:9)
+  at <global> (tests/js_error/source_locations/expression/assign_op/get_private_property.js:12:1)

--- a/tests/js_error/source_locations/expression/assign_op/get_private_property.js
+++ b/tests/js_error/source_locations/expression/assign_op/get_private_property.js
@@ -1,0 +1,12 @@
+class C {
+  get #foo() {
+    throw new Error();
+  }
+
+  test() {
+    this.#foo += 1;
+  }
+}
+
+var c = new C();
+c.test();

--- a/tests/js_error/source_locations/expression/assign_op/get_property.exp
+++ b/tests/js_error/source_locations/expression/assign_op/get_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at get foo (tests/js_error/source_locations/expression/assign_op/get_property.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/assign_op/get_property.js:7:4)

--- a/tests/js_error/source_locations/expression/assign_op/get_property.js
+++ b/tests/js_error/source_locations/expression/assign_op/get_property.js
@@ -1,0 +1,7 @@
+var obj = {
+  get foo() {
+    throw new Error();
+  }
+};
+
+obj['fo' + 'o'] += 1;

--- a/tests/js_error/source_locations/expression/assign_op/get_super_property.exp
+++ b/tests/js_error/source_locations/expression/assign_op/get_super_property.exp
@@ -1,0 +1,4 @@
+Error: 
+  at get foo (tests/js_error/source_locations/expression/assign_op/get_super_property.js:3:11)
+  at test (tests/js_error/source_locations/expression/assign_op/get_super_property.js:9:10)
+  at <global> (tests/js_error/source_locations/expression/assign_op/get_super_property.js:14:1)

--- a/tests/js_error/source_locations/expression/assign_op/get_super_property.js
+++ b/tests/js_error/source_locations/expression/assign_op/get_super_property.js
@@ -1,0 +1,14 @@
+class B {
+  get foo() {
+    throw new Error();
+  }
+}
+
+class C extends B {
+  test() {
+    super['fo' + 'o'] += 1;
+  }
+}
+
+var c = new C();
+c.test();

--- a/tests/js_error/source_locations/expression/delete/delete_binding.exp
+++ b/tests/js_error/source_locations/expression/delete/delete_binding.exp
@@ -1,0 +1,3 @@
+Error: 
+  at has (tests/js_error/source_locations/expression/delete/delete_binding.js:5:13)
+  at <global> (tests/js_error/source_locations/expression/delete/delete_binding.js:11:3)

--- a/tests/js_error/source_locations/expression/delete/delete_binding.js
+++ b/tests/js_error/source_locations/expression/delete/delete_binding.js
@@ -1,0 +1,12 @@
+var obj = new Proxy(
+  { foo: 1 },
+  {
+    has() {
+      throw new Error()
+    }
+  }
+);
+
+with (obj) {
+  delete foo;
+}

--- a/tests/js_error/source_locations/expression/delete/member_delete_property.exp
+++ b/tests/js_error/source_locations/expression/delete/member_delete_property.exp
@@ -1,0 +1,2 @@
+TypeError: cannot delete property
+  at <global> (tests/js_error/source_locations/expression/delete/member_delete_property.js:6:1)

--- a/tests/js_error/source_locations/expression/delete/member_delete_property.js
+++ b/tests/js_error/source_locations/expression/delete/member_delete_property.js
@@ -1,0 +1,6 @@
+"use strict";
+
+var obj = {};
+Object.defineProperty(obj, 'foo', { value: 1, configurable: false });
+
+delete obj.foo;

--- a/tests/js_error/source_locations/expression/member/get_named_property.exp
+++ b/tests/js_error/source_locations/expression/member/get_named_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at get foo (tests/js_error/source_locations/expression/member/get_named_property.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/member/get_named_property.js:7:4)

--- a/tests/js_error/source_locations/expression/member/get_named_property.js
+++ b/tests/js_error/source_locations/expression/member/get_named_property.js
@@ -1,0 +1,7 @@
+var obj = {
+  get foo() {
+    throw new Error();
+  }
+};
+
+obj.foo;

--- a/tests/js_error/source_locations/expression/member/get_named_property_optional.exp
+++ b/tests/js_error/source_locations/expression/member/get_named_property_optional.exp
@@ -1,0 +1,3 @@
+Error: 
+  at get foo (tests/js_error/source_locations/expression/member/get_named_property_optional.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/member/get_named_property_optional.js:7:5)

--- a/tests/js_error/source_locations/expression/member/get_named_property_optional.js
+++ b/tests/js_error/source_locations/expression/member/get_named_property_optional.js
@@ -1,0 +1,7 @@
+var obj = {
+  get foo() {
+    throw new Error();
+  }
+};
+
+obj?.foo;

--- a/tests/js_error/source_locations/expression/member/get_private_property.exp
+++ b/tests/js_error/source_locations/expression/member/get_private_property.exp
@@ -1,0 +1,4 @@
+Error: 
+  at get #foo (tests/js_error/source_locations/expression/member/get_private_property.js:3:11)
+  at test (tests/js_error/source_locations/expression/member/get_private_property.js:7:9)
+  at <global> (tests/js_error/source_locations/expression/member/get_private_property.js:12:1)

--- a/tests/js_error/source_locations/expression/member/get_private_property.js
+++ b/tests/js_error/source_locations/expression/member/get_private_property.js
@@ -1,0 +1,12 @@
+class C {
+  get #foo() {
+    throw new Error();
+  }
+
+  test() {
+    this.#foo
+  }
+}
+
+var c = new C();
+c.test();

--- a/tests/js_error/source_locations/expression/member/get_property.exp
+++ b/tests/js_error/source_locations/expression/member/get_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at get foo (tests/js_error/source_locations/expression/member/get_property.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/member/get_property.js:7:4)

--- a/tests/js_error/source_locations/expression/member/get_property.js
+++ b/tests/js_error/source_locations/expression/member/get_property.js
@@ -1,0 +1,7 @@
+var obj = {
+  get foo() {
+    throw new Error();
+  }
+};
+
+obj['fo' + 'o'];

--- a/tests/js_error/source_locations/expression/member/get_property_optional.exp
+++ b/tests/js_error/source_locations/expression/member/get_property_optional.exp
@@ -1,0 +1,3 @@
+Error: 
+  at get foo (tests/js_error/source_locations/expression/member/get_property_optional.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/member/get_property_optional.js:7:6)

--- a/tests/js_error/source_locations/expression/member/get_property_optional.js
+++ b/tests/js_error/source_locations/expression/member/get_property_optional.js
@@ -1,0 +1,7 @@
+var obj = {
+  get foo() {
+    throw new Error();
+  }
+};
+
+obj?.['fo' + 'o'];

--- a/tests/js_error/source_locations/expression/super_member/get_named_super_property.exp
+++ b/tests/js_error/source_locations/expression/super_member/get_named_super_property.exp
@@ -1,0 +1,4 @@
+Error: 
+  at get foo (tests/js_error/source_locations/expression/super_member/get_named_super_property.js:3:11)
+  at test (tests/js_error/source_locations/expression/super_member/get_named_super_property.js:9:10)
+  at <global> (tests/js_error/source_locations/expression/super_member/get_named_super_property.js:14:1)

--- a/tests/js_error/source_locations/expression/super_member/get_named_super_property.js
+++ b/tests/js_error/source_locations/expression/super_member/get_named_super_property.js
@@ -1,0 +1,14 @@
+class B {
+  get foo() {
+    throw new Error();
+  }
+}
+
+class C extends B {
+  test() {
+    super.foo
+  }
+}
+
+var c = new C();
+c.test();

--- a/tests/js_error/source_locations/expression/super_member/get_super_property.exp
+++ b/tests/js_error/source_locations/expression/super_member/get_super_property.exp
@@ -1,0 +1,4 @@
+Error: 
+  at get foo (tests/js_error/source_locations/expression/super_member/get_super_property.js:3:11)
+  at test (tests/js_error/source_locations/expression/super_member/get_super_property.js:9:10)
+  at <global> (tests/js_error/source_locations/expression/super_member/get_super_property.js:14:1)

--- a/tests/js_error/source_locations/expression/super_member/get_super_property.js
+++ b/tests/js_error/source_locations/expression/super_member/get_super_property.js
@@ -1,0 +1,14 @@
+class B {
+  get foo() {
+    throw new Error();
+  }
+}
+
+class C extends B {
+  test() {
+    super['fo' + 'o']
+  }
+}
+
+var c = new C();
+c.test();

--- a/tests/js_error/source_locations/expression/update/get_named_property.exp
+++ b/tests/js_error/source_locations/expression/update/get_named_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at get foo (tests/js_error/source_locations/expression/update/get_named_property.js:3:11)
+  at <global> (tests/js_error/source_locations/expression/update/get_named_property.js:7:4)

--- a/tests/js_error/source_locations/expression/update/get_named_property.js
+++ b/tests/js_error/source_locations/expression/update/get_named_property.js
@@ -1,0 +1,7 @@
+var obj = {
+  get foo() {
+    throw new Error();
+  }
+};
+
+obj.foo++;

--- a/tests/js_error/source_locations/expression/update/get_private_property.exp
+++ b/tests/js_error/source_locations/expression/update/get_private_property.exp
@@ -1,0 +1,4 @@
+Error: 
+  at get #foo (tests/js_error/source_locations/expression/update/get_private_property.js:3:11)
+  at test (tests/js_error/source_locations/expression/update/get_private_property.js:7:9)
+  at <global> (tests/js_error/source_locations/expression/update/get_private_property.js:12:1)

--- a/tests/js_error/source_locations/expression/update/get_private_property.js
+++ b/tests/js_error/source_locations/expression/update/get_private_property.js
@@ -1,0 +1,12 @@
+class C {
+  get #foo() {
+    throw new Error()
+  }
+
+  test() {
+    this.#foo++;
+  }
+}
+
+var c = new C();
+c.test();

--- a/tests/js_error/source_locations/expression/update/get_property.exp
+++ b/tests/js_error/source_locations/expression/update/get_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at get foo (tests/js_error/source_locations/expression/update/get_property.js:4:11)
+  at <global> (tests/js_error/source_locations/expression/update/get_property.js:8:4)

--- a/tests/js_error/source_locations/expression/update/get_property.js
+++ b/tests/js_error/source_locations/expression/update/get_property.js
@@ -1,0 +1,8 @@
+
+var obj = {
+  get foo() {
+    throw new Error();
+  }
+};
+
+obj['fo' + 'o']++;

--- a/tests/js_error/source_locations/expression/update/set_named_property.exp
+++ b/tests/js_error/source_locations/expression/update/set_named_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at set foo (tests/js_error/source_locations/expression/update/set_named_property.js:6:11)
+  at <global> (tests/js_error/source_locations/expression/update/set_named_property.js:10:4)

--- a/tests/js_error/source_locations/expression/update/set_named_property.js
+++ b/tests/js_error/source_locations/expression/update/set_named_property.js
@@ -1,7 +1,10 @@
 var obj = {
+  get foo() {
+    return 1
+  },
   set foo(_) {
     throw new Error();
   }
 };
 
-({ x: obj['fo' + 'o'] } = { x: 1 });
+obj.foo = 1;

--- a/tests/js_error/source_locations/expression/update/set_private_property.exp
+++ b/tests/js_error/source_locations/expression/update/set_private_property.exp
@@ -1,0 +1,4 @@
+Error: 
+  at set #foo (tests/js_error/source_locations/expression/update/set_private_property.js:7:11)
+  at test (tests/js_error/source_locations/expression/update/set_private_property.js:11:9)
+  at <global> (tests/js_error/source_locations/expression/update/set_private_property.js:16:1)

--- a/tests/js_error/source_locations/expression/update/set_private_property.js
+++ b/tests/js_error/source_locations/expression/update/set_private_property.js
@@ -1,0 +1,16 @@
+class C {
+  get #foo() {
+    return 1;
+  }
+
+  set #foo(_) {
+    throw new Error()
+  }
+
+  test() {
+    this.#foo++;
+  }
+}
+
+var c = new C();
+c.test();

--- a/tests/js_error/source_locations/expression/update/set_property.exp
+++ b/tests/js_error/source_locations/expression/update/set_property.exp
@@ -1,0 +1,3 @@
+Error: 
+  at set foo (tests/js_error/source_locations/expression/update/set_property.js:6:11)
+  at <global> (tests/js_error/source_locations/expression/update/set_property.js:10:4)

--- a/tests/js_error/source_locations/expression/update/set_property.js
+++ b/tests/js_error/source_locations/expression/update/set_property.js
@@ -1,0 +1,10 @@
+var obj = {
+  get foo() {
+    return 1
+  },
+  set foo(_) {
+    throw new Error();
+  }
+};
+
+obj['fo' + 'o'] = 1;

--- a/tests/js_error/source_locations/expression/update/set_super_property.exp
+++ b/tests/js_error/source_locations/expression/update/set_super_property.exp
@@ -1,0 +1,4 @@
+Error: 
+  at set foo (tests/js_error/source_locations/expression/update/set_super_property.js:7:11)
+  at test (tests/js_error/source_locations/expression/update/set_super_property.js:13:10)
+  at <global> (tests/js_error/source_locations/expression/update/set_super_property.js:18:1)

--- a/tests/js_error/source_locations/expression/update/set_super_property.js
+++ b/tests/js_error/source_locations/expression/update/set_super_property.js
@@ -1,0 +1,18 @@
+class B {
+  get foo() {
+    return 1;
+  }
+
+  set foo(_) {
+    throw new Error()
+  }
+}
+
+class C extends B {
+  test() {
+    super.foo++;
+  }
+}
+
+var c = new C();
+c.test();

--- a/tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.exp
@@ -1,0 +1,4 @@
+Error: 
+  at get value (tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.js:8:19)
+  at generator (tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.js:17:3)
+  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.js
+++ b/tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.js
@@ -1,0 +1,21 @@
+var iterable = {
+  [Symbol.asyncIterator]() {
+    return {
+      next() {
+        return {
+          done: false,
+          get value() {
+            throw new Error();
+          },
+        };
+      }
+    }
+  }
+};
+
+async function *generator() {
+  yield* iterable;
+}
+
+var iter = generator();
+await iter.next();

--- a/tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_done_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_done_throws.exp
@@ -1,0 +1,5 @@
+Error: 
+  at get done (tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_done_throws.js:8:19)
+  at generator (tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_done_throws.js:20:3)
+  at next (<native>)
+  at <global> (tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_done_throws.js:24:1)

--- a/tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_done_throws.js
+++ b/tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_done_throws.js
@@ -1,0 +1,24 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return {
+          value: 1,
+          get done() {
+            throw new Error();
+          }
+        };
+      },
+      get return() {
+        throw new Error();
+      }
+    }
+  }
+};
+
+function *generator() {
+  yield* iterable;
+}
+
+var iter = generator();
+iter.next();

--- a/tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_value_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_value_throws.exp
@@ -1,0 +1,5 @@
+Error: 
+  at get value (tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_value_throws.js:8:19)
+  at generator (tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_value_throws.js:20:3)
+  at next (<native>)
+  at <global> (tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_value_throws.js:24:1)

--- a/tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_value_throws.js
+++ b/tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_value_throws.js
@@ -1,0 +1,24 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return {
+          done: true,
+          get value() {
+            throw new Error();
+          },
+        };
+      },
+      get return() {
+        throw new Error();
+      }
+    }
+  }
+};
+
+function *generator() {
+  yield* iterable;
+}
+
+var iter = generator();
+iter.next();

--- a/tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_done_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_done_throws.exp
@@ -1,0 +1,5 @@
+Error: 
+  at get done (tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_done_throws.js:10:19)
+  at generator (tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_done_throws.js:20:3)
+  at return (<native>)
+  at <global> (tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_done_throws.js:25:1)

--- a/tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_done_throws.js
+++ b/tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_done_throws.js
@@ -1,0 +1,25 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      return() {
+        return {
+          get done() {
+            throw new Error();
+          },
+          value: 1,
+        }
+      }
+    };
+  }
+}
+
+function *generator() {
+  yield* iterable;
+}
+
+let iter = generator();
+iter.next();
+iter.return();

--- a/tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_value_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_value_throws.exp
@@ -1,0 +1,5 @@
+Error: 
+  at get value (tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_value_throws.js:10:19)
+  at generator (tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_value_throws.js:20:3)
+  at return (<native>)
+  at <global> (tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_value_throws.js:25:1)

--- a/tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_value_throws.js
+++ b/tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_value_throws.js
@@ -1,0 +1,25 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      return() {
+        return {
+          get value() {
+            throw new Error();
+          },
+          done: true,
+        }
+      }
+    };
+  }
+}
+
+function *generator() {
+  yield* iterable;
+}
+
+let iter = generator();
+iter.next();
+iter.return();

--- a/tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_done_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_done_throws.exp
@@ -1,0 +1,5 @@
+Error: 
+  at get done (tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_done_throws.js:10:19)
+  at generator (tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_done_throws.js:20:3)
+  at throw (<native>)
+  at <global> (tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_done_throws.js:25:1)

--- a/tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_done_throws.js
+++ b/tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_done_throws.js
@@ -1,0 +1,25 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      throw() {
+        return {
+          get done() {
+            throw new Error();
+          },
+          value: 1,
+        }
+      }
+    };
+  }
+}
+
+function *generator() {
+  yield* iterable;
+}
+
+let iter = generator();
+iter.next();
+iter.throw();

--- a/tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_value_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_value_throws.exp
@@ -1,0 +1,5 @@
+Error: 
+  at get value (tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_value_throws.js:10:19)
+  at generator (tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_value_throws.js:20:3)
+  at throw (<native>)
+  at <global> (tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_value_throws.js:25:1)

--- a/tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_value_throws.js
+++ b/tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_value_throws.js
@@ -1,0 +1,25 @@
+var iterable = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return { value: 1, done: false };
+      },
+      throw() {
+        return {
+          get value() {
+            throw new Error();
+          },
+          done: true,
+        }
+      }
+    };
+  }
+}
+
+function *generator() {
+  yield* iterable;
+}
+
+let iter = generator();
+iter.next();
+iter.throw();


### PR DESCRIPTION
## Summary

Write entries to the BytecodeSourceMap for all property related instructions. We now write source map entries for:

- GetProperty
- GetNamedProperty
- GetSuperProperty
- GetNamedSuperProperty
- GetPrivateProperty
- SetProperty
- SetNamedProperty
- SetSuperProperty
- SetPrivateProperty
- DefineProperty
- DefineNamedProperty
- DefinePrivateProperty
- DeleteProperty
- DeleteBinding

## Tests

Added error snapshot tests for all implemented instructions, verifying that reported source position is correct.