### PR TITLE
[bytecode] Source positions for remaining instructions

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -1611,9 +1611,11 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
     /// Generate the bytecode for a function.
     fn generate(mut self, func: &ast::Function) -> EmitResult<EmitFunctionResult> {
+        let func_pos = func.loc.start;
+
         // Base constructors initialize class fields immediately
         if !self.is_derived_constructor() {
-            self.gen_initialize_class_fields(Register::this(), func.loc.start)?;
+            self.gen_initialize_class_fields(Register::this(), func_pos)?;
         }
 
         // Async functions reserve a register for the promise object
@@ -1796,7 +1798,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 // If function is a generator then run GeneratorStart once body is ready to be
                 // evaluated.
                 if let Some(generator_reg) = generator_reg {
-                    self.writer.generator_start_instruction(generator_reg);
+                    self.writer
+                        .generator_start_instruction(generator_reg, func_pos);
                 }
 
                 // Continue to the function body
@@ -5826,9 +5829,11 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         dest: ExprDest,
     ) -> EmitResult<GenRegister> {
         let dest = self.allocate_destination(dest)?;
+        let import_pos = expr.loc.start;
 
         let specifier = self.gen_expression(&expr.source)?;
-        self.writer.dynamic_import_instruction(dest, specifier);
+        self.writer
+            .dynamic_import_instruction(dest, specifier, import_pos);
 
         self.register_allocator.release(specifier);
 

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1646,6 +1646,7 @@ define_instructions!(
     CheckThisInitialized {
         camel_case: CheckThisInitializedInstruction,
         snake_case: check_this_initialized_instruction,
+        can_throw: true,
         operands: {
             [0] value: Register,
         }

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1816,6 +1816,7 @@ define_instructions!(
     GeneratorStart {
         camel_case: GeneratorStartInstruction,
         snake_case: generator_start_instruction,
+        can_throw: true,
         operands: {
             [0] generator: Register,
         }
@@ -1902,6 +1903,7 @@ define_instructions!(
     DynamicImport {
         camel_case: DynamicImportInstruction,
         snake_case: dynamic_import_instruction,
+        can_throw: true,
         operands: {
             [0] dest: Register,
             [1] specifier: Register,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1862,6 +1862,7 @@ define_instructions!(
     Await {
         camel_case: AwaitInstruction,
         snake_case: await_instruction,
+        can_throw: true,
         operands: {
             [0] completion_value_dest: Register,
             [1] completion_type_dest: Register,

--- a/tests/js_error/source_locations/destructure/member/super_check_this_initialized.exp
+++ b/tests/js_error/source_locations/destructure/member/super_check_this_initialized.exp
@@ -1,0 +1,3 @@
+ReferenceError: this is not initialized
+  at C (tests/js_error/source_locations/destructure/member/super_check_this_initialized.js:7:11)
+  at <global> (tests/js_error/source_locations/destructure/member/super_check_this_initialized.js:11:9)

--- a/tests/js_error/source_locations/destructure/member/super_check_this_initialized.js
+++ b/tests/js_error/source_locations/destructure/member/super_check_this_initialized.js
@@ -1,0 +1,11 @@
+class B {
+  foo = 1;
+}
+
+class C extends B {
+  constructor() {
+    ({ x: super.foo } = { x: 1 });
+  }
+}
+
+var c = new C();

--- a/tests/js_error/source_locations/expression/assign/super_check_this_initialized.exp
+++ b/tests/js_error/source_locations/expression/assign/super_check_this_initialized.exp
@@ -1,0 +1,3 @@
+ReferenceError: this is not initialized
+  at C (tests/js_error/source_locations/expression/assign/super_check_this_initialized.js:7:5)
+  at <global> (tests/js_error/source_locations/expression/assign/super_check_this_initialized.js:11:1)

--- a/tests/js_error/source_locations/expression/assign/super_check_this_initialized.js
+++ b/tests/js_error/source_locations/expression/assign/super_check_this_initialized.js
@@ -1,0 +1,11 @@
+class B {
+  foo = 1;
+}
+
+class C extends B {
+  constructor() {
+    super.foo = 2;
+  }
+}
+
+new C();

--- a/tests/js_error/source_locations/expression/await/await_throws_module.exp
+++ b/tests/js_error/source_locations/expression/await/await_throws_module.exp
@@ -1,0 +1,5 @@
+Error: Error on get
+  at get (tests/js_error/source_locations/expression/await/await_throws_module.js:2:63)
+  at <module> (tests/js_error/source_locations/expression/await/await_throws_module.js:4:1)
+  at <anonymous> (<native>)
+  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/expression/await/await_throws_module.js
+++ b/tests/js_error/source_locations/expression/await/await_throws_module.js
@@ -1,0 +1,4 @@
+let promise = new Promise(() => {});
+Object.defineProperty(promise, 'constructor', { get() { throw new Error('Error on get'); } });
+
+await promise;

--- a/tests/js_error/source_locations/expression/super_member/check_this_initialized.exp
+++ b/tests/js_error/source_locations/expression/super_member/check_this_initialized.exp
@@ -1,0 +1,3 @@
+ReferenceError: this is not initialized
+  at C (tests/js_error/source_locations/expression/super_member/check_this_initialized.js:7:5)
+  at <global> (tests/js_error/source_locations/expression/super_member/check_this_initialized.js:11:1)

--- a/tests/js_error/source_locations/expression/super_member/check_this_initialized.js
+++ b/tests/js_error/source_locations/expression/super_member/check_this_initialized.js
@@ -1,0 +1,11 @@
+class B {
+  foo = 1;
+}
+
+class C extends B {
+  constructor() {
+    super.foo;
+  }
+}
+
+new C();

--- a/tests/js_error/source_locations/expression/this/check_this_initialized.exp
+++ b/tests/js_error/source_locations/expression/this/check_this_initialized.exp
@@ -1,0 +1,3 @@
+ReferenceError: this is not initialized
+  at C (tests/js_error/source_locations/expression/this/check_this_initialized.js:5:5)
+  at <global> (tests/js_error/source_locations/expression/this/check_this_initialized.js:9:1)

--- a/tests/js_error/source_locations/expression/this/check_this_initialized.js
+++ b/tests/js_error/source_locations/expression/this/check_this_initialized.js
@@ -1,0 +1,9 @@
+class B {}
+
+class C extends B {
+  constructor() {
+    this;
+  }
+}
+
+new C();

--- a/tests/js_error/source_locations/expression/update/super_check_this_initialized.exp
+++ b/tests/js_error/source_locations/expression/update/super_check_this_initialized.exp
@@ -1,0 +1,3 @@
+ReferenceError: this is not initialized
+  at C (tests/js_error/source_locations/expression/update/super_check_this_initialized.js:7:5)
+  at <global> (tests/js_error/source_locations/expression/update/super_check_this_initialized.js:11:1)

--- a/tests/js_error/source_locations/expression/update/super_check_this_initialized.js
+++ b/tests/js_error/source_locations/expression/update/super_check_this_initialized.js
@@ -1,0 +1,11 @@
+class B {
+  foo = 1;
+}
+
+class C extends B {
+  constructor() {
+    super.foo++;
+  }
+}
+
+new C();

--- a/tests/js_error/source_locations/expression/yield/await_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield/await_throws_module.exp
@@ -1,0 +1,7 @@
+Error: 
+  at get (tests/js_error/source_locations/expression/yield/await_throws_module.js:2:63)
+  at generator (tests/js_error/source_locations/expression/yield/await_throws_module.js:5:3)
+  at next (<native>)
+  at <module> (tests/js_error/source_locations/expression/yield/await_throws_module.js:9:7)
+  at <anonymous> (<native>)
+  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/expression/yield/await_throws_module.js
+++ b/tests/js_error/source_locations/expression/yield/await_throws_module.js
@@ -1,0 +1,9 @@
+let promise = new Promise(() => {});
+Object.defineProperty(promise, 'constructor', { get() { throw new Error(); } });
+
+async function *generator() {
+  yield promise;
+}
+
+let gen = generator();
+await gen.next();

--- a/tests/js_error/source_locations/expression/yield_star/await_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/await_throws_module.exp
@@ -1,0 +1,7 @@
+Error: 
+  at get (tests/js_error/source_locations/expression/yield_star/await_throws_module.js:2:63)
+  at generator (tests/js_error/source_locations/expression/yield_star/await_throws_module.js:15:3)
+  at next (<native>)
+  at <module> (tests/js_error/source_locations/expression/yield_star/await_throws_module.js:19:7)
+  at <anonymous> (<native>)
+  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/await_throws_module.js
+++ b/tests/js_error/source_locations/expression/yield_star/await_throws_module.js
@@ -1,0 +1,19 @@
+let promise = new Promise(() => {});
+Object.defineProperty(promise, 'constructor', { get() { throw new Error(); } });
+
+let iter = {
+  [Symbol.asyncIterator]() {
+    return {
+      next() {
+        return promise
+      }
+    };
+  }
+}
+
+async function *generator() {
+  yield* iter;
+}
+
+let gen = generator();
+await gen.next();

--- a/tests/js_error/source_locations/statement/for_await/await_throws_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/await_throws_module.exp
@@ -1,0 +1,6 @@
+Error: 
+  at get (tests/js_error/source_locations/statement/for_await/await_throws_module.js:2:63)
+  at foo (tests/js_error/source_locations/statement/for_await/await_throws_module.js:15:20)
+  at <module> (tests/js_error/source_locations/statement/for_await/await_throws_module.js:18:7)
+  at <anonymous> (<native>)
+  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/statement/for_await/await_throws_module.js
+++ b/tests/js_error/source_locations/statement/for_await/await_throws_module.js
@@ -1,0 +1,18 @@
+let promise = new Promise(() => {});
+Object.defineProperty(promise, 'constructor', { get() { throw new Error(); } });
+
+var iterable = {
+  [Symbol.asyncIterator]() {
+    return {
+      next() {
+        return promise;
+      }
+    }
+  }
+};
+
+async function foo() {
+  for await (var x of iterable) {}
+}
+
+await foo();

--- a/tests/js_error/source_locations/statement/return/await_throws_module.exp
+++ b/tests/js_error/source_locations/statement/return/await_throws_module.exp
@@ -1,0 +1,7 @@
+Error: 
+  at get (tests/js_error/source_locations/statement/return/await_throws_module.js:2:63)
+  at generator (tests/js_error/source_locations/statement/return/await_throws_module.js:5:3)
+  at next (<native>)
+  at <module> (tests/js_error/source_locations/statement/return/await_throws_module.js:9:7)
+  at <anonymous> (<native>)
+  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/statement/return/await_throws_module.js
+++ b/tests/js_error/source_locations/statement/return/await_throws_module.js
@@ -1,0 +1,9 @@
+let promise = new Promise(() => {});
+Object.defineProperty(promise, 'constructor', { get() { throw new Error(); } });
+
+async function *generator() {
+  return promise;
+}
+
+let gen = generator();
+await gen.next();

--- a/tests/js_error/source_locations/statement/return/check_this_initialized.exp
+++ b/tests/js_error/source_locations/statement/return/check_this_initialized.exp
@@ -1,0 +1,3 @@
+ReferenceError: this is not initialized
+  at C (tests/js_error/source_locations/statement/return/check_this_initialized.js:8:3)
+  at <global> (tests/js_error/source_locations/statement/return/check_this_initialized.js:11:1)

--- a/tests/js_error/source_locations/statement/return/check_this_initialized.js
+++ b/tests/js_error/source_locations/statement/return/check_this_initialized.js
@@ -1,0 +1,11 @@
+class B {
+  foo = 1;
+}
+
+class C extends B {
+  constructor() {
+    return;
+  }
+}
+
+new C();


### PR DESCRIPTION
## Summary

Write entries to the BytecodeSourceMap for all remaining instructions. We now write source map entries for:

- GeneratorStart
- DynamicImport
- Await
- CheckThisInitialized

With this PR all instructions that can throw have source map entries generated.

## Tests

Added error snapshot tests for all implemented instructions, verifying that reported source position is correct.