### PR TITLE
[runtime] Implement Promise.try proposal

### DIFF
--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -426,6 +426,7 @@ builtin_names!(
     (trim_end, "trimEnd"),
     (trim_start, "trimStart"),
     (trunc, "trunc"),
+    (try_, "try"),
     (undefined, "undefined"),
     (unicode, "unicode"),
     (unicode_sets, "unicodeSets"),

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -435,6 +435,7 @@ rust_runtime_functions!(
     PromiseConstructor::race,
     PromiseConstructor::reject,
     PromiseConstructor::resolve,
+    PromiseConstructor::try_,
     PromiseConstructor::with_resolvers,
     promise_constructor::reject_builtin_function,
     promise_constructor::resolve_builtin_function,

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -172,7 +172,6 @@
       "import-attributes",
       "iterator-helpers",
       "json-modules",
-      "promise-try",
       "regexp-modifiers",
 
       // Other unimplemented features


### PR DESCRIPTION
## Summary

Implement the Promise.try proposal https://github.com/tc39/proposal-promise-try.

## Tests

All promise-try test262 tests are now enabled and pass.