### PR TITLE
[tests] Support raw module tests

### DIFF
--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -8,9 +8,6 @@
       //
       ////////////////////////////////////////
 
-      // Support raw module tests in test harness
-      "language/module-code/import-attributes/allow-nlt-before-with.js",
-
       // A variety of failures in introduced SpiderMonkey tests
       "staging/sm/*",
 

--- a/tests/test262/src/index.rs
+++ b/tests/test262/src/index.rs
@@ -14,6 +14,9 @@ pub struct Test {
     pub expected_result: ExpectedResult,
     pub mode: TestMode,
     pub is_async: bool,
+    // Run test without modifying the source file or evaluating any other scripts from test harness.
+    // For scripts the test is run once, in non-strict mode.
+    pub is_raw: bool,
     // Files that must be evaluated in the global scope prior to test execution. Paths are
     // relative to the test262/harness directory.
     pub includes: Vec<String>,
@@ -46,9 +49,6 @@ pub enum TestMode {
     NonStrictScript,
     // Run test as module, which is always in strict mode
     Module,
-    // Run test once in non-strict mode, making sure to not modify the source file or evaluate any
-    // other scripts from test haarness.
-    Raw,
 }
 
 impl ExpectedResult {
@@ -155,6 +155,7 @@ impl TestIndex {
         };
 
         let mut is_async = false;
+        let mut is_raw = false;
         let mut includes = vec![];
 
         let mut mode = TestMode::Script;
@@ -171,7 +172,7 @@ impl TestIndex {
                         mode = TestMode::Module;
                     }
                     "raw" => {
-                        mode = TestMode::Raw;
+                        is_raw = true;
                     }
                     "async" => {
                         is_async = true;
@@ -206,6 +207,7 @@ impl TestIndex {
             expected_result,
             mode,
             is_async,
+            is_raw,
             includes,
             features,
         };


### PR DESCRIPTION
## Summary

Add support to the test runner for raw module tests. We make `is_raw` its own flag on tests, and allow the test mode to be either a script or module. Note that the test262 test suite must be reindexed after this change.

## Tests

This allows us to run the `/language/module-code/import-attributes/allow-nlt-before-with.js` test.