### PR TITLE
[regexp] Refactor word boundary bytecode to use word comparison instruction on both sides of boundary

### DIFF
--- a/src/js/runtime/regexp/instruction.rs
+++ b/src/js/runtime/regexp/instruction.rs
@@ -96,12 +96,23 @@ pub enum OpCode {
     /// Layout: [[opcode: u8] [padding: u24]]
     AssertEndOrNewline,
 
-    /// Assert a word boundary (\b)
+    /// Move to the previous code point as part of checking a word boundary. Must be called after
+    /// the current code point has been checked to see if it is a word, with the result of the check
+    /// still stored in the compare register. Compare register will be stored in the word boundary
+    /// register to compare against the previous code point.
+    ///
+    /// Layout: [[opcode: u8] [padding: u24]]
+    WordBoundaryMoveToPrevious,
+
+    /// Assert a word boundary (\b). Must be called after WordBoundaryMoveToPrevious, and restores
+    /// to the place in the input stream before WordBoundaryMoveToPrevious was called.
+    ///
     ///
     /// Layout: [[opcode: u8] [padding: u24]]
     AssertWordBoundary,
 
-    /// Assert not a word boundary (\B)
+    /// Assert not a word boundary (\B). Must be called after WordBoundaryMoveToPrevious, and
+    /// restores to the place in the input stream before WordBoundaryMoveToPrevious was called.
     ///
     /// Layout: [[opcode: u8] [padding: u24]]
     AssertNotWordBoundary,
@@ -210,6 +221,7 @@ impl OpCode {
             OpCode::AssertEnd => AssertEndInstruction::SIZE,
             OpCode::AssertStartOrNewline => AssertStartOrNewlineInstruction::SIZE,
             OpCode::AssertEndOrNewline => AssertEndOrNewlineInstruction::SIZE,
+            OpCode::WordBoundaryMoveToPrevious => WordBoundaryMoveToPreviousInstruction::SIZE,
             OpCode::AssertWordBoundary => AssertWordBoundaryInstruction::SIZE,
             OpCode::AssertNotWordBoundary => AssertNotWordBoundaryInstruction::SIZE,
             OpCode::Backreference => BackreferenceInstruction::SIZE,
@@ -277,6 +289,9 @@ impl Instruction {
             OpCode::AssertEndOrNewline => {
                 self.cast::<AssertEndOrNewlineInstruction>().debug_print()
             }
+            OpCode::WordBoundaryMoveToPrevious => self
+                .cast::<WordBoundaryMoveToPreviousInstruction>()
+                .debug_print(),
             OpCode::AssertWordBoundary => {
                 self.cast::<AssertWordBoundaryInstruction>().debug_print()
             }
@@ -384,6 +399,10 @@ nullary_regexp_bytcode_instruction!(AssertStartInstruction, OpCode::AssertStart)
 nullary_regexp_bytcode_instruction!(AssertEndInstruction, OpCode::AssertEnd);
 nullary_regexp_bytcode_instruction!(AssertStartOrNewlineInstruction, OpCode::AssertStartOrNewline);
 nullary_regexp_bytcode_instruction!(AssertEndOrNewlineInstruction, OpCode::AssertEndOrNewline);
+nullary_regexp_bytcode_instruction!(
+    WordBoundaryMoveToPreviousInstruction,
+    OpCode::WordBoundaryMoveToPrevious
+);
 nullary_regexp_bytcode_instruction!(AssertWordBoundaryInstruction, OpCode::AssertWordBoundary);
 nullary_regexp_bytcode_instruction!(
     AssertNotWordBoundaryInstruction,

--- a/tests/js_regexp_bytecode/word_boundary/basic.exp
+++ b/tests/js_regexp_bytecode/word_boundary/basic.exp
@@ -1,0 +1,29 @@
+[CompiledRegExpObject: /a\bc/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Literal(a)
+    10: CompareIsWord
+    11: WordBoundaryMoveToPrevious
+    12: CompareIsWord
+    13: AssertWordBoundary
+    14: Literal(c)
+    15: MarkCapturePoint(1)
+    17: Accept
+}
+
+[CompiledRegExpObject: /a\Bc/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Literal(a)
+    10: CompareIsWord
+    11: WordBoundaryMoveToPrevious
+    12: CompareIsWord
+    13: AssertNotWordBoundary
+    14: Literal(c)
+    15: MarkCapturePoint(1)
+    17: Accept
+}

--- a/tests/js_regexp_bytecode/word_boundary/basic.js
+++ b/tests/js_regexp_bytecode/word_boundary/basic.js
@@ -1,0 +1,3 @@
+// Simple word boundary tests
+/a\bc/;
+/a\Bc/;


### PR DESCRIPTION
## Summary

We plan on changing how bytecode for word character class comparisons is generated, in preparation for fixes to case insensitive mode. First let's refactor word boundary assertions to use a `CompareIsWord` instruction on each side of the boundary. This consolidates on `CompareIsWord` as the only place where word comparisons occur.

We accomplish this by making word boundary assertions a multiple step process:
1. Execute `CompareIsWord` and save the comparison register to a new "word boundary register"
2. Check the previous code point with `CompareIsWord`. We temporarily peek the previous code point with the new `WordBoundaryMoveToPrevious` instruction.
3. Finally we check whether the word boundary comparisons match in `AssertWordBoundary` and `AssertNotWordBoundary`

## Tests

Added regexp bytecode snapshot tests for word boundary assertions.