### PR TITLE
[regexp] Parse non-BMP code points in non-unicode mode RegExps as two code units

### DIFF
--- a/tests/js_parser/regexp/groups.exp
+++ b/tests/js_parser/regexp/groups.exp
@@ -1,6 +1,6 @@
 {
   type: "Program",
-  loc: "1:1-17:20",
+  loc: "1:1-21:22",
   body: [
     {
       type: "ExpressionStatement",
@@ -383,6 +383,74 @@
                           ],
                         },
                       ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "20:1-20:21",
+      kind: {
+        type: "Literal",
+        loc: "20:1-20:20",
+        raw: "/(?<𝑓𝑜𝑥>)/",
+        value: {
+          pattern: "(?<𝑓𝑜𝑥>)",
+          flags: "",
+        },
+        regexp: {
+          type: "RegExp",
+          alternatives: [
+            {
+              type: "Alternative",
+              terms: [
+                {
+                  type: "CaptureGroup",
+                  index: 1,
+                  name: "𝑓𝑜𝑥",
+                  alternatives: [
+                    {
+                      type: "Alternative",
+                      terms: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "21:1-21:22",
+      kind: {
+        type: "Literal",
+        loc: "21:1-21:21",
+        raw: "/(?<𝑓𝑜𝑥>)/u",
+        value: {
+          pattern: "(?<𝑓𝑜𝑥>)",
+          flags: "u",
+        },
+        regexp: {
+          type: "RegExp",
+          alternatives: [
+            {
+              type: "Alternative",
+              terms: [
+                {
+                  type: "CaptureGroup",
+                  index: 1,
+                  name: "𝑓𝑜𝑥",
+                  alternatives: [
+                    {
+                      type: "Alternative",
+                      terms: [],
                     },
                   ],
                 },

--- a/tests/js_parser/regexp/groups.js
+++ b/tests/js_parser/regexp/groups.js
@@ -15,3 +15,7 @@
 
 // Nested capture groups
 /(a(?<name>b(c)))/;
+
+// Unicode in named capture group
+/(?<𝑓𝑜𝑥>)/;
+/(?<𝑓𝑜𝑥>)/u;

--- a/tests/js_parser/regexp/unicode.exp
+++ b/tests/js_parser/regexp/unicode.exp
@@ -1,0 +1,66 @@
+{
+  type: "Program",
+  loc: "1:1-3:10",
+  body: [
+    {
+      type: "ExpressionStatement",
+      loc: "2:1-2:8",
+      kind: {
+        type: "Literal",
+        loc: "2:1-2:7",
+        raw: "/𠮷/",
+        value: {
+          pattern: "𠮷",
+          flags: "",
+        },
+        regexp: {
+          type: "RegExp",
+          alternatives: [
+            {
+              type: "Alternative",
+              terms: [
+                {
+                  type: "Literal",
+                  value: "������",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "3:1-3:10",
+      kind: {
+        type: "Literal",
+        loc: "3:1-3:9",
+        raw: "/[𠮷]/",
+        value: {
+          pattern: "[𠮷]",
+          flags: "",
+        },
+        regexp: {
+          type: "RegExp",
+          alternatives: [
+            {
+              type: "Alternative",
+              terms: [
+                {
+                  type: "CharacterClass",
+                  is_inverted: false,
+                  ranges: [
+                    "Single(\uD842)",
+                    "Single(\uDFB7)",
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  ],
+  sourceType: "script",
+  has_use_strict_directive: false,
+}

--- a/tests/js_parser/regexp/unicode.js
+++ b/tests/js_parser/regexp/unicode.js
@@ -1,0 +1,3 @@
+// Unicode in non-unicode mode is treated as separate code units
+/𠮷/;
+/[𠮷]/;


### PR DESCRIPTION
## Summary

Fixes a bug when parsing non-BMP code points in non-unicode mode RegExps. In non-unicode mode RegExps treat the source string as UTF-16 but treat each surrogate code point individually instead of as a single code point.

We were doing this correctly on RegExps that are parsed from the heap but were failing to do this while parsing RegExps from the original UTF-8 source text. If we are parsing a UTF-8 RegExp we must first translate it to UTF-16 so that the code units can be parsed individually.

This also exposes a bug in group name parsing in non-unicode mode. In non-unicode mode we should parse high surrogate, low surrogate pairs into a single code point.

## Tests

- Added a parser test that verifies a non-BMP code points is encoded as individual code units both as a literal and in a class.
- Added a parser test for unicode in group names.
- Fixes 4 test262 unicode sets tests that were failing due to this behavior