### PR TITLE
[regexp] Compile class string disjunctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,5 @@ For more information on testing see the [testing README](./tests/README.md).
 
 All features up to ES2024 have been implemented (as well as all stage 4 proposals as of 2024-09-15), except for the following features:
 
-- UnicodeSets proposal
 - SharedArrayBuffer
 - Atomics

--- a/tests/js_regexp_bytecode/class/string_disjunction.exp
+++ b/tests/js_regexp_bytecode/class/string_disjunction.exp
@@ -1,0 +1,124 @@
+[CompiledRegExpObject: /[\q{ab}c]/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Branch(15, 19)
+    12: MarkCapturePoint(1)
+    14: Accept
+    15: Literal(a)
+    16: Literal(b)
+    17: Jump(12)
+    19: Literal(c)
+    20: Jump(12)
+}
+
+[CompiledRegExpObject: /[\q{}]/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: ConsumeIfTrue
+    10: MarkCapturePoint(1)
+    12: Accept
+}
+
+[CompiledRegExpObject: /[\q{ab|abcde|abc}]/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Branch(21, 15)
+    12: MarkCapturePoint(1)
+    14: Accept
+    15: Branch(28, 18)
+    18: Branch(33, 37)
+    21: Literal(a)
+    22: Literal(b)
+    23: Literal(c)
+    24: Literal(d)
+    25: Literal(e)
+    26: Jump(12)
+    28: Literal(a)
+    29: Literal(b)
+    30: Literal(c)
+    31: Jump(12)
+    33: Literal(a)
+    34: Literal(b)
+    35: Jump(12)
+    37: ConsumeIfTrue
+    38: Jump(12)
+}
+
+[CompiledRegExpObject: /[\q{a|b|c|de}]/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Branch(15, 19)
+    12: MarkCapturePoint(1)
+    14: Accept
+    15: Literal(d)
+    16: Literal(e)
+    17: Jump(12)
+    19: CompareBetween(a, d)
+    21: ConsumeIfTrue
+    22: Jump(12)
+}
+
+[CompiledRegExpObject: /[\q{aa|bb}\q{cc}[\q{dd}]]/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Branch(24, 15)
+    12: MarkCapturePoint(1)
+    14: Accept
+    15: Branch(28, 18)
+    18: Branch(32, 21)
+    21: Branch(36, 40)
+    24: Literal(a)
+    25: Literal(a)
+    26: Jump(12)
+    28: Literal(b)
+    29: Literal(b)
+    30: Jump(12)
+    32: Literal(c)
+    33: Literal(c)
+    34: Jump(12)
+    36: Literal(d)
+    37: Literal(d)
+    38: Jump(12)
+    40: ConsumeIfTrue
+    41: Jump(12)
+}
+
+[CompiledRegExpObject: /[\q{aa|bb}&&\q{bb|cc}]/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Branch(15, 19)
+    12: MarkCapturePoint(1)
+    14: Accept
+    15: Literal(b)
+    16: Literal(b)
+    17: Jump(12)
+    19: ConsumeIfTrue
+    20: Jump(12)
+}
+
+[CompiledRegExpObject: /[\q{aa|bb}--\q{aa}]/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Branch(15, 19)
+    12: MarkCapturePoint(1)
+    14: Accept
+    15: Literal(b)
+    16: Literal(b)
+    17: Jump(12)
+    19: ConsumeIfTrue
+    20: Jump(12)
+}

--- a/tests/js_regexp_bytecode/class/string_disjunction.js
+++ b/tests/js_regexp_bytecode/class/string_disjunction.js
@@ -1,0 +1,17 @@
+/[\q{ab}c]/v;
+/[\q{}]/v;
+
+// Multiple alternatives
+/[\q{ab|abcde|abc}]/v;
+
+// Single code point strings are treated as single code points
+/[\q{a|b|c|de}]/v;
+
+// Unions
+/[\q{aa|bb}\q{cc}[\q{dd}]]/v;
+
+// Intersection
+/[\q{aa|bb}&&\q{bb|cc}]/v;
+
+// Subtraction
+/[\q{aa|bb}--\q{aa}]/v;

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -22,6 +22,47 @@
       "built-ins/Object/freeze/typedarray-backed-by-resizable-buffer.js",
       "built-ins/String/prototype/replace/regexp-capture-by-index.js",
 
+      // Unicode properties of strings are not supported (e.g. RGI_Emoji), as they are not yet
+      // supported in icu4x.
+      "built-ins/RegExp/unicodeSets/generated/character-class-difference-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/character-class-escape-difference-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/character-class-escape-intersection-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/character-class-escape-union-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/character-class-intersection-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/character-class-union-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/character-difference-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/character-intersection-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/character-property-escape-difference-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/character-property-escape-intersection-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/character-property-escape-union-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/character-union-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-difference-character-class-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-difference-character-class.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-difference-character-property-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-difference-character.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-difference-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-difference-string-literal.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-intersection-character-class-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-intersection-character-class.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-intersection-character-property-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-intersection-character.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-intersection-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-intersection-string-literal.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-union-character-class-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-union-character-class.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-union-character-property-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-union-character.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-union-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-union-string-literal.js",
+      "built-ins/RegExp/unicodeSets/generated/rgi-emoji-13.1.js",
+      "built-ins/RegExp/unicodeSets/generated/rgi-emoji-14.0.js",
+      "built-ins/RegExp/unicodeSets/generated/rgi-emoji-15.0.js",
+      "built-ins/RegExp/unicodeSets/generated/rgi-emoji-15.1.js",
+      "built-ins/RegExp/unicodeSets/generated/rgi-emoji-16.0.js",
+      "built-ins/RegExp/unicodeSets/generated/string-literal-difference-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/string-literal-intersection-property-of-strings-escape.js",
+      "built-ins/RegExp/unicodeSets/generated/string-literal-union-property-of-strings-escape.js",
+
       ////////////////////////////////////////
       //
       // Known divergences (Do not plan on fixing)
@@ -173,7 +214,6 @@
       "json-modules",
 
       // Other unimplemented features
-      "regexp-v-flag",
       "SharedArrayBuffer",
       "Atomics"
     ]


### PR DESCRIPTION
## Summary

Generate RegExp bytecode for class string disjunctions (`\q{...}`). These are emitted as simple disjunctions over string literals, which jumps to the code point set comparisons if none match.

This is the last piece of https://github.com/tc39/proposal-regexp-v-flag planned to be implemented right now, so let's also mark unicode sets as implemented. The only unimplemented feature is unicode properties of strings (e.g. RGI_Emoji), which is not yet supported by icu4x. Instead we mark the relevant test262 tests as known failures for now.

## Tests

- Added regexp bytecode snapshot tests for class string disjunctions
- Mark test262 unicode sets tests as supported, all now pass (except for the ignored unicode properties of strings tests)