### PR TITLE
[runtime] Fix Date.prototype.setUTCMilliseconds when called on a NaN date

### DIFF
--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -1064,7 +1064,7 @@ impl DatePrototype {
         let milliseconds_arg = get_argument(cx, arguments, 0);
         let milliseconds = to_number(cx, milliseconds_arg)?.as_number();
 
-        if milliseconds.is_nan() {
+        if date_value.is_nan() {
             return Ok(cx.nan());
         }
 

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -18,7 +18,6 @@
       "language/statements/with/set-mutable-binding-idref-with-proxy-env.js",
 
       // Misc bugs
-      "built-ins/Date/prototype/setUTCMilliseconds/date-value-read-before-tonumber-when-date-is-invalid.js",
       "built-ins/Object/freeze/typedarray-backed-by-resizable-buffer.js",
       "built-ins/String/prototype/replace/regexp-capture-by-index.js",
 


### PR DESCRIPTION
## Summary

Fix a bug when `Date.prototype.setUTCMilliseconds` was called on a NaN Date. We should always return NaN in this case, but instead were incorrectly checking if the milliseconds arguments was NaN.

This was exposed by a new test262 test.

## Tests

- test262 `built-ins/Date/prototype/setUTCMilliseconds/date-value-read-before-tonumber-when-date-is-invalid.js` now passes