### PR TITLE
[runtime] TypedArray.[[PreventExtensions]] returns false for resizable ararys

### DIFF
--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -18,7 +18,6 @@
       "language/statements/with/set-mutable-binding-idref-with-proxy-env.js",
 
       // Misc bugs
-      "built-ins/Object/freeze/typedarray-backed-by-resizable-buffer.js",
       "built-ins/String/prototype/replace/regexp-capture-by-index.js",
 
       // Unicode properties of strings are not supported (e.g. RGI_Emoji), as they are not yet


### PR DESCRIPTION
## Summary

In https://github.com/tc39/ecma262/pull/3453 TypedArray.[[PreventExtensions]] was updated to always return false if the array is not fixed-size. Bring our implementation in accordance with this spec change.

This was exposed by a new test262 test.

## Tests

- `built-ins/Object/freeze/typedarray-backed-by-resizable-buffer.js` now passes