### PR TITLE
[runtime] Fix GetSubstitution on the template string $10 when index is out of range

### DIFF
--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -1541,21 +1541,23 @@ impl SubstitutionTemplate {
                         continue;
                     }
 
-                    // If index is multiple digits, check if only the first digit is in range
-                    if index >= 11 {
+                    // If index is multiple digits but out of range, instead treat as a single digit
+                    // followed by a literal.
+                    if index >= 10 {
+                        // Check if the first digit is in range
                         let first_digit_index = index / 10;
                         if first_digit_index <= indexed_captures.len() {
                             if let Some(captured_string) =
                                 indexed_captures.get(first_digit_index - 1).unwrap()
                             {
                                 string_parts.push(*captured_string);
-
-                                // Append second digit as a literal
-                                let second_digit_char = (index % 10) as u32 + '0' as u32;
-                                let second_digit_string =
-                                    FlatString::from_code_point(cx, second_digit_char);
-                                string_parts.push(second_digit_string.as_string().to_handle())
                             }
+
+                            // Append second digit as a literal
+                            let second_digit_char = (index % 10) as u32 + '0' as u32;
+                            let second_digit_string =
+                                FlatString::from_code_point(cx, second_digit_char);
+                            string_parts.push(second_digit_string.as_string().to_handle());
 
                             continue;
                         }

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -17,9 +17,6 @@
       "language/statements/with/set-mutable-binding-idref-compound-assign-with-proxy-env.js",
       "language/statements/with/set-mutable-binding-idref-with-proxy-env.js",
 
-      // Misc bugs
-      "built-ins/String/prototype/replace/regexp-capture-by-index.js",
-
       // Unicode properties of strings are not supported (e.g. RGI_Emoji), as they are not yet
       // supported in icu4x.
       "built-ins/RegExp/unicodeSets/generated/character-class-difference-property-of-strings-escape.js",


### PR DESCRIPTION
## Summary

Fixes a bug in GetSubstitution replacement templates, where we were incorrectly handling the template string $10 when the number of capture groups was < 10. We were incorrectly only handling the templates $11 and above (where we instead interpret the template as $1 followed by a literal digit).

We also fix another bug here where we were failing to append the second digit as a literal if the $1 failed to match.

Exposed by a new test262 test.

## Tests

- `built-ins/String/prototype/replace/regexp-capture-by-index.js` now passes