### PR TITLE
[runtime] Call HasProperty again when loading or storing to object environment

### DIFF
--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -2512,8 +2512,9 @@ impl VM {
             let name = name.as_string().to_handle();
 
             let scope = self.scope().to_handle();
+            let is_strict = self.closure().function_ptr().is_strict();
 
-            if let Some(value) = scope.lookup(cx, name)? {
+            if let Some(value) = scope.lookup(cx, name, is_strict)? {
                 self.write_register(dest, *value);
                 Ok(())
             } else {

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -11,12 +11,6 @@
       // A variety of failures in introduced SpiderMonkey tests
       "staging/sm/*",
 
-      // Missing call to `has` during dynamic lookup of proxy
-      "language/statements/with/get-binding-value-call-with-proxy-env.js",
-      "language/statements/with/get-binding-value-idref-with-proxy-env.js",
-      "language/statements/with/set-mutable-binding-idref-compound-assign-with-proxy-env.js",
-      "language/statements/with/set-mutable-binding-idref-with-proxy-env.js",
-
       // Unicode properties of strings are not supported (e.g. RGI_Emoji), as they are not yet
       // supported in icu4x.
       "built-ins/RegExp/unicodeSets/generated/character-class-difference-property-of-strings-escape.js",
@@ -182,6 +176,9 @@
       "language/expressions/compound-assignment/S11.13.2_A7.7_T4.js",
       "language/expressions/compound-assignment/S11.13.2_A7.8_T4.js",
       "language/expressions/compound-assignment/S11.13.2_A7.9_T4.js",
+
+      // Compound member assignment resolves LHS twice
+      "language/statements/with/set-mutable-binding-idref-compound-assign-with-proxy-env.js",
 
       // Update expressions call GetValue on reference twice 
       "language/statements/with/unscopables-inc-dec.js",


### PR DESCRIPTION
## Summary

Fixes spec non-compliance exposed by new test262 tests. HasProperty should be called when loading or storing dynamically from an object environment in GetBindingValue and SetMutableBinding. In addition we should error if in strict mode and the property does not still exist at the HasProperty check.

## Tests

Fixes:
- `language/statements/with/set-mutable-binding-idref-with-proxy-env.js`
- `language/statements/with/get-binding-value-idref-with-proxy-env.js`
- `language/statements/with/set-mutable-binding-idref-with-proxy-env.js`

Keep ignoring the failing `language/statements/with/set-mutable-binding-idref-compound-assign-with-proxy-env.js`, which we do not plan on fixing as it fails due to compound assignment resolving the LHS twice.