### PR TITLE
[tests] Bump test262

### DIFF
--- a/tests/test262/install_test262.sh
+++ b/tests/test262/install_test262.sh
@@ -6,8 +6,8 @@ CURRENT_DIR=$(cd "$(dirname "$0")" && pwd)
 TEST262_REPO_DIR="$CURRENT_DIR/test262"
 
 # Pinned commit hash of test262 repo that we test off of. Be sure to also update README.md.
-# Last updated on 2025-01-05
-TEST262_COMMIT_SHA="8296db887368bbffa3379f995a1e628ddbe8421f"
+# Last updated on 2025-02-07
+TEST262_COMMIT_SHA="bc5c14176e2b11a78859571eb693f028c8822458"
 
 # Clone the test262 repo if it is not already present
 if [ ! -d "$TEST262_REPO_DIR" ]; then


### PR DESCRIPTION
## Summary

Upgrade test262 to the latest commit, https://github.com/tc39/test262/commit/bc5c14176e2b11a78859571eb693f028c8822458.

## Tests

Test262 test suite with `--ignore-unimplemented` continues to pass.