### PR TITLE
[tests] Expose $262.gc() method

### DIFF
--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -13,6 +13,7 @@ use super::{
     error::{syntax_error, syntax_parse_error, type_error},
     function::get_argument,
     gc::HandleScope,
+    gc_object::GcObject,
     intrinsics::{array_buffer_constructor::ArrayBufferObject, intrinsics::Intrinsic},
     object_value::ObjectValue,
     string_value::StringValue,
@@ -44,6 +45,8 @@ impl Test262Object {
         let detach_array_buffer_key =
             PropertyKey::string(cx, detach_array_buffer_string).to_handle(cx);
         object.intrinsic_func(cx, detach_array_buffer_key, Self::detach_array_buffer, 1, realm);
+
+        object.intrinsic_func(cx, cx.names.gc(), GcObject::run, 0, realm);
 
         object.to_handle()
     }

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -11,6 +11,9 @@
       // A variety of failures in introduced SpiderMonkey tests
       "staging/sm/*",
 
+      // Causes stack overflow
+      "staging/sm/extensions/recursion.js",
+
       // Unicode properties of strings are not supported (e.g. RGI_Emoji), as they are not yet
       // supported in icu4x.
       "built-ins/RegExp/unicodeSets/generated/character-class-difference-property-of-strings-escape.js",


### PR DESCRIPTION
## Summary

Expose the `$262.gc()` method on the global test262 object. This allows triggering garbage collection from test262 tests.

## Tests

Fixes a number of test262 `staging/sm/` tests, which are currently still disabled.

Also separate out the only `staging/sm/` test which causes the test runner itself to fail: `staging/sm/extensions/recursion.js`.