### PR TITLE
[runtime] Lazily generate stack traces on errors

### DIFF
--- a/src/js/runtime/bytecode/stack_frame.rs
+++ b/src/js/runtime/bytecode/stack_frame.rs
@@ -252,6 +252,7 @@ impl StackFrame {
     }
 
     /// Iterate upwards through stack frames, starting at this stack frame.
+    #[allow(unused)]
     #[inline]
     pub fn iter(&self) -> StackFrameIter {
         StackFrameIter { current_frame: Some(*self) }

--- a/src/js/runtime/collections/array.rs
+++ b/src/js/runtime/collections/array.rs
@@ -39,7 +39,9 @@ impl<T: Clone> BsArray<T> {
 
         array
     }
+}
 
+impl<T> BsArray<T> {
     pub fn new_uninit(cx: Context, kind: ObjectKind, length: usize) -> HeapPtr<Self> {
         let size = Self::calculate_size_in_bytes(length);
         let mut array = cx.alloc_uninit_with_size::<BsArray<T>>(size);
@@ -71,7 +73,7 @@ impl<T: Clone> BsArray<T> {
     }
 }
 
-impl<T: Clone> HeapObject for HeapPtr<BsArray<T>> {
+impl<T> HeapObject for HeapPtr<BsArray<T>> {
     fn byte_size(&self) -> usize {
         BsArray::<T>::calculate_size_in_bytes(self.len())
     }

--- a/src/js/runtime/gc/handle.rs
+++ b/src/js/runtime/gc/handle.rs
@@ -412,6 +412,13 @@ impl Escapable for u32 {
     }
 }
 
+impl<T> Escapable for HeapPtr<T> {
+    #[inline]
+    fn escape(&self, _: Context) -> Self {
+        *self
+    }
+}
+
 impl Escapable for Handle<Value> {
     #[inline]
     fn escape(&self, cx: Context) -> Self {

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -68,6 +68,7 @@ use crate::js::runtime::{
     scope::Scope,
     scope_names::ScopeNames,
     source_file::SourceFile,
+    stack_trace::{stack_frame_info_array_byte_size, stack_frame_info_array_visit_pointers},
     string_object::StringObject,
     string_value::StringValue,
     value::{BigIntValue, SymbolValue},
@@ -186,6 +187,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::ValueArray => value_array_byte_size(self.cast()),
             ObjectKind::ByteArray => byte_array_byte_size(self.cast()),
             ObjectKind::ModuleRequestArray => module_request_array_byte_size(self.cast()),
+            ObjectKind::StackFrameInfoArray => stack_frame_info_array_byte_size(self.cast()),
             ObjectKind::FinalizationRegistryCells => {
                 self.cast::<FinalizationRegistryCells>().byte_size()
             }
@@ -330,6 +332,9 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::ByteArray => byte_array_visit_pointers(self.cast_mut(), visitor),
             ObjectKind::ModuleRequestArray => {
                 module_request_array_visit_pointers(self.cast_mut(), visitor)
+            }
+            ObjectKind::StackFrameInfoArray => {
+                stack_frame_info_array_visit_pointers(self.cast_mut(), visitor)
             }
             ObjectKind::FinalizationRegistryCells => self
                 .cast::<FinalizationRegistryCells>()

--- a/src/js/runtime/intrinsics/error_constructor.rs
+++ b/src/js/runtime/intrinsics/error_constructor.rs
@@ -10,33 +10,97 @@ use crate::{
         gc::{HeapObject, HeapVisitor},
         object_descriptor::ObjectKind,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::{object_create, object_create_from_constructor},
         realm::Realm,
-        stack_trace::attach_stack_trace_to_error,
+        stack_trace::{create_current_stack_frame_info, create_stack_trace, StackFrameInfoArray},
+        string_value::FlatString,
         type_utilities::to_string,
         Context, Handle, HeapPtr, Value,
     },
+    set_uninit,
 };
 
 use super::intrinsics::Intrinsic;
 
 extend_object! {
-    pub struct ErrorObject {}
+    pub struct ErrorObject {
+        // Cached stack trace, or the minimal information cached to lazily generate the stack trace
+        // when first accessed.
+        stack_trace_state: StackTraceState,
+    }
+}
+
+/// The stack trace is lazily generated. Contains either the cached stack trace string itself or the
+/// minimal stack frame information needed to generated the full stack trace.
+enum StackTraceState {
+    /// No stack frame info has been generated yet. This should only be true while the error has not
+    /// been fully created.
+    Uninitialized,
+    /// Minimal stack frame info has been generated which can be lazily used to build the full stack
+    /// trace.
+    StackFrameInfo(HeapPtr<StackFrameInfoArray>),
+    /// The full stack trace string has been generated and cached.
+    Generated(HeapPtr<FlatString>),
 }
 
 impl ErrorObject {
-    fn new_from_constructor(
+    pub fn new(cx: Context, prototype: Intrinsic, skip_current_frame: bool) -> Handle<ErrorObject> {
+        let error =
+            object_create::<ErrorObject>(cx, ObjectKind::ErrorObject, prototype).to_handle();
+
+        Self::initialize_stack_trace(cx, error, skip_current_frame);
+
+        error
+    }
+
+    pub fn new_from_constructor(
         cx: Context,
         constructor: Handle<ObjectValue>,
+        prototype: Intrinsic,
+        skip_current_frame: bool,
     ) -> EvalResult<Handle<ErrorObject>> {
-        let object = object_create_from_constructor::<ErrorObject>(
+        let error = object_create_from_constructor::<ErrorObject>(
             cx,
             constructor,
             ObjectKind::ErrorObject,
-            Intrinsic::ErrorPrototype,
-        )?;
+            prototype,
+        )?
+        .to_handle();
 
-        Ok(object.to_handle())
+        Self::initialize_stack_trace(cx, error, skip_current_frame);
+
+        Ok(error)
+    }
+
+    fn initialize_stack_trace(
+        cx: Context,
+        mut error: Handle<ErrorObject>,
+        skip_current_frame: bool,
+    ) {
+        // Initialize remaining state before collecting stack frame info, as we must ensure all
+        // fields are initialized before a GC could potentially occur.
+        set_uninit!(error.stack_trace_state, StackTraceState::Uninitialized);
+
+        // Collect and cache the minimal stack frame info for the current stack trace
+        let stack_frame_info = create_current_stack_frame_info(cx, skip_current_frame);
+        error.stack_trace_state = StackTraceState::StackFrameInfo(stack_frame_info);
+    }
+}
+
+impl Handle<ErrorObject> {
+    /// Return the stack trace for this error. Stack trace is lazily generated on first access.
+    pub fn get_stack_trace(&mut self, cx: Context) -> Handle<FlatString> {
+        match self.stack_trace_state {
+            StackTraceState::Generated(stack_frame) => stack_frame.to_handle(),
+            StackTraceState::StackFrameInfo(stack_frame_info) => {
+                let stack_trace = create_stack_trace(cx, *self, stack_frame_info.to_handle());
+                self.stack_trace_state = StackTraceState::Generated(stack_trace);
+                stack_trace.to_handle()
+            }
+            StackTraceState::Uninitialized => {
+                panic!("Expected stack trace state to be initialized")
+            }
+        }
     }
 }
 
@@ -76,7 +140,12 @@ impl ErrorConstructor {
             cx.current_function()
         };
 
-        let object = ErrorObject::new_from_constructor(cx, new_target)?;
+        let object = ErrorObject::new_from_constructor(
+            cx,
+            new_target,
+            Intrinsic::ErrorPrototype,
+            /* skip_current_frame */ true,
+        )?;
 
         let message = get_argument(cx, arguments, 0);
         if !message.is_undefined() {
@@ -88,8 +157,6 @@ impl ErrorConstructor {
                 message_string.into(),
             );
         }
-
-        attach_stack_trace_to_error(cx, object, /* skip_current_frame */ true);
 
         let options_arg = get_argument(cx, arguments, 1);
         install_error_cause(cx, object, options_arg)?;
@@ -127,5 +194,13 @@ impl HeapObject for HeapPtr<ErrorObject> {
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
         self.visit_object_pointers(visitor);
+
+        match &mut self.stack_trace_state {
+            StackTraceState::Uninitialized => {}
+            StackTraceState::StackFrameInfo(stack_frame_info) => {
+                visitor.visit_pointer(stack_frame_info);
+            }
+            StackTraceState::Generated(stack_trace) => visitor.visit_pointer(stack_trace),
+        }
     }
 }

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -300,6 +300,7 @@ rust_runtime_functions!(
     DatePrototype::to_utc_string,
     DatePrototype::value_of,
     ErrorConstructor::construct,
+    ErrorPrototype::get_stack,
     ErrorPrototype::to_string,
     EvalErrorConstructor::construct,
     FinalizationRegistryConstructor::construct,

--- a/src/js/runtime/object_descriptor.rs
+++ b/src/js/runtime/object_descriptor.rs
@@ -148,6 +148,7 @@ pub enum ObjectKind {
     ValueArray,
     ByteArray,
     ModuleRequestArray,
+    StackFrameInfoArray,
     FinalizationRegistryCells,
     GlobalScopes,
 
@@ -369,6 +370,7 @@ impl BaseDescriptors {
         other_heap_object_descriptor!(ObjectKind::ValueArray);
         other_heap_object_descriptor!(ObjectKind::ByteArray);
         other_heap_object_descriptor!(ObjectKind::ModuleRequestArray);
+        other_heap_object_descriptor!(ObjectKind::StackFrameInfoArray);
         other_heap_object_descriptor!(ObjectKind::FinalizationRegistryCells);
         other_heap_object_descriptor!(ObjectKind::GlobalScopes);
 


### PR DESCRIPTION
## Summary

Lazily generate error stack traces instead of generating the entire stack trace string on error creation. This is accomplished by fetching the minimal information needed to construct the stack trace on error creation: an array of stack frames, each of which contains the bytecode function and current bytecode offset within that function. This array of stack frames is then attached to the error at creation. When the new `Error.prototype.stack` getter is called this stack frame info is used to generate and cache the full stack trace string.

## Tests

All tests continue to pass.