### PR TITLE
[runtime] Stack traces skip initial realm and module native frames

### DIFF
--- a/src/js/runtime/bytecode/stack_frame.rs
+++ b/src/js/runtime/bytecode/stack_frame.rs
@@ -37,7 +37,7 @@ use super::{constant_table::ConstantTable, function::Closure};
 ///     +------------------+                     ^                ^
 ///     |       regn       |  (last register)    | callee's frame |
 ///     +------------------+  <- sp              +----------------+
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct StackFrame {
     /// Stack frames are centered around the frame pointer
     fp: *const StackSlotValue,

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -144,6 +144,10 @@ pub struct VM {
     /// The frame pointer
     fp: *mut StackSlotValue,
 
+    /// The stack frame directly above the last stack frame that should breported in a stack trace,
+    /// if there is one.
+    stack_trace_top: Option<StackFrame>,
+
     stack: Vec<StackSlotValue>,
 }
 
@@ -194,6 +198,18 @@ impl VM {
     fn stack_ptr_end(&self) -> *const StackSlotValue {
         self.stack.as_ptr_range().end
     }
+
+    pub fn stack_trace_top(&self) -> Option<StackFrame> {
+        self.stack_trace_top
+    }
+
+    pub fn mark_stack_trace_top(&mut self) {
+        self.stack_trace_top = if self.fp().is_null() {
+            None
+        } else {
+            Some(self.stack_frame())
+        };
+    }
 }
 
 impl VM {
@@ -210,6 +226,7 @@ impl VM {
             pc: std::ptr::null(),
             sp: std::ptr::null_mut(),
             fp: std::ptr::null_mut(),
+            stack_trace_top: None,
 
             stack,
         };

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -241,6 +241,7 @@ impl Context {
 
     /// Execute a program, running until the task queue is empty.
     pub fn run_script(&mut self, bytecode_script: BytecodeScript) -> EvalResult<()> {
+        self.vm().mark_stack_trace_top();
         self.vm().execute_script(bytecode_script)?;
         self.run_all_tasks()?;
 

--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -108,6 +108,7 @@ pub fn load_requested_modules_static_resolve(
 
     // Mark the module resolution phase as complete
     cx.has_finished_module_resolution = true;
+    cx.vm().mark_stack_trace_top();
 
     let evaluate_promise = module_evaluate(cx, module);
 

--- a/src/js/runtime/stack_trace.rs
+++ b/src/js/runtime/stack_trace.rs
@@ -52,7 +52,14 @@ fn gather_current_stack_frames(mut cx: Context, skip_current_frame: bool) -> Vec
         (Some(cx.vm().stack_frame()), cx.vm().pc())
     };
 
+    let stack_trace_top = cx.vm().stack_trace_top();
+
     while let Some(stack_frame) = stack_frame_opt {
+        // Stop if we've reached the first stack frame that should not be included in the trace
+        if Some(stack_frame) == stack_trace_top {
+            break;
+        }
+
         // Skip the last frame if it's a dummy frame for the realm
         if stack_frame.previous_frame().is_none() {
             let function = stack_frame.closure().function_ptr();

--- a/tests/js_error/source_locations/expression/await/await_throws_module.exp
+++ b/tests/js_error/source_locations/expression/await/await_throws_module.exp
@@ -1,5 +1,3 @@
 Error: Error on get
   at get (tests/js_error/source_locations/expression/await/await_throws_module.js:2:63)
   at <module> (tests/js_error/source_locations/expression/await/await_throws_module.js:4:1)
-  at <anonymous> (<native>)
-  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/expression/yield/await_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield/await_throws_module.exp
@@ -3,5 +3,3 @@ Error:
   at generator (tests/js_error/source_locations/expression/yield/await_throws_module.js:5:3)
   at next (<native>)
   at <module> (tests/js_error/source_locations/expression/yield/await_throws_module.js:9:7)
-  at <anonymous> (<native>)
-  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/async_iterator_close_finish_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/async_iterator_close_finish_throws_module.exp
@@ -1,3 +1,2 @@
 TypeError: iterator's return method must return an object
   at generator (tests/js_error/source_locations/expression/yield_star/async_iterator_close_finish_throws_module.js:15:3)
-  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/await_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/await_throws_module.exp
@@ -3,5 +3,3 @@ Error:
   at generator (tests/js_error/source_locations/expression/yield_star/await_throws_module.js:15:3)
   at next (<native>)
   at <module> (tests/js_error/source_locations/expression/yield_star/await_throws_module.js:19:7)
-  at <anonymous> (<native>)
-  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.exp
@@ -3,5 +3,3 @@ Error:
   at generator (tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.js:8:3)
   at next (<native>)
   at <module> (tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.js:12:7)
-  at <anonymous> (<native>)
-  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.exp
@@ -1,4 +1,3 @@
 Error: 
   at get value (tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.js:8:19)
   at generator (tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.js:17:3)
-  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/loads/load_from_module_uninitialized.exp
+++ b/tests/js_error/source_locations/loads/load_from_module_uninitialized.exp
@@ -1,4 +1,2 @@
 ReferenceError: module value is not initialized
   at <module> (tests/js_error/source_locations/loads/load_from_module_uninitialized.js:1:1)
-  at <anonymous> (<native>)
-  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/statement/for_await/await_throws_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/await_throws_module.exp
@@ -2,5 +2,3 @@ Error:
   at get (tests/js_error/source_locations/statement/for_await/await_throws_module.js:2:63)
   at foo (tests/js_error/source_locations/statement/for_await/await_throws_module.js:15:20)
   at <module> (tests/js_error/source_locations/statement/for_await/await_throws_module.js:18:7)
-  at <anonymous> (<native>)
-  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/statement/for_await/get_async_iterator_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/get_async_iterator_module.exp
@@ -2,5 +2,3 @@ Error:
   at <anonymous> (tests/js_error/source_locations/statement/for_await/get_async_iterator_module.js:3:11)
   at foo (tests/js_error/source_locations/statement/for_await/get_async_iterator_module.js:8:23)
   at <module> (tests/js_error/source_locations/statement/for_await/get_async_iterator_module.js:11:7)
-  at <anonymous> (<native>)
-  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.exp
@@ -2,5 +2,3 @@ TypeError: iterator's next method must return an object
   at next (<native>)
   at foo (tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.js:12:20)
   at <module> (tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.js:15:7)
-  at <anonymous> (<native>)
-  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.exp
@@ -3,5 +3,3 @@ Error:
   at next (<native>)
   at foo (tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.js:13:20)
   at <module> (tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.js:16:7)
-  at <anonymous> (<native>)
-  at <anonymous> (<native>)

--- a/tests/js_error/source_locations/statement/return/await_throws_module.exp
+++ b/tests/js_error/source_locations/statement/return/await_throws_module.exp
@@ -3,5 +3,3 @@ Error:
   at generator (tests/js_error/source_locations/statement/return/await_throws_module.js:5:3)
   at next (<native>)
   at <module> (tests/js_error/source_locations/statement/return/await_throws_module.js:9:7)
-  at <anonymous> (<native>)
-  at <anonymous> (<native>)

--- a/tests/js_error/stack_trace/dynamic_import_async_module.exp
+++ b/tests/js_error/stack_trace/dynamic_import_async_module.exp
@@ -1,4 +1,4 @@
 Error: test
-  at foo (/Users/hanshalverson/Documents/brimstone/tests/js_error/stack_trace/top_level_await_module.js:2:9)
-  at <module> (/Users/hanshalverson/Documents/brimstone/tests/js_error/stack_trace/top_level_await_module.js:5:7)
+  at foo (tests/js_error/stack_trace/top_level_await_module.js:2:9)
+  at <module> (tests/js_error/stack_trace/top_level_await_module.js:5:7)
   at <anonymous> (<native>)

--- a/tests/js_error/stack_trace/dynamic_import_async_module.exp
+++ b/tests/js_error/stack_trace/dynamic_import_async_module.exp
@@ -1,0 +1,4 @@
+Error: test
+  at foo (/Users/hanshalverson/Documents/brimstone/tests/js_error/stack_trace/top_level_await_module.js:2:9)
+  at <module> (/Users/hanshalverson/Documents/brimstone/tests/js_error/stack_trace/top_level_await_module.js:5:7)
+  at <anonymous> (<native>)

--- a/tests/js_error/stack_trace/dynamic_import_async_module.js
+++ b/tests/js_error/stack_trace/dynamic_import_async_module.js
@@ -1,0 +1,5 @@
+async function foo() {
+  await import('./top_level_await_module.js');
+}
+
+await foo();

--- a/tests/js_error/stack_trace/dynamic_import_module.exp
+++ b/tests/js_error/stack_trace/dynamic_import_module.exp
@@ -1,4 +1,4 @@
 Error: test
-  at bar (/Users/hanshalverson/Documents/brimstone/tests/js_error/stack_trace/script_top_level_error.js:2:9)
-  at <module> (/Users/hanshalverson/Documents/brimstone/tests/js_error/stack_trace/script_top_level_error.js:5:1)
+  at bar (tests/js_error/stack_trace/script_top_level_error.js:2:9)
+  at <module> (tests/js_error/stack_trace/script_top_level_error.js:5:1)
   at <anonymous> (<native>)

--- a/tests/js_error/stack_trace/dynamic_import_module.exp
+++ b/tests/js_error/stack_trace/dynamic_import_module.exp
@@ -1,0 +1,4 @@
+Error: test
+  at bar (/Users/hanshalverson/Documents/brimstone/tests/js_error/stack_trace/script_top_level_error.js:2:9)
+  at <module> (/Users/hanshalverson/Documents/brimstone/tests/js_error/stack_trace/script_top_level_error.js:5:1)
+  at <anonymous> (<native>)

--- a/tests/js_error/stack_trace/dynamic_import_module.js
+++ b/tests/js_error/stack_trace/dynamic_import_module.js
@@ -1,0 +1,5 @@
+async function foo() {
+  await import('./script_top_level_error.js');
+}
+
+await foo();

--- a/tests/js_error/stack_trace/eval_throws.exp
+++ b/tests/js_error/stack_trace/eval_throws.exp
@@ -1,0 +1,5 @@
+Error: test
+  at bar (<eval>:1:24)
+  at <eval> (<eval>:1:45)
+  at foo (tests/js_error/stack_trace/eval_throws.js:2:3)
+  at <global> (tests/js_error/stack_trace/eval_throws.js:5:1)

--- a/tests/js_error/stack_trace/eval_throws.js
+++ b/tests/js_error/stack_trace/eval_throws.js
@@ -1,0 +1,5 @@
+function foo() {
+  eval('function bar() { throw new Error("test") }; bar()');
+}
+
+foo();

--- a/tests/js_error/stack_trace/module_top_level_error.exp
+++ b/tests/js_error/stack_trace/module_top_level_error.exp
@@ -1,0 +1,3 @@
+Error: test
+  at foo (tests/js_error/stack_trace/module_top_level_error.js:2:9)
+  at <module> (tests/js_error/stack_trace/module_top_level_error.js:5:1)

--- a/tests/js_error/stack_trace/module_top_level_error.js
+++ b/tests/js_error/stack_trace/module_top_level_error.js
@@ -1,0 +1,5 @@
+function foo() {
+  throw new Error('test');
+}
+
+foo();

--- a/tests/js_error/stack_trace/promise_then_module.exp
+++ b/tests/js_error/stack_trace/promise_then_module.exp
@@ -1,0 +1,2 @@
+Error: test
+  at <anonymous> (tests/js_error/stack_trace/promise_then_module.js:2:9)

--- a/tests/js_error/stack_trace/promise_then_module.js
+++ b/tests/js_error/stack_trace/promise_then_module.js
@@ -1,0 +1,3 @@
+await (Promise.resolve()).then(() => {
+  throw new Error('test');
+})

--- a/tests/js_error/stack_trace/script_top_level_error.exp
+++ b/tests/js_error/stack_trace/script_top_level_error.exp
@@ -1,0 +1,3 @@
+Error: test
+  at bar (tests/js_error/stack_trace/script_top_level_error.js:2:9)
+  at <global> (tests/js_error/stack_trace/script_top_level_error.js:5:1)

--- a/tests/js_error/stack_trace/script_top_level_error.js
+++ b/tests/js_error/stack_trace/script_top_level_error.js
@@ -1,0 +1,5 @@
+function bar() {
+  throw new Error('test')
+}
+
+bar();

--- a/tests/js_error/stack_trace/top_level_await_module.exp
+++ b/tests/js_error/stack_trace/top_level_await_module.exp
@@ -1,0 +1,3 @@
+Error: test
+  at foo (tests/js_error/stack_trace/top_level_await_module.js:2:9)
+  at <module> (tests/js_error/stack_trace/top_level_await_module.js:5:7)

--- a/tests/js_error/stack_trace/top_level_await_module.js
+++ b/tests/js_error/stack_trace/top_level_await_module.js
@@ -1,0 +1,5 @@
+async function foo() {
+  throw new Error('test');
+}
+
+await foo();


### PR DESCRIPTION
## Summary

Stack traces should not show the preliminary `<anonymous> (<native>)` frames at the top of the stack. These preliminary native frames comes from the initial realm stack frame and module setup.

We ignore these frames by marking the top stack frame, which notes the first stack frame that should not be included in the trace. We then make sure to mark the top stack frame before executing scripts or modules or resuming code execution during a task.

Note that there are still cases where anonymous native frames end up in the stack, such as when an error is thrown from a dynamic import.

## Tests

Added error snapshot tests for eliding these preliminary native frames.

Also makes all paths in the snapshot test output relative to the current directory, making tests containing absolute paths work across machines.