### PR TITLE
[common] Tweak formatting of error messages

### DIFF
--- a/src/js/common/error.rs
+++ b/src/js/common/error.rs
@@ -175,7 +175,7 @@ impl ErrorFormatter {
         // Finally write the stack trace if one exists
         if let Some(stack_trace) = self.stack_trace {
             if has_source_info {
-                self.builder.push_str("\nStack:\n");
+                self.builder.push_str("\nStack trace:\n");
             }
 
             self.builder.push_str(&stack_trace);

--- a/tests/js_error/error_types/eval.exp
+++ b/tests/js_error/error_types/eval.exp
@@ -3,5 +3,5 @@ Error: This is an error
   |
 1 | throw new Error('This is an error');
   |       ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/error_types/eval.js:1:7)

--- a/tests/js_error/source_locations/class/fields/init_call_derived_constructor.exp
+++ b/tests/js_error/source_locations/class/fields/init_call_derived_constructor.exp
@@ -3,7 +3,7 @@ TypeError: BigInt cannot be converted to number
   |
 4 |   field = 1 + 2n;
   |             ^
-Stack:
+Stack trace:
   at fieldsInitializer (tests/js_error/source_locations/class/fields/init_call_derived_constructor.js:4:13)
   at C (tests/js_error/source_locations/class/fields/init_call_derived_constructor.js:8:5)
   at <global> (tests/js_error/source_locations/class/fields/init_call_derived_constructor.js:12:1)

--- a/tests/js_error/source_locations/class/fields/init_call_no_constructor.exp
+++ b/tests/js_error/source_locations/class/fields/init_call_no_constructor.exp
@@ -3,7 +3,7 @@ TypeError: BigInt cannot be converted to number
   |
 3 |   field = 1 + 2n;
   |             ^
-Stack:
+Stack trace:
   at fieldsInitializer (tests/js_error/source_locations/class/fields/init_call_no_constructor.js:3:13)
   at C (tests/js_error/source_locations/class/fields/init_call_no_constructor.js:2:1)
   at <global> (tests/js_error/source_locations/class/fields/init_call_no_constructor.js:6:1)

--- a/tests/js_error/source_locations/class/fields/init_call_with_constructor.exp
+++ b/tests/js_error/source_locations/class/fields/init_call_with_constructor.exp
@@ -3,7 +3,7 @@ TypeError: BigInt cannot be converted to number
   |
 3 |   field = 1 + 2n;
   |             ^
-Stack:
+Stack trace:
   at fieldsInitializer (tests/js_error/source_locations/class/fields/init_call_with_constructor.js:3:13)
   at C (tests/js_error/source_locations/class/fields/init_call_with_constructor.js:5:3)
   at <global> (tests/js_error/source_locations/class/fields/init_call_with_constructor.js:8:1)

--- a/tests/js_error/source_locations/class/fields/to_property_key.exp
+++ b/tests/js_error/source_locations/class/fields/to_property_key.exp
@@ -3,6 +3,6 @@ Error:
   |
 1 | var poisoned = { toString() { throw new Error() } };
   |                                     ^
-Stack:
+Stack trace:
   at toString (tests/js_error/source_locations/class/fields/to_property_key.js:1:37)
   at <global> (tests/js_error/source_locations/class/fields/to_property_key.js:4:4)

--- a/tests/js_error/source_locations/class/methods/to_property_key.exp
+++ b/tests/js_error/source_locations/class/methods/to_property_key.exp
@@ -3,6 +3,6 @@ Error:
   |
 1 | var poisoned = { toString() { throw new Error() } };
   |                                     ^
-Stack:
+Stack trace:
   at toString (tests/js_error/source_locations/class/methods/to_property_key.js:1:37)
   at <global> (tests/js_error/source_locations/class/methods/to_property_key.js:4:4)

--- a/tests/js_error/source_locations/class/new_class.exp
+++ b/tests/js_error/source_locations/class/new_class.exp
@@ -3,5 +3,5 @@ TypeError: super class must be a constructor
   |
 1 | (class C extends 1 {})
   |  ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/class/new_class.js:1:2)

--- a/tests/js_error/source_locations/class/static_initializer/call.exp
+++ b/tests/js_error/source_locations/class/static_initializer/call.exp
@@ -3,6 +3,6 @@ Error:
   |
 4 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at staticInitializer (tests/js_error/source_locations/class/static_initializer/call.js:4:11)
   at <global> (tests/js_error/source_locations/class/static_initializer/call.js:2:1)

--- a/tests/js_error/source_locations/destructure/array/element_iterator_next.exp
+++ b/tests/js_error/source_locations/destructure/array/element_iterator_next.exp
@@ -3,6 +3,6 @@ Error:
   |
 8 |           throw new Error();
   |                 ^
-Stack:
+Stack trace:
   at next (tests/js_error/source_locations/destructure/array/element_iterator_next.js:8:17)
   at <global> (tests/js_error/source_locations/destructure/array/element_iterator_next.js:19:9)

--- a/tests/js_error/source_locations/destructure/array/get_iterator.exp
+++ b/tests/js_error/source_locations/destructure/array/get_iterator.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at <anonymous> (tests/js_error/source_locations/destructure/array/get_iterator.js:3:11)
   at <global> (tests/js_error/source_locations/destructure/array/get_iterator.js:7:5)

--- a/tests/js_error/source_locations/destructure/array/hole_iterator_next.exp
+++ b/tests/js_error/source_locations/destructure/array/hole_iterator_next.exp
@@ -3,6 +3,6 @@ Error:
   |
 8 |           throw new Error();
   |                 ^
-Stack:
+Stack trace:
   at next (tests/js_error/source_locations/destructure/array/hole_iterator_next.js:8:17)
   at <global> (tests/js_error/source_locations/destructure/array/hole_iterator_next.js:19:9)

--- a/tests/js_error/source_locations/destructure/array/iterator_close_empty.exp
+++ b/tests/js_error/source_locations/destructure/array/iterator_close_empty.exp
@@ -3,6 +3,6 @@ Error:
   |
 8 |         throw new Error();
   |               ^
-Stack:
+Stack trace:
   at get return (tests/js_error/source_locations/destructure/array/iterator_close_empty.js:8:15)
   at <global> (tests/js_error/source_locations/destructure/array/iterator_close_empty.js:14:5)

--- a/tests/js_error/source_locations/destructure/array/iterator_close_non_empty.exp
+++ b/tests/js_error/source_locations/destructure/array/iterator_close_non_empty.exp
@@ -3,6 +3,6 @@ Error:
   |
 8 |         throw new Error();
   |               ^
-Stack:
+Stack trace:
   at get return (tests/js_error/source_locations/destructure/array/iterator_close_non_empty.js:8:15)
   at <global> (tests/js_error/source_locations/destructure/array/iterator_close_non_empty.js:14:5)

--- a/tests/js_error/source_locations/destructure/array/rest_iterator_next.exp
+++ b/tests/js_error/source_locations/destructure/array/rest_iterator_next.exp
@@ -3,6 +3,6 @@ Error:
   |
 5 |         throw new Error();
   |               ^
-Stack:
+Stack trace:
   at next (tests/js_error/source_locations/destructure/array/rest_iterator_next.js:5:15)
   at <global> (tests/js_error/source_locations/destructure/array/rest_iterator_next.js:11:6)

--- a/tests/js_error/source_locations/destructure/member/set_named_property.exp
+++ b/tests/js_error/source_locations/destructure/member/set_named_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at set foo (tests/js_error/source_locations/destructure/member/set_named_property.js:3:11)
   at <global> (tests/js_error/source_locations/destructure/member/set_named_property.js:7:10)

--- a/tests/js_error/source_locations/destructure/member/set_private_property.exp
+++ b/tests/js_error/source_locations/destructure/member/set_private_property.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error()
   |           ^
-Stack:
+Stack trace:
   at set #foo (tests/js_error/source_locations/destructure/member/set_private_property.js:3:11)
   at test (tests/js_error/source_locations/destructure/member/set_private_property.js:7:15)
   at <global> (tests/js_error/source_locations/destructure/member/set_private_property.js:12:1)

--- a/tests/js_error/source_locations/destructure/member/set_property.exp
+++ b/tests/js_error/source_locations/destructure/member/set_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at set foo (tests/js_error/source_locations/destructure/member/set_property.js:3:11)
   at <global> (tests/js_error/source_locations/destructure/member/set_property.js:7:10)

--- a/tests/js_error/source_locations/destructure/member/set_super_property.exp
+++ b/tests/js_error/source_locations/destructure/member/set_super_property.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error()
   |           ^
-Stack:
+Stack trace:
   at set foo (tests/js_error/source_locations/destructure/member/set_super_property.js:3:11)
   at test (tests/js_error/source_locations/destructure/member/set_super_property.js:9:16)
   at <global> (tests/js_error/source_locations/destructure/member/set_super_property.js:14:1)

--- a/tests/js_error/source_locations/destructure/member/super_check_this_initialized.exp
+++ b/tests/js_error/source_locations/destructure/member/super_check_this_initialized.exp
@@ -3,6 +3,6 @@ ReferenceError: this is not initialized
   |
 7 |     ({ x: super.foo } = { x: 1 });
   |           ^
-Stack:
+Stack trace:
   at C (tests/js_error/source_locations/destructure/member/super_check_this_initialized.js:7:11)
   at <global> (tests/js_error/source_locations/destructure/member/super_check_this_initialized.js:11:9)

--- a/tests/js_error/source_locations/destructure/object/copy_data_properties_throws.exp
+++ b/tests/js_error/source_locations/destructure/object/copy_data_properties_throws.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error()
   |           ^
-Stack:
+Stack trace:
   at getOwnPropertyDescriptor (tests/js_error/source_locations/destructure/object/copy_data_properties_throws.js:3:11)
   at <global> (tests/js_error/source_locations/destructure/object/copy_data_properties_throws.js:10:7)

--- a/tests/js_error/source_locations/destructure/object/copy_data_properties_to_object.exp
+++ b/tests/js_error/source_locations/destructure/object/copy_data_properties_to_object.exp
@@ -3,5 +3,5 @@ TypeError: null has no properties
   |
 1 | var {...a} = null;
   |     ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/destructure/object/copy_data_properties_to_object.js:1:5)

--- a/tests/js_error/source_locations/destructure/object/empty_to_object.exp
+++ b/tests/js_error/source_locations/destructure/object/empty_to_object.exp
@@ -3,5 +3,5 @@ TypeError: null has no properties
   |
 1 | var {} = null;
   |     ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/destructure/object/empty_to_object.js:1:5)

--- a/tests/js_error/source_locations/destructure/object/get_named_property.exp
+++ b/tests/js_error/source_locations/destructure/object/get_named_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get foo (tests/js_error/source_locations/destructure/object/get_named_property.js:3:11)
   at <global> (tests/js_error/source_locations/destructure/object/get_named_property.js:7:7)

--- a/tests/js_error/source_locations/destructure/object/get_property.exp
+++ b/tests/js_error/source_locations/destructure/object/get_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get foo (tests/js_error/source_locations/destructure/object/get_property.js:3:11)
   at <global> (tests/js_error/source_locations/destructure/object/get_property.js:7:7)

--- a/tests/js_error/source_locations/destructure/object/to_property_key_rest.exp
+++ b/tests/js_error/source_locations/destructure/object/to_property_key_rest.exp
@@ -3,6 +3,6 @@ Error:
   |
 1 | var poisoned = { toString() { throw new Error() } };
   |                                     ^
-Stack:
+Stack trace:
   at toString (tests/js_error/source_locations/destructure/object/to_property_key_rest.js:1:37)
   at <global> (tests/js_error/source_locations/destructure/object/to_property_key_rest.js:3:8)

--- a/tests/js_error/source_locations/expression/array/spread_get_iterator.exp
+++ b/tests/js_error/source_locations/expression/array/spread_get_iterator.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at <anonymous> (tests/js_error/source_locations/expression/array/spread_get_iterator.js:3:11)
   at <global> (tests/js_error/source_locations/expression/array/spread_get_iterator.js:7:2)

--- a/tests/js_error/source_locations/expression/array/spread_iterator_next.exp
+++ b/tests/js_error/source_locations/expression/array/spread_iterator_next.exp
@@ -3,6 +3,6 @@ Error:
   |
 5 |         throw new Error();
   |               ^
-Stack:
+Stack trace:
   at next (tests/js_error/source_locations/expression/array/spread_iterator_next.js:5:15)
   at <global> (tests/js_error/source_locations/expression/array/spread_iterator_next.js:11:2)

--- a/tests/js_error/source_locations/expression/assign/set_named_property.exp
+++ b/tests/js_error/source_locations/expression/assign/set_named_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at set foo (tests/js_error/source_locations/expression/assign/set_named_property.js:3:11)
   at <global> (tests/js_error/source_locations/expression/assign/set_named_property.js:7:4)

--- a/tests/js_error/source_locations/expression/assign/set_private_property.exp
+++ b/tests/js_error/source_locations/expression/assign/set_private_property.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error()
   |           ^
-Stack:
+Stack trace:
   at set #foo (tests/js_error/source_locations/expression/assign/set_private_property.js:3:11)
   at test (tests/js_error/source_locations/expression/assign/set_private_property.js:7:9)
   at <global> (tests/js_error/source_locations/expression/assign/set_private_property.js:12:1)

--- a/tests/js_error/source_locations/expression/assign/set_property.exp
+++ b/tests/js_error/source_locations/expression/assign/set_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at set foo (tests/js_error/source_locations/expression/assign/set_property.js:3:11)
   at <global> (tests/js_error/source_locations/expression/assign/set_property.js:7:4)

--- a/tests/js_error/source_locations/expression/assign/set_super_property.exp
+++ b/tests/js_error/source_locations/expression/assign/set_super_property.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error()
   |           ^
-Stack:
+Stack trace:
   at set foo (tests/js_error/source_locations/expression/assign/set_super_property.js:3:11)
   at test (tests/js_error/source_locations/expression/assign/set_super_property.js:9:10)
   at <global> (tests/js_error/source_locations/expression/assign/set_super_property.js:14:1)

--- a/tests/js_error/source_locations/expression/assign/super_check_this_initialized.exp
+++ b/tests/js_error/source_locations/expression/assign/super_check_this_initialized.exp
@@ -3,6 +3,6 @@ ReferenceError: this is not initialized
   |
 7 |     super.foo = 2;
   |     ^
-Stack:
+Stack trace:
   at C (tests/js_error/source_locations/expression/assign/super_check_this_initialized.js:7:5)
   at <global> (tests/js_error/source_locations/expression/assign/super_check_this_initialized.js:11:1)

--- a/tests/js_error/source_locations/expression/assign_op/add.exp
+++ b/tests/js_error/source_locations/expression/assign_op/add.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 2 | x += 2n;
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/assign_op/add.js:2:3)

--- a/tests/js_error/source_locations/expression/assign_op/bit_and.exp
+++ b/tests/js_error/source_locations/expression/assign_op/bit_and.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 2 | x &= 2n;
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/assign_op/bit_and.js:2:3)

--- a/tests/js_error/source_locations/expression/assign_op/bit_or.exp
+++ b/tests/js_error/source_locations/expression/assign_op/bit_or.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 2 | x |= 2n;
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/assign_op/bit_or.js:2:3)

--- a/tests/js_error/source_locations/expression/assign_op/bit_xor.exp
+++ b/tests/js_error/source_locations/expression/assign_op/bit_xor.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 2 | x ^= 2n;
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/assign_op/bit_xor.js:2:3)

--- a/tests/js_error/source_locations/expression/assign_op/div.exp
+++ b/tests/js_error/source_locations/expression/assign_op/div.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 2 | x /= 2n;
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/assign_op/div.js:2:3)

--- a/tests/js_error/source_locations/expression/assign_op/exp.exp
+++ b/tests/js_error/source_locations/expression/assign_op/exp.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 2 | x **= 2n;
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/assign_op/exp.js:2:3)

--- a/tests/js_error/source_locations/expression/assign_op/get_named_property.exp
+++ b/tests/js_error/source_locations/expression/assign_op/get_named_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get foo (tests/js_error/source_locations/expression/assign_op/get_named_property.js:3:11)
   at <global> (tests/js_error/source_locations/expression/assign_op/get_named_property.js:7:4)

--- a/tests/js_error/source_locations/expression/assign_op/get_private_property.exp
+++ b/tests/js_error/source_locations/expression/assign_op/get_private_property.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get #foo (tests/js_error/source_locations/expression/assign_op/get_private_property.js:3:11)
   at test (tests/js_error/source_locations/expression/assign_op/get_private_property.js:7:9)
   at <global> (tests/js_error/source_locations/expression/assign_op/get_private_property.js:12:1)

--- a/tests/js_error/source_locations/expression/assign_op/get_property.exp
+++ b/tests/js_error/source_locations/expression/assign_op/get_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get foo (tests/js_error/source_locations/expression/assign_op/get_property.js:3:11)
   at <global> (tests/js_error/source_locations/expression/assign_op/get_property.js:7:4)

--- a/tests/js_error/source_locations/expression/assign_op/get_super_property.exp
+++ b/tests/js_error/source_locations/expression/assign_op/get_super_property.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get foo (tests/js_error/source_locations/expression/assign_op/get_super_property.js:3:11)
   at test (tests/js_error/source_locations/expression/assign_op/get_super_property.js:9:10)
   at <global> (tests/js_error/source_locations/expression/assign_op/get_super_property.js:14:1)

--- a/tests/js_error/source_locations/expression/assign_op/mul.exp
+++ b/tests/js_error/source_locations/expression/assign_op/mul.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 2 | x *= 2n;
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/assign_op/mul.js:2:3)

--- a/tests/js_error/source_locations/expression/assign_op/rem.exp
+++ b/tests/js_error/source_locations/expression/assign_op/rem.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 2 | x %= 2n;
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/assign_op/rem.js:2:3)

--- a/tests/js_error/source_locations/expression/assign_op/shift_left.exp
+++ b/tests/js_error/source_locations/expression/assign_op/shift_left.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 2 | x <<= 2n;
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/assign_op/shift_left.js:2:3)

--- a/tests/js_error/source_locations/expression/assign_op/shift_right_arithmetic.exp
+++ b/tests/js_error/source_locations/expression/assign_op/shift_right_arithmetic.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 2 | x >>= 2n;
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/assign_op/shift_right_arithmetic.js:2:3)

--- a/tests/js_error/source_locations/expression/assign_op/shift_right_logical.exp
+++ b/tests/js_error/source_locations/expression/assign_op/shift_right_logical.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 2 | x >>>= 2n;
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/assign_op/shift_right_logical.js:2:3)

--- a/tests/js_error/source_locations/expression/assign_op/sub.exp
+++ b/tests/js_error/source_locations/expression/assign_op/sub.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 2 | x -= 2n;
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/assign_op/sub.js:2:3)

--- a/tests/js_error/source_locations/expression/await/await_throws_module.exp
+++ b/tests/js_error/source_locations/expression/await/await_throws_module.exp
@@ -3,6 +3,6 @@ Error: Error on get
   |
 2 | Object.defineProperty(promise, 'constructor', { get() { throw new Error('Error on get'); } });
   |                                                               ^
-Stack:
+Stack trace:
   at get (tests/js_error/source_locations/expression/await/await_throws_module.js:2:63)
   at <module> (tests/js_error/source_locations/expression/await/await_throws_module.js:4:1)

--- a/tests/js_error/source_locations/expression/binary/add.exp
+++ b/tests/js_error/source_locations/expression/binary/add.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 1 | 1 + 2n
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/add.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/bit_and.exp
+++ b/tests/js_error/source_locations/expression/binary/bit_and.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 1 | 1 & 2n
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/bit_and.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/bit_or.exp
+++ b/tests/js_error/source_locations/expression/binary/bit_or.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 1 | 1 | 2n
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/bit_or.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/bit_xor.exp
+++ b/tests/js_error/source_locations/expression/binary/bit_xor.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 1 | 1 ^ 2n
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/bit_xor.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/div.exp
+++ b/tests/js_error/source_locations/expression/binary/div.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 1 | 1 / 2n
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/div.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/exp.exp
+++ b/tests/js_error/source_locations/expression/binary/exp.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 1 | 1 ** 2n
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/exp.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/greater_than.exp
+++ b/tests/js_error/source_locations/expression/binary/greater_than.exp
@@ -3,5 +3,5 @@ TypeError: symbol cannot be converted to number
   |
 1 | 1 > Symbol.iterator
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/greater_than.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/greater_than_or_eqaul.exp
+++ b/tests/js_error/source_locations/expression/binary/greater_than_or_eqaul.exp
@@ -3,5 +3,5 @@ TypeError: symbol cannot be converted to number
   |
 1 | 1 >= Symbol.iterator
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/greater_than_or_eqaul.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/in.exp
+++ b/tests/js_error/source_locations/expression/binary/in.exp
@@ -3,5 +3,5 @@ TypeError: right side of 'in' must be an object
   |
 1 | 1 in null
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/in.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/instanceof.exp
+++ b/tests/js_error/source_locations/expression/binary/instanceof.exp
@@ -3,5 +3,5 @@ TypeError: invalid instanceof operand
   |
 1 | ({}) instanceof null
   |      ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/instanceof.js:1:6)

--- a/tests/js_error/source_locations/expression/binary/less_than.exp
+++ b/tests/js_error/source_locations/expression/binary/less_than.exp
@@ -3,5 +3,5 @@ TypeError: symbol cannot be converted to number
   |
 1 | 1 < Symbol.iterator
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/less_than.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/less_than_or_equal.exp
+++ b/tests/js_error/source_locations/expression/binary/less_than_or_equal.exp
@@ -3,5 +3,5 @@ TypeError: symbol cannot be converted to number
   |
 1 | 1 <= Symbol.iterator
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/less_than_or_equal.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/loose_equal.exp
+++ b/tests/js_error/source_locations/expression/binary/loose_equal.exp
@@ -3,6 +3,6 @@ Error:
   |
 1 | 1 == ({ [Symbol.toPrimitive]() { throw new Error() } })
   |                                        ^
-Stack:
+Stack trace:
   at <anonymous> (tests/js_error/source_locations/expression/binary/loose_equal.js:1:40)
   at <global> (tests/js_error/source_locations/expression/binary/loose_equal.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/loose_not_equal.exp
+++ b/tests/js_error/source_locations/expression/binary/loose_not_equal.exp
@@ -3,6 +3,6 @@ Error:
   |
 1 | 1 != ({ [Symbol.toPrimitive]() { throw new Error() } })
   |                                        ^
-Stack:
+Stack trace:
   at <anonymous> (tests/js_error/source_locations/expression/binary/loose_not_equal.js:1:40)
   at <global> (tests/js_error/source_locations/expression/binary/loose_not_equal.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/mul.exp
+++ b/tests/js_error/source_locations/expression/binary/mul.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 1 | 1 * 2n
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/mul.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/rem.exp
+++ b/tests/js_error/source_locations/expression/binary/rem.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 1 | 1 % 2n
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/rem.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/shift_left.exp
+++ b/tests/js_error/source_locations/expression/binary/shift_left.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 1 | 1 << 2n
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/shift_left.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/shift_right_arithmetic.exp
+++ b/tests/js_error/source_locations/expression/binary/shift_right_arithmetic.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 1 | 1 >> 2n
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/shift_right_arithmetic.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/shift_right_logical.exp
+++ b/tests/js_error/source_locations/expression/binary/shift_right_logical.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 1 | 1 >>> 2n
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/shift_right_logical.js:1:3)

--- a/tests/js_error/source_locations/expression/binary/sub.exp
+++ b/tests/js_error/source_locations/expression/binary/sub.exp
@@ -3,5 +3,5 @@ TypeError: BigInt cannot be converted to number
   |
 1 | 1 - 2n
   |   ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/binary/sub.js:1:3)

--- a/tests/js_error/source_locations/expression/call/basic.exp
+++ b/tests/js_error/source_locations/expression/call/basic.exp
@@ -3,7 +3,7 @@ Error: This is an error
    |
 10 |   throw new Error('This is an error');
    |         ^
-Stack:
+Stack trace:
   at baz (tests/js_error/source_locations/expression/call/basic.js:10:9)
   at bar (tests/js_error/source_locations/expression/call/basic.js:6:3)
   at foo (tests/js_error/source_locations/expression/call/basic.js:2:3)

--- a/tests/js_error/source_locations/expression/call/call_maybe_eval.exp
+++ b/tests/js_error/source_locations/expression/call/call_maybe_eval.exp
@@ -3,6 +3,6 @@ Error:
   |
 2 |   throw new Error();
   |         ^
-Stack:
+Stack trace:
   at eval (tests/js_error/source_locations/expression/call/call_maybe_eval.js:2:9)
   at <global> (tests/js_error/source_locations/expression/call/call_maybe_eval.js:5:1)

--- a/tests/js_error/source_locations/expression/call/call_maybe_eval_varargs.exp
+++ b/tests/js_error/source_locations/expression/call/call_maybe_eval_varargs.exp
@@ -3,6 +3,6 @@ Error:
   |
 2 |   throw new Error();
   |         ^
-Stack:
+Stack trace:
   at eval (tests/js_error/source_locations/expression/call/call_maybe_eval_varargs.js:2:9)
   at <global> (tests/js_error/source_locations/expression/call/call_maybe_eval_varargs.js:5:1)

--- a/tests/js_error/source_locations/expression/call/call_varargs.exp
+++ b/tests/js_error/source_locations/expression/call/call_varargs.exp
@@ -3,6 +3,6 @@ Error:
   |
 2 |   throw new Error();
   |         ^
-Stack:
+Stack trace:
   at foo (tests/js_error/source_locations/expression/call/call_varargs.js:2:9)
   at <global> (tests/js_error/source_locations/expression/call/call_varargs.js:5:1)

--- a/tests/js_error/source_locations/expression/call/call_with_receiver.exp
+++ b/tests/js_error/source_locations/expression/call/call_with_receiver.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at method (tests/js_error/source_locations/expression/call/call_with_receiver.js:3:11)
   at <global> (tests/js_error/source_locations/expression/call/call_with_receiver.js:7:1)

--- a/tests/js_error/source_locations/expression/construct/basic.exp
+++ b/tests/js_error/source_locations/expression/construct/basic.exp
@@ -3,6 +3,6 @@ Error:
   |
 2 |   throw new Error()
   |         ^
-Stack:
+Stack trace:
   at foo (tests/js_error/source_locations/expression/construct/basic.js:2:9)
   at <global> (tests/js_error/source_locations/expression/construct/basic.js:5:2)

--- a/tests/js_error/source_locations/expression/construct/construct_varargs.exp
+++ b/tests/js_error/source_locations/expression/construct/construct_varargs.exp
@@ -3,6 +3,6 @@ Error:
   |
 2 |   throw new Error();
   |         ^
-Stack:
+Stack trace:
   at foo (tests/js_error/source_locations/expression/construct/construct_varargs.js:2:9)
   at <global> (tests/js_error/source_locations/expression/construct/construct_varargs.js:5:2)

--- a/tests/js_error/source_locations/expression/delete/delete_binding.exp
+++ b/tests/js_error/source_locations/expression/delete/delete_binding.exp
@@ -3,6 +3,6 @@ Error:
   |
 5 |       throw new Error()
   |             ^
-Stack:
+Stack trace:
   at has (tests/js_error/source_locations/expression/delete/delete_binding.js:5:13)
   at <global> (tests/js_error/source_locations/expression/delete/delete_binding.js:11:3)

--- a/tests/js_error/source_locations/expression/delete/error_delete_super_property.exp
+++ b/tests/js_error/source_locations/expression/delete/error_delete_super_property.exp
@@ -3,6 +3,6 @@ ReferenceError: cannot delete super property
   |
 5 |     delete super.x;
   |     ^
-Stack:
+Stack trace:
   at deleteSuperProperty (tests/js_error/source_locations/expression/delete/error_delete_super_property.js:5:5)
   at <global> (tests/js_error/source_locations/expression/delete/error_delete_super_property.js:10:1)

--- a/tests/js_error/source_locations/expression/delete/member_delete_property.exp
+++ b/tests/js_error/source_locations/expression/delete/member_delete_property.exp
@@ -3,5 +3,5 @@ TypeError: cannot delete property
   |
 6 | delete obj.foo;
   | ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/delete/member_delete_property.js:6:1)

--- a/tests/js_error/source_locations/expression/member/get_named_property.exp
+++ b/tests/js_error/source_locations/expression/member/get_named_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get foo (tests/js_error/source_locations/expression/member/get_named_property.js:3:11)
   at <global> (tests/js_error/source_locations/expression/member/get_named_property.js:7:4)

--- a/tests/js_error/source_locations/expression/member/get_named_property_optional.exp
+++ b/tests/js_error/source_locations/expression/member/get_named_property_optional.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get foo (tests/js_error/source_locations/expression/member/get_named_property_optional.js:3:11)
   at <global> (tests/js_error/source_locations/expression/member/get_named_property_optional.js:7:5)

--- a/tests/js_error/source_locations/expression/member/get_private_property.exp
+++ b/tests/js_error/source_locations/expression/member/get_private_property.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get #foo (tests/js_error/source_locations/expression/member/get_private_property.js:3:11)
   at test (tests/js_error/source_locations/expression/member/get_private_property.js:7:9)
   at <global> (tests/js_error/source_locations/expression/member/get_private_property.js:12:1)

--- a/tests/js_error/source_locations/expression/member/get_property.exp
+++ b/tests/js_error/source_locations/expression/member/get_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get foo (tests/js_error/source_locations/expression/member/get_property.js:3:11)
   at <global> (tests/js_error/source_locations/expression/member/get_property.js:7:4)

--- a/tests/js_error/source_locations/expression/member/get_property_optional.exp
+++ b/tests/js_error/source_locations/expression/member/get_property_optional.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get foo (tests/js_error/source_locations/expression/member/get_property_optional.js:3:11)
   at <global> (tests/js_error/source_locations/expression/member/get_property_optional.js:7:6)

--- a/tests/js_error/source_locations/expression/object/literal_copy_data_properties.exp
+++ b/tests/js_error/source_locations/expression/object/literal_copy_data_properties.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error()
   |           ^
-Stack:
+Stack trace:
   at getOwnPropertyDescriptor (tests/js_error/source_locations/expression/object/literal_copy_data_properties.js:3:11)
   at <global> (tests/js_error/source_locations/expression/object/literal_copy_data_properties.js:10:4)

--- a/tests/js_error/source_locations/expression/super_call/basic.exp
+++ b/tests/js_error/source_locations/expression/super_call/basic.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at A (tests/js_error/source_locations/expression/super_call/basic.js:3:11)
   at B (tests/js_error/source_locations/expression/super_call/basic.js:9:5)
   at <global> (tests/js_error/source_locations/expression/super_call/basic.js:13:1)

--- a/tests/js_error/source_locations/expression/super_call/check_super_already_called.exp
+++ b/tests/js_error/source_locations/expression/super_call/check_super_already_called.exp
@@ -3,6 +3,6 @@ ReferenceError: super constructor called multiple times
   |
 6 |     super();
   |     ^
-Stack:
+Stack trace:
   at C (tests/js_error/source_locations/expression/super_call/check_super_already_called.js:6:5)
   at <global> (tests/js_error/source_locations/expression/super_call/check_super_already_called.js:10:1)

--- a/tests/js_error/source_locations/expression/super_call/construct_varargs.exp
+++ b/tests/js_error/source_locations/expression/super_call/construct_varargs.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at A (tests/js_error/source_locations/expression/super_call/construct_varargs.js:3:11)
   at B (tests/js_error/source_locations/expression/super_call/construct_varargs.js:9:5)
   at <global> (tests/js_error/source_locations/expression/super_call/construct_varargs.js:13:1)

--- a/tests/js_error/source_locations/expression/super_call/default_super_call.exp
+++ b/tests/js_error/source_locations/expression/super_call/default_super_call.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error()
   |           ^
-Stack:
+Stack trace:
   at B (tests/js_error/source_locations/expression/super_call/default_super_call.js:3:11)
   at C (tests/js_error/source_locations/expression/super_call/default_super_call.js:7:1)
   at <global> (tests/js_error/source_locations/expression/super_call/default_super_call.js:10:1)

--- a/tests/js_error/source_locations/expression/super_member/check_this_initialized.exp
+++ b/tests/js_error/source_locations/expression/super_member/check_this_initialized.exp
@@ -3,6 +3,6 @@ ReferenceError: this is not initialized
   |
 7 |     super.foo;
   |     ^
-Stack:
+Stack trace:
   at C (tests/js_error/source_locations/expression/super_member/check_this_initialized.js:7:5)
   at <global> (tests/js_error/source_locations/expression/super_member/check_this_initialized.js:11:1)

--- a/tests/js_error/source_locations/expression/super_member/get_named_super_property.exp
+++ b/tests/js_error/source_locations/expression/super_member/get_named_super_property.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get foo (tests/js_error/source_locations/expression/super_member/get_named_super_property.js:3:11)
   at test (tests/js_error/source_locations/expression/super_member/get_named_super_property.js:9:10)
   at <global> (tests/js_error/source_locations/expression/super_member/get_named_super_property.js:14:1)

--- a/tests/js_error/source_locations/expression/super_member/get_super_property.exp
+++ b/tests/js_error/source_locations/expression/super_member/get_super_property.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get foo (tests/js_error/source_locations/expression/super_member/get_super_property.js:3:11)
   at test (tests/js_error/source_locations/expression/super_member/get_super_property.js:9:10)
   at <global> (tests/js_error/source_locations/expression/super_member/get_super_property.js:14:1)

--- a/tests/js_error/source_locations/expression/template/tagged_template_call_with_receiver.exp
+++ b/tests/js_error/source_locations/expression/template/tagged_template_call_with_receiver.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at foo (tests/js_error/source_locations/expression/template/tagged_template_call_with_receiver.js:3:11)
   at <global> (tests/js_error/source_locations/expression/template/tagged_template_call_with_receiver.js:7:1)

--- a/tests/js_error/source_locations/expression/template/tagged_template_throws.exp
+++ b/tests/js_error/source_locations/expression/template/tagged_template_throws.exp
@@ -3,6 +3,6 @@ Error:
   |
 2 |   throw new Error()
   |         ^
-Stack:
+Stack trace:
   at foo (tests/js_error/source_locations/expression/template/tagged_template_throws.js:2:9)
   at <global> (tests/js_error/source_locations/expression/template/tagged_template_throws.js:5:1)

--- a/tests/js_error/source_locations/expression/template/to_string_first_part.exp
+++ b/tests/js_error/source_locations/expression/template/to_string_first_part.exp
@@ -3,5 +3,5 @@ TypeError: symbol cannot be converted to string
   |
 1 | `${Symbol.iterator} foo`;
   |    ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/template/to_string_first_part.js:1:4)

--- a/tests/js_error/source_locations/expression/template/to_string_later_part.exp
+++ b/tests/js_error/source_locations/expression/template/to_string_later_part.exp
@@ -3,5 +3,5 @@ TypeError: symbol cannot be converted to string
   |
 1 | `${1} ${Symbol.iterator}`
   |         ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/template/to_string_later_part.js:1:9)

--- a/tests/js_error/source_locations/expression/template/to_string_single_expression.exp
+++ b/tests/js_error/source_locations/expression/template/to_string_single_expression.exp
@@ -3,5 +3,5 @@ TypeError: symbol cannot be converted to string
   |
 1 | `${Symbol.iterator}`
   |    ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/template/to_string_single_expression.js:1:4)

--- a/tests/js_error/source_locations/expression/this/check_this_initialized.exp
+++ b/tests/js_error/source_locations/expression/this/check_this_initialized.exp
@@ -3,6 +3,6 @@ ReferenceError: this is not initialized
   |
 5 |     this;
   |     ^
-Stack:
+Stack trace:
   at C (tests/js_error/source_locations/expression/this/check_this_initialized.js:5:5)
   at <global> (tests/js_error/source_locations/expression/this/check_this_initialized.js:9:1)

--- a/tests/js_error/source_locations/expression/typeof/load_dynamic_throws.exp
+++ b/tests/js_error/source_locations/expression/typeof/load_dynamic_throws.exp
@@ -3,7 +3,7 @@ Error: Error on get
   |
 3 |     throw new Error('Error on get');
   |           ^
-Stack:
+Stack trace:
   at get (tests/js_error/source_locations/expression/typeof/load_dynamic_throws.js:3:11)
   at <eval> (<eval>:1:8)
   at <global> (tests/js_error/source_locations/expression/typeof/load_dynamic_throws.js:7:1)

--- a/tests/js_error/source_locations/expression/typeof/load_global_throws.exp
+++ b/tests/js_error/source_locations/expression/typeof/load_global_throws.exp
@@ -3,6 +3,6 @@ Error: Error on get
   |
 3 |     throw new Error('Error on get');
   |           ^
-Stack:
+Stack trace:
   at get (tests/js_error/source_locations/expression/typeof/load_global_throws.js:3:11)
   at <global> (tests/js_error/source_locations/expression/typeof/load_global_throws.js:7:8)

--- a/tests/js_error/source_locations/expression/unary/bit_not.exp
+++ b/tests/js_error/source_locations/expression/unary/bit_not.exp
@@ -3,5 +3,5 @@ TypeError: symbol cannot be converted to number
   |
 1 | ~Symbol.iterator;
   | ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/unary/bit_not.js:1:1)

--- a/tests/js_error/source_locations/expression/unary/neg.exp
+++ b/tests/js_error/source_locations/expression/unary/neg.exp
@@ -3,5 +3,5 @@ TypeError: symbol cannot be converted to number
   |
 1 | -Symbol.iterator;
   | ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/unary/neg.js:1:1)

--- a/tests/js_error/source_locations/expression/unary/plus_to_number.exp
+++ b/tests/js_error/source_locations/expression/unary/plus_to_number.exp
@@ -3,5 +3,5 @@ TypeError: symbol cannot be converted to number
   |
 1 | (+Symbol.iterator)
   |  ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/unary/plus_to_number.js:1:2)

--- a/tests/js_error/source_locations/expression/update/error_const.exp
+++ b/tests/js_error/source_locations/expression/update/error_const.exp
@@ -3,6 +3,6 @@ TypeError: can't assign constant `x`
   |
 3 |   x++;
   |   ^
-Stack:
+Stack trace:
   at test (tests/js_error/source_locations/expression/update/error_const.js:3:3)
   at <global> (tests/js_error/source_locations/expression/update/error_const.js:6:1)

--- a/tests/js_error/source_locations/expression/update/get_named_property.exp
+++ b/tests/js_error/source_locations/expression/update/get_named_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get foo (tests/js_error/source_locations/expression/update/get_named_property.js:3:11)
   at <global> (tests/js_error/source_locations/expression/update/get_named_property.js:7:4)

--- a/tests/js_error/source_locations/expression/update/get_private_property.exp
+++ b/tests/js_error/source_locations/expression/update/get_private_property.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error()
   |           ^
-Stack:
+Stack trace:
   at get #foo (tests/js_error/source_locations/expression/update/get_private_property.js:3:11)
   at test (tests/js_error/source_locations/expression/update/get_private_property.js:7:9)
   at <global> (tests/js_error/source_locations/expression/update/get_private_property.js:12:1)

--- a/tests/js_error/source_locations/expression/update/get_property.exp
+++ b/tests/js_error/source_locations/expression/update/get_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 4 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at get foo (tests/js_error/source_locations/expression/update/get_property.js:4:11)
   at <global> (tests/js_error/source_locations/expression/update/get_property.js:8:4)

--- a/tests/js_error/source_locations/expression/update/member_to_numeric.exp
+++ b/tests/js_error/source_locations/expression/update/member_to_numeric.exp
@@ -3,5 +3,5 @@ TypeError: symbol cannot be converted to number
   |
 5 | obj.a++;
   | ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/expression/update/member_to_numeric.js:5:1)

--- a/tests/js_error/source_locations/expression/update/set_named_property.exp
+++ b/tests/js_error/source_locations/expression/update/set_named_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 6 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at set foo (tests/js_error/source_locations/expression/update/set_named_property.js:6:11)
   at <global> (tests/js_error/source_locations/expression/update/set_named_property.js:10:4)

--- a/tests/js_error/source_locations/expression/update/set_private_property.exp
+++ b/tests/js_error/source_locations/expression/update/set_private_property.exp
@@ -3,7 +3,7 @@ Error:
   |
 7 |     throw new Error()
   |           ^
-Stack:
+Stack trace:
   at set #foo (tests/js_error/source_locations/expression/update/set_private_property.js:7:11)
   at test (tests/js_error/source_locations/expression/update/set_private_property.js:11:9)
   at <global> (tests/js_error/source_locations/expression/update/set_private_property.js:16:1)

--- a/tests/js_error/source_locations/expression/update/set_property.exp
+++ b/tests/js_error/source_locations/expression/update/set_property.exp
@@ -3,6 +3,6 @@ Error:
   |
 6 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at set foo (tests/js_error/source_locations/expression/update/set_property.js:6:11)
   at <global> (tests/js_error/source_locations/expression/update/set_property.js:10:4)

--- a/tests/js_error/source_locations/expression/update/set_super_property.exp
+++ b/tests/js_error/source_locations/expression/update/set_super_property.exp
@@ -3,7 +3,7 @@ Error:
   |
 7 |     throw new Error()
   |           ^
-Stack:
+Stack trace:
   at set foo (tests/js_error/source_locations/expression/update/set_super_property.js:7:11)
   at test (tests/js_error/source_locations/expression/update/set_super_property.js:13:10)
   at <global> (tests/js_error/source_locations/expression/update/set_super_property.js:18:1)

--- a/tests/js_error/source_locations/expression/update/super_check_this_initialized.exp
+++ b/tests/js_error/source_locations/expression/update/super_check_this_initialized.exp
@@ -3,6 +3,6 @@ ReferenceError: this is not initialized
   |
 7 |     super.foo++;
   |     ^
-Stack:
+Stack trace:
   at C (tests/js_error/source_locations/expression/update/super_check_this_initialized.js:7:5)
   at <global> (tests/js_error/source_locations/expression/update/super_check_this_initialized.js:11:1)

--- a/tests/js_error/source_locations/expression/yield/await_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield/await_throws_module.exp
@@ -3,7 +3,7 @@ Error:
   |
 2 | Object.defineProperty(promise, 'constructor', { get() { throw new Error(); } });
   |                                                               ^
-Stack:
+Stack trace:
   at get (tests/js_error/source_locations/expression/yield/await_throws_module.js:2:63)
   at generator (tests/js_error/source_locations/expression/yield/await_throws_module.js:5:3)
   at next (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/async_iterator_close_finish_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/async_iterator_close_finish_throws_module.exp
@@ -3,5 +3,5 @@ TypeError: iterator's return method must return an object
    |
 15 |   yield* iterable;
    |   ^
-Stack:
+Stack trace:
   at generator (tests/js_error/source_locations/expression/yield_star/async_iterator_close_finish_throws_module.js:15:3)

--- a/tests/js_error/source_locations/expression/yield_star/async_iterator_close_start_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/async_iterator_close_start_throws_module.exp
@@ -3,7 +3,7 @@ Error:
   |
 8 |         throw new Error();
   |               ^
-Stack:
+Stack trace:
   at get return (tests/js_error/source_locations/expression/yield_star/async_iterator_close_start_throws_module.js:8:15)
   at generator (tests/js_error/source_locations/expression/yield_star/async_iterator_close_start_throws_module.js:15:3)
   at throw (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/await_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/await_throws_module.exp
@@ -3,7 +3,7 @@ Error:
   |
 2 | Object.defineProperty(promise, 'constructor', { get() { throw new Error(); } });
   |                                                               ^
-Stack:
+Stack trace:
   at get (tests/js_error/source_locations/expression/yield_star/await_throws_module.js:2:63)
   at generator (tests/js_error/source_locations/expression/yield_star/await_throws_module.js:15:3)
   at next (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/error_iterator_no_throw_method.exp
+++ b/tests/js_error/source_locations/expression/yield_star/error_iterator_no_throw_method.exp
@@ -3,7 +3,7 @@ TypeError: iterator does not have a throw method
    |
 12 |   yield* iterable;
    |   ^
-Stack:
+Stack trace:
   at generator (tests/js_error/source_locations/expression/yield_star/error_iterator_no_throw_method.js:12:3)
   at throw (<native>)
   at <global> (tests/js_error/source_locations/expression/yield_star/error_iterator_no_throw_method.js:17:1)

--- a/tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at <anonymous> (tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.js:3:11)
   at generator (tests/js_error/source_locations/expression/yield_star/get_async_iterator_throws_module.js:8:3)
   at next (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/get_iterator_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/get_iterator_throws.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at <anonymous> (tests/js_error/source_locations/expression/yield_star/get_iterator_throws.js:3:11)
   at generator (tests/js_error/source_locations/expression/yield_star/get_iterator_throws.js:8:3)
   at next (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/iterator_close_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/iterator_close_throws.exp
@@ -3,7 +3,7 @@ Error:
   |
 8 |         throw new Error();
   |               ^
-Stack:
+Stack trace:
   at get return (tests/js_error/source_locations/expression/yield_star/iterator_close_throws.js:8:15)
   at generator (tests/js_error/source_locations/expression/yield_star/iterator_close_throws.js:15:3)
   at throw (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/next_check_iterator_result_object_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/next_check_iterator_result_object_throws.exp
@@ -3,7 +3,7 @@ TypeError: iterator result must be an object
    |
 12 |   yield* iterable;
    |   ^
-Stack:
+Stack trace:
   at generator (tests/js_error/source_locations/expression/yield_star/next_check_iterator_result_object_throws.js:12:3)
   at next (<native>)
   at <global> (tests/js_error/source_locations/expression/yield_star/next_check_iterator_result_object_throws.js:16:1)

--- a/tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.exp
+++ b/tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.exp
@@ -3,6 +3,6 @@ Error:
   |
 8 |             throw new Error();
   |                   ^
-Stack:
+Stack trace:
   at get value (tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.js:8:19)
   at generator (tests/js_error/source_locations/expression/yield_star/next_result_async_get_named_property_value_throws_module.js:17:3)

--- a/tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_done_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_done_throws.exp
@@ -3,7 +3,7 @@ Error:
   |
 8 |             throw new Error();
   |                   ^
-Stack:
+Stack trace:
   at get done (tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_done_throws.js:8:19)
   at generator (tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_done_throws.js:20:3)
   at next (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_value_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_value_throws.exp
@@ -3,7 +3,7 @@ Error:
   |
 8 |             throw new Error();
   |                   ^
-Stack:
+Stack trace:
   at get value (tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_value_throws.js:8:19)
   at generator (tests/js_error/source_locations/expression/yield_star/next_result_get_named_property_value_throws.js:20:3)
   at next (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/next_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/next_throws.exp
@@ -3,7 +3,7 @@ Error: next
   |
 5 |         throw new Error('next');
   |               ^
-Stack:
+Stack trace:
   at next (tests/js_error/source_locations/expression/yield_star/next_throws.js:5:15)
   at generator (tests/js_error/source_locations/expression/yield_star/next_throws.js:12:3)
   at next (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/return_check_iterator_result_object_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/return_check_iterator_result_object_throws.exp
@@ -3,7 +3,7 @@ TypeError: iterator result must be an object
    |
 15 |   yield* iterable;
    |   ^
-Stack:
+Stack trace:
   at generator (tests/js_error/source_locations/expression/yield_star/return_check_iterator_result_object_throws.js:15:3)
   at return (<native>)
   at <global> (tests/js_error/source_locations/expression/yield_star/return_check_iterator_result_object_throws.js:20:1)

--- a/tests/js_error/source_locations/expression/yield_star/return_get_method_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/return_get_method_throws.exp
@@ -3,7 +3,7 @@ Error: get return
   |
 8 |         throw new Error('get return');
   |               ^
-Stack:
+Stack trace:
   at get return (tests/js_error/source_locations/expression/yield_star/return_get_method_throws.js:8:15)
   at generator (tests/js_error/source_locations/expression/yield_star/return_get_method_throws.js:15:3)
   at return (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_done_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_done_throws.exp
@@ -3,7 +3,7 @@ Error:
    |
 10 |             throw new Error();
    |                   ^
-Stack:
+Stack trace:
   at get done (tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_done_throws.js:10:19)
   at generator (tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_done_throws.js:20:3)
   at return (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_value_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_value_throws.exp
@@ -3,7 +3,7 @@ Error:
    |
 10 |             throw new Error();
    |                   ^
-Stack:
+Stack trace:
   at get value (tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_value_throws.js:10:19)
   at generator (tests/js_error/source_locations/expression/yield_star/return_result_get_named_property_value_throws.js:20:3)
   at return (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/return_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/return_throws.exp
@@ -3,7 +3,7 @@ Error: return
   |
 8 |         throw new Error('return');
   |               ^
-Stack:
+Stack trace:
   at return (tests/js_error/source_locations/expression/yield_star/return_throws.js:8:15)
   at generator (tests/js_error/source_locations/expression/yield_star/return_throws.js:15:3)
   at return (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/throw_check_iterator_result_object_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/throw_check_iterator_result_object_throws.exp
@@ -3,7 +3,7 @@ TypeError: iterator result must be an object
    |
 15 |   yield* iterable;
    |   ^
-Stack:
+Stack trace:
   at generator (tests/js_error/source_locations/expression/yield_star/throw_check_iterator_result_object_throws.js:15:3)
   at throw (<native>)
   at <global> (tests/js_error/source_locations/expression/yield_star/throw_check_iterator_result_object_throws.js:20:1)

--- a/tests/js_error/source_locations/expression/yield_star/throw_get_method_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/throw_get_method_throws.exp
@@ -3,7 +3,7 @@ Error: get throw
   |
 8 |         throw new Error('get throw');
   |               ^
-Stack:
+Stack trace:
   at get throw (tests/js_error/source_locations/expression/yield_star/throw_get_method_throws.js:8:15)
   at generator (tests/js_error/source_locations/expression/yield_star/throw_get_method_throws.js:15:3)
   at throw (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_done_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_done_throws.exp
@@ -3,7 +3,7 @@ Error:
    |
 10 |             throw new Error();
    |                   ^
-Stack:
+Stack trace:
   at get done (tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_done_throws.js:10:19)
   at generator (tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_done_throws.js:20:3)
   at throw (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_value_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_value_throws.exp
@@ -3,7 +3,7 @@ Error:
    |
 10 |             throw new Error();
    |                   ^
-Stack:
+Stack trace:
   at get value (tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_value_throws.js:10:19)
   at generator (tests/js_error/source_locations/expression/yield_star/throw_result_get_named_property_value_throws.js:20:3)
   at throw (<native>)

--- a/tests/js_error/source_locations/expression/yield_star/throw_throws.exp
+++ b/tests/js_error/source_locations/expression/yield_star/throw_throws.exp
@@ -3,7 +3,7 @@ Error: throw
   |
 8 |         throw new Error('throw');
   |               ^
-Stack:
+Stack trace:
   at throw (tests/js_error/source_locations/expression/yield_star/throw_throws.js:8:15)
   at generator (tests/js_error/source_locations/expression/yield_star/throw_throws.js:15:3)
   at throw (<native>)

--- a/tests/js_error/source_locations/loads/check_tdz_global.exp
+++ b/tests/js_error/source_locations/loads/check_tdz_global.exp
@@ -3,5 +3,5 @@ ReferenceError: can't access `x` before initialization
   |
 1 | (x);
   |  ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/loads/check_tdz_global.js:1:2)

--- a/tests/js_error/source_locations/loads/check_tdz_local.exp
+++ b/tests/js_error/source_locations/loads/check_tdz_local.exp
@@ -3,6 +3,6 @@ ReferenceError: can't access `x` before initialization
   |
 2 |   x;
   |   ^
-Stack:
+Stack trace:
   at test (tests/js_error/source_locations/loads/check_tdz_local.js:2:3)
   at <global> (tests/js_error/source_locations/loads/check_tdz_local.js:6:1)

--- a/tests/js_error/source_locations/loads/load_dynamic_unresolved.exp
+++ b/tests/js_error/source_locations/loads/load_dynamic_unresolved.exp
@@ -3,7 +3,7 @@ ReferenceError: x is not defined
   |
 1 | x
   | ^
-Stack:
+Stack trace:
   at <eval> (<eval>:1:1)
   at test (tests/js_error/source_locations/loads/load_dynamic_unresolved.js:2:3)
   at <global> (tests/js_error/source_locations/loads/load_dynamic_unresolved.js:5:1)

--- a/tests/js_error/source_locations/loads/load_from_module_uninitialized.exp
+++ b/tests/js_error/source_locations/loads/load_from_module_uninitialized.exp
@@ -3,5 +3,5 @@ ReferenceError: module value is not initialized
   |
 1 | x = 2;
   | ^
-Stack:
+Stack trace:
   at <module> (tests/js_error/source_locations/loads/load_from_module_uninitialized.js:1:1)

--- a/tests/js_error/source_locations/loads/load_global_unresolved.exp
+++ b/tests/js_error/source_locations/loads/load_global_unresolved.exp
@@ -3,6 +3,6 @@ ReferenceError: x is not defined
   |
 3 |   x;
   |   ^
-Stack:
+Stack trace:
   at test (tests/js_error/source_locations/loads/load_global_unresolved.js:3:3)
   at <global> (tests/js_error/source_locations/loads/load_global_unresolved.js:6:1)

--- a/tests/js_error/source_locations/statement/for_await/async_iterator_close_start_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/async_iterator_close_start_module.exp
@@ -3,7 +3,7 @@ Error:
   |
 8 |         throw new Error();
   |               ^
-Stack:
+Stack trace:
   at get return (tests/js_error/source_locations/statement/for_await/async_iterator_close_start_module.js:8:15)
   at return (<native>)
   at foo (tests/js_error/source_locations/statement/for_await/async_iterator_close_start_module.js:15:20)

--- a/tests/js_error/source_locations/statement/for_await/await_throws_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/await_throws_module.exp
@@ -3,7 +3,7 @@ Error:
   |
 2 | Object.defineProperty(promise, 'constructor', { get() { throw new Error(); } });
   |                                                               ^
-Stack:
+Stack trace:
   at get (tests/js_error/source_locations/statement/for_await/await_throws_module.js:2:63)
   at foo (tests/js_error/source_locations/statement/for_await/await_throws_module.js:15:20)
   at <module> (tests/js_error/source_locations/statement/for_await/await_throws_module.js:18:7)

--- a/tests/js_error/source_locations/statement/for_await/get_async_iterator_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/get_async_iterator_module.exp
@@ -3,7 +3,7 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at <anonymous> (tests/js_error/source_locations/statement/for_await/get_async_iterator_module.js:3:11)
   at foo (tests/js_error/source_locations/statement/for_await/get_async_iterator_module.js:8:23)
   at <module> (tests/js_error/source_locations/statement/for_await/get_async_iterator_module.js:11:7)

--- a/tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.exp
@@ -3,7 +3,7 @@ Error:
   |
 5 |         throw new Error()
   |               ^
-Stack:
+Stack trace:
   at next (tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.js:5:15)
   at next (<native>)
   at foo (tests/js_error/source_locations/statement/for_await/next_call_with_receiver_module.js:13:20)

--- a/tests/js_error/source_locations/statement/for_in/for_in_next.exp
+++ b/tests/js_error/source_locations/statement/for_in/for_in_next.exp
@@ -3,6 +3,6 @@ Error:
   |
 7 |       throw new Error()
   |             ^
-Stack:
+Stack trace:
   at has (tests/js_error/source_locations/statement/for_in/for_in_next.js:7:13)
   at <global> (tests/js_error/source_locations/statement/for_in/for_in_next.js:12:12)

--- a/tests/js_error/source_locations/statement/for_in/new_for_in_iterator.exp
+++ b/tests/js_error/source_locations/statement/for_in/new_for_in_iterator.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error()
   |           ^
-Stack:
+Stack trace:
   at ownKeys (tests/js_error/source_locations/statement/for_in/new_for_in_iterator.js:3:11)
   at <global> (tests/js_error/source_locations/statement/for_in/new_for_in_iterator.js:7:15)

--- a/tests/js_error/source_locations/statement/for_of/get_iterator.exp
+++ b/tests/js_error/source_locations/statement/for_of/get_iterator.exp
@@ -3,6 +3,6 @@ Error:
   |
 3 |     throw new Error();
   |           ^
-Stack:
+Stack trace:
   at <anonymous> (tests/js_error/source_locations/statement/for_of/get_iterator.js:3:11)
   at <global> (tests/js_error/source_locations/statement/for_of/get_iterator.js:7:15)

--- a/tests/js_error/source_locations/statement/for_of/iterator_close.exp
+++ b/tests/js_error/source_locations/statement/for_of/iterator_close.exp
@@ -3,6 +3,6 @@ Error:
   |
 8 |         throw new Error();
   |               ^
-Stack:
+Stack trace:
   at get return (tests/js_error/source_locations/statement/for_of/iterator_close.js:8:15)
   at <global> (tests/js_error/source_locations/statement/for_of/iterator_close.js:14:12)

--- a/tests/js_error/source_locations/statement/for_of/iterator_next.exp
+++ b/tests/js_error/source_locations/statement/for_of/iterator_next.exp
@@ -3,6 +3,6 @@ Error:
   |
 5 |         throw new Error();
   |               ^
-Stack:
+Stack trace:
   at next (tests/js_error/source_locations/statement/for_of/iterator_next.js:5:15)
   at <global> (tests/js_error/source_locations/statement/for_of/iterator_next.js:11:12)

--- a/tests/js_error/source_locations/statement/return/await_throws_module.exp
+++ b/tests/js_error/source_locations/statement/return/await_throws_module.exp
@@ -3,7 +3,7 @@ Error:
   |
 2 | Object.defineProperty(promise, 'constructor', { get() { throw new Error(); } });
   |                                                               ^
-Stack:
+Stack trace:
   at get (tests/js_error/source_locations/statement/return/await_throws_module.js:2:63)
   at generator (tests/js_error/source_locations/statement/return/await_throws_module.js:5:3)
   at next (<native>)

--- a/tests/js_error/source_locations/statement/return/check_this_initialized.exp
+++ b/tests/js_error/source_locations/statement/return/check_this_initialized.exp
@@ -3,6 +3,6 @@ ReferenceError: this is not initialized
   |
 8 |   }
   |   ^
-Stack:
+Stack trace:
   at C (tests/js_error/source_locations/statement/return/check_this_initialized.js:8:3)
   at <global> (tests/js_error/source_locations/statement/return/check_this_initialized.js:11:1)

--- a/tests/js_error/source_locations/statement/with/push_with_scope_throws.exp
+++ b/tests/js_error/source_locations/statement/with/push_with_scope_throws.exp
@@ -3,5 +3,5 @@ TypeError: null has no properties
   |
 2 | with (null) {}
   | ^
-Stack:
+Stack trace:
   at <global> (tests/js_error/source_locations/statement/with/push_with_scope_throws.js:2:1)

--- a/tests/js_error/source_locations/stores/error_const.exp
+++ b/tests/js_error/source_locations/stores/error_const.exp
@@ -3,6 +3,6 @@ TypeError: can't assign constant `x`
   |
 3 |   x = 2;
   |   ^
-Stack:
+Stack trace:
   at test (tests/js_error/source_locations/stores/error_const.js:3:3)
   at <global> (tests/js_error/source_locations/stores/error_const.js:6:1)

--- a/tests/js_error/source_locations/stores/store_dynamic_unresolved.exp
+++ b/tests/js_error/source_locations/stores/store_dynamic_unresolved.exp
@@ -3,7 +3,7 @@ ReferenceError: x is not defined
   |
 1 | x = 1
   | ^
-Stack:
+Stack trace:
   at <eval> (<eval>:1:1)
   at test (tests/js_error/source_locations/stores/store_dynamic_unresolved.js:4:3)
   at <global> (tests/js_error/source_locations/stores/store_dynamic_unresolved.js:7:1)

--- a/tests/js_error/source_locations/stores/store_global_unresolved.exp
+++ b/tests/js_error/source_locations/stores/store_global_unresolved.exp
@@ -3,6 +3,6 @@ ReferenceError: x is not defined
   |
 5 |   x = 1;
   |   ^
-Stack:
+Stack trace:
   at test (tests/js_error/source_locations/stores/store_global_unresolved.js:5:3)
   at <global> (tests/js_error/source_locations/stores/store_global_unresolved.js:8:1)

--- a/tests/js_error/stack_trace/dynamic_import_async_module.exp
+++ b/tests/js_error/stack_trace/dynamic_import_async_module.exp
@@ -3,7 +3,7 @@ Error: test
   |
 2 |   throw new Error('test');
   |         ^
-Stack:
+Stack trace:
   at foo (tests/js_error/stack_trace/top_level_await_module.js:2:9)
   at <module> (tests/js_error/stack_trace/top_level_await_module.js:5:7)
   at <anonymous> (<native>)

--- a/tests/js_error/stack_trace/dynamic_import_module.exp
+++ b/tests/js_error/stack_trace/dynamic_import_module.exp
@@ -3,7 +3,7 @@ Error: test
   |
 2 |   throw new Error('test')
   |         ^
-Stack:
+Stack trace:
   at bar (tests/js_error/stack_trace/script_top_level_error.js:2:9)
   at <module> (tests/js_error/stack_trace/script_top_level_error.js:5:1)
   at <anonymous> (<native>)

--- a/tests/js_error/stack_trace/eval_throws.exp
+++ b/tests/js_error/stack_trace/eval_throws.exp
@@ -3,7 +3,7 @@ Error: test
   |
 1 | function bar() { throw new Error("test") }; bar()
   |                        ^
-Stack:
+Stack trace:
   at bar (<eval>:1:24)
   at <eval> (<eval>:1:45)
   at foo (tests/js_error/stack_trace/eval_throws.js:2:3)

--- a/tests/js_error/stack_trace/module_top_level_error.exp
+++ b/tests/js_error/stack_trace/module_top_level_error.exp
@@ -3,6 +3,6 @@ Error: test
   |
 2 |   throw new Error('test');
   |         ^
-Stack:
+Stack trace:
   at foo (tests/js_error/stack_trace/module_top_level_error.js:2:9)
   at <module> (tests/js_error/stack_trace/module_top_level_error.js:5:1)

--- a/tests/js_error/stack_trace/promise_then_module.exp
+++ b/tests/js_error/stack_trace/promise_then_module.exp
@@ -3,5 +3,5 @@ Error: test
   |
 2 |   throw new Error('test');
   |         ^
-Stack:
+Stack trace:
   at <anonymous> (tests/js_error/stack_trace/promise_then_module.js:2:9)

--- a/tests/js_error/stack_trace/script_top_level_error.exp
+++ b/tests/js_error/stack_trace/script_top_level_error.exp
@@ -3,6 +3,6 @@ Error: test
   |
 2 |   throw new Error('test')
   |         ^
-Stack:
+Stack trace:
   at bar (tests/js_error/stack_trace/script_top_level_error.js:2:9)
   at <global> (tests/js_error/stack_trace/script_top_level_error.js:5:1)

--- a/tests/js_error/stack_trace/top_level_await_module.exp
+++ b/tests/js_error/stack_trace/top_level_await_module.exp
@@ -3,6 +3,6 @@ Error: test
   |
 2 |   throw new Error('test');
   |         ^
-Stack:
+Stack trace:
   at foo (tests/js_error/stack_trace/top_level_await_module.js:2:9)
   at <module> (tests/js_error/stack_trace/top_level_await_module.js:5:7)


### PR DESCRIPTION
## Summary

Make a small tweak to error messages. Use the header "Stack trace:" instead of "Stack:".

## Tests

Re-recorded all error snapshot tests.