### PR TITLE
[runtime] Implement JSON modules

### DIFF
--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -4285,10 +4285,14 @@ impl VM {
         let module_scope = self.top_scope();
 
         // May allocate
-        let mut module = module_scope.module_scope_module().to_handle();
-        let object = module.get_import_meta_object(self.cx());
+        let value = if let Some(module) = module_scope.module_scope_module() {
+            let object = module.to_handle().get_import_meta_object(self.cx());
+            object.as_value()
+        } else {
+            Value::undefined()
+        };
 
-        self.write_register(dest, object.as_value());
+        self.write_register(dest, value);
     }
 
     #[inline]

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -55,9 +55,11 @@ use crate::js::runtime::{
         import_attributes::ImportAttributes,
         module_namespace_object::ModuleNamespaceObject,
         source_text_module::{
+            module_option_array_byte_size, module_option_array_visit_pointers,
             module_request_array_byte_size, module_request_array_visit_pointers, ExportMapField,
             SourceTextModule,
         },
+        synthetic_module::SyntheticModule,
     },
     object_descriptor::{ObjectDescriptor, ObjectKind},
     object_value::{NamedPropertiesMapField, ObjectValue},
@@ -160,6 +162,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::GlobalNames => self.cast::<GlobalNames>().byte_size(),
             ObjectKind::ClassNames => self.cast::<ClassNames>().byte_size(),
             ObjectKind::SourceTextModule => self.cast::<SourceTextModule>().byte_size(),
+            ObjectKind::SyntheticModule => self.cast::<SyntheticModule>().byte_size(),
             ObjectKind::ModuleNamespaceObject => self.cast::<ModuleNamespaceObject>().byte_size(),
             ObjectKind::ImportAttributes => self.cast::<ImportAttributes>().byte_size(),
             ObjectKind::Generator => self.cast::<GeneratorObject>().byte_size(),
@@ -187,6 +190,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::ValueArray => value_array_byte_size(self.cast()),
             ObjectKind::ByteArray => byte_array_byte_size(self.cast()),
             ObjectKind::ModuleRequestArray => module_request_array_byte_size(self.cast()),
+            ObjectKind::ModuleOptionArray => module_option_array_byte_size(self.cast()),
             ObjectKind::StackFrameInfoArray => stack_frame_info_array_byte_size(self.cast()),
             ObjectKind::FinalizationRegistryCells => {
                 self.cast::<FinalizationRegistryCells>().byte_size()
@@ -276,6 +280,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::GlobalNames => self.cast::<GlobalNames>().visit_pointers(visitor),
             ObjectKind::ClassNames => self.cast::<ClassNames>().visit_pointers(visitor),
             ObjectKind::SourceTextModule => self.cast::<SourceTextModule>().visit_pointers(visitor),
+            ObjectKind::SyntheticModule => self.cast::<SyntheticModule>().visit_pointers(visitor),
             ObjectKind::ModuleNamespaceObject => {
                 self.cast::<ModuleNamespaceObject>().visit_pointers(visitor)
             }
@@ -332,6 +337,9 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::ByteArray => byte_array_visit_pointers(self.cast_mut(), visitor),
             ObjectKind::ModuleRequestArray => {
                 module_request_array_visit_pointers(self.cast_mut(), visitor)
+            }
+            ObjectKind::ModuleOptionArray => {
+                module_option_array_visit_pointers(self.cast_mut(), visitor)
             }
             ObjectKind::StackFrameInfoArray => {
                 stack_frame_info_array_visit_pointers(self.cast_mut(), visitor)

--- a/src/js/runtime/intrinsics/mod.rs
+++ b/src/js/runtime/intrinsics/mod.rs
@@ -35,7 +35,7 @@ pub mod global_object;
 #[allow(clippy::module_inception)]
 pub mod intrinsics;
 mod iterator_prototype;
-mod json_object;
+pub mod json_object;
 pub mod map_constructor;
 pub mod map_iterator;
 pub mod map_object;

--- a/src/js/runtime/module/import_attributes.rs
+++ b/src/js/runtime/module/import_attributes.rs
@@ -48,6 +48,16 @@ impl ImportAttributes {
             InlineArray::<HeapPtr<FlatString>>::calculate_size_in_bytes(num_entries);
         Self::ATTRIBUTE_PAIRS_OFFSET + attributes_size
     }
+
+    pub fn has_attribute_with_value(&self, key: &str, value: &str) -> bool {
+        for attribute_pair in self.attribute_pairs.as_slice().chunks_exact(2) {
+            if attribute_pair[0].eq_str(key) && attribute_pair[1].eq_str(value) {
+                return true;
+            }
+        }
+
+        false
+    }
 }
 
 impl PartialEq for HeapPtr<ImportAttributes> {

--- a/src/js/runtime/module/mod.rs
+++ b/src/js/runtime/module/mod.rs
@@ -2,6 +2,7 @@ pub mod execute;
 pub mod import_attributes;
 mod linker;
 pub mod loader;
+#[allow(clippy::module_inception)]
 pub mod module;
 pub mod module_namespace_object;
 pub mod source_text_module;

--- a/src/js/runtime/module/mod.rs
+++ b/src/js/runtime/module/mod.rs
@@ -2,5 +2,7 @@ pub mod execute;
 pub mod import_attributes;
 mod linker;
 pub mod loader;
+pub mod module;
 pub mod module_namespace_object;
 pub mod source_text_module;
+pub mod synthetic_module;

--- a/src/js/runtime/module/module.rs
+++ b/src/js/runtime/module/module.rs
@@ -1,0 +1,89 @@
+use std::{
+    collections::HashSet,
+    sync::{LazyLock, Mutex},
+};
+
+use crate::{
+    heap_trait_object,
+    js::runtime::{
+        boxed_value::BoxedValue, gc::HeapItem, promise_object::PromiseObject,
+        string_value::FlatString, Context, EvalResult, Handle, HeapPtr,
+    },
+};
+
+use super::{
+    module_namespace_object::ModuleNamespaceObject, source_text_module::SourceTextModule,
+    synthetic_module::SyntheticModule,
+};
+
+/// A generic module. May be a SourceTextModule or a SyntheticModule.
+pub trait Module {
+    fn as_enum(&self) -> ModuleEnum;
+
+    fn as_source_text_module(&self) -> Option<Handle<SourceTextModule>> {
+        None
+    }
+
+    fn load_requested_modules(&self, cx: Context) -> Handle<PromiseObject>;
+
+    fn get_exported_names(
+        &self,
+        cx: Context,
+        exported_names: &mut HashSet<Handle<FlatString>>,
+        visited_set: &mut HashSet<ModuleId>,
+    );
+
+    fn resolve_export(
+        &self,
+        cx: Context,
+        export_name: HeapPtr<FlatString>,
+        resolve_set: &mut Vec<(HeapPtr<FlatString>, HeapPtr<SourceTextModule>)>,
+    ) -> ResolveExportResult;
+
+    fn link(&self, cx: Context) -> EvalResult<()>;
+
+    fn evaluate(&self, cx: Context) -> Handle<PromiseObject>;
+
+    fn get_namespace_object(&mut self, cx: Context) -> HeapPtr<ModuleNamespaceObject>;
+}
+
+pub enum ModuleEnum {
+    SourceText(Handle<SourceTextModule>),
+    Synthetic(Handle<SyntheticModule>),
+}
+
+#[derive(Clone, Copy)]
+pub enum ResolveExportResult {
+    Resolved { name: ResolveExportName, module: DynModule },
+    Ambiguous,
+    Circular,
+    None,
+}
+
+#[derive(Clone, Copy)]
+pub enum ResolveExportName {
+    /// No local name since this is a namespace import.
+    Namespace,
+    /// The local name of the binding in the module.
+    Local { name: HeapPtr<FlatString>, boxed_value: HeapPtr<BoxedValue> },
+}
+
+heap_trait_object!(Module, DynModule, HeapDynModule, into_dyn_module);
+
+impl DynModule {
+    pub fn as_heap_item(self) -> Handle<HeapItem> {
+        self.data.cast()
+    }
+}
+
+pub type ModuleId = usize;
+
+static NEXT_MODULE_ID: LazyLock<Mutex<usize>> = LazyLock::new(|| Mutex::new(0));
+
+pub fn next_module_id() -> ModuleId {
+    let mut next_module_id = NEXT_MODULE_ID.lock().unwrap();
+    let module_id = *next_module_id;
+    *next_module_id += 1;
+
+    module_id
+}

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -936,10 +936,8 @@ pub fn module_option_array_visit_pointers(
 ) {
     array.visit_pointers(visitor);
 
-    for module_opt in array.as_mut_slice() {
-        if let Some(module) = module_opt {
-            module.visit_pointers(visitor);
-        }
+    for module in array.as_mut_slice().iter_mut().flatten() {
+        module.visit_pointers(visitor);
     }
 }
 

--- a/src/js/runtime/module/synthetic_module.rs
+++ b/src/js/runtime/module/synthetic_module.rs
@@ -1,0 +1,233 @@
+use std::collections::HashSet;
+
+use crate::{
+    js::runtime::{
+        abstract_operations::call_object,
+        boxed_value::BoxedValue,
+        gc::{HeapObject, HeapVisitor},
+        interned_strings::InternedStrings,
+        intrinsics::intrinsics::Intrinsic,
+        module::module::next_module_id,
+        object_descriptor::{ObjectDescriptor, ObjectKind},
+        promise_object::{coerce_to_ordinary_promise, PromiseCapability, PromiseObject},
+        scope::Scope,
+        scope_names::{ScopeFlags, ScopeNameFlags, ScopeNames},
+        string_value::FlatString,
+        Context, EvalResult, Handle, HeapPtr, Realm, Value,
+    },
+    must, set_uninit,
+};
+
+use super::{
+    module::{DynModule, Module, ModuleEnum, ModuleId, ResolveExportName, ResolveExportResult},
+    module_namespace_object::ModuleNamespaceObject,
+    source_text_module::SourceTextModule,
+};
+
+#[repr(C)]
+pub struct SyntheticModule {
+    descriptor: HeapPtr<ObjectDescriptor>,
+    /// Unique identifier for this module. Can be used as a stable identifier.
+    id: ModuleId,
+    /// The kind of synthetic module.
+    kind: SyntheticModuleKind,
+    /// Scope for the module.
+    module_scope: HeapPtr<Scope>,
+    /// Namespace object for this module. This is lazily created when first accessed.
+    namespace_object: Option<HeapPtr<ModuleNamespaceObject>>,
+}
+
+pub enum SyntheticModuleKind {
+    /// A module which sets the given value as the default export.
+    DefaultExport(Value),
+}
+
+impl SyntheticModule {
+    /// Create a new SyntheticModule with the given exported names. Caller is responsible for
+    /// initializing the kind field.
+    fn new(
+        cx: Context,
+        realm: Handle<Realm>,
+        export_names: &[Handle<FlatString>],
+    ) -> HeapPtr<SyntheticModule> {
+        // Create module scope for the module, with an entry for each exported name
+        let name_flags = export_names
+            .iter()
+            .map(|_| ScopeNameFlags::empty())
+            .collect::<Vec<_>>();
+        let scope_names = ScopeNames::new(cx, ScopeFlags::empty(), export_names, &name_flags);
+        let mut module_scope = Scope::new_module(cx, scope_names, realm.global_object());
+
+        // Initialize all scope entries to undefined
+        for i in 0..scope_names.len() {
+            let boxed_value = BoxedValue::new(cx, cx.undefined());
+            module_scope.set_heap_item_slot(i, boxed_value.as_heap_item());
+        }
+
+        let mut module = cx.alloc_uninit::<SyntheticModule>();
+
+        // Note that kind is not initialized here, as it is initialized by the caller
+        set_uninit!(module.descriptor, cx.base_descriptors.get(ObjectKind::SyntheticModule));
+        set_uninit!(module.id, next_module_id());
+        set_uninit!(module.module_scope, *module_scope);
+        set_uninit!(module.namespace_object, None);
+
+        module
+    }
+
+    pub fn new_default_export(
+        cx: Context,
+        realm: Handle<Realm>,
+        default_export_value: Handle<Value>,
+    ) -> Handle<SyntheticModule> {
+        let default_export_name = cx.names.default.as_string().as_flat().to_handle();
+        let mut module = Self::new(cx, realm, &[default_export_name]);
+
+        set_uninit!(module.kind, SyntheticModuleKind::DefaultExport(*default_export_value));
+
+        module.to_handle()
+    }
+
+    fn calculate_size_in_bytes() -> usize {
+        std::mem::size_of::<SyntheticModule>()
+    }
+
+    #[inline]
+    pub fn id(&self) -> ModuleId {
+        self.id
+    }
+
+    #[inline]
+    pub fn module_scope_ptr(&self) -> HeapPtr<Scope> {
+        self.module_scope
+    }
+}
+
+impl Handle<SyntheticModule> {
+    pub fn as_dyn_module(&self) -> DynModule {
+        self.into_dyn_module()
+    }
+
+    fn evaluate_default_export_module(
+        &self,
+        cx: Context,
+        default_export_value: Handle<Value>,
+    ) -> EvalResult<Handle<Value>> {
+        // Find the default export name in the module scope and then set the default export value
+        let default_export_name = cx.names.default.as_string().as_flat();
+        let scope_index = self
+            .module_scope_ptr()
+            .scope_names_ptr()
+            .lookup_name(default_export_name)
+            .unwrap();
+
+        let mut export_boxed_value = self.module_scope_ptr().get_module_slot(scope_index);
+        export_boxed_value.set(*default_export_value);
+
+        Ok(cx.undefined())
+    }
+}
+
+impl Module for Handle<SyntheticModule> {
+    fn as_enum(&self) -> ModuleEnum {
+        ModuleEnum::Synthetic(*self)
+    }
+
+    fn load_requested_modules(&self, cx: Context) -> Handle<PromiseObject> {
+        must!(coerce_to_ordinary_promise(cx, cx.undefined()))
+    }
+
+    fn get_exported_names(
+        &self,
+        _: Context,
+        exported_names: &mut HashSet<Handle<FlatString>>,
+        visited_set: &mut HashSet<ModuleId>,
+    ) {
+        visited_set.insert(self.id());
+
+        let scope_names = self.module_scope_ptr().scope_names_ptr();
+        for name in scope_names.name_ptrs() {
+            exported_names.insert(name.to_handle());
+        }
+    }
+
+    fn resolve_export(
+        &self,
+        cx: Context,
+        export_name: HeapPtr<FlatString>,
+        _: &mut Vec<(HeapPtr<FlatString>, HeapPtr<SourceTextModule>)>,
+    ) -> ResolveExportResult {
+        // Resolve the export name by looking through module bindings, returning one if found
+        let module_scope = self.module_scope_ptr();
+        let export_name = InternedStrings::get(cx, export_name);
+
+        if let Some(scope_index) = module_scope.scope_names_ptr().lookup_name(export_name) {
+            let boxed_value = module_scope.get_module_slot(scope_index);
+            ResolveExportResult::Resolved {
+                name: ResolveExportName::Local { name: export_name, boxed_value },
+                module: self.as_dyn_module(),
+            }
+        } else {
+            ResolveExportResult::None
+        }
+    }
+
+    fn link(&self, _: Context) -> EvalResult<()> {
+        // Left empty, module scope and bindings were already created during module creation
+        Ok(())
+    }
+
+    fn evaluate(&self, cx: Context) -> Handle<PromiseObject> {
+        let result = match self.kind {
+            SyntheticModuleKind::DefaultExport(default_export_value) => {
+                self.evaluate_default_export_module(cx, default_export_value.to_handle(cx))
+            }
+        };
+
+        let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
+        let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
+        let promise = capability.promise().cast::<PromiseObject>();
+
+        match result {
+            Ok(result) => {
+                must!(call_object(cx, capability.resolve(), cx.undefined(), &[result]));
+            }
+            Err(error) => {
+                must!(call_object(cx, capability.reject(), cx.undefined(), &[error]));
+            }
+        }
+
+        promise
+    }
+
+    /// Returns the namespace object used when this module is namespace imported. Lazily creates the
+    /// cached namespace object and exports map.
+    fn get_namespace_object(&mut self, cx: Context) -> HeapPtr<ModuleNamespaceObject> {
+        if let Some(namespace_object) = self.namespace_object {
+            return namespace_object;
+        }
+
+        // Create and cache the namespace object for this module
+        let namespace_object = ModuleNamespaceObject::new(cx, self.as_dyn_module());
+        self.namespace_object = Some(namespace_object);
+
+        namespace_object
+    }
+}
+
+impl HeapObject for HeapPtr<SyntheticModule> {
+    fn byte_size(&self) -> usize {
+        SyntheticModule::calculate_size_in_bytes()
+    }
+
+    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut self.descriptor);
+
+        match &mut self.kind {
+            SyntheticModuleKind::DefaultExport(value) => visitor.visit_value(value),
+        }
+
+        visitor.visit_pointer(&mut self.module_scope);
+        visitor.visit_pointer_opt(&mut self.namespace_object);
+    }
+}

--- a/src/js/runtime/object_descriptor.rs
+++ b/src/js/runtime/object_descriptor.rs
@@ -117,6 +117,7 @@ pub enum ObjectKind {
     ClassNames,
 
     SourceTextModule,
+    SyntheticModule,
     ModuleNamespaceObject,
     ImportAttributes,
 
@@ -148,6 +149,7 @@ pub enum ObjectKind {
     ValueArray,
     ByteArray,
     ModuleRequestArray,
+    ModuleOptionArray,
     StackFrameInfoArray,
     FinalizationRegistryCells,
     GlobalScopes,
@@ -337,6 +339,7 @@ impl BaseDescriptors {
         other_heap_object_descriptor!(ObjectKind::ClassNames);
 
         other_heap_object_descriptor!(ObjectKind::SourceTextModule);
+        other_heap_object_descriptor!(ObjectKind::SyntheticModule);
         register_descriptor!(
             ObjectKind::ModuleNamespaceObject,
             ModuleNamespaceObject,
@@ -370,6 +373,7 @@ impl BaseDescriptors {
         other_heap_object_descriptor!(ObjectKind::ValueArray);
         other_heap_object_descriptor!(ObjectKind::ByteArray);
         other_heap_object_descriptor!(ObjectKind::ModuleRequestArray);
+        other_heap_object_descriptor!(ObjectKind::ModuleOptionArray);
         other_heap_object_descriptor!(ObjectKind::StackFrameInfoArray);
         other_heap_object_descriptor!(ObjectKind::FinalizationRegistryCells);
         other_heap_object_descriptor!(ObjectKind::GlobalScopes);

--- a/src/js/runtime/scope.rs
+++ b/src/js/runtime/scope.rs
@@ -169,13 +169,19 @@ impl Scope {
         self.get_slot(0).as_pointer().cast::<Realm>()
     }
 
-    /// Return the module stored in this module scope.
+    /// Return the source text module stored in this module scope, if one exists.
     ///
     /// Should only be called on module scopes.
     #[inline]
-    pub fn module_scope_module(&self) -> HeapPtr<SourceTextModule> {
+    pub fn module_scope_module(&self) -> Option<HeapPtr<SourceTextModule>> {
         debug_assert!(self.kind == ScopeKind::Module);
-        self.get_slot(0).as_pointer().cast::<SourceTextModule>()
+
+        let module = self.get_slot(0).as_pointer();
+        if module.descriptor().kind() == ObjectKind::SourceTextModule {
+            Some(module.cast::<SourceTextModule>())
+        } else {
+            None
+        }
     }
 }
 

--- a/src/js/runtime/string_value.rs
+++ b/src/js/runtime/string_value.rs
@@ -1143,6 +1143,22 @@ impl PartialEq for Handle<FlatString> {
     }
 }
 
+impl HeapPtr<FlatString> {
+    /// Compare a flat string against a Rust `&str`.
+    pub fn eq_str(&self, other: &str) -> bool {
+        let mut iter1 = self.iter_code_points();
+        let mut iter2 = other.chars();
+
+        while let (Some(code_point_1), Some(code_point_2)) = (iter1.next(), iter2.next()) {
+            if code_point_1 != code_point_2 as CodePoint {
+                return false;
+            }
+        }
+
+        iter1.next().is_none() && iter2.next().is_none()
+    }
+}
+
 impl Eq for HeapPtr<FlatString> {}
 
 impl Eq for Handle<FlatString> {}

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -206,7 +206,6 @@
     "features": [
       // Stage 4 proposals
       "iterator-helpers",
-      "json-modules",
 
       // Other unimplemented features
       "SharedArrayBuffer",


### PR DESCRIPTION
## Summary

Implement the JSON modules proposal (https://github.com/tc39/proposal-json-modules). JSON modules can now be imported using the import attribute `with { type: "json" }`.

Most of this PR is refactoring module loading/linking/execution to support multiple module types - both the existing `SourceTextModule` and the new `SyntheticModule`. Both implement the `Module` trait which declares common behavior across all modules.

`SyntheticModules` are essentially wrappers around a module scope which contains all the exports of that module.

JSON modules are then implemented as the first `SyntheticModule` using `JSON.parse` to parse the source text and storing the result as the module's default export.

## Tests

Enable `json-modules` test262 tests, all pass.