### PR TITLE
[runtime] Fix GC bugs from new error formatting

### DIFF
--- a/src/js/runtime/collections/array.rs
+++ b/src/js/runtime/collections/array.rs
@@ -117,3 +117,16 @@ pub fn byte_array_visit_pointers(
 ) {
     byte_array.visit_pointers(visitor);
 }
+
+/// A generic array of opaque 32-bit values. Corresponds to ObjectKind::U32Array.
+///
+/// Can be used for any kind of opaque 32-bit data.
+pub type U32Array = BsArray<u32>;
+
+pub fn u32_array_byte_size(array: HeapPtr<U32Array>) -> usize {
+    U32Array::calculate_size_in_bytes(array.len())
+}
+
+pub fn u32_array_visit_pointers(array: &mut HeapPtr<U32Array>, visitor: &mut impl HeapVisitor) {
+    array.visit_pointers(visitor);
+}

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -13,8 +13,8 @@ use crate::js::runtime::{
     class_names::ClassNames,
     collections::{
         array::{
-            byte_array_byte_size, byte_array_visit_pointers, value_array_byte_size,
-            value_array_visit_pointers,
+            byte_array_byte_size, byte_array_visit_pointers, u32_array_byte_size,
+            u32_array_visit_pointers, value_array_byte_size, value_array_visit_pointers,
         },
         vec::{value_vec_byte_size, value_vec_visit_pointers},
     },
@@ -189,6 +189,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::ModuleCacheMap => ModuleCacheField::byte_size(&self.cast()),
             ObjectKind::ValueArray => value_array_byte_size(self.cast()),
             ObjectKind::ByteArray => byte_array_byte_size(self.cast()),
+            ObjectKind::U32Array => u32_array_byte_size(self.cast()),
             ObjectKind::ModuleRequestArray => module_request_array_byte_size(self.cast()),
             ObjectKind::ModuleOptionArray => module_option_array_byte_size(self.cast()),
             ObjectKind::StackFrameInfoArray => stack_frame_info_array_byte_size(self.cast()),
@@ -335,6 +336,7 @@ impl HeapObject for HeapPtr<HeapItem> {
             }
             ObjectKind::ValueArray => value_array_visit_pointers(self.cast_mut(), visitor),
             ObjectKind::ByteArray => byte_array_visit_pointers(self.cast_mut(), visitor),
+            ObjectKind::U32Array => u32_array_visit_pointers(self.cast_mut(), visitor),
             ObjectKind::ModuleRequestArray => {
                 module_request_array_visit_pointers(self.cast_mut(), visitor)
             }

--- a/src/js/runtime/object_descriptor.rs
+++ b/src/js/runtime/object_descriptor.rs
@@ -148,6 +148,7 @@ pub enum ObjectKind {
     // Arrays
     ValueArray,
     ByteArray,
+    U32Array,
     ModuleRequestArray,
     ModuleOptionArray,
     StackFrameInfoArray,
@@ -372,6 +373,7 @@ impl BaseDescriptors {
 
         other_heap_object_descriptor!(ObjectKind::ValueArray);
         other_heap_object_descriptor!(ObjectKind::ByteArray);
+        other_heap_object_descriptor!(ObjectKind::U32Array);
         other_heap_object_descriptor!(ObjectKind::ModuleRequestArray);
         other_heap_object_descriptor!(ObjectKind::ModuleOptionArray);
         other_heap_object_descriptor!(ObjectKind::StackFrameInfoArray);

--- a/src/js/runtime/source_file.rs
+++ b/src/js/runtime/source_file.rs
@@ -90,7 +90,7 @@ impl Handle<SourceFile> {
         // Lazily generate line offsets when first requested
         let raw_line_offsets = calculate_line_offsets(self.contents_as_slice());
         let line_offsets_object =
-            LineOffsetArray::new_from_slice(cx, ObjectKind::ByteArray, &raw_line_offsets);
+            LineOffsetArray::new_from_slice(cx, ObjectKind::U32Array, &raw_line_offsets);
 
         self.line_offsets = Some(line_offsets_object);
 

--- a/src/js/runtime/stack_trace.rs
+++ b/src/js/runtime/stack_trace.rs
@@ -160,7 +160,7 @@ pub fn create_stack_trace(
 
                 // Save the source position if it is for the first frame
                 if i == 0 {
-                    let source_file = func.source_file_ptr().unwrap();
+                    let source_file = func.source_file_ptr().unwrap().to_handle();
                     first_source_file_line_col = Some((source_file, line, column));
                 }
             }
@@ -174,8 +174,10 @@ pub fn create_stack_trace(
     }
 
     let frames = cx.alloc_string_ptr(&stack_trace);
+    let source_file_line_col =
+        first_source_file_line_col.map(|(file, line, col)| (*file, line, col));
 
-    CachedStackTraceInfo { frames, source_file_line_col: first_source_file_line_col }
+    CachedStackTraceInfo { frames, source_file_line_col }
 }
 
 /// Prepare for a stack trace to be formatted. Perform any allocations that will be needed, such as


### PR DESCRIPTION
## Summary

Fix two GC bugs found when running in GC stress test mode, due to changes made to error formatting.

1. Fix the source file heap pointer held over an allocation in `create_stack_trace`
2. Line offsets array cannot have descriptor `ObjectKind::ByteArray` as this calculates the wrong size during GC and only copies a portion of the line offsets array. Instead use the new `ObjectKind::U32` array which calculates the correct byte size.

## Tests

`cargo run --features gc_stress_test` now does not trigger any GC bugs