### PR TITLE
[runtime] Implement Iterator.prototype.toArray

### DIFF
--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -399,6 +399,7 @@ builtin_names!(
     (then, "then"),
     (this, "this"),
     (throw, "throw"),
+    (to_array, "toArray"),
     (to_date_string, "toDateString"),
     (to_exponential, "toExponential"),
     (to_fixed, "toFixed"),

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -345,6 +345,7 @@ rust_runtime_functions!(
     IteratorPrototype::set_constructor,
     IteratorPrototype::set_to_string_tag,
     IteratorPrototype::some,
+    IteratorPrototype::to_array,
     JSONObject::parse,
     JSONObject::stringify,
     MapConstructor::construct,


### PR DESCRIPTION
## Summary

Implement the `Iterator.prototype.toArray` method from the Iterator helpers proposal
(https://github.com/tc39/proposal-iterator-helpers).

## Tests

All test262 `Iterator.prototype.toArray` methods pass as well as the failing `built-ins/Iterator/from/get-next-method-only`.