### PR TITLE
[runtime] Implement Iterator.prototype.{filter, flatMap, map}, completing iterator helpers proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For more information on testing see the [testing README](./tests/README.md).
 
 ## Missing features
 
-All features up to ES2024 have been implemented (as well as all stage 4 proposals as of 2024-09-15), except for the following features:
+All features up to ES2024 have been implemented (as well as all stage 4 proposals as of 2025-02-13), except for the following features:
 
 - SharedArrayBuffer
 - Atomics

--- a/src/js/runtime/intrinsics/iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_prototype.rs
@@ -38,6 +38,7 @@ impl IteratorPrototype {
         object.intrinsic_func(cx, cx.names.every(), Self::every, 1, realm);
         object.intrinsic_func(cx, cx.names.find(), Self::find, 1, realm);
         object.intrinsic_func(cx, cx.names.for_each(), Self::for_each, 1, realm);
+        object.intrinsic_func(cx, cx.names.map_(), Self::map, 1, realm);
         object.intrinsic_func(cx, cx.names.reduce(), Self::reduce, 1, realm);
         object.intrinsic_func(cx, cx.names.some(), Self::some, 1, realm);
         object.intrinsic_func(cx, cx.names.take(), Self::take, 1, realm);
@@ -261,6 +262,30 @@ impl IteratorPrototype {
                 Ok(_) => counter += 1,
             }
         }
+    }
+
+    /// Iterator.prototype.map (https://tc39.es/ecma262/#sec-iterator.prototype.map)
+    pub fn map(
+        cx: Context,
+        this_value: Handle<Value>,
+        arguments: &[Handle<Value>],
+        _: Option<Handle<ObjectValue>>,
+    ) -> EvalResult<Handle<Value>> {
+        if !this_value.is_object() {
+            return type_error(cx, "Iterator.prototype.map called on non-object");
+        }
+
+        // Verify the mapper argument is a function, closing the underlying iterator if not
+        let mapper_arg = get_argument(cx, arguments, 0);
+        if !is_callable(mapper_arg) {
+            let error = type_error_value(cx, "Iterator.prototype.map mapper is not a function");
+            return iterator_close(cx, this_value.as_object(), Err(error));
+        }
+        let mapper = mapper_arg.as_object();
+
+        // Get the underlying iterator and create a new iterator helper map object
+        let iterated = get_iterator_direct(cx, this_value.as_object())?;
+        Ok(IteratorHelperObject::new_map(cx, &iterated, mapper).as_value())
     }
 
     /// Iterator.prototype.reduce (https://tc39.es/ecma262/#sec-iterator.prototype.reduce)

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -345,6 +345,7 @@ rust_runtime_functions!(
     IteratorPrototype::for_each,
     IteratorPrototype::get_constructor,
     IteratorPrototype::iterator_prototype_get_to_string_tag,
+    IteratorPrototype::map,
     IteratorPrototype::reduce,
     IteratorPrototype::set_constructor,
     IteratorPrototype::set_to_string_tag,

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -341,6 +341,7 @@ rust_runtime_functions!(
     IteratorHelperPrototype::return_,
     IteratorPrototype::drop,
     IteratorPrototype::every,
+    IteratorPrototype::filter,
     IteratorPrototype::find,
     IteratorPrototype::for_each,
     IteratorPrototype::get_constructor,

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -343,6 +343,7 @@ rust_runtime_functions!(
     IteratorPrototype::every,
     IteratorPrototype::filter,
     IteratorPrototype::find,
+    IteratorPrototype::flat_map,
     IteratorPrototype::for_each,
     IteratorPrototype::get_constructor,
     IteratorPrototype::iterator_prototype_get_to_string_tag,

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -204,9 +204,6 @@
   // Tests for unimplemented features. Counts against test262 progress.
   "unimplemented": {
     "features": [
-      // Stage 4 proposals
-      "iterator-helpers",
-
       // Other unimplemented features
       "SharedArrayBuffer",
       "Atomics"


### PR DESCRIPTION
## Summary

Finish implementing the iterator helpers proposal (https://github.com/tc39/proposal-iterator-helpers). The remaining methods to implement are `Iterator.prototype.{filter, flatMap, map}` which all use the new iterator helper objects introduced in https://github.com/Hans-Halverson/brimstone/pull/130.

With this PR all stage 4 proposals as of the current day (2/13/2025) have been implemented except for `SharedArrayBuffer` and `Atomics`.

## Tests

Stop ignoring all test262 iterator helpers tests. All test262 iterator helpers tests pass.