### PR TITLE
[common] Error message source location uses the lowest location found in stack

### DIFF
--- a/src/js/runtime/stack_trace.rs
+++ b/src/js/runtime/stack_trace.rs
@@ -158,8 +158,8 @@ pub fn create_stack_trace(
                 // Append the line and column to the function name
                 stack_trace.push_str(&format!(":{}:{}", line, column));
 
-                // Save the source position if it is for the first frame
-                if i == 0 {
+                // Save the first source position that is found
+                if first_source_file_line_col.is_none() {
                     let source_file = func.source_file_ptr().unwrap().to_handle();
                     first_source_file_line_col = Some((source_file, line, column));
                 }

--- a/tests/js_error/source_locations/statement/for_await/async_iterator_close_finish_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/async_iterator_close_finish_module.exp
@@ -1,3 +1,8 @@
 TypeError: return method must return an object
+   ┌ tests/js_error/source_locations/statement/for_await/async_iterator_close_finish_module.js:15:20
+   |
+15 |   for await (var x of iterable) {
+   |                    ^
+Stack trace:
   at return (<native>)
   at foo (tests/js_error/source_locations/statement/for_await/async_iterator_close_finish_module.js:15:20)

--- a/tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.exp
+++ b/tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.exp
@@ -1,4 +1,9 @@
 TypeError: iterator's next method must return an object
+   ┌ tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.js:12:20
+   |
+12 |   for await (var x of iter) {}
+   |                    ^
+Stack trace:
   at next (<native>)
   at foo (tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.js:12:20)
   at <module> (tests/js_error/source_locations/statement/for_await/iterator_unpack_result_module.js:15:7)

--- a/tests/js_error/stack_trace/use_nearest_location.exp
+++ b/tests/js_error/stack_trace/use_nearest_location.exp
@@ -1,0 +1,10 @@
+TypeError: generator is already executing
+  ┌ tests/js_error/stack_trace/use_nearest_location.js:3:20
+  |
+3 | var i = { next() { ii.next() } };
+  |                    ^
+Stack trace:
+  at next (<native>)
+  at next (tests/js_error/stack_trace/use_nearest_location.js:3:20)
+  at next (<native>)
+  at <global> (tests/js_error/stack_trace/use_nearest_location.js:5:1)

--- a/tests/js_error/stack_trace/use_nearest_location.js
+++ b/tests/js_error/stack_trace/use_nearest_location.js
@@ -1,0 +1,5 @@
+// Error comes from native Iterator.next, but the location in source message should point to
+// the next method below.
+var i = { next() { ii.next() } };
+var ii = Iterator.prototype.map.call(i, x => x);
+ii.next(); 


### PR DESCRIPTION
## Summary

We display a source location and snippet when printing error messages, however the source location is used from the lowest frame in the stack if one exists. This means that errors thrown from native functions will not display a source location.

Instead let's find and use the lowest source location on the stack when caching stack frame info.

## Tests

Added error snapshot test verifying that throwing from a native frame displays the lowest possible source location in stack.