### PR TITLE
[runtime] Pass new target to rust runtime functions via the stack instead of as native function parameter

### DIFF
--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -397,7 +397,6 @@ pub fn await_return_resolve(
     mut cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let value = get_argument(cx, arguments, 0);
 
@@ -416,7 +415,6 @@ pub fn await_return_reject(
     mut cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let value = get_argument(cx, arguments, 0);
 

--- a/src/js/runtime/bound_function_object.rs
+++ b/src/js/runtime/bound_function_object.rs
@@ -145,7 +145,6 @@ impl BoundFunctionObject {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let bound_function = cx.current_function();
 
@@ -171,7 +170,7 @@ impl BoundFunctionObject {
         all_arguments.extend(arguments.iter());
 
         // If there is a new_target this was called as a constructor
-        if let Some(new_target) = new_target {
+        if let Some(new_target) = cx.current_new_target() {
             let new_target = if same_object_value_handles(bound_function, new_target) {
                 bound_target_function
             } else {

--- a/src/js/runtime/builtin_function.rs
+++ b/src/js/runtime/builtin_function.rs
@@ -2,31 +2,22 @@ use crate::js::runtime::bytecode::function::Closure;
 
 use super::{
     bytecode::function::BytecodeFunction,
-    eval_result::EvalResult,
     function::{build_function_name, set_function_length, set_function_name},
-    intrinsics::intrinsics::Intrinsic,
+    intrinsics::{intrinsics::Intrinsic, rust_runtime::RustRuntimeFunction},
     object_value::ObjectValue,
     property_key::PropertyKey,
     realm::Realm,
-    Context, Handle, Value,
+    Context, Handle,
 };
 
 /// Built-in Function Object (https://tc39.es/ecma262/#sec-built-in-function-objects)
 pub struct BuiltinFunction {}
 
-// Function pointer to a builtin function
-pub type BuiltinFunctionPtr = fn(
-    cx: Context,
-    this_value: Handle<Value>,
-    arguments: &[Handle<Value>],
-    new_target: Option<Handle<ObjectValue>>,
-) -> EvalResult<Handle<Value>>;
-
 impl BuiltinFunction {
     /// Create a new builtin function. Function is not a constructor.
     pub fn create(
         cx: Context,
-        builtin_func: BuiltinFunctionPtr,
+        builtin_func: RustRuntimeFunction,
         length: u32,
         name: Handle<PropertyKey>,
         realm: Handle<Realm>,
@@ -48,7 +39,7 @@ impl BuiltinFunction {
 
     fn create_builtin_function(
         cx: Context,
-        builtin_func: BuiltinFunctionPtr,
+        builtin_func: RustRuntimeFunction,
         length: u32,
         name: Handle<PropertyKey>,
         realm: Handle<Realm>,
@@ -82,7 +73,7 @@ impl BuiltinFunction {
 
     pub fn create_builtin_function_without_properties(
         cx: Context,
-        builtin_func: BuiltinFunctionPtr,
+        builtin_func: RustRuntimeFunction,
         name: Option<Handle<PropertyKey>>,
         realm: Handle<Realm>,
         prototype: Option<Handle<ObjectValue>>,
@@ -106,7 +97,7 @@ impl BuiltinFunction {
     /// Create the constructor function for an intrinsic.
     pub fn intrinsic_constructor(
         cx: Context,
-        builtin_func: BuiltinFunctionPtr,
+        builtin_func: RustRuntimeFunction,
         length: u32,
         name: Handle<PropertyKey>,
         realm: Handle<Realm>,

--- a/src/js/runtime/console.rs
+++ b/src/js/runtime/console.rs
@@ -34,7 +34,6 @@ impl ConsoleObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let use_colors = stdout_should_use_colors(&cx.options);
         let opts = FormatOptions::new(use_colors);

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -316,6 +316,21 @@ impl Context {
         self.vm().closure().to_handle().into()
     }
 
+    pub fn current_new_target(&mut self) -> Option<Handle<ObjectValue>> {
+        let new_target_index = self.vm().closure().function().new_target_index();
+        if let Some(index) = new_target_index {
+            let new_target = self.vm().get_register_at_index(index);
+            if new_target.is_undefined() {
+                return None;
+            }
+
+            debug_assert!(new_target.is_object());
+            Some(new_target.as_object().to_handle())
+        } else {
+            None
+        }
+    }
+
     pub fn global_symbol_registry(&self) -> HeapPtr<GlobalSymbolRegistry> {
         self.global_symbol_registry
     }

--- a/src/js/runtime/gc_object.rs
+++ b/src/js/runtime/gc_object.rs
@@ -34,12 +34,7 @@ impl GcObject {
         });
     }
 
-    pub fn run(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
-    ) -> EvalResult<Handle<Value>> {
+    pub fn run(cx: Context, _: Handle<Value>, _: &[Handle<Value>]) -> EvalResult<Handle<Value>> {
         Heap::run_gc(cx);
         Ok(cx.undefined())
     }

--- a/src/js/runtime/global_names.rs
+++ b/src/js/runtime/global_names.rs
@@ -102,7 +102,6 @@ pub fn global_declaration_instantiation_runtime(
     cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let global_names = arguments.first().unwrap().cast::<GlobalNames>();
     let realm = cx.current_realm();

--- a/src/js/runtime/intrinsics/aggregate_error_constructor.rs
+++ b/src/js/runtime/intrinsics/aggregate_error_constructor.rs
@@ -69,9 +69,8 @@ impl AggregateErrorConstructor {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        let new_target = if let Some(new_target) = new_target {
+        let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
             cx.current_function()

--- a/src/js/runtime/intrinsics/array_buffer_constructor.rs
+++ b/src/js/runtime/intrinsics/array_buffer_constructor.rs
@@ -166,12 +166,11 @@ impl ArrayBufferConstructor {
 
     /// ArrayBuffer (https://tc39.es/ecma262/#sec-arraybuffer-length)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        let new_target = if let Some(new_target) = new_target {
+        let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
             return type_error(cx, "ArrayBuffer constructor must be called with new");
@@ -198,7 +197,6 @@ impl ArrayBufferConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         if !value.is_object() {

--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -57,7 +57,6 @@ impl ArrayBufferPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let array_buffer = require_array_buffer(cx, this_value, "byteLength")?;
 
@@ -70,7 +69,6 @@ impl ArrayBufferPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let array_buffer = require_array_buffer(cx, this_value, "detached")?;
         Ok(cx.bool(array_buffer.is_detached()))
@@ -81,7 +79,6 @@ impl ArrayBufferPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let array_buffer = require_array_buffer(cx, this_value, "maxByteLength")?;
 
@@ -98,7 +95,6 @@ impl ArrayBufferPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let array_buffer = require_array_buffer(cx, this_value, "resizable")?;
         Ok(cx.bool(!array_buffer.is_fixed_length()))
@@ -109,7 +105,6 @@ impl ArrayBufferPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let mut array_buffer = require_array_buffer(cx, this_value, "resize")?;
 
@@ -162,7 +157,6 @@ impl ArrayBufferPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let mut array_buffer = require_array_buffer(cx, this_value, "slice")?;
 
@@ -245,7 +239,6 @@ impl ArrayBufferPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let array_buffer = require_array_buffer(cx, this_value, "transfer")?;
         let new_length = get_argument(cx, arguments, 0);
@@ -261,7 +254,6 @@ impl ArrayBufferPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let array_buffer = require_array_buffer(cx, this_value, "transferToFixedLength")?;
         let new_length = get_argument(cx, arguments, 0);

--- a/src/js/runtime/intrinsics/array_constructor.rs
+++ b/src/js/runtime/intrinsics/array_constructor.rs
@@ -58,9 +58,10 @@ impl ArrayConstructor {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        let new_target = new_target.unwrap_or_else(|| cx.current_function());
+        let new_target = cx
+            .current_new_target()
+            .unwrap_or_else(|| cx.current_function());
         let proto = get_prototype_from_constructor(cx, new_target, Intrinsic::ArrayPrototype)?;
 
         if arguments.is_empty() {
@@ -109,7 +110,6 @@ impl ArrayConstructor {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         // Determine if map function was provided and is callable
         let map_function_arg = get_argument(cx, arguments, 1);
@@ -217,7 +217,6 @@ impl ArrayConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let is_array = is_array(cx, argument)?;
@@ -229,7 +228,6 @@ impl ArrayConstructor {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let length = arguments.len();
         let length_value = Value::from(length).to_handle(cx);

--- a/src/js/runtime/intrinsics/array_iterator.rs
+++ b/src/js/runtime/intrinsics/array_iterator.rs
@@ -125,7 +125,6 @@ impl ArrayIteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let mut array_iterator = ArrayIterator::cast_from_value(cx, this_value)?;
         let array = array_iterator.array();

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -106,7 +106,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -136,7 +135,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let array = array_species_create(cx, object, 0)?;
@@ -223,7 +221,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -329,7 +326,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         Ok(ArrayIterator::new(cx, object, ArrayIteratorKind::KeyAndValue).as_value())
@@ -340,7 +336,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -380,7 +375,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -432,7 +426,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -483,7 +476,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -509,7 +501,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -535,7 +526,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -562,7 +552,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -589,7 +578,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -684,7 +672,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -717,7 +704,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -754,7 +740,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -799,7 +784,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -845,7 +829,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -884,7 +867,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         Ok(ArrayIterator::new(cx, object, ArrayIteratorKind::Key).as_value())
@@ -895,7 +877,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -949,7 +930,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -989,7 +969,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1017,7 +996,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1046,7 +1024,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1106,7 +1083,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1165,7 +1141,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1223,7 +1198,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1267,7 +1241,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1335,7 +1308,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1375,7 +1347,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let compare_function_arg = get_argument(cx, arguments, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
@@ -1415,7 +1386,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1517,7 +1487,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1552,7 +1521,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1579,7 +1547,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let compare_function_arg = get_argument(cx, arguments, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
@@ -1615,7 +1582,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1688,7 +1654,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let array = to_object(cx, this_value)?;
         let func = get(cx, array, cx.names.join())?;
@@ -1707,7 +1672,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1751,7 +1715,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         Ok(ArrayIterator::new(cx, object, ArrayIteratorKind::Value).as_value())
@@ -1762,7 +1725,6 @@ impl ArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
@@ -91,7 +91,6 @@ impl AsyncFromSyncIteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
@@ -124,7 +123,6 @@ impl AsyncFromSyncIteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
@@ -176,7 +174,6 @@ impl AsyncFromSyncIteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
@@ -298,7 +295,6 @@ pub fn create_continuing_iter_result_object(
     cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let value = get_argument(cx, arguments, 0);
     Ok(create_iter_result_object(cx, value, /* is_done */ false))
@@ -308,7 +304,6 @@ pub fn create_done_iter_result_object(
     cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let value = get_argument(cx, arguments, 0);
     Ok(create_iter_result_object(cx, value, /* is_done */ true))
@@ -318,7 +313,6 @@ pub fn async_from_sync_iterator_continuation_on_reject(
     mut cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the iterator passed from the caller
     let current_function = cx.current_function();

--- a/src/js/runtime/intrinsics/async_function_constructor.rs
+++ b/src/js/runtime/intrinsics/async_function_constructor.rs
@@ -36,13 +36,12 @@ impl AsyncFunctionConstructor {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let constructor = cx.current_function();
         Ok(create_dynamic_function(
             cx,
             constructor,
-            new_target,
+            cx.current_new_target(),
             arguments,
             /* is_async */ true,
             /* is_generator */ false,

--- a/src/js/runtime/intrinsics/async_generator_function_constructor.rs
+++ b/src/js/runtime/intrinsics/async_generator_function_constructor.rs
@@ -36,13 +36,12 @@ impl AsyncGeneratorFunctionConstructor {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let constructor = cx.current_function();
         Ok(create_dynamic_function(
             cx,
             constructor,
-            new_target,
+            cx.current_new_target(),
             arguments,
             /* is_async */ true,
             /* is_generator */ true,

--- a/src/js/runtime/intrinsics/async_generator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_generator_prototype.rs
@@ -58,7 +58,6 @@ impl AsyncGeneratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
 
@@ -96,7 +95,6 @@ impl AsyncGeneratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
 
@@ -126,7 +124,6 @@ impl AsyncGeneratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let error = get_argument(cx, arguments, 0);
 

--- a/src/js/runtime/intrinsics/bigint_constructor.rs
+++ b/src/js/runtime/intrinsics/bigint_constructor.rs
@@ -77,12 +77,11 @@ impl BigIntConstructor {
 
     /// BigInt (https://tc39.es/ecma262/#sec-bigint-constructor-number-value)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        if new_target.is_some() {
+        if cx.current_new_target().is_some() {
             return type_error(cx, "BigInt is not a constructor");
         }
 
@@ -111,7 +110,6 @@ impl BigIntConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let bits_arg = get_argument(cx, arguments, 0);
         let bits = to_index(cx, bits_arg)?;
@@ -146,7 +144,6 @@ impl BigIntConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let bits_arg = get_argument(cx, arguments, 0);
         let bits = to_index(cx, bits_arg)?;

--- a/src/js/runtime/intrinsics/bigint_prototype.rs
+++ b/src/js/runtime/intrinsics/bigint_prototype.rs
@@ -40,7 +40,6 @@ impl BigIntPrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let bigint_value = this_bigint_value(cx, this_value)?;
 
@@ -66,7 +65,6 @@ impl BigIntPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         Ok(this_bigint_value(cx, this_value)?.into())
     }

--- a/src/js/runtime/intrinsics/boolean_constructor.rs
+++ b/src/js/runtime/intrinsics/boolean_constructor.rs
@@ -106,14 +106,13 @@ impl BooleanConstructor {
 
     /// Boolean (https://tc39.es/ecma262/#sec-boolean-constructor-boolean-value)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let bool_value = to_boolean(*get_argument(cx, arguments, 0));
 
-        match new_target {
+        match cx.current_new_target() {
             None => Ok(cx.bool(bool_value)),
             Some(new_target) => {
                 Ok(BooleanObject::new_from_constructor(cx, new_target, bool_value)?.as_value())

--- a/src/js/runtime/intrinsics/boolean_prototype.rs
+++ b/src/js/runtime/intrinsics/boolean_prototype.rs
@@ -29,7 +29,6 @@ impl BooleanPrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let bool_value = this_boolean_value(cx, this_value)?;
         let string_value = if bool_value { "true" } else { "false" };
@@ -42,7 +41,6 @@ impl BooleanPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let bool_value = this_boolean_value(cx, this_value)?;
         Ok(cx.bool(bool_value))

--- a/src/js/runtime/intrinsics/data_view_constructor.rs
+++ b/src/js/runtime/intrinsics/data_view_constructor.rs
@@ -96,12 +96,11 @@ impl DataViewConstructor {
 
     /// DataView (https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        let new_target = if let Some(new_target) = new_target {
+        let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
             return type_error(cx, "DataView constructor must be called with new");

--- a/src/js/runtime/intrinsics/data_view_prototype.rs
+++ b/src/js/runtime/intrinsics/data_view_prototype.rs
@@ -70,7 +70,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let data_view = require_is_data_view(cx, this_value)?;
         Ok(data_view.viewed_array_buffer().as_value())
@@ -81,7 +80,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let data_view = require_is_data_view(cx, this_value)?;
         let data_view_record = make_data_view_with_buffer_witness_record(data_view);
@@ -100,7 +98,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let data_view = require_is_data_view(cx, this_value)?;
         let data_view_record = make_data_view_with_buffer_witness_record(data_view);
@@ -117,7 +114,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, from_big_int64_element, i64::swap_bytes)
     }
@@ -127,7 +123,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, from_big_uint64_element, u64::swap_bytes)
     }
@@ -137,7 +132,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, from_float32_element, |element| {
             let bits = f32::to_bits(element);
@@ -150,7 +144,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, from_float64_element, |element| {
             let bits = f64::to_bits(element);
@@ -163,7 +156,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, from_int8_element, |element| element)
     }
@@ -173,7 +165,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, from_int16_element, i16::swap_bytes)
     }
@@ -183,7 +174,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, from_int32_element, i32::swap_bytes)
     }
@@ -193,7 +183,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, from_uint8_element, |element| element)
     }
@@ -203,7 +192,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, from_uint16_element, u16::swap_bytes)
     }
@@ -213,7 +201,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, from_uint32_element, u32::swap_bytes)
     }
@@ -223,7 +210,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -240,7 +226,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -257,7 +242,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -277,7 +261,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -297,7 +280,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(cx, this_value, arguments, ContentType::Number, to_int8_element, |element| {
             element
@@ -309,7 +291,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -326,7 +307,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -343,7 +323,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -360,7 +339,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -377,7 +355,6 @@ impl DataViewPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,

--- a/src/js/runtime/intrinsics/date_constructor.rs
+++ b/src/js/runtime/intrinsics/date_constructor.rs
@@ -51,12 +51,11 @@ impl DateConstructor {
 
     /// Date (https://tc39.es/ecma262/#sec-date)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        let new_target = if let Some(new_target) = new_target {
+        let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
             return Ok(to_date_string(cx, get_current_unix_time()).as_value());
@@ -146,12 +145,7 @@ impl DateConstructor {
     }
 
     /// Date.now (https://tc39.es/ecma262/#sec-date.now)
-    pub fn now(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
-    ) -> EvalResult<Handle<Value>> {
+    pub fn now(cx: Context, _: Handle<Value>, _: &[Handle<Value>]) -> EvalResult<Handle<Value>> {
         Ok(Value::from(get_current_unix_time()).to_handle(cx))
     }
 
@@ -160,7 +154,6 @@ impl DateConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let string_arg = get_argument(cx, arguments, 0);
         let string = to_string(cx, string_arg)?;
@@ -177,7 +170,6 @@ impl DateConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let number_of_args = arguments.len();
 

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -132,7 +132,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -154,7 +153,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -176,7 +174,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -201,7 +198,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -223,7 +219,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -248,7 +243,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -273,7 +267,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -295,7 +288,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -320,7 +312,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if let Some(date_value) = this_date_value(this_value) {
             Ok(Value::from(date_value).to_handle(cx))
@@ -334,7 +325,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -356,7 +346,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -378,7 +367,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -400,7 +388,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -422,7 +409,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -444,7 +430,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -469,7 +454,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -494,7 +478,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -519,7 +502,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -544,7 +526,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -576,7 +557,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let mut date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -623,7 +603,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -691,7 +670,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -731,7 +709,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -790,7 +767,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -834,7 +810,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -886,7 +861,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if this_date_value(this_value).is_none() {
             return type_error(cx, "Date.prototype.setTime method must be called on Date object");
@@ -905,7 +879,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -938,7 +911,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let mut date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -983,7 +955,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1050,7 +1021,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1088,7 +1058,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1145,7 +1114,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1190,7 +1158,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1240,7 +1207,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1272,7 +1238,6 @@ impl DatePrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1315,7 +1280,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
 
@@ -1333,7 +1297,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1352,7 +1315,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1371,7 +1333,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1390,7 +1351,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1406,7 +1366,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1440,7 +1399,6 @@ impl DatePrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1477,7 +1435,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
@@ -1493,7 +1450,6 @@ impl DatePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Date.prototype[@@toPrimitive] must be called on object");

--- a/src/js/runtime/intrinsics/error_constructor.rs
+++ b/src/js/runtime/intrinsics/error_constructor.rs
@@ -141,9 +141,8 @@ impl ErrorConstructor {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        let new_target = if let Some(new_target) = new_target {
+        let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
             cx.current_function()

--- a/src/js/runtime/intrinsics/error_prototype.rs
+++ b/src/js/runtime/intrinsics/error_prototype.rs
@@ -35,7 +35,6 @@ impl ErrorPrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "expected object");
@@ -71,7 +70,6 @@ impl ErrorPrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         // Check that `stack` getter was called on an error object
         if !this_value.is_object() || !this_value.as_object().is_error() {

--- a/src/js/runtime/intrinsics/finalization_registry_constructor.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_constructor.rs
@@ -33,12 +33,11 @@ impl FinalizationRegistryConstructor {
 
     /// FinalizationRegistry (https://tc39.es/ecma262/#sec-finalization-registry-cleanup-callback)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        let new_target = if let Some(new_target) = new_target {
+        let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
             return type_error(cx, "FinalizationRegistry constructor must be called with new");

--- a/src/js/runtime/intrinsics/finalization_registry_prototype.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_prototype.rs
@@ -39,7 +39,6 @@ impl FinalizationRegistryPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let registry_object =
             if let Some(registry_object) = this_finalization_registry_value(this_value) {
@@ -89,7 +88,6 @@ impl FinalizationRegistryPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let registry_object =
             if let Some(registry_object) = this_finalization_registry_value(this_value) {

--- a/src/js/runtime/intrinsics/function_constructor.rs
+++ b/src/js/runtime/intrinsics/function_constructor.rs
@@ -33,13 +33,12 @@ impl FunctionConstructor {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let constructor = cx.current_function();
         Ok(create_dynamic_function(
             cx,
             constructor,
-            new_target,
+            cx.current_new_target(),
             arguments,
             /* is_async */ false,
             /* is_generator */ false,

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -95,7 +95,6 @@ impl FunctionPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !is_callable(this_value) {
             return type_error(cx, "value is not a function");
@@ -117,7 +116,6 @@ impl FunctionPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !is_callable(this_value) {
             return type_error(cx, "value is not a function");
@@ -174,7 +172,6 @@ impl FunctionPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !is_callable(this_value) {
             return type_error(cx, "value is not a function");
@@ -193,7 +190,6 @@ impl FunctionPrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Function.prototype.toString expected a function");
@@ -247,7 +243,6 @@ impl FunctionPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let has_instance = ordinary_has_instance(cx, this_value, argument)?;

--- a/src/js/runtime/intrinsics/generator_function_constructor.rs
+++ b/src/js/runtime/intrinsics/generator_function_constructor.rs
@@ -36,13 +36,12 @@ impl GeneratorFunctionConstructor {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let constructor = cx.current_function();
         Ok(create_dynamic_function(
             cx,
             constructor,
-            new_target,
+            cx.current_new_target(),
             arguments,
             /* is_async */ false,
             /* is_generator */ true,

--- a/src/js/runtime/intrinsics/generator_prototype.rs
+++ b/src/js/runtime/intrinsics/generator_prototype.rs
@@ -45,7 +45,6 @@ impl GeneratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         generator_resume(cx, this_value, value)
@@ -56,7 +55,6 @@ impl GeneratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         generator_resume_abrupt(cx, this_value, value, GeneratorCompletionType::Return)
@@ -67,7 +65,6 @@ impl GeneratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let error = get_argument(cx, arguments, 0);
         generator_resume_abrupt(cx, this_value, error, GeneratorCompletionType::Throw)

--- a/src/js/runtime/intrinsics/global_object.rs
+++ b/src/js/runtime/intrinsics/global_object.rs
@@ -12,7 +12,6 @@ use crate::js::{
         eval::eval::perform_eval,
         function::get_argument,
         gc::HandleScope,
-        object_value::ObjectValue,
         property_descriptor::PropertyDescriptor,
         string_parsing::{parse_signed_decimal_literal, skip_string_whitespace, StringLexer},
         string_value::{FlatString, StringValue},
@@ -156,7 +155,6 @@ pub fn eval(
     cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let code_arg = get_argument(cx, arguments, 0);
 
@@ -168,7 +166,6 @@ pub fn is_finite(
     cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let argument = get_argument(cx, arguments, 0);
     let num = to_number(cx, argument)?;
@@ -180,7 +177,6 @@ pub fn is_nan(
     cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let argument = get_argument(cx, arguments, 0);
     let num = to_number(cx, argument)?;
@@ -192,7 +188,6 @@ pub fn parse_float(
     cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let input_string_arg = get_argument(cx, arguments, 0);
     let input_string = to_string(cx, input_string_arg)?;
@@ -215,7 +210,6 @@ pub fn parse_int(
     cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let input_string_arg = get_argument(cx, arguments, 0);
     let input_string = to_string(cx, input_string_arg)?;
@@ -329,7 +323,6 @@ pub fn decode_uri(
     cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let uri_arg = get_argument(cx, arguments, 0);
     let uri_string = to_string(cx, uri_arg)?;
@@ -342,7 +335,6 @@ pub fn decode_uri_component(
     cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let uri_component_arg = get_argument(cx, arguments, 0);
     let uri_component_string = to_string(cx, uri_component_arg)?;
@@ -458,7 +450,6 @@ pub fn encode_uri(
     cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let uri_arg = get_argument(cx, arguments, 0);
     let uri_string = to_string(cx, uri_arg)?;
@@ -471,7 +462,6 @@ pub fn encode_uri_component(
     cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     let uri_component_arg = get_argument(cx, arguments, 0);
     let uri_component_string = to_string(cx, uri_component_arg)?;

--- a/src/js/runtime/intrinsics/intrinsics.rs
+++ b/src/js/runtime/intrinsics/intrinsics.rs
@@ -487,7 +487,6 @@ pub fn throw_type_error(
     cx: Context,
     _: Handle<Value>,
     _: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     type_error(cx, "'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them")
 }

--- a/src/js/runtime/intrinsics/iterator_constructor.rs
+++ b/src/js/runtime/intrinsics/iterator_constructor.rs
@@ -49,8 +49,8 @@ impl IteratorConstructor {
         mut cx: Context,
         _: Handle<Value>,
         _: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
+        let new_target = cx.current_new_target();
         let throw_type_error = match new_target {
             None => true,
             Some(new_target) => new_target.ptr_eq(&cx.current_function()),
@@ -74,7 +74,6 @@ impl IteratorConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         let iterator = get_iterator_flattenable(cx, value, /* reject_primitives */ false)?;
@@ -160,7 +159,6 @@ impl WrapForValidIteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         // Check if called on a WrappedIteratorObject
         if this_value.is_object() {
@@ -179,7 +177,6 @@ impl WrapForValidIteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         // Check if called on a WrappedIteratorObject
         if this_value.is_object() {

--- a/src/js/runtime/intrinsics/iterator_helper_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_prototype.rs
@@ -37,7 +37,6 @@ impl IteratorHelperPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         // GenerateResume adapted for Iterator Helper Objects
         let mut object = match validate_iterator_helper_object(this_value) {
@@ -87,7 +86,6 @@ impl IteratorHelperPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let mut object = match validate_iterator_helper_object(this_value) {
             None => {

--- a/src/js/runtime/intrinsics/iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_prototype.rs
@@ -68,7 +68,6 @@ impl IteratorPrototype {
         cx: Context,
         _: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         Ok(cx.get_intrinsic(Intrinsic::IteratorConstructor).as_value())
     }
@@ -78,7 +77,6 @@ impl IteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
 
@@ -98,7 +96,6 @@ impl IteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Iterator.prototype.drop called on non-object");
@@ -137,7 +134,6 @@ impl IteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Iterator.prototype.every called on non-object");
@@ -183,7 +179,6 @@ impl IteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Iterator.prototype.filter called on non-object");
@@ -208,7 +203,6 @@ impl IteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Iterator.prototype.find called on non-object");
@@ -253,7 +247,6 @@ impl IteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Iterator.prototype.flatMap called on non-object");
@@ -277,7 +270,6 @@ impl IteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Iterator.prototype.forEach called on non-object");
@@ -320,7 +312,6 @@ impl IteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Iterator.prototype.map called on non-object");
@@ -344,7 +335,6 @@ impl IteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Iterator.prototype.reduce called on non-object");
@@ -409,7 +399,6 @@ impl IteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Iterator.prototype.some called on non-object");
@@ -454,7 +443,6 @@ impl IteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Iterator.prototype.take called on non-object");
@@ -493,7 +481,6 @@ impl IteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Iterator.prototype.toArray called on non-object");
@@ -517,7 +504,6 @@ impl IteratorPrototype {
         cx: Context,
         _: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         Ok(cx.names.iterator().as_string().as_value())
     }
@@ -527,7 +513,6 @@ impl IteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
 

--- a/src/js/runtime/intrinsics/json_object.rs
+++ b/src/js/runtime/intrinsics/json_object.rs
@@ -57,7 +57,6 @@ impl JSONObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let text_arg = get_argument(cx, arguments, 0);
         let text_string = to_string(cx, text_arg)?;
@@ -143,7 +142,6 @@ impl JSONObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         // Replacer arg may be a function or property list
         let replacer_arg = get_argument(cx, arguments, 1);

--- a/src/js/runtime/intrinsics/map_constructor.rs
+++ b/src/js/runtime/intrinsics/map_constructor.rs
@@ -51,12 +51,11 @@ impl MapConstructor {
 
     /// Map (https://tc39.es/ecma262/#sec-map-iterable)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        let new_target = if let Some(new_target) = new_target {
+        let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
             return type_error(cx, "Map constructor must be called with new");
@@ -85,7 +84,6 @@ impl MapConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let items = get_argument(cx, arguments, 0);
         let callback = get_argument(cx, arguments, 1);

--- a/src/js/runtime/intrinsics/map_iterator.rs
+++ b/src/js/runtime/intrinsics/map_iterator.rs
@@ -102,7 +102,6 @@ impl MapIteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let mut map_iterator = MapIterator::cast_from_value(cx, this_value)?;
 

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -63,7 +63,6 @@ impl MapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let map = if let Some(map) = this_map_value(this_value) {
             map
@@ -81,7 +80,6 @@ impl MapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let map = if let Some(map) = this_map_value(this_value) {
             map
@@ -100,7 +98,6 @@ impl MapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let map = if let Some(map) = this_map_value(this_value) {
             map
@@ -116,7 +113,6 @@ impl MapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let map = if let Some(map) = this_map_value(this_value) {
             map
@@ -154,7 +150,6 @@ impl MapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let map = if let Some(map) = this_map_value(this_value) {
             map
@@ -175,7 +170,6 @@ impl MapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let map = if let Some(map) = this_map_value(this_value) {
             map
@@ -193,7 +187,6 @@ impl MapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let map = if let Some(map) = this_map_value(this_value) {
             map
@@ -209,7 +202,6 @@ impl MapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let map = if let Some(map) = this_map_value(this_value) {
             map
@@ -235,7 +227,6 @@ impl MapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let map = if let Some(map) = this_map_value(this_value) {
             map
@@ -251,7 +242,6 @@ impl MapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let map = if let Some(map) = this_map_value(this_value) {
             map

--- a/src/js/runtime/intrinsics/math_object.rs
+++ b/src/js/runtime/intrinsics/math_object.rs
@@ -100,7 +100,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -117,7 +116,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -129,7 +127,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -141,7 +138,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -153,7 +149,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -165,7 +160,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -177,7 +171,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -189,7 +182,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let y_arg = get_argument(cx, arguments, 0);
         let y = to_number(cx, y_arg)?;
@@ -205,7 +197,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -217,7 +208,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -234,7 +224,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_uint32(cx, argument)?;
@@ -246,7 +235,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -258,7 +246,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -270,7 +257,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -282,7 +268,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -294,7 +279,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -311,7 +295,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -323,7 +306,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let mut sum = Value::smi(0);
         let mut has_infinity: bool = false;
@@ -368,7 +350,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let x_arg = get_argument(cx, arguments, 0);
         let x = to_uint32(cx, x_arg)?;
@@ -386,7 +367,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -398,7 +378,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -410,7 +389,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -422,7 +400,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -434,7 +411,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let mut highest = Value::number(f64::NEG_INFINITY);
         let mut found_nan = false;
@@ -468,7 +444,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let mut lowest = Value::number(f64::INFINITY);
         let mut found_nan = false;
@@ -502,7 +477,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let base_arg = get_argument(cx, arguments, 0);
         let base = to_number(cx, base_arg)?;
@@ -514,12 +488,7 @@ impl MathObject {
     }
 
     /// Math.random (https://tc39.es/ecma262/#sec-math.random)
-    pub fn random(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
-    ) -> EvalResult<Handle<Value>> {
+    pub fn random(cx: Context, _: Handle<Value>, _: &[Handle<Value>]) -> EvalResult<Handle<Value>> {
         let n = rand::thread_rng().gen::<f64>();
         Ok(cx.number(n))
     }
@@ -529,7 +498,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -555,7 +523,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = *to_number(cx, argument)?;
@@ -587,7 +554,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -599,7 +565,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -611,7 +576,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -623,7 +587,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -635,7 +598,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;
@@ -647,7 +609,6 @@ impl MathObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_number(cx, argument)?;

--- a/src/js/runtime/intrinsics/native_error.rs
+++ b/src/js/runtime/intrinsics/native_error.rs
@@ -77,9 +77,8 @@ macro_rules! create_native_error {
                 mut cx: Context,
                 _: Handle<Value>,
                 arguments: &[Handle<Value>],
-                new_target: Option<Handle<ObjectValue>>,
             ) -> EvalResult<Handle<Value>> {
-                let new_target = if let Some(new_target) = new_target {
+                let new_target = if let Some(new_target) = cx.current_new_target() {
                     new_target
                 } else {
                     cx.current_function()

--- a/src/js/runtime/intrinsics/number_constructor.rs
+++ b/src/js/runtime/intrinsics/number_constructor.rs
@@ -144,10 +144,9 @@ impl NumberConstructor {
 
     /// Number (https://tc39.es/ecma262/#sec-number-constructor-number-value)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let number_value = if arguments.is_empty() {
             0.0
@@ -162,7 +161,7 @@ impl NumberConstructor {
             }
         };
 
-        match new_target {
+        match cx.current_new_target() {
             None => Ok(Value::from(number_value).to_handle(cx)),
             Some(new_target) => {
                 Ok(NumberObject::new_from_constructor(cx, new_target, number_value)?.as_value())
@@ -175,7 +174,6 @@ impl NumberConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         if !value.is_number() {
@@ -190,7 +188,6 @@ impl NumberConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         Ok(cx.bool(is_integral_number(*value)))
@@ -201,7 +198,6 @@ impl NumberConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         if !value.is_number() {
@@ -216,7 +212,6 @@ impl NumberConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         if !is_integral_number(*value) {

--- a/src/js/runtime/intrinsics/number_prototype.rs
+++ b/src/js/runtime/intrinsics/number_prototype.rs
@@ -38,7 +38,6 @@ impl NumberPrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let number_value = this_number_value(cx, this_value)?;
         let mut number = number_value.as_number();
@@ -118,7 +117,6 @@ impl NumberPrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let number_value = this_number_value(cx, this_value)?;
         let mut number = number_value.as_number();
@@ -164,9 +162,8 @@ impl NumberPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        Self::to_string(cx, this_value, &[], None)
+        Self::to_string(cx, this_value, &[])
     }
 
     /// Number.prototype.toPrecision (https://tc39.es/ecma262/#sec-number.prototype.toprecision)
@@ -174,7 +171,6 @@ impl NumberPrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let number_value = this_number_value(cx, this_value)?;
 
@@ -259,7 +255,6 @@ impl NumberPrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let number_value = this_number_value(cx, this_value)?;
 
@@ -365,7 +360,6 @@ impl NumberPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let number_value = this_number_value(cx, this_value)?;
         Ok(number_value.to_handle(cx))

--- a/src/js/runtime/intrinsics/object_constructor.rs
+++ b/src/js/runtime/intrinsics/object_constructor.rs
@@ -103,9 +103,8 @@ impl ObjectConstructor {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        if let Some(new_target) = new_target {
+        if let Some(new_target) = cx.current_new_target() {
             if !cx.current_function().ptr_eq(&new_target) {
                 let new_object = object_create_from_constructor::<ObjectValue>(
                     cx,
@@ -131,7 +130,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let to_arg = get_argument(cx, arguments, 0);
         let to = to_object(cx, to_arg)?;
@@ -169,7 +167,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let proto = get_argument(cx, arguments, 0);
         let proto = if proto.is_object() {
@@ -197,7 +194,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = get_argument(cx, arguments, 0);
         if !object.is_object() {
@@ -245,7 +241,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = get_argument(cx, arguments, 0);
         if !object.is_object() {
@@ -268,7 +263,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object_arg = get_argument(cx, arguments, 0);
         let object = to_object(cx, object_arg)?;
@@ -281,7 +275,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = get_argument(cx, arguments, 0);
         if !object.is_object() {
@@ -300,7 +293,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let iterable_arg = get_argument(cx, arguments, 0);
         let iterable = require_object_coercible(cx, iterable_arg)?;
@@ -319,7 +311,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object_arg = get_argument(cx, arguments, 0);
         let object = to_object(cx, object_arg)?;
@@ -338,7 +329,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object_arg = get_argument(cx, arguments, 0);
         let object = to_object(cx, object_arg)?;
@@ -367,7 +357,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object_arg = get_argument(cx, arguments, 0);
         let symbol_keys = Self::get_own_property_keys(cx, object_arg, true)?;
@@ -379,7 +368,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object_arg = get_argument(cx, arguments, 0);
         let symbol_keys = Self::get_own_property_keys(cx, object_arg, false)?;
@@ -414,7 +402,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object_arg = get_argument(cx, arguments, 0);
         let object = to_object(cx, object_arg)?;
@@ -431,7 +418,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let items = get_argument(cx, arguments, 0);
         let callback = get_argument(cx, arguments, 1);
@@ -456,7 +442,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object_arg = get_argument(cx, arguments, 0);
         let object = to_object(cx, object_arg)?;
@@ -473,7 +458,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let is_same = same_value(get_argument(cx, arguments, 0), get_argument(cx, arguments, 1));
         Ok(cx.bool(is_same))
@@ -484,7 +468,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         if !value.is_object() {
@@ -500,7 +483,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         if !value.is_object() {
@@ -516,7 +498,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         if !value.is_object() {
@@ -532,7 +513,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object_arg = get_argument(cx, arguments, 0);
         let object = to_object(cx, object_arg)?;
@@ -545,7 +525,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         if !value.is_object() {
@@ -564,7 +543,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = get_argument(cx, arguments, 0);
         if !object.is_object() {
@@ -583,7 +561,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object_arg = get_argument(cx, arguments, 0);
         let object = require_object_coercible(cx, object_arg)?;
@@ -614,7 +591,6 @@ impl ObjectConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object_arg = get_argument(cx, arguments, 0);
         let object = to_object(cx, object_arg)?;

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -74,7 +74,6 @@ impl ObjectPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let property_arg = get_argument(cx, arguments, 0);
         let property_key = to_property_key(cx, property_arg)?;
@@ -89,7 +88,6 @@ impl ObjectPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         if !value.is_object() {
@@ -119,7 +117,6 @@ impl ObjectPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let property_arg = get_argument(cx, arguments, 0);
         let property_key = to_property_key(cx, property_arg)?;
@@ -136,7 +133,6 @@ impl ObjectPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         invoke(cx, this_value, cx.names.to_string(), &[])
     }
@@ -146,7 +142,6 @@ impl ObjectPrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if this_value.is_undefined() {
             return Ok(cx.alloc_string("[object Undefined]").as_value());
@@ -201,7 +196,6 @@ impl ObjectPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         Ok(to_object(cx, this_value)?.as_value())
     }
@@ -211,7 +205,6 @@ impl ObjectPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         match object.get_prototype_of(cx)? {
@@ -225,7 +218,6 @@ impl ObjectPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
 
@@ -254,7 +246,6 @@ impl ObjectPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
 
@@ -277,7 +268,6 @@ impl ObjectPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
 
@@ -300,7 +290,6 @@ impl ObjectPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let key_arg = get_argument(cx, arguments, 0);
@@ -333,7 +322,6 @@ impl ObjectPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let key_arg = get_argument(cx, arguments, 0);

--- a/src/js/runtime/intrinsics/promise_prototype.rs
+++ b/src/js/runtime/intrinsics/promise_prototype.rs
@@ -43,7 +43,6 @@ impl PromisePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let on_rejected = get_argument(cx, arguments, 0);
         invoke(cx, this_value, cx.names.then(), &[cx.undefined(), on_rejected])
@@ -54,7 +53,6 @@ impl PromisePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Promise.prototype.finally called on non-object");
@@ -147,7 +145,6 @@ impl PromisePrototype {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let current_function = cx.current_function();
 
@@ -178,7 +175,6 @@ impl PromisePrototype {
         mut cx: Context,
         _: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let current_function = cx.current_function();
         Ok(Self::get_value(cx, current_function))
@@ -188,7 +184,6 @@ impl PromisePrototype {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let current_function = cx.current_function();
 
@@ -219,7 +214,6 @@ impl PromisePrototype {
         mut cx: Context,
         _: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let current_function = cx.current_function();
         let value = Self::get_value(cx, current_function);
@@ -232,7 +226,6 @@ impl PromisePrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !is_promise(*this_value) {
             return type_error(cx, "Promise.prototype.then called on non-promise");

--- a/src/js/runtime/intrinsics/proxy_constructor.rs
+++ b/src/js/runtime/intrinsics/proxy_constructor.rs
@@ -36,12 +36,11 @@ impl ProxyConstructor {
 
     /// Proxy (https://tc39.es/ecma262/#sec-proxy-target-handler)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        if new_target.is_none() {
+        if cx.current_new_target().is_none() {
             return type_error(cx, "Proxy is a constructor");
         }
 
@@ -56,7 +55,6 @@ impl ProxyConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         let handler = get_argument(cx, arguments, 1);
@@ -82,12 +80,7 @@ impl ProxyConstructor {
     }
 }
 
-pub fn revoke(
-    mut cx: Context,
-    _: Handle<Value>,
-    _: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
-) -> EvalResult<Handle<Value>> {
+pub fn revoke(mut cx: Context, _: Handle<Value>, _: &[Handle<Value>]) -> EvalResult<Handle<Value>> {
     // Find the proxy object attached to this closure via a private property
     let mut revoke_function = cx.current_function();
     let proxy_object_property =

--- a/src/js/runtime/intrinsics/reflect_object.rs
+++ b/src/js/runtime/intrinsics/reflect_object.rs
@@ -65,7 +65,6 @@ impl ReflectObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !is_callable(target) {
@@ -84,7 +83,6 @@ impl ReflectObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !is_constructor_value(target) {
@@ -115,7 +113,6 @@ impl ReflectObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
@@ -139,7 +136,6 @@ impl ReflectObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
@@ -159,7 +155,6 @@ impl ReflectObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
@@ -183,7 +178,6 @@ impl ReflectObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
@@ -206,7 +200,6 @@ impl ReflectObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
@@ -223,7 +216,6 @@ impl ReflectObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
@@ -243,7 +235,6 @@ impl ReflectObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
@@ -259,7 +250,6 @@ impl ReflectObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
@@ -276,7 +266,6 @@ impl ReflectObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
@@ -292,7 +281,6 @@ impl ReflectObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
@@ -318,7 +306,6 @@ impl ReflectObject {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -150,14 +150,13 @@ impl RegExpConstructor {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let pattern_arg = get_argument(cx, arguments, 0);
         let flags_arg = get_argument(cx, arguments, 1);
 
         let pattern_is_regexp = is_regexp(cx, pattern_arg)?;
 
-        let new_target = match new_target {
+        let new_target = match cx.current_new_target() {
             None => {
                 let new_target = cx.current_function();
 

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -78,7 +78,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let regexp_object = if let Some(regexp_object) = as_regexp_object(this_value) {
             regexp_object
@@ -97,7 +96,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::DOT_ALL)
     }
@@ -107,7 +105,6 @@ impl RegExpPrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Expected a regular expression");
@@ -171,7 +168,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::GLOBAL)
     }
@@ -181,7 +177,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::HAS_INDICES)
     }
@@ -191,7 +186,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::IGNORE_CASE)
     }
@@ -201,7 +195,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "RegExpr.prototype[@@match] must be called on object");
@@ -273,7 +266,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "RegExpr.prototype[@@matchAll] must be called on object");
@@ -310,7 +302,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::MULTILINE)
     }
@@ -320,7 +311,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "RegExpr.prototype[@@replace] must be called on object");
@@ -511,7 +501,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "RegExpr.prototype[@@search] must be called on object");
@@ -550,7 +539,6 @@ impl RegExpPrototype {
         mut cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if this_value.is_object() {
             let this_object = this_value.as_object();
@@ -572,7 +560,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let regexp_object = if this_value.is_object() {
             this_value.as_object()
@@ -714,7 +701,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::STICKY)
     }
@@ -724,7 +710,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let regexp_object = if this_value.is_object() {
             this_value.as_object()
@@ -745,7 +730,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Expected a regular expression");
@@ -774,7 +758,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::UNICODE_AWARE)
     }
@@ -784,7 +767,6 @@ impl RegExpPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::UNICODE_SETS)
     }

--- a/src/js/runtime/intrinsics/regexp_string_iterator.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator.rs
@@ -99,7 +99,6 @@ impl RegExpStringIteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let mut regexp_iterator = RegExpStringIterator::cast_from_value(cx, this_value)?;
 

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 use crate::{
     js::runtime::{
         async_generator_object, bound_function_object::BoundFunctionObject, console::ConsoleObject,
-        gc_object::GcObject, global_names, module, object_value::ObjectValue,
-        promise_object::PromiseCapability, test_262_object::Test262Object, Context, EvalResult,
-        Handle, Value,
+        gc_object::GcObject, global_names, module, promise_object::PromiseCapability,
+        test_262_object::Test262Object, Context, EvalResult, Handle, Value,
     },
     static_assert,
 };
@@ -99,11 +98,10 @@ pub type RustRuntimeFunctionId = u16;
 // Check that the number of runtime functions fits in the RustRuntimeFunctionId type.
 static_assert!(NUM_RUST_RUNTIME_FUNCTIONS <= (1 << (RustRuntimeFunctionId::BITS as usize)));
 
-type RustRuntimeFunction = fn(
+pub type RustRuntimeFunction = fn(
     cx: Context,
     this_value: Handle<Value>,
     arguments: &[Handle<Value>],
-    new_target: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>>;
 
 impl RustRuntimeFunctionRegistry {
@@ -654,7 +652,6 @@ pub fn return_this(
     _: Context,
     this_value: Handle<Value>,
     _: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     Ok(this_value)
 }
@@ -665,7 +662,6 @@ pub fn return_undefined(
     cx: Context,
     _: Handle<Value>,
     _: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     Ok(cx.undefined())
 }

--- a/src/js/runtime/intrinsics/set_constructor.rs
+++ b/src/js/runtime/intrinsics/set_constructor.rs
@@ -36,12 +36,11 @@ impl SetConstructor {
 
     /// Set (https://tc39.es/ecma262/#sec-set-iterable)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        let new_target = if let Some(new_target) = new_target {
+        let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
             return type_error(cx, "Set constructor must be called with new");

--- a/src/js/runtime/intrinsics/set_iterator.rs
+++ b/src/js/runtime/intrinsics/set_iterator.rs
@@ -99,7 +99,6 @@ impl SetIteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let mut set_iterator = SetIterator::cast_from_value(cx, this_value)?;
 

--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -84,7 +84,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let set = if let Some(set) = this_set_value(this_value) {
             set
@@ -106,7 +105,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let set = if let Some(set) = this_set_value(this_value) {
             set
@@ -124,7 +122,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let set = if let Some(set) = this_set_value(this_value) {
             set
@@ -143,7 +140,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
@@ -205,7 +201,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let set = if let Some(set) = this_set_value(this_value) {
             set
@@ -221,7 +216,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let set = if let Some(set) = this_set_value(this_value) {
             set
@@ -257,7 +251,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let set = if let Some(set) = this_set_value(this_value) {
             set
@@ -278,7 +271,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
@@ -345,7 +337,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
@@ -408,7 +399,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
@@ -453,7 +443,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
@@ -497,7 +486,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let set = if let Some(set) = this_set_value(this_value) {
             set
@@ -513,7 +501,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
@@ -558,7 +545,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
@@ -594,7 +580,6 @@ impl SetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let set = if let Some(set) = this_set_value(this_value) {
             set

--- a/src/js/runtime/intrinsics/string_constructor.rs
+++ b/src/js/runtime/intrinsics/string_constructor.rs
@@ -47,11 +47,12 @@ impl StringConstructor {
 
     /// String (https://tc39.es/ecma262/#sec-string-constructor-string-value)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
+        let new_target = cx.current_new_target();
+
         let string_value = if arguments.is_empty() {
             cx.names.empty_string().as_string()
         } else {
@@ -78,7 +79,6 @@ impl StringConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         // Common case, return a single code unit string
         if arguments.len() == 1 {
@@ -100,7 +100,6 @@ impl StringConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         macro_rules! get_code_point {
             ($arg:expr) => {{
@@ -144,7 +143,6 @@ impl StringConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let substitution_count = arguments.len() - 1;
 

--- a/src/js/runtime/intrinsics/string_iterator.rs
+++ b/src/js/runtime/intrinsics/string_iterator.rs
@@ -70,7 +70,6 @@ impl StringIteratorPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let mut string_iterator = StringIterator::cast_from_value(cx, this_value)?;
 

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -101,7 +101,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -134,7 +133,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -156,7 +154,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -177,7 +174,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -198,7 +194,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let mut concat_string = to_string(cx, object)?;
@@ -216,7 +211,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -257,7 +251,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -286,7 +279,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -313,7 +305,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -326,7 +317,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -356,7 +346,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -385,7 +374,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let this_object = require_object_coercible(cx, this_value)?;
 
@@ -414,7 +402,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let this_object = require_object_coercible(cx, this_value)?;
 
@@ -466,7 +453,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -515,7 +501,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let max_length_arg = get_argument(cx, arguments, 0);
         let fill_string_arg = get_argument(cx, arguments, 1);
@@ -528,7 +513,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let max_length_arg = get_argument(cx, arguments, 0);
         let fill_string_arg = get_argument(cx, arguments, 1);
@@ -595,7 +579,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -616,7 +599,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
 
@@ -697,7 +679,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
 
@@ -812,7 +793,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
 
@@ -843,7 +823,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -890,7 +869,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
 
@@ -985,7 +963,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -1033,7 +1010,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -1063,7 +1039,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -1076,7 +1051,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         this_string_value(cx, this_value)
     }
@@ -1086,7 +1060,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -1099,7 +1072,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -1112,7 +1084,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -1125,7 +1096,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -1138,7 +1108,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;
@@ -1151,7 +1120,6 @@ impl StringPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
         let string = to_string(cx, object)?;

--- a/src/js/runtime/intrinsics/symbol_constructor.rs
+++ b/src/js/runtime/intrinsics/symbol_constructor.rs
@@ -117,12 +117,11 @@ impl SymbolConstructor {
 
     /// Symbol (https://tc39.es/ecma262/#sec-symbol-description)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        if new_target.is_some() {
+        if cx.current_new_target().is_some() {
             return type_error(cx, "Symbol is not a constructor");
         }
 
@@ -141,7 +140,6 @@ impl SymbolConstructor {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let string_key = to_string(cx, argument)?.flatten();
@@ -163,7 +161,6 @@ impl SymbolConstructor {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let symbol_value = get_argument(cx, arguments, 0);
         if !symbol_value.is_symbol() {

--- a/src/js/runtime/intrinsics/symbol_prototype.rs
+++ b/src/js/runtime/intrinsics/symbol_prototype.rs
@@ -53,7 +53,6 @@ impl SymbolPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let symbol_value = this_symbol_value(cx, this_value)?;
         match symbol_value.as_symbol().description() {
@@ -67,7 +66,6 @@ impl SymbolPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let symbol_value = this_symbol_value(cx, this_value)?;
         Ok(symbol_descriptive_string(cx, symbol_value.as_symbol()).as_value())
@@ -78,7 +76,6 @@ impl SymbolPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         this_symbol_value(cx, this_value)
     }

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -64,7 +64,6 @@ impl TypedArrayConstructor {
         cx: Context,
         _: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         type_error(cx, "TypedArray constructor is abstract and cannot be called")
     }
@@ -74,7 +73,6 @@ impl TypedArrayConstructor {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !is_constructor_value(this_value) {
             return type_error(cx, "TypedArray.from must be called on constructor");
@@ -169,7 +167,6 @@ impl TypedArrayConstructor {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !is_constructor_value(this_value) {
             return type_error(cx, "TypedArray.of must be called on constructor");
@@ -611,12 +608,11 @@ macro_rules! create_typed_array_constructor {
 
             /// TypedArray (https://tc39.es/ecma262/#sec-typedarray)
             pub fn construct(
-                cx: Context,
+                mut cx: Context,
                 _: Handle<Value>,
                 arguments: &[Handle<Value>],
-                new_target: Option<Handle<ObjectValue>>,
             ) -> EvalResult<Handle<Value>> {
-                let new_target = if let Some(new_target) = new_target {
+                let new_target = if let Some(new_target) = cx.current_new_target() {
                     new_target
                 } else {
                     return type_error(

--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -110,7 +110,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -143,7 +142,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = require_typed_array(cx, this_value)?;
         Ok(typed_array.viewed_array_buffer().as_value())
@@ -154,7 +152,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = require_typed_array(cx, this_value)?;
 
@@ -173,7 +170,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = require_typed_array(cx, this_value)?;
 
@@ -190,7 +186,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -319,7 +314,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array_object = typed_array_record.typed_array.into_object_value();
@@ -332,7 +326,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -373,7 +366,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -439,7 +431,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -497,7 +488,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -526,7 +516,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -555,7 +544,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -585,7 +573,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -615,7 +602,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -653,7 +639,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -701,7 +686,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -750,7 +734,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -792,7 +775,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array_object = typed_array_record.typed_array.into_object_value();
@@ -805,7 +787,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -862,7 +843,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = require_typed_array(cx, this_value)?;
 
@@ -881,7 +861,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -923,7 +902,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -971,7 +949,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -1019,7 +996,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -1058,7 +1034,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -1208,7 +1183,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -1310,7 +1284,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -1351,7 +1324,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let compare_function_arg = get_argument(cx, arguments, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
@@ -1388,7 +1360,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = require_typed_array(cx, this_value)?;
         let buffer = typed_array.viewed_array_buffer();
@@ -1459,7 +1430,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -1494,7 +1464,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -1524,7 +1493,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let compare_function_arg = get_argument(cx, arguments, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
@@ -1563,7 +1531,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array_object = typed_array_record.typed_array.into_object_value();
@@ -1576,7 +1543,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = validate_typed_array(cx, this_value)?;
         let typed_array = typed_array_record.typed_array;
@@ -1649,7 +1615,6 @@ impl TypedArrayPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return Ok(cx.undefined());

--- a/src/js/runtime/intrinsics/weak_map_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_map_constructor.rs
@@ -40,12 +40,11 @@ impl WeakMapConstructor {
 
     /// WeakMap (https://tc39.es/ecma262/#sec-weakmap-iterable)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        let new_target = if let Some(new_target) = new_target {
+        let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
             return type_error(cx, "WeakMap constructor must be called with new");

--- a/src/js/runtime/intrinsics/weak_map_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_map_prototype.rs
@@ -36,7 +36,6 @@ impl WeakMapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let weak_map_object = if let Some(weak_map_object) = this_weak_map_value(this_value) {
             weak_map_object
@@ -59,7 +58,6 @@ impl WeakMapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let weak_map_object = if let Some(weak_map_object) = this_weak_map_value(this_value) {
             weak_map_object
@@ -84,7 +82,6 @@ impl WeakMapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let weak_map_object = if let Some(weak_map_object) = this_weak_map_value(this_value) {
             weak_map_object
@@ -107,7 +104,6 @@ impl WeakMapPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let weak_map_object = if let Some(weak_map_object) = this_weak_map_value(this_value) {
             weak_map_object

--- a/src/js/runtime/intrinsics/weak_ref_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_ref_constructor.rs
@@ -90,12 +90,11 @@ impl WeakRefConstructor {
 
     /// WeakRef (https://tc39.es/ecma262/#sec-weak-ref-target)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        let new_target = if let Some(new_target) = new_target {
+        let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
             return type_error(cx, "WeakRef constructor must be called with new");

--- a/src/js/runtime/intrinsics/weak_ref_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_ref_prototype.rs
@@ -32,7 +32,6 @@ impl WeakRefPrototype {
         cx: Context,
         this_value: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         if let Some(weak_ref_object) = this_weak_ref_value(this_value) {
             Ok(weak_ref_object.weak_ref_target().to_handle(cx))

--- a/src/js/runtime/intrinsics/weak_set_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_set_constructor.rs
@@ -38,12 +38,11 @@ impl WeakSetConstructor {
 
     /// WeakSet (https://tc39.es/ecma262/#sec-weakset-iterable)
     pub fn construct(
-        cx: Context,
+        mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        new_target: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
-        let new_target = if let Some(new_target) = new_target {
+        let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
             return type_error(cx, "WeakSet constructor must be called with new");

--- a/src/js/runtime/intrinsics/weak_set_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_set_prototype.rs
@@ -35,7 +35,6 @@ impl WeakSetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let weak_set_object = if let Some(weak_set_object) = this_weak_set_value(this_value) {
             weak_set_object
@@ -58,7 +57,6 @@ impl WeakSetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let weak_set_object = if let Some(weak_set_object) = this_weak_set_value(this_value) {
             weak_set_object
@@ -81,7 +79,6 @@ impl WeakSetPrototype {
         cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let weak_set_object = if let Some(weak_set_object) = this_weak_set_value(this_value) {
             weak_set_object

--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -4,13 +4,16 @@ use crate::{
     if_abrupt_reject_promise,
     js::runtime::{
         abstract_operations::{call_object, enumerable_own_property_names, KeyOrValue},
-        builtin_function::{BuiltinFunction, BuiltinFunctionPtr},
+        builtin_function::BuiltinFunction,
         context::ModuleCacheKey,
         error::type_error_value,
         function::get_argument,
         get,
         interned_strings::InternedStrings,
-        intrinsics::{intrinsics::Intrinsic, promise_prototype::perform_promise_then},
+        intrinsics::{
+            intrinsics::Intrinsic, promise_prototype::perform_promise_then,
+            rust_runtime::RustRuntimeFunction,
+        },
         module::{
             module::{DynModule, ModuleEnum},
             synthetic_module::SyntheticModule,
@@ -126,7 +129,6 @@ pub fn load_requested_modules_static_resolve(
     mut cx: Context,
     _: Handle<Value>,
     _: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the module and capbility passed from `execute_module`
     let current_function = cx.current_function();
@@ -157,7 +159,6 @@ pub fn load_requested_modules_reject(
     mut cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the capbility passed from `execute_module`
     let current_function = cx.current_function();
@@ -169,7 +170,7 @@ pub fn load_requested_modules_reject(
     Ok(cx.undefined())
 }
 
-fn callback(cx: Context, func: BuiltinFunctionPtr) -> Handle<ObjectValue> {
+fn callback(cx: Context, func: RustRuntimeFunction) -> Handle<ObjectValue> {
     BuiltinFunction::create_builtin_function_without_properties(
         cx,
         func,
@@ -396,7 +397,6 @@ pub fn async_module_execution_fulfilled(
     mut cx: Context,
     _: Handle<Value>,
     _: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the module passed from `execute_async_module`
     let current_function = cx.current_function();
@@ -537,7 +537,6 @@ pub fn async_module_execution_rejected_runtime(
     mut cx: Context,
     _: Handle<Value>,
     arguments: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the module passed from `execute_async_module`
     let current_function = cx.current_function();
@@ -666,7 +665,6 @@ pub fn load_requested_modules_dynamic_resolve(
     mut cx: Context,
     _: Handle<Value>,
     _: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the module and capability passed from the caller
     let current_function = cx.current_function();
@@ -712,7 +710,6 @@ pub fn module_evaluate_dynamic_resolve(
     mut cx: Context,
     _: Handle<Value>,
     _: &[Handle<Value>],
-    _: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the module and capbility passed from the caller
     let current_function = cx.current_function();

--- a/src/js/runtime/module/loader.rs
+++ b/src/js/runtime/module/loader.rs
@@ -254,5 +254,5 @@ fn parse_json_file_at_path(mut cx: Context, path: &Path) -> EvalResult<Handle<Va
         Err(error) => return syntax_parse_error(cx, &error),
     };
 
-    JSONObject::parse(cx, cx.undefined(), &[file_contents.as_value()], None)
+    JSONObject::parse(cx, cx.undefined(), &[file_contents.as_value()])
 }

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -12,7 +12,7 @@ use super::{
     array_object::ArrayObject,
     array_properties::ArrayProperties,
     async_generator_object::AsyncGeneratorObject,
-    builtin_function::{BuiltinFunction, BuiltinFunctionPtr},
+    builtin_function::BuiltinFunction,
     bytecode::function::Closure,
     collections::{BsIndexMap, BsIndexMapField},
     error::type_error,
@@ -26,9 +26,10 @@ use super::{
         finalization_registry_object::FinalizationRegistryObject,
         iterator_constructor::WrappedValidIterator, iterator_helper_object::IteratorHelperObject,
         map_object::MapObject, number_constructor::NumberObject, object_prototype::ObjectPrototype,
-        regexp_constructor::RegExpObject, set_object::SetObject, symbol_constructor::SymbolObject,
-        typed_array::DynTypedArray, weak_map_object::WeakMapObject,
-        weak_ref_constructor::WeakRefObject, weak_set_object::WeakSetObject,
+        regexp_constructor::RegExpObject, rust_runtime::RustRuntimeFunction, set_object::SetObject,
+        symbol_constructor::SymbolObject, typed_array::DynTypedArray,
+        weak_map_object::WeakMapObject, weak_ref_constructor::WeakRefObject,
+        weak_set_object::WeakSetObject,
     },
     object_descriptor::ObjectKind,
     promise_object::PromiseObject,
@@ -437,7 +438,7 @@ impl Handle<ObjectValue> {
         &mut self,
         cx: Context,
         name: Handle<PropertyKey>,
-        func: BuiltinFunctionPtr,
+        func: RustRuntimeFunction,
         realm: Handle<Realm>,
     ) {
         let getter = BuiltinFunction::create(cx, func, 0, name, realm, None, Some("get"));
@@ -449,8 +450,8 @@ impl Handle<ObjectValue> {
         &mut self,
         cx: Context,
         name: Handle<PropertyKey>,
-        getter: BuiltinFunctionPtr,
-        setter: BuiltinFunctionPtr,
+        getter: RustRuntimeFunction,
+        setter: RustRuntimeFunction,
         realm: Handle<Realm>,
     ) {
         let getter = BuiltinFunction::create(cx, getter, 0, name, realm, None, Some("get"));
@@ -463,7 +464,7 @@ impl Handle<ObjectValue> {
         &mut self,
         cx: Context,
         name: Handle<PropertyKey>,
-        func: BuiltinFunctionPtr,
+        func: RustRuntimeFunction,
         length: u32,
         realm: Handle<Realm>,
     ) {

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -537,7 +537,6 @@ impl PromiseCapability {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         // Get the capability object that was attached to the executor function
         let current_function = cx.current_function();

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -107,7 +107,6 @@ impl Test262Object {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         if !argument.is_string() {
@@ -127,7 +126,6 @@ impl Test262Object {
         cx: Context,
         _: Handle<Value>,
         _: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         // Create a new realm that also has the test262 object installed
         let realm = Realm::new(cx);
@@ -140,7 +138,6 @@ impl Test262Object {
         mut cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let script_text = get_argument(cx, arguments, 0);
         if !script_text.is_string() {
@@ -184,7 +181,6 @@ impl Test262Object {
         cx: Context,
         _: Handle<Value>,
         arguments: &[Handle<Value>],
-        _: Option<Handle<ObjectValue>>,
     ) -> EvalResult<Handle<Value>> {
         let value = get_argument(cx, arguments, 0);
         if !value.is_object() {


### PR DESCRIPTION
## Summary

The new target object is passed to rust runtime functions as the last parameter to the native rust function itself. This is not ideal as we must pass `None` for regular calls and all rust runtime functions contain an often useless parameter.

Instead let's pass the new target object via the stack for rust runtime functions. This matches how the new target object is passed for JS functions and allows us to only pay for the new target when constructing. Rust runtime functions that are constructors now have a single register which holds the new target, which is an object if the new target was passed and otherwise is undefined.

## Tests

All tests continue to pass.