### PR TITLE
[runtime] Add mode to track handle usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ zerovec = "0.11.0"
 [features]
 # Run the garbage collector in stress test mode
 gc_stress_test = []
+# Collect handle use statistics
+handle_stats = []
 
 [lib]
 doctest = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,13 +57,20 @@ fn main() {
     let args = Args::parse();
     let cx = create_context(&args);
 
-    cx.execute_then_drop(|cx| match evaluate(cx, &args) {
-        Ok(_) => (),
-        Err(err) => {
-            let supports_color = stderr_should_use_colors(&cx.options);
-            let format_options = FormatOptions::new(supports_color);
+    cx.execute_then_drop(|cx| {
+        let result = evaluate(cx, &args);
 
-            print_error_message_and_exit(&err.format(cx, &format_options));
+        #[cfg(feature = "handle_stats")]
+        println!("{:?}", cx.heap.info().handle_context().handle_stats());
+
+        match result {
+            Ok(_) => (),
+            Err(err) => {
+                let supports_color = stderr_should_use_colors(&cx.options);
+                let format_options = FormatOptions::new(supports_color);
+
+                print_error_message_and_exit(&err.format(cx, &format_options));
+            }
         }
     })
 }

--- a/tests/test262/Cargo.toml
+++ b/tests/test262/Cargo.toml
@@ -14,5 +14,5 @@ threadpool = "1.8.1"
 yaml-rust = "0.4.5"
 
 [features]
-# Run the garbage collector in stress test mode
 gc_stress_test = ["brimstone/gc_stress_test"]
+handle_stats = ["brimstone/handle_stats"]

--- a/tests/test262/src/runner.rs
+++ b/tests/test262/src/runner.rs
@@ -257,6 +257,9 @@ fn run_single_test(
         check_expected_completion(cx, test, completion, duration)
     }));
 
+    #[cfg(feature = "handle_stats")]
+    println!("{:?}", cx.heap.info().handle_context().handle_stats());
+
     cx.drop();
 
     match panic_result {


### PR DESCRIPTION
## Summary

Add a compile time feature to track usage of handles. Track both the current number of the handles and max concurrent number of handles that have been seen. When mode is enabled handle statistics are printed at the end of the run.

## Tests

Verify that `bs` and test262 runners both work correctly in handle stats mode.