### PR TITLE
[runtime] Introduce HandleScopeGuard and macros, use to reduce max handle use during initialization

### DIFF
--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -1,3 +1,5 @@
+use crate::handle_scope_guard;
+
 use super::{context::Context, property_key::PropertyKey, value::SymbolValue, Handle};
 
 // All built-in string property keys referenced in the spec
@@ -29,12 +31,13 @@ macro_rules! builtin_names {
 
         impl Context {
             pub fn init_builtin_names(&mut self) {
-                $(
+                $({
+                    handle_scope_guard!(*self);
                     self.names.$rust_name = {
                         let string_value = self.alloc_string($js_name).as_string();
                         PropertyKey::string_not_array_index(*self, string_value)
                     };
-                )*
+                })*
             }
         }
     };
@@ -474,12 +477,13 @@ macro_rules! builtin_symbols {
 
         impl Context {
             pub fn init_builtin_symbols(&mut self) {
-                $(
+                $({
+                    handle_scope_guard!(*self);
                     self.well_known_symbols.$rust_name = {
                         let description = self.alloc_string($description).as_string();
                         *PropertyKey::symbol(SymbolValue::new(*self, Some(description), /* is_private */ false))
                     };
-                )*
+                })*
             }
         }
     };

--- a/src/js/runtime/gc/mod.rs
+++ b/src/js/runtime/gc/mod.rs
@@ -6,7 +6,9 @@ mod heap_object;
 mod heap_trait_object;
 mod pointer;
 
-pub use handle::{Escapable, Handle, HandleContents, HandleScope, ToHandleContents};
+pub use handle::{
+    Escapable, Handle, HandleContents, HandleScope, HandleScopeGuard, ToHandleContents,
+};
 pub use heap::{Heap, HeapInfo};
 pub use heap_item::HeapItem;
 pub use heap_object::{HeapObject, HeapVisitor, IsHeapObject};

--- a/src/js/runtime/object_descriptor.rs
+++ b/src/js/runtime/object_descriptor.rs
@@ -184,7 +184,7 @@ impl ObjectDescriptor {
         descriptor: Handle<ObjectDescriptor>,
         kind: ObjectKind,
         flags: DescFlags,
-    ) -> Handle<ObjectDescriptor>
+    ) -> HeapPtr<ObjectDescriptor>
     where
         Handle<T>: VirtualObject,
     {
@@ -195,7 +195,7 @@ impl ObjectDescriptor {
         set_uninit!(desc.kind, kind);
         set_uninit!(desc.flags, flags);
 
-        desc.to_handle()
+        desc
     }
 
     #[inline]
@@ -240,7 +240,8 @@ impl BaseDescriptors {
             fake_descriptor_handle,
             ObjectKind::Descriptor,
             DescFlags::empty(),
-        );
+        )
+        .to_handle();
         descriptor.descriptor = *descriptor;
         descriptors[ObjectKind::Descriptor as usize] = *descriptor;
 
@@ -248,7 +249,7 @@ impl BaseDescriptors {
             ($object_kind:expr, $object_ty:ty, $flags:expr) => {
                 let desc =
                     ObjectDescriptor::new::<$object_ty>(cx, descriptor, $object_kind, $flags);
-                descriptors[$object_kind as usize] = *desc;
+                descriptors[$object_kind as usize] = desc;
             };
         }
 

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -5,7 +5,7 @@ use std::{
     num::NonZeroU32,
 };
 
-use crate::set_uninit;
+use crate::{handle_scope_guard, set_uninit};
 
 use super::{
     accessor::Accessor,
@@ -421,15 +421,21 @@ impl Handle<ObjectValue> {
         key: Handle<PropertyKey>,
         value: Handle<Value>,
     ) {
+        handle_scope_guard!(cx);
+
         self.set_property(cx, key, Property::data(value, true, false, true))
     }
 
     pub fn instrinsic_length_prop(&mut self, cx: Context, length: i32) {
+        handle_scope_guard!(cx);
+
         let length_value = cx.smi(length);
         self.set_property(cx, cx.names.length(), Property::data(length_value, false, false, true))
     }
 
     pub fn intrinsic_name_prop(&mut self, mut cx: Context, name: &str) {
+        handle_scope_guard!(cx);
+
         let name_value = cx.alloc_string(name).into();
         self.set_property(cx, cx.names.name(), Property::data(name_value, false, false, true))
     }
@@ -441,6 +447,8 @@ impl Handle<ObjectValue> {
         func: RustRuntimeFunction,
         realm: Handle<Realm>,
     ) {
+        handle_scope_guard!(cx);
+
         let getter = BuiltinFunction::create(cx, func, 0, name, realm, None, Some("get"));
         let accessor_value = Accessor::new(cx, Some(getter), None);
         self.set_property(cx, name, Property::accessor(accessor_value.into(), false, true));
@@ -454,6 +462,8 @@ impl Handle<ObjectValue> {
         setter: RustRuntimeFunction,
         realm: Handle<Realm>,
     ) {
+        handle_scope_guard!(cx);
+
         let getter = BuiltinFunction::create(cx, getter, 0, name, realm, None, Some("get"));
         let setter = BuiltinFunction::create(cx, setter, 1, name, realm, None, Some("set"));
         let accessor_value = Accessor::new(cx, Some(getter), Some(setter));
@@ -468,6 +478,8 @@ impl Handle<ObjectValue> {
         length: u32,
         realm: Handle<Realm>,
     ) {
+        handle_scope_guard!(cx);
+
         let func = BuiltinFunction::create(cx, func, length, name, realm, None, None).into();
         self.intrinsic_data_prop(cx, name, func);
     }
@@ -478,6 +490,8 @@ impl Handle<ObjectValue> {
         key: Handle<PropertyKey>,
         value: Handle<Value>,
     ) {
+        handle_scope_guard!(cx);
+
         self.set_property(cx, key, Property::data(value, false, false, false));
     }
 }


### PR DESCRIPTION
## Summary

Introduce `HandleScopeGuard` which enters a handle scope until the guard's `drop` is called. This allows us to place a `HandleScopeGuard` at the top of an existing block instead of having to nest in a `HandleScope::new`.

Also create macros for using these guards: `handle_scope_guard` for guard creation and `in_handle_scope` for wrapping a block in a handle scope.

Use these new macros to introduce handle scopes more granularly during context/realm initialization. Previously the max handle count for executing an empty file was 53 (i.e. static overhead during context/realm creation). Now the max handle count for executing an empty file is 53.

## Tests

All tests still pass.