### PR TITLE
[runtime] Use handle_scope macro instead of HandleScope::new

### DIFF
--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -6,10 +6,12 @@ use std::{
     rc::Rc,
 };
 
-use crate::js::{
-    common::{options::Options, wtf_8::Wtf8String},
-    parser::{analyze::analyze, parse_module, parse_script, print_program, source::Source},
-    runtime::gc::HandleScope,
+use crate::{
+    handle_scope,
+    js::{
+        common::{options::Options, wtf_8::Wtf8String},
+        parser::{analyze::analyze, parse_module, parse_script, print_program, source::Source},
+    },
 };
 
 use super::{
@@ -145,7 +147,7 @@ impl Context {
         cx.heap.info().set_context(cx);
         cx.vm = Some(Box::new(VM::new(cx)));
 
-        HandleScope::new(cx, |mut cx| {
+        handle_scope!(cx, {
             // Initialize all uninitialized fields
             cx.base_descriptors = BaseDescriptors::new(cx);
             InternedStrings::init(cx);

--- a/src/js/runtime/gc/handle.rs
+++ b/src/js/runtime/gc/handle.rs
@@ -227,6 +227,7 @@ impl Drop for HandleScopeGuard {
     }
 }
 
+/// A guard which enters a handle scope and exits it when dropped. Does not escape any values.
 #[macro_export]
 macro_rules! handle_scope_guard {
     ($cx:expr) => {
@@ -234,12 +235,16 @@ macro_rules! handle_scope_guard {
     };
 }
 
+/// Enter a handle scope and execute the given statement. Returns and escapes the result of
+/// executing the statement.
 #[macro_export]
-macro_rules! in_handle_scope {
-    ($cx:expr, $block:block) => {{
-        $crate::handle_scope_guard!($cx);
-        $block
-    }};
+macro_rules! handle_scope {
+    ($cx:expr, $body:stmt) => {
+        $crate::js::runtime::gc::HandleScope::new($cx, |_| {
+            let result = { $body };
+            result
+        })
+    };
 }
 
 /// Number of handles contained in a single handle block. Default to 4KB handle blocks.

--- a/src/js/runtime/gc_object.rs
+++ b/src/js/runtime/gc_object.rs
@@ -1,15 +1,12 @@
 use crate::{
+    handle_scope,
     js::runtime::{abstract_operations::define_property_or_throw, PropertyDescriptor},
     must,
 };
 
 use super::{
-    eval_result::EvalResult,
-    gc::{HandleScope, Heap},
-    intrinsics::intrinsics::Intrinsic,
-    object_value::ObjectValue,
-    realm::Realm,
-    Context, Handle, Value,
+    eval_result::EvalResult, gc::Heap, intrinsics::intrinsics::Intrinsic,
+    object_value::ObjectValue, realm::Realm, Context, Handle, Value,
 };
 
 pub struct GcObject;
@@ -27,7 +24,7 @@ impl GcObject {
     /// Install the GC object on the realm's global object.
     #[allow(unused)]
     pub fn install(cx: Context, realm: Handle<Realm>) {
-        HandleScope::new(cx, |cx| {
+        handle_scope!(cx, {
             let gc_object = GcObject::new(cx, realm);
             let desc = PropertyDescriptor::data(gc_object.as_value(), true, false, true);
             must!(define_property_or_throw(cx, realm.global_object(), cx.names.gc(), desc))

--- a/src/js/runtime/intrinsics/global_object.rs
+++ b/src/js/runtime/intrinsics/global_object.rs
@@ -1,5 +1,5 @@
 use crate::{
-    handle_scope_guard,
+    handle_scope, handle_scope_guard,
     js::{
         common::{
             unicode::{encode_utf8_codepoint, get_hex_value, is_continuation_byte},
@@ -13,7 +13,6 @@ use crate::{
             error::uri_error,
             eval::eval::perform_eval,
             function::get_argument,
-            gc::HandleScope,
             property_descriptor::PropertyDescriptor,
             string_parsing::{parse_signed_decimal_literal, skip_string_whitespace, StringLexer},
             string_value::{FlatString, StringValue},
@@ -28,7 +27,7 @@ use super::intrinsics::Intrinsic;
 
 /// SetDefaultGlobalBindings (https://tc39.es/ecma262/#sec-setdefaultglobalbindings)
 pub fn set_default_global_bindings(cx: Context, realm: Handle<Realm>) -> EvalResult<()> {
-    HandleScope::new(cx, |cx| {
+    handle_scope!(cx, {
         macro_rules! value_prop {
             ($name:expr, $value:expr, $is_writable:expr, $is_enumerable:expr, $is_configurable:expr) => {{
                 handle_scope_guard!(cx);

--- a/src/js/runtime/module/linker.rs
+++ b/src/js/runtime/module/linker.rs
@@ -1,9 +1,11 @@
-use crate::js::runtime::{
-    boxed_value::BoxedValue,
-    error::syntax_error,
-    gc::HandleScope,
-    module::{module::ModuleEnum, source_text_module::ModuleState},
-    Context, EvalResult, Handle,
+use crate::{
+    handle_scope,
+    js::runtime::{
+        boxed_value::BoxedValue,
+        error::syntax_error,
+        module::{module::ModuleEnum, source_text_module::ModuleState},
+        Context, EvalResult, Handle,
+    },
 };
 
 use super::{
@@ -115,7 +117,7 @@ impl GraphLinker {
 
         // Can isolate InitializeEnvironment in a separate handle scope since handles cannot be
         // stored anywhere else and escape.
-        HandleScope::new(cx, |cx| initialize_environment(cx, module))?;
+        handle_scope!(cx, initialize_environment(cx, module))?;
 
         debug_assert!(module.dfs_ancestor_index() <= module.dfs_index());
 
@@ -207,7 +209,7 @@ fn initialize_environment(cx: Context, module: Handle<SourceTextModule>) -> Eval
 }
 
 pub fn link(cx: Context, module: Handle<SourceTextModule>) -> EvalResult<()> {
-    HandleScope::new(cx, |cx| {
+    handle_scope!(cx, {
         let mut linker = GraphLinker::new();
         linker.link(cx, module)
     })

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -3,11 +3,11 @@ use std::{collections::HashSet, hash::Hash, num::NonZeroUsize};
 use indexmap::IndexSet;
 
 use crate::{
-    field_offset,
+    field_offset, handle_scope,
     js::runtime::{
         bytecode::function::BytecodeFunction,
         collections::{BsArray, BsHashMap, BsHashMapField, BsVec, BsVecField, InlineArray},
-        gc::{HandleScope, HeapItem, HeapObject, HeapVisitor},
+        gc::{HeapItem, HeapObject, HeapVisitor},
         module::{
             execute::module_evaluate, import_attributes::ImportAttributes, module::next_module_id,
             module_namespace_object::ModuleNamespaceObject,
@@ -635,7 +635,7 @@ impl Module for Handle<SourceTextModule> {
             return namespace_object;
         }
 
-        HandleScope::new(cx, |cx| {
+        handle_scope!(cx, {
             // Lazily initialize the exports map
             self.exports = Some(ExportMap::new(cx, ObjectKind::ExportMap, 4));
 

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -1,7 +1,5 @@
 use crate::{
-    field_offset,
-    js::{parser::scope_tree::REALM_SCOPE_SLOT_NAME, runtime::gc::HandleScope},
-    must, set_uninit,
+    field_offset, handle_scope, js::parser::scope_tree::REALM_SCOPE_SLOT_NAME, must, set_uninit,
 };
 
 use super::{
@@ -47,7 +45,7 @@ const INTRINSICS_BYTE_OFFSET: usize = field_offset!(Realm, intrinsics);
 impl Realm {
     /// InitializeHostDefinedRealm (https://tc39.es/ecma262/#sec-initializehostdefinedrealm)
     pub fn new(cx: Context) -> Handle<Realm> {
-        HandleScope::new(cx, |cx| {
+        handle_scope!(cx, {
             let realm = Realm::new_uninit(cx);
             must!(set_default_global_bindings(cx, realm));
             realm
@@ -57,7 +55,7 @@ impl Realm {
     /// Realm initializes intrinsics but leaves other properties uninitialized. Must call
     /// `initialize` before using.
     fn new_uninit(cx: Context) -> Handle<Realm> {
-        HandleScope::new(cx, |cx| {
+        handle_scope!(cx, {
             // Realm record must be created before setting up intrinsics, as realm must be referenced
             // during intrinsic creation.
             let size = Self::calculate_size_in_bytes();

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use crate::{
+    handle_scope,
     js::{
         parser::{analyze::analyze, parse_script, source::Source},
         runtime::{bytecode::generator::BytecodeProgramGenerator, get},
@@ -12,7 +13,6 @@ use super::{
     abstract_operations::set,
     error::{syntax_error, syntax_parse_error, type_error},
     function::get_argument,
-    gc::HandleScope,
     gc_object::GcObject,
     intrinsics::{array_buffer_constructor::ArrayBufferObject, intrinsics::Intrinsic},
     object_value::ObjectValue,
@@ -51,8 +51,8 @@ impl Test262Object {
         object.to_handle()
     }
 
-    pub fn install(cx: Context, realm: Handle<Realm>) {
-        HandleScope::new(cx, |mut cx| {
+    pub fn install(mut cx: Context, realm: Handle<Realm>) {
+        handle_scope!(cx, {
             // Create the test262 object
             let test_262_object = Test262Object::new(cx, realm);
 


### PR DESCRIPTION
## Summary

Introduce a new macro for creating handle scopes: `handle_scope!(cx, { block })`, which will be used instead of `HandleScope::new`. This is slightly simpler and allows us to change to internals in the future.

## Tests

No functionality changed, all tests continue to pass.