### PR TITLE
[runtime] Remove unnecessary "[Symbol.toPrimitive]" builtin name

### DIFF
--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -52,7 +52,6 @@ builtin_names!(
     (__lookup_getter__, "__lookupGetter__"),
     (__lookup_setter__, "__lookupSetter__"),
     (__proto__, "__proto__"),
-    (symbol_to_primitive, "[Symbol.toPrimitive]"),
     (bytes_per_element, "BYTES_PER_ELEMENT"),
     (e, "E"),
     (epsilon, "EPSILON"),

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -108,16 +108,9 @@ impl DatePrototype {
 
         // [Symbol.toPrimitive] property
         let to_primitive_key = cx.well_known_symbols.to_primitive();
-        let to_primitive_func = BuiltinFunction::create(
-            cx,
-            Self::to_primitive,
-            1,
-            cx.names.symbol_to_primitive(),
-            realm,
-            None,
-            None,
-        )
-        .into();
+        let to_primitive_func =
+            BuiltinFunction::create(cx, Self::to_primitive, 1, to_primitive_key, realm, None, None)
+                .into();
         object.set_property(
             cx,
             to_primitive_key,

--- a/src/js/runtime/intrinsics/symbol_prototype.rs
+++ b/src/js/runtime/intrinsics/symbol_prototype.rs
@@ -21,16 +21,9 @@ impl SymbolPrototype {
 
         // [Symbol.toPrimitive] property
         let to_primitive_key = cx.well_known_symbols.to_primitive();
-        let to_primitive_func = BuiltinFunction::create(
-            cx,
-            Self::value_of,
-            1,
-            cx.names.symbol_to_primitive(),
-            realm,
-            None,
-            None,
-        )
-        .into();
+        let to_primitive_func =
+            BuiltinFunction::create(cx, Self::value_of, 1, to_primitive_key, realm, None, None)
+                .into();
         object.set_property(
             cx,
             to_primitive_key,


### PR DESCRIPTION
## Summary

The name `"[Symbol.toPrimitive]"` does not need to be explicitly defined as a buliting name. Instead we can create functions whose name is the well known `Symbol.toPrimitive`.

## Tests

All tests pass.