### PR TITLE
[runtime] Implement RegExp.escape

### DIFF
--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -185,6 +185,7 @@ builtin_names!(
     (entries, "entries"),
     (enumerable, "enumerable"),
     (errors, "errors"),
+    (escape, "escape"),
     (eval, "eval"),
     (every, "every"),
     (exec, "exec"),

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -497,6 +497,7 @@ rust_runtime_functions!(
     ReflectObject::set,
     ReflectObject::set_prototype_of,
     RegExpConstructor::construct,
+    RegExpConstructor::escape,
     RegExpPrototype::dot_all,
     RegExpPrototype::exec,
     RegExpPrototype::flags,

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -248,7 +248,6 @@
       "Intl.Locale-info",
       "Intl.NumberFormat-v3",
       "Math.sumPrecise",
-      "RegExp.escape",
       "Temporal",
       "ShadowRealm"
     ]


### PR DESCRIPTION
## Summary

Implement the `RegExp.escape` proposal (https://github.com/tc39/proposal-regex-escaping).

## Tests

Start running test262 `RegExp.escape` tests, all pass.