### PR TITLE
[runtime] Fix bugs exposed in Float16Array tests

### DIFF
--- a/src/js/common/math.rs
+++ b/src/js/common/math.rs
@@ -53,12 +53,14 @@ pub fn f64_to_f16(value: f64) -> f16 {
         f16::INFINITY.to_bits()
     } else if input < F64_TO_F16_NORMAL_THRESHOLD {
         let adjusted_input = f64::from_bits(input) + f64::from_bits(F64_TO_F16_DENORMAL_MAGIC);
-        (adjusted_input.to_bits() - F64_TO_F16_DENORMAL_MAGIC) as u16
+        (adjusted_input
+            .to_bits()
+            .wrapping_sub(F64_TO_F16_DENORMAL_MAGIC)) as u16
     } else {
         let is_mantissa_odd = (input >> (52 - 10)) & 1;
 
-        input += F64_TO_F16_NORMAL_MAGIC;
-        input += is_mantissa_odd;
+        input = input.wrapping_add(F64_TO_F16_NORMAL_MAGIC);
+        input = input.wrapping_add(is_mantissa_odd);
 
         (input >> (52 - 10)) as u16
     };


### PR DESCRIPTION
## Summary

Fix two bugs exposed by test262 due to the addition of Float16Array tests.

1. We should use wrapping arithmetic during `f64_to_f16` to avoid failures in debug mode.
2. When transferring an ArrayBuffer we were not handling the case where the old and new ArrayBuffers have different length. We were always using the old ArrayBuffer as the backing store in this case without resizing and potentially zeroing the new range of the array. Instead if the length is changing on transfer we should always copy to a new array, zeroing the new range if the ArrayBuffer is growing.

## Tests

All test262 tests now pass in both release mode and GC stress test mode.