### PR TITLE
[tests] Run snapshot tests in workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "brimstone_tests"
+version = "0.1.0"
+dependencies = [
+ "brimstone",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "src",
   "src/brimstone_icu_collections",
   "src/brimstone_macros",
+  "tests",
   "tests/harness",
 ]
 resolver = "2"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "brimstone_tests"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dev-dependencies]
+brimstone.workspace = true
+
+[[test]]
+name = "snapshot_tests"
+path = "snapshot_tests.rs"

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -14,7 +14,7 @@ use brimstone::js::{
 use std::{
     cmp::min,
     env, error, fs,
-    path::Path,
+    path::{Path, PathBuf},
     rc::Rc,
     sync::{LazyLock, Mutex},
 };
@@ -26,6 +26,8 @@ const RECORD_ENV_VAR: &str = "RECORD";
 static DIRECTORY_PREFIX_PATH: LazyLock<String> = LazyLock::new(|| {
     std::env::current_dir()
         .unwrap()
+        .parent()
+        .unwrap()
         .to_string_lossy()
         .to_string()
         + "/"
@@ -35,10 +37,14 @@ struct TestEnv {
     errors: Vec<String>,
 }
 
+fn get_test_root(dirname: &str) -> PathBuf {
+    std::env::current_dir().unwrap().join(dirname)
+}
+
 #[test]
 fn js_parser_snapshot_tests() -> GenericResult<()> {
     let options = Options::default();
-    let parser_tests_dir = Path::new(file!()).parent().unwrap().join("js_parser");
+    let parser_tests_dir = get_test_root("js_parser");
     run_snapshot_tests(&parser_tests_dir, &mut |path| print_ast(path, &options))
 }
 
@@ -49,7 +55,7 @@ fn print_ast(path: &str, options: &Options) -> GenericResult<String> {
 
 #[test]
 fn js_error_snapshot_tests() -> GenericResult<()> {
-    let error_tests_dir = Path::new(file!()).parent().unwrap().join("js_error");
+    let error_tests_dir = get_test_root("js_error");
     run_snapshot_tests(&error_tests_dir, &mut |path| print_error(path))
 }
 
@@ -73,16 +79,13 @@ fn print_error(path: &str) -> GenericResult<String> {
 
 #[test]
 fn js_bytecode_snapshot_tests() -> GenericResult<()> {
-    let bytecode_tests_dir = Path::new(file!()).parent().unwrap().join("js_bytecode");
+    let bytecode_tests_dir = get_test_root("js_bytecode");
     run_snapshot_tests(&bytecode_tests_dir, &mut |path| print_bytecode(path))
 }
 
 #[test]
 fn js_regexp_bytecode_snapshot_tests() -> GenericResult<()> {
-    let regexp_bytecode_tests_dir = Path::new(file!())
-        .parent()
-        .unwrap()
-        .join("js_regexp_bytecode");
+    let regexp_bytecode_tests_dir = get_test_root("js_regexp_bytecode");
     run_snapshot_tests(&regexp_bytecode_tests_dir, &mut |path| print_regexp_bytecode(path))
 }
 


### PR DESCRIPTION
## Summary

The move to Cargo workspaces did not properly account for the snapshot tests, meaning they are not currently run with `cargo test`. To fix this we make the entire `tests` directory a crate which reference `snapshot_tests.rs` as a test. Now `cargo test` will run snapshot tests as before.

## Tests

`cargo test` now runs snapshot tests. Verify `RECORD=1 cargo test` can be used to re-record snapshot tests.