### PR TITLE
[tests] Run Annex B test262 tests

### DIFF
--- a/tests/harness/src/index.rs
+++ b/tests/harness/src/index.rs
@@ -22,6 +22,8 @@ pub struct Test {
     /// Run test without modifying the source file or evaluating any other scripts from test harness.
     /// For scripts the test is run once, in non-strict mode.
     pub is_raw: bool,
+    /// Run test with Annex B mode enabled.
+    pub is_annex_b: bool,
     /// Files that must be evaluated in the global scope prior to test execution. Paths are
     /// relative to the test262/harness directory.
     pub includes: Vec<String>,
@@ -222,6 +224,8 @@ impl TestIndex {
         let path = test_path.strip_prefix(suite_root).unwrap();
         let path = path.to_string_lossy().into_owned();
 
+        let is_annex_b = path.contains("annexB");
+
         let test = Test {
             path: path.clone(),
             suite,
@@ -229,6 +233,7 @@ impl TestIndex {
             mode,
             is_async,
             is_raw,
+            is_annex_b,
             includes,
             features,
         };

--- a/tests/harness/src/runner.rs
+++ b/tests/harness/src/runner.rs
@@ -21,10 +21,14 @@ use crate::{
 
 use brimstone::js::{
     self,
-    common::{error::FormatOptions, options::Options, wtf_8::Wtf8String},
+    common::{
+        error::FormatOptions,
+        options::{Options, OptionsBuilder},
+        wtf_8::Wtf8String,
+    },
     runtime::{
         bytecode::generator::BytecodeProgramGenerator, get, test_262_object::Test262Object,
-        to_console_string, to_string, Context, EvalResult, Handle, Value,
+        to_console_string, to_string, Context, ContextBuilder, EvalResult, Handle, Value,
     },
 };
 
@@ -219,8 +223,11 @@ fn run_single_test(
     force_strict_mode: bool,
     start_timestamp: SystemTime,
 ) -> TestResult {
+    // Set up options for test
+    let options = OptionsBuilder::new().annex_b(test.is_annex_b).build();
+
     // Each test is executed in its own realm
-    let cx = Context::default();
+    let cx = ContextBuilder::new().set_options(Rc::new(options)).build();
     let options = cx.options.clone();
 
     // Each realm has access to the test262 object


### PR DESCRIPTION
## Summary

Run all test262 tests in the `annexB` directory in Annex B mode.

## Tests

A few more test262 tests now pass when run with `--all annexB/` to run Annex B tests.