### PR TITLE
[tests] Benchmark parsing common open JS libraries

### DIFF
--- a/src/benches/.gitignore
+++ b/src/benches/.gitignore
@@ -1,0 +1,1 @@
+fixtures

--- a/src/benches/README.md
+++ b/src/benches/README.md
@@ -1,0 +1,19 @@
+# Benchmarks
+
+Brimstone's performance testing is found in this directory.
+
+## Installation
+
+Some tests use fixtures installed from various NPM modules. To install run:
+
+```
+./install.sh
+```
+
+## Running
+
+To run all benchmarks, run the following from any directory in the workspace:
+
+```
+cargo bench -p brimstone
+```

--- a/src/benches/install.sh
+++ b/src/benches/install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+CURRENT_DIR=$(cd "$(dirname "$0")" && pwd)
+FIXTURES_DIR="$CURRENT_DIR/fixtures"
+
+rm -rf "$FIXTURES_DIR"
+mkdir -p "$FIXTURES_DIR"
+
+# Install the necessary dependencies and extract fixtures
+npm install typescript@5.7.3
+cp "$CURRENT_DIR/node_modules/typescript/lib/typescript.js" "$FIXTURES_DIR/typescript.js"
+
+npm install acorn@8.14.0
+cp "$CURRENT_DIR/node_modules/acorn/dist/acorn.js" "$FIXTURES_DIR/acorn.js"
+
+npm install react@19.0.0
+cp "$CURRENT_DIR/node_modules/react/cjs/react.production.js" "$FIXTURES_DIR/react.js"
+
+# Clean up all generated files outside fixtures directory
+rm -rf "$CURRENT_DIR/node_modules"
+rm -f "$CURRENT_DIR/package-lock.json"
+rm -f "$CURRENT_DIR/package.json"


### PR DESCRIPTION
## Summary

Add some simple parser benchmark tests. Let's use artifacts from some common open source libraries, namely react, typescript, and acorn.

An installation script is included which must be run before running benchmarks for the first time.

## Tests

Verify all benchmark tests pass with `cargo bench -p brimstone`