### PR TITLE
[common] Upgrade to Rust 1.85.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.80.1"
+channel = "1.85.0"

--- a/src/js/common/varint.rs
+++ b/src/js/common/varint.rs
@@ -1,8 +1,8 @@
-/// A simple varint encoding, optimized for space. Identical to the varint encoding used in
-/// protobufs.
-///
-/// High bit signals if there are more bytes to read. Lower 7 bits are the payload. Concatenate
-/// all 7 byte payloads in a sequence to get the full number.
+//! A simple varint encoding, optimized for space. Identical to the varint encoding used in
+//! protobufs.
+//!
+//! High bit signals if there are more bytes to read. Lower 7 bits are the payload. Concatenate
+//! all 7 byte payloads in a sequence to get the full number.
 
 /// Encode a value as a varint and append it to the given buffer.
 pub fn encode_varint(buf: &mut Vec<u8>, value: usize) {

--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -298,7 +298,7 @@ impl<'a> Analyzer<'a> {
     }
 }
 
-impl<'a> AstVisitor for Analyzer<'a> {
+impl AstVisitor for Analyzer<'_> {
     fn visit_program(&mut self, program: &mut Program) {
         if program.is_strict_mode {
             self.enter_strict_mode_context();
@@ -1333,7 +1333,7 @@ impl Analyzer<'_> {
         let is_bad_constructor = match method.kind {
             ClassMethodKind::Constructor => method.value.is_async() || method.value.is_generator(),
             ClassMethodKind::Get | ClassMethodKind::Set if !method.is_static => {
-                key_name_bytes.map_or(false, |name| name == "constructor".as_bytes())
+                key_name_bytes.is_some_and(|name| name == "constructor".as_bytes())
             }
             _ => false,
         };
@@ -1344,7 +1344,7 @@ impl Analyzer<'_> {
 
         if method.is_static
             && !method.is_private
-            && key_name_bytes.map_or(false, |name| name == "prototype".as_bytes())
+            && key_name_bytes.is_some_and(|name| name == "prototype".as_bytes())
         {
             self.emit_error(method.loc, ParseError::ClassStaticPrototype);
         }

--- a/src/js/parser/lexer_stream.rs
+++ b/src/js/parser/lexer_stream.rs
@@ -148,7 +148,7 @@ impl<'a> Utf8LexerStream<'a> {
     }
 }
 
-impl<'a> LexerStream for Utf8LexerStream<'a> {
+impl LexerStream for Utf8LexerStream<'_> {
     #[inline]
     fn pos(&self) -> Pos {
         self.pos
@@ -233,7 +233,7 @@ impl<'a> LexerStream for Utf8LexerStream<'a> {
     }
 
     #[allow(refining_impl_trait)]
-    fn iter_slice<'b, 'c>(&'b self, _: Pos, _: Pos) -> impl 'c + DoubleEndedIterator<Item = u32> {
+    fn iter_slice<'b>(&self, _: Pos, _: Pos) -> impl 'b + DoubleEndedIterator<Item = u32> {
         // Stub implementation
         CodePointIterator::from_raw_one_byte_slice(&[])
     }
@@ -294,7 +294,7 @@ impl<'a> HeapOneByteLexerStream<'a> {
     }
 }
 
-impl<'a> LexerStream for HeapOneByteLexerStream<'a> {
+impl LexerStream for HeapOneByteLexerStream<'_> {
     #[inline]
     fn pos(&self) -> Pos {
         self.pos
@@ -386,11 +386,7 @@ impl<'a> LexerStream for HeapOneByteLexerStream<'a> {
         Ok(code_point)
     }
 
-    fn iter_slice<'b, 'c>(
-        &'b self,
-        start: Pos,
-        end: Pos,
-    ) -> impl 'c + DoubleEndedIterator<Item = u32> {
+    fn iter_slice<'b>(&self, start: Pos, end: Pos) -> impl 'b + DoubleEndedIterator<Item = u32> {
         CodePointIterator::from_raw_one_byte_slice(&self.buf[start..end])
     }
 
@@ -457,7 +453,7 @@ impl<'a> HeapTwoByteCodeUnitLexerStream<'a> {
     }
 }
 
-impl<'a> LexerStream for HeapTwoByteCodeUnitLexerStream<'a> {
+impl LexerStream for HeapTwoByteCodeUnitLexerStream<'_> {
     #[inline]
     fn pos(&self) -> Pos {
         self.pos
@@ -549,11 +545,7 @@ impl<'a> LexerStream for HeapTwoByteCodeUnitLexerStream<'a> {
         Ok(code_point)
     }
 
-    fn iter_slice<'b, 'c>(
-        &'b self,
-        start: Pos,
-        end: Pos,
-    ) -> impl 'c + DoubleEndedIterator<Item = u32> {
+    fn iter_slice<'b>(&self, start: Pos, end: Pos) -> impl 'b + DoubleEndedIterator<Item = u32> {
         CodeUnitIterator::from_raw_two_byte_slice(&self.buf[start..end])
             .map(|code_unit| code_unit as u32)
     }
@@ -650,7 +642,7 @@ impl<'a> HeapTwoByteCodePointLexerStream<'a> {
     }
 }
 
-impl<'a> LexerStream for HeapTwoByteCodePointLexerStream<'a> {
+impl LexerStream for HeapTwoByteCodePointLexerStream<'_> {
     #[inline]
     fn pos(&self) -> Pos {
         self.pos
@@ -774,11 +766,7 @@ impl<'a> LexerStream for HeapTwoByteCodePointLexerStream<'a> {
         Ok(code_point)
     }
 
-    fn iter_slice<'b, 'c>(
-        &'b self,
-        start: Pos,
-        end: Pos,
-    ) -> impl 'c + DoubleEndedIterator<Item = u32> {
+    fn iter_slice<'b>(&self, start: Pos, end: Pos) -> impl 'b + DoubleEndedIterator<Item = u32> {
         CodePointIterator::from_raw_two_byte_slice(&self.buf[start..end])
     }
 

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -6203,7 +6203,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         // If there is a rest element all keys must be saved in a contiguous sequence of temporary
         // registers so they can be passed to the CopyDataProperties instruction.
-        let has_rest_element = pattern.properties.last().map_or(false, |p| p.is_rest);
+        let has_rest_element = pattern.properties.last().is_some_and(|p| p.is_rest);
 
         let mut saved_keys = vec![];
         if has_rest_element {
@@ -9731,7 +9731,7 @@ type FunctionVec = BsVec<HeapPtr<BytecodeFunction>>;
 
 struct FunctionVecField<'a>(&'a mut Option<Handle<FunctionVec>>);
 
-impl<'a> BsVecField<HeapPtr<BytecodeFunction>> for FunctionVecField<'a> {
+impl BsVecField<HeapPtr<BytecodeFunction>> for FunctionVecField<'_> {
     fn new_vec(cx: Context, capacity: usize) -> HeapPtr<FunctionVec> {
         BsVec::new(cx, ObjectKind::ValueVec, capacity)
     }

--- a/src/js/runtime/collections/hash_map.rs
+++ b/src/js/runtime/collections/hash_map.rs
@@ -312,7 +312,7 @@ impl<K, V> Entry<K, V> {
 
 pub struct GcUnsafeEntriesIter<'a, K, V>(slice::Iter<'a, Entry<K, V>>);
 
-impl<'a, K: Clone, V: Clone> Iterator for GcUnsafeEntriesIter<'a, K, V> {
+impl<K: Clone, V: Clone> Iterator for GcUnsafeEntriesIter<'_, K, V> {
     type Item = (K, V);
 
     #[inline]
@@ -354,7 +354,7 @@ impl<'a, K: Clone, V: Clone> Iterator for GcUnsafeEntriesIterMut<'a, K, V> {
 
 pub struct GcUnsafeKeysIter<'a, K, V>(slice::Iter<'a, Entry<K, V>>);
 
-impl<'a, K: Clone, V: Clone> Iterator for GcUnsafeKeysIter<'a, K, V> {
+impl<K: Clone, V: Clone> Iterator for GcUnsafeKeysIter<'_, K, V> {
     type Item = K;
 
     #[inline]

--- a/src/js/runtime/collections/index_map.rs
+++ b/src/js/runtime/collections/index_map.rs
@@ -500,7 +500,7 @@ impl<K, V> Entry<K, V> {
 
 pub struct GcUnsafeEntriesIter<'a, K, V>(slice::Iter<'a, Entry<K, V>>);
 
-impl<'a, K: Clone, V: Clone> Iterator for GcUnsafeEntriesIter<'a, K, V> {
+impl<K: Clone, V: Clone> Iterator for GcUnsafeEntriesIter<'_, K, V> {
     type Item = (K, V);
 
     #[inline]
@@ -542,7 +542,7 @@ impl<'a, K: Clone, V: Clone> Iterator for GcUnsafeEntriesIterMut<'a, K, V> {
 
 pub struct GcUnsafeKeysIter<'a, K, V>(slice::Iter<'a, Entry<K, V>>);
 
-impl<'a, K: Clone, V: Clone> Iterator for GcUnsafeKeysIter<'a, K, V> {
+impl<K: Clone, V: Clone> Iterator for GcUnsafeKeysIter<'_, K, V> {
     type Item = K;
 
     #[inline]

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -344,44 +344,41 @@ pub fn validate_and_apply_property_descriptor(
         }
     }
 
-    match &mut object {
-        Some(object) => {
-            // For every field in new descriptor that is present, set the corresponding attribute in
-            // the existing descriptor.
-            let mut property = object.get_property(cx, key).unwrap();
+    if let Some(object) = &mut object {
+        // For every field in new descriptor that is present, set the corresponding attribute in
+        // the existing descriptor.
+        let mut property = object.get_property(cx, key).unwrap();
 
-            if let Some(is_enumerable) = desc.is_enumerable {
-                property.set_is_enumerable(is_enumerable);
-            }
-
-            if let Some(is_configurable) = desc.is_configurable {
-                property.set_is_configurable(is_configurable);
-            }
-
-            if desc.is_data_descriptor() {
-                if let Some(is_writable) = desc.is_writable {
-                    property.set_is_writable(is_writable);
-                }
-
-                if let Some(value) = desc.value {
-                    property.set_value(value);
-                }
-            } else {
-                if desc.has_get {
-                    let mut accessor_value = Accessor::from_value(property.value());
-                    accessor_value.get = desc.get.map(|x| *x);
-                }
-
-                if desc.has_set {
-                    let mut accessor_value = Accessor::from_value(property.value());
-                    accessor_value.set = desc.set.map(|x| *x);
-                }
-            }
-
-            // Set modified property on object
-            object.set_property(cx, key, property);
+        if let Some(is_enumerable) = desc.is_enumerable {
+            property.set_is_enumerable(is_enumerable);
         }
-        None => {}
+
+        if let Some(is_configurable) = desc.is_configurable {
+            property.set_is_configurable(is_configurable);
+        }
+
+        if desc.is_data_descriptor() {
+            if let Some(is_writable) = desc.is_writable {
+                property.set_is_writable(is_writable);
+            }
+
+            if let Some(value) = desc.value {
+                property.set_value(value);
+            }
+        } else {
+            if desc.has_get {
+                let mut accessor_value = Accessor::from_value(property.value());
+                accessor_value.get = desc.get.map(|x| *x);
+            }
+
+            if desc.has_set {
+                let mut accessor_value = Accessor::from_value(property.value());
+                accessor_value.set = desc.set.map(|x| *x);
+            }
+        }
+
+        // Set modified property on object
+        object.set_property(cx, key, property);
     }
 
     true

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -77,6 +77,11 @@ use super::{
 /// - Decoding a double is simply bitwise negating the entire value. Same with encoding.
 /// - Undefined and Null tags differ by a single bit, so can mask and compare to check nullish
 ///   values instead of needing two comparisons.
+#[derive(Clone, Copy)]
+pub struct Value {
+    // Used as raw bitfield. NonZero for option inline niche optimization.
+    raw_bits: NonZeroU64,
+}
 
 const TAG_SHIFT: u64 = 48;
 
@@ -107,12 +112,6 @@ const FALSE: u64 = Value::bool(false).as_raw_bits();
 const SMI_MAX: f64 = i32::MAX as f64;
 const SMI_MIN: f64 = i32::MIN as f64;
 const SMI_ZERO: u64 = Value::smi(0).as_raw_bits();
-
-#[derive(Clone, Copy)]
-pub struct Value {
-    // Used as raw bitfield. NonZero for option inline niche optimization.
-    raw_bits: NonZeroU64,
-}
 
 impl Value {
     #[inline]
@@ -369,7 +368,7 @@ impl Value {
     pub const fn double(value: f64) -> Value {
         // f64::to_bits is not yet stable as a const fn. We only pass simple values in a const
         // context so perform a raw transmute until f64::to_bits is const stabilized.
-        let double_bits = unsafe { std::mem::transmute::<f64, u64>(value) };
+        let double_bits = value.to_bits();
         Value::from_raw_bits(!double_bits)
     }
 


### PR DESCRIPTION
## Summary

Upgrade to the latest version of rust, 1.85.0.

The only changes needed are fixes for a number of new lint warnings.

## Tests

All tests pass.