### PR TITLE
[parser] AST uses Wtf8String instead of String in all nodes

### DIFF
--- a/src/js/common/wtf_8.rs
+++ b/src/js/common/wtf_8.rs
@@ -24,14 +24,14 @@ impl Wtf8String {
     }
 
     #[inline]
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str(string: &str) -> Self {
-        Self::from_bytes_unchecked(string.as_bytes())
+    pub fn from_bytes_unchecked(bytes: &[u8]) -> Self {
+        Wtf8String { buf: bytes.to_vec() }
     }
 
     #[inline]
-    pub fn from_bytes_unchecked(bytes: &[u8]) -> Self {
-        Wtf8String { buf: bytes.to_vec() }
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(string: &str) -> Self {
+        Self::from_bytes_unchecked(string.as_bytes())
     }
 
     #[inline]
@@ -215,5 +215,14 @@ impl Borrow<[u8]> for Wtf8String {
     #[inline]
     fn borrow(&self) -> &[u8] {
         self.as_bytes()
+    }
+}
+
+impl From<char> for Wtf8String {
+    fn from(c: char) -> Self {
+        let mut buf = [0; 4];
+        let byte_length = encode_utf8_codepoint(&mut buf, c as u32);
+
+        Wtf8String { buf: buf[..byte_length].to_vec() }
     }
 }

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -136,7 +136,7 @@ pub enum Toplevel {
 
 pub struct Identifier {
     pub loc: Loc,
-    pub name: String,
+    pub name: Wtf8String,
 
     /// Reference to the scope that contains the binding for this identifier, or tagged as
     /// unresolved if the scope could not be statically determined.
@@ -146,7 +146,7 @@ pub struct Identifier {
 }
 
 impl Identifier {
-    pub fn new(loc: Loc, name: String) -> Identifier {
+    pub fn new(loc: Loc, name: Wtf8String) -> Identifier {
         Identifier { loc, name, scope: TaggedResolvedScope::unresolved_global() }
     }
 
@@ -155,7 +155,7 @@ impl Identifier {
     }
 
     pub fn get_private_name_binding(&self) -> &Binding {
-        let private_name = format!("#{}", self.name);
+        let private_name = Wtf8String::from_string(format!("#{}", self.name));
         self.scope.unwrap_resolved().get_binding(&private_name)
     }
 }
@@ -786,12 +786,12 @@ pub type LabelId = u16;
 
 pub struct Label {
     pub loc: Loc,
-    pub name: String,
+    pub name: Wtf8String,
     pub id: LabelId,
 }
 
 impl Label {
-    pub fn new(loc: Loc, name: String) -> Label {
+    pub fn new(loc: Loc, name: Wtf8String) -> Label {
         Label { loc, name, id: 0 }
     }
 }
@@ -1282,11 +1282,11 @@ impl SuperMemberExpression {
         }
     }
 
-    pub fn home_object_name(&self) -> &'static str {
+    pub fn home_object_name(&self) -> &'static Wtf8String {
         if self.is_static {
-            STATIC_HOME_OBJECT_BINDING_NAME
+            &STATIC_HOME_OBJECT_BINDING_NAME
         } else {
-            HOME_OBJECT_BINDING_NAME
+            &HOME_OBJECT_BINDING_NAME
         }
     }
 }

--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -47,7 +47,7 @@ pub enum ParseError {
     NullishCoalesceMixedWithLogical,
     HashNotFollowedByIdentifier,
     ForEachInitInvalidVarDecl,
-    NameRedeclaration(Box<(String, BindingKind)>),
+    NameRedeclaration(Box<(Wtf8String, BindingKind)>),
     DuplicateLabel,
     LabelNotFound,
     WithInStrictMode,
@@ -71,10 +71,10 @@ pub enum ParseError {
     ClassStaticPrototype,
     InvalidPatternInitializer,
     #[allow(clippy::box_collection)]
-    DuplicatePrivateName(Box<String>),
+    DuplicatePrivateName(Box<Wtf8String>),
     PrivateNameOutsideClass,
     #[allow(clippy::box_collection)]
-    PrivateNameNotDefined(Box<String>),
+    PrivateNameNotDefined(Box<Wtf8String>),
     PrivateNameConstructor,
     ArgumentsInClassInitializer,
     NewTargetOutsideFunction,
@@ -140,15 +140,15 @@ impl ParseError {
         ParseError::ExpectedToken(Box::new((actual, expected)))
     }
 
-    pub fn new_name_redeclaration(name: String, kind: BindingKind) -> ParseError {
+    pub fn new_name_redeclaration(name: Wtf8String, kind: BindingKind) -> ParseError {
         ParseError::NameRedeclaration(Box::new((name, kind)))
     }
 
-    pub fn new_duplicate_private_name(name: String) -> ParseError {
+    pub fn new_duplicate_private_name(name: Wtf8String) -> ParseError {
         ParseError::DuplicatePrivateName(Box::new(name))
     }
 
-    pub fn new_private_name_not_defined(name: String) -> ParseError {
+    pub fn new_private_name_not_defined(name: Wtf8String) -> ParseError {
         ParseError::PrivateNameNotDefined(Box::new(name))
     }
 }
@@ -244,7 +244,7 @@ impl fmt::Display for ParseError {
             }
             ParseError::NameRedeclaration(payload) => {
                 let (name, kind) = payload.as_ref();
-                if name == ANONYMOUS_DEFAULT_EXPORT_NAME {
+                if name == &*ANONYMOUS_DEFAULT_EXPORT_NAME {
                     write!(f, "Default export was already declared in this module")
                 } else {
                     let kind_string = match kind {

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -747,7 +747,7 @@ impl<'a> Printer<'a> {
         let id = expr.to_id();
 
         self.start_node("PrivateIdentifier", &id.loc);
-        self.property("name", id.name.as_str(), Printer::print_str);
+        self.property("name", &id.name, Printer::print_wtf8_string);
         self.end_node();
     }
 
@@ -961,9 +961,9 @@ impl<'a> Printer<'a> {
         self.print_identifier_parts(&id.loc, &id.name);
     }
 
-    fn print_identifier_parts(&mut self, loc: &Loc, name: &str) {
+    fn print_identifier_parts(&mut self, loc: &Loc, name: &Wtf8String) {
         self.start_node("Identifier", loc);
-        self.property("name", name, Printer::print_str);
+        self.property("name", name, Printer::print_wtf8_string);
         self.end_node();
     }
 
@@ -1197,13 +1197,6 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn print_optional_string(&mut self, string: Option<&String>) {
-        match string {
-            None => self.print_null(),
-            Some(string) => self.print_str(string),
-        }
-    }
-
     fn print_optional_wtf8_string(&mut self, string: Option<&Wtf8String>) {
         match string {
             None => self.print_null(),
@@ -1304,7 +1297,7 @@ impl<'a> Printer<'a> {
     fn print_regexp_capture_group(&mut self, group: &CaptureGroup) {
         self.start_regexp_node("CaptureGroup");
         self.property("index", group.index, Printer::print_number);
-        self.property("name", group.name.as_ref(), Printer::print_optional_string);
+        self.property("name", group.name.as_ref(), Printer::print_optional_wtf8_string);
         self.print_disjunction(&group.disjunction);
         self.end_node();
     }

--- a/src/js/parser/regexp.rs
+++ b/src/js/parser/regexp.rs
@@ -9,7 +9,7 @@ pub struct RegExp {
     pub flags: RegExpFlags,
     pub has_duplicate_named_capture_groups: bool,
     // All capture groups with their names if one was provided
-    pub capture_groups: Vec<Option<String>>,
+    pub capture_groups: Vec<Option<Wtf8String>>,
 }
 
 bitflags! {
@@ -143,7 +143,7 @@ pub type CaptureGroupIndex = u32;
 
 pub struct CaptureGroup {
     /// Optional capture group name
-    pub name: Option<String>,
+    pub name: Option<Wtf8String>,
     /// Index of the capture group in the RegExp
     pub index: CaptureGroupIndex,
     pub disjunction: Disjunction,

--- a/src/js/parser/token.rs
+++ b/src/js/parser/token.rs
@@ -8,7 +8,7 @@ use super::loc::Loc;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token {
-    Identifier(String),
+    Identifier(Wtf8String),
     NumberLiteral(f64),
     StringLiteral(Wtf8String),
     BigIntLiteral(BigInt),
@@ -141,7 +141,7 @@ pub enum Token {
 impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let str = match self {
-            Token::Identifier(name) => name,
+            Token::Identifier(name) => return f.write_str(&name.to_string()),
             Token::NumberLiteral(lit) => return f.write_str(&lit.to_string()),
             Token::StringLiteral(lit) => return f.write_str(&lit.to_string()),
             Token::BigIntLiteral(lit) => return write!(f, "{}n", lit),

--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -72,7 +72,7 @@ impl MappedArgumentsObject {
         scope: Handle<Scope>,
         num_parameters: usize,
     ) -> Handle<MappedArgumentsObject> {
-        let shadowed_name = InternedStrings::get_str(cx, SHADOWED_SCOPE_SLOT_NAME).as_flat();
+        let shadowed_name = InternedStrings::get_wtf8_str(cx, &SHADOWED_SCOPE_SLOT_NAME).as_flat();
 
         let size = Self::calculate_size_in_bytes(num_parameters);
         let mut object = object_create_with_size::<MappedArgumentsObject>(

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -263,7 +263,7 @@ impl Handle<Realm> {
         self.lexical_names = LexicalNamesMap::new_initial(cx, ObjectKind::LexicalNamesMap);
 
         // All global scopes have the realm in their first slot
-        let binding_names = &[InternedStrings::get_str(cx, REALM_SCOPE_SLOT_NAME).as_flat()];
+        let binding_names = &[InternedStrings::get_wtf8_str(cx, &REALM_SCOPE_SLOT_NAME).as_flat()];
         let binding_flags = &[ScopeNameFlags::empty()];
         let scope_names =
             ScopeNames::new(cx, ScopeFlags::IS_VAR_SCOPE, binding_names, binding_flags);

--- a/src/js/runtime/regexp/compiled_regexp.rs
+++ b/src/js/runtime/regexp/compiled_regexp.rs
@@ -61,7 +61,7 @@ impl CompiledRegExpObject {
             .map(|capture_group| {
                 if let Some(name_string) = capture_group {
                     has_named_capture_groups = true;
-                    Some(cx.alloc_string_ptr(name_string).to_handle())
+                    Some(cx.alloc_wtf8_string_ptr(name_string).to_handle())
                 } else {
                     None
                 }


### PR DESCRIPTION
## Summary

We plan on allocating the AST using a bump pointer allocator. This means that all heap allocations in the AST must use the allocator API. We can use the `allocator_api2` crate for simple built-in collections like `Vec` but all more complex, non-std, and custom collections must find a way to support the allocator API.

The built-in `String` type does not support custom allocators. Luckily our custom `Wtf8String` can easily be modified to use a custom allocator, and most strings in the AST are already `Wtf8String`s. This PR refactors all remaining instances of `String` to `Wtf8String` in the AST, RegExp AST, and AST scope nodes.

This is for the most part a straightforward migration. A `Wtf8String` can be created by consuming a `String` and serves as a strictly weaker representation - i.e. may contain unpaired surrogate code points. This slight weakening is not meaningful anywhere we were using the built-in `String` type.

Note that we now represent global built-in string names as `static LazyLock` instead of `&'static str`.

## Tests

All tests pass.