### PR TITLE
[parser] Move Rc<Source> out of AST and into ParseProgramResult

### DIFF
--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -1654,7 +1654,7 @@ impl Analyzer<'_> {
 }
 
 pub fn analyze(parse_result: &mut ParseProgramResult) -> Result<(), LocalizedParseErrors> {
-    let source = parse_result.program.source.clone();
+    let source = parse_result.source.clone();
     let mut analyzer = Analyzer::new(source, &mut parse_result.scope_tree);
     analyzer.visit_program(&mut parse_result.program);
 

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -2,7 +2,6 @@ use std::{
     fmt::{self, Debug},
     hash,
     ptr::{self, NonNull},
-    rc::Rc,
 };
 
 use bitflags::bitflags;
@@ -16,7 +15,6 @@ use super::{
     scope_tree::{
         AstScopeNode, Binding, HOME_OBJECT_BINDING_NAME, STATIC_HOME_OBJECT_BINDING_NAME,
     },
-    source::Source,
 };
 
 pub type P<T> = Box<T>;
@@ -85,7 +83,6 @@ pub struct Program {
     pub loc: Loc,
     pub toplevels: Vec<Toplevel>,
     pub kind: ProgramKind,
-    pub source: Rc<Source>,
     /// Whether the function is in strict mode, which could be inherited from surrounding context
     /// (e.g. in a direct eval or module)
     pub is_strict_mode: bool,
@@ -102,7 +99,6 @@ impl Program {
         loc: Loc,
         toplevels: Vec<Toplevel>,
         kind: ProgramKind,
-        source: Rc<Source>,
         scope: AstPtr<AstScopeNode>,
         is_strict_mode: bool,
         has_use_strict_directive: bool,
@@ -111,7 +107,6 @@ impl Program {
             loc,
             toplevels,
             kind,
-            source,
             is_strict_mode,
             has_use_strict_directive,
             has_top_level_await: false,

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -386,15 +386,15 @@ impl<'a> Parser<'a> {
             loc,
             toplevels,
             ProgramKind::Script,
-            self.lexer.source.clone(),
             scope,
             self.in_strict_mode,
             has_use_strict_directive,
         );
 
         let scope_tree = self.scope_builder.finish_ast_scope_tree();
+        let source = self.lexer.source.clone();
 
-        Ok(ParseProgramResult { program, scope_tree })
+        Ok(ParseProgramResult { program, scope_tree, source })
     }
 
     fn parse_directive_prologue(&mut self) -> ParseResult<bool> {
@@ -449,15 +449,15 @@ impl<'a> Parser<'a> {
             loc,
             toplevels,
             ProgramKind::Module,
-            self.lexer.source.clone(),
             scope,
             self.in_strict_mode,
             /* has_use_strict_directive */ false,
         );
 
         let scope_tree = self.scope_builder.finish_ast_scope_tree();
+        let source = self.lexer.source.clone();
 
-        Ok(ParseProgramResult { program, scope_tree })
+        Ok(ParseProgramResult { program, scope_tree, source })
     }
 
     fn parse_toplevel(&mut self) -> ParseResult<Toplevel> {
@@ -4850,6 +4850,7 @@ impl Expression {
 pub struct ParseProgramResult {
     pub program: Program,
     pub scope_tree: ScopeTree,
+    pub source: Rc<Source>,
 }
 
 pub struct ParseFunctionResult {

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -3,6 +3,7 @@ use crate::js::common::wtf_8::Wtf8String;
 
 use super::ast::*;
 use super::loc::{find_line_col_for_pos, Loc};
+use super::parser::ParseProgramResult;
 use super::regexp::{
     Alternative, AnonymousGroup, Assertion, Backreference, CaptureGroup, CharacterClass,
     ClassExpressionType, ClassRange, Disjunction, Lookaround, Quantifier, RegExp, RegExpFlags,
@@ -1407,8 +1408,8 @@ impl<'a> Printer<'a> {
 }
 
 // Prints JSON in ESTree format
-pub fn print_program(program: &Program) -> String {
-    let mut printer = Printer::new(&program.source);
-    printer.print_program(program);
+pub fn print_program(parse_result: &ParseProgramResult) -> String {
+    let mut printer = Printer::new(&parse_result.source);
+    printer.print_program(&parse_result.program);
     printer.finish()
 }

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -171,7 +171,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
         debug_assert!(parse_result.program.kind == ProgramKind::Script);
 
         handle_scope!(cx, {
-            let source = parse_result.program.source.clone();
+            let source = parse_result.source.clone();
             let mut generator = Self::new(cx, &parse_result.scope_tree, realm, source);
             let script = generator.generate_script_program(&parse_result.program)?;
 
@@ -234,7 +234,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
         debug_assert!(parse_result.program.kind == ProgramKind::Module);
 
         handle_scope!(cx, {
-            let source = parse_result.program.source.clone();
+            let source = parse_result.source.clone();
             let mut generator = Self::new(cx, &parse_result.scope_tree, realm, source);
             let module = generator.generate_module_program(&parse_result.program)?;
 
@@ -628,7 +628,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
     ) -> EmitResult<Handle<BytecodeFunction>> {
         handle_scope!(cx, {
             let mut generator =
-                Self::new(cx, &parse_result.scope_tree, realm, parse_result.program.source.clone());
+                Self::new(cx, &parse_result.scope_tree, realm, parse_result.source.clone());
             let function = generator.generate_eval(&parse_result.program);
 
             generator.dump_bytecode_functions();

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -205,7 +205,7 @@ impl Context {
         analyze(&mut parse_result)?;
 
         if self.options.print_ast {
-            println!("{}", print_program(&parse_result.program));
+            println!("{}", print_program(&parse_result));
         }
 
         // Generate bytecode for the program
@@ -227,7 +227,7 @@ impl Context {
         analyze(&mut parse_result)?;
 
         if self.options.print_ast {
-            println!("{}", print_program(&parse_result.program));
+            println!("{}", print_program(&parse_result));
         }
 
         // Generate bytecode for the program

--- a/src/js/runtime/module/loader.rs
+++ b/src/js/runtime/module/loader.rs
@@ -220,7 +220,7 @@ pub fn host_load_imported_module(
     }
 
     if cx.options.print_ast {
-        println!("{}", print_program(&parse_result.program));
+        println!("{}", print_program(&parse_result));
     }
 
     // Finally generate the SourceTextModule for the parsed module

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -53,7 +53,7 @@ fn print_ast(path: &str) -> GenericResult<String> {
         .build();
 
     let parse_result = parse_script_or_module(path, &options)?;
-    Ok(parser::print_program(&parse_result.program))
+    Ok(parser::print_program(&parse_result))
 }
 
 #[test]


### PR DESCRIPTION
## Summary

We want the entire AST to be allocated by a bump allocator, meaning it cannot own any values allocated with another allocator. This includes the `Rc<Source>` held by the root `Program` node. Instead we can move the program source up to be held by the `ParseProgramResult` instead.

## Tests

All tests pass.