### PR TITLE
[common] Use jemalloc as global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ dependencies = [
  "rand",
  "ryu-js",
  "supports-color",
+ "tikv-jemallocator",
  "zerotrie",
  "zerovec",
 ]
@@ -127,6 +128,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -917,6 +927,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1008,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ serde = "1.0.152"
 serde_json = "1.0.91"
 supports-color = "3.0.2"
 syn = "2.0.27"
+tikv-jemallocator = "0.6"
 threadpool = "1.8.1"
 yaml-rust = "0.4.5"
 

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -25,6 +25,9 @@ rand.workspace = true
 ryu-js.workspace = true
 supports-color.workspace = true
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.6"
+
 # Internal crates
 brimstone_icu_collections.workspace = true
 brimstone_macros.workspace = true

--- a/src/js/common/alloc.rs
+++ b/src/js/common/alloc.rs
@@ -1,0 +1,6 @@
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;

--- a/src/js/common/mod.rs
+++ b/src/js/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod alloc;
 pub mod constants;
 pub mod error;
 pub mod icu;


### PR DESCRIPTION
## Summary

Looking at flamegraphs of performance a large amount of time is spent in system malloc/free/madvise calls. Let's switch to using jemalloc on supported platforms and it performs much better in practice.

For example when running the entire integration test suite with `cargo brimstone -r`, using jemalloc reduced the runtime from ~6.6s to ~5.4s.

This also prevents a regression when switching to an arena allocator for the AST, which appeared to be hitting slow madvise calls and significantly regressed performance.

## Tests

All tests pass.