### PR TITLE
[parser] Use custom AstBox and AstSlice type

### DIFF
--- a/src/benches/benches.rs
+++ b/src/benches/benches.rs
@@ -101,6 +101,9 @@ fn analyze_step<'a>(
 fn generate_step(
     (cx, _pcx, analyzed_result): (Context, ParseContext, AnalyzedProgramResult),
 ) -> (Context, BytecodeScript) {
+    // Fix the lifetime
+    let analyzed_result = unsafe { std::mem::transmute(analyzed_result) };
+
     let bytecode_program = BytecodeProgramGenerator::generate_from_parse_script_result(
         cx,
         &analyzed_result,

--- a/src/js/common/alloc.rs
+++ b/src/js/common/alloc.rs
@@ -7,7 +7,7 @@ static GLOBAL: Jemalloc = Jemalloc;
 
 use allocator_api2::alloc::Allocator;
 
-pub use allocator_api2::{boxed::Box, vec, vec::Vec};
+pub use allocator_api2::{vec, vec::Vec};
 
 pub fn slice_to_alloc_vec<T: Clone, A: Allocator>(slice: &[T], alloc: A) -> Vec<T, A> {
     let mut vec = Vec::with_capacity_in(slice.len(), alloc);

--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -404,7 +404,7 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
         // Body of switch statement is in its own scope
         self.enter_scope(stmt.scope);
 
-        for case in &mut stmt.cases {
+        for case in stmt.cases.iter_mut() {
             if case.test.is_none() {
                 if !seen_default {
                     seen_default = true;
@@ -626,7 +626,7 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
     fn visit_object_expression(&mut self, expr: &mut ObjectExpression<'a>) {
         // Do not allow duplicate __proto__ initializer properties
         let mut has_proto_init = false;
-        for property in &expr.properties {
+        for property in expr.properties.iter() {
             if let PropertyKind::Init = property.kind {
                 // Must be a simple proto initializer
                 if !property.is_computed && !property.is_method && property.value.is_some() {
@@ -875,7 +875,7 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
         let field_init_scope = class.fields_initializer_scope;
         let static_init_scope = class.static_initializer_scope;
 
-        for element in &mut class.body {
+        for element in class.body.iter_mut() {
             match element {
                 ClassElement::Method(method) => {
                     if method.kind == ClassMethodKind::Constructor {
@@ -934,7 +934,7 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
     }
 
     fn visit_import_declaration(&mut self, import: &mut ImportDeclaration<'a>) {
-        for specifier in &import.specifiers {
+        for specifier in import.specifiers.iter() {
             match specifier {
                 ImportSpecifier::Default(ImportDefaultSpecifier { local, .. })
                 | ImportSpecifier::Named(ImportNamedSpecifier { local, .. })
@@ -953,7 +953,7 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
         // Check for duplicate keys
         let mut seen_keys: HashSet<&[u8]> = HashSet::new();
 
-        for attribute in &attributes.attributes {
+        for attribute in attributes.attributes.iter() {
             let name_slice = match attribute.key.as_ref() {
                 Expression::Id(id) => id.name.as_bytes(),
                 Expression::String(literal) => literal.value.as_bytes(),
@@ -986,7 +986,7 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
             self.add_export(id.loc, id.name.as_arena_str());
         });
 
-        for specifier in &mut export.specifiers {
+        for specifier in export.specifiers.iter_mut() {
             // Only need to resolve the specifier's local binding if it is not a re-export
             if export.source.is_none() {
                 // Local is guaranteed to be an identifier if this is not a re-export
@@ -1096,7 +1096,7 @@ impl<'a> Analyzer<'a> {
         // function parameters.
         self.in_parameters_stack.push(true);
 
-        for param in &mut func.params {
+        for param in func.params.iter_mut() {
             self.visit_function_param(param);
         }
 
@@ -1221,7 +1221,7 @@ impl<'a> Analyzer<'a> {
         let mut private_names = HashMap::new();
         let mut has_private_accessor_pair = false;
 
-        for element in &mut class.body {
+        for element in class.body.iter_mut() {
             let private_id = match element {
                 ClassElement::Property(ClassProperty { is_private: true, key, .. }) => {
                     let private_id = key.expr.to_id_mut();
@@ -1317,7 +1317,7 @@ impl<'a> Analyzer<'a> {
         // the AST so that it can be identified during bytecode generation.
         if has_private_accessor_pair {
             let mut marked_pairs = HashSet::new();
-            for element in &mut class.body {
+            for element in class.body.iter_mut() {
                 if let ClassElement::Method(ClassMethod {
                     is_private: true,
                     kind: ClassMethodKind::Get | ClassMethodKind::Set,
@@ -1457,7 +1457,7 @@ impl<'a> Analyzer<'a> {
         var_decl: &mut VariableDeclaration<'a>,
         is_for_each_init: bool,
     ) {
-        for declaration in &var_decl.declarations {
+        for declaration in var_decl.declarations.iter() {
             if var_decl.kind == VarKind::Const && declaration.init.is_none() && !is_for_each_init {
                 self.emit_error(declaration.loc, ParseError::ConstWithoutInitializer);
             }

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -7,6 +7,7 @@ use std::{
     ptr::{self, NonNull},
 };
 
+use allocator_api2::alloc::Allocator;
 use bitflags::bitflags;
 use bumpalo::Bump;
 use hashbrown::{DefaultHashBuilder, HashSet};
@@ -30,8 +31,6 @@ use super::{
 };
 
 pub type AstAlloc<'a> = &'a Bump;
-
-pub type AstVec<'a, T> = alloc::Vec<T, AstAlloc<'a>>;
 
 pub type ArenaVec<'a, T> = alloc::Vec<T, AstAlloc<'a>>;
 
@@ -67,16 +66,6 @@ impl<'a, T> AstBox<'a, T> {
         let ptr = self.ptr.as_ptr();
         unsafe { ptr.read() }
     }
-
-    #[inline]
-    pub fn as_ref(&self) -> &T {
-        self.deref()
-    }
-
-    #[inline]
-    pub fn as_mut(&mut self) -> &mut T {
-        self.deref_mut()
-    }
 }
 
 impl<T> Deref for AstBox<'_, T> {
@@ -95,24 +84,79 @@ impl<T> DerefMut for AstBox<'_, T> {
     }
 }
 
-pub struct AstVecBuilder<'a, T>(ArenaVec<'a, T>);
+impl<T> AsRef<T> for AstBox<'_, T> {
+    #[inline]
+    fn as_ref(&self) -> &T {
+        self.deref()
+    }
+}
 
-impl<'a, T> AstVecBuilder<'a, T> {
-    pub fn new(vec: ArenaVec<'a, T>) -> Self {
-        AstVecBuilder(vec)
+impl<T> AsMut<T> for AstBox<'_, T> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut T {
+        self.deref_mut()
+    }
+}
+
+/// An owned, arena allocated slice in the AST.
+///
+/// Assumes that contents are fully arena-allocated and does not own data from outside the arena.
+/// This allows for not needing to call a destructor.
+pub struct AstSlice<'a, T> {
+    ptr: *mut T,
+    len: usize,
+    data: PhantomData<&'a T>,
+}
+
+impl<'a, T> AstSlice<'a, T> {
+    fn new_from_raw_parts(ptr: *mut T, len: usize) -> AstSlice<'a, T> {
+        AstSlice { ptr, len, data: PhantomData }
     }
 
-    pub fn build(mut self) -> &'a mut [T] {
+    pub fn new_empty() -> AstSlice<'a, T> {
+        let ptr = unsafe { NonNull::dangling().as_mut() };
+        Self::new_from_raw_parts(ptr, 0)
+    }
+
+    pub fn into_vec<A: Allocator>(self, alloc: A) -> alloc::Vec<T, A> {
+        unsafe { alloc::Vec::from_raw_parts_in(self.ptr, self.len, self.len, alloc) }
+    }
+}
+
+impl<T> Deref for AstSlice<'_, T> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &[T] {
+        unsafe { std::slice::from_raw_parts(self.ptr.cast_const(), self.len) }
+    }
+}
+
+impl<T> DerefMut for AstSlice<'_, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut [T] {
+        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+}
+
+pub struct AstSliceBuilder<'a, T>(ArenaVec<'a, T>);
+
+impl<'a, T> AstSliceBuilder<'a, T> {
+    pub fn new(vec: ArenaVec<'a, T>) -> Self {
+        AstSliceBuilder(vec)
+    }
+
+    pub fn build(mut self) -> AstSlice<'a, T> {
         // Intentionally leak inner vector
         let ptr = self.as_mut_ptr();
         let len = self.len();
         std::mem::forget(self);
 
-        unsafe { std::slice::from_raw_parts_mut(ptr, len) }
+        AstSlice::new_from_raw_parts(ptr, len)
     }
 }
 
-impl<'a, T> Deref for AstVecBuilder<'a, T> {
+impl<'a, T> Deref for AstSliceBuilder<'a, T> {
     type Target = ArenaVec<'a, T>;
 
     fn deref(&self) -> &Self::Target {
@@ -120,7 +164,7 @@ impl<'a, T> Deref for AstVecBuilder<'a, T> {
     }
 }
 
-impl<'a, T> DerefMut for AstVecBuilder<'a, T> {
+impl<T> DerefMut for AstSliceBuilder<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -165,13 +209,13 @@ impl<T> AstPtr<T> {
     }
 }
 
-impl<T> std::convert::AsRef<T> for AstPtr<T> {
+impl<T> AsRef<T> for AstPtr<T> {
     fn as_ref(&self) -> &T {
         unsafe { self.ptr.as_ref() }
     }
 }
 
-impl<T> std::convert::AsMut<T> for AstPtr<T> {
+impl<T> AsMut<T> for AstPtr<T> {
     fn as_mut(&mut self) -> &mut T {
         unsafe { self.ptr.as_mut() }
     }
@@ -207,7 +251,7 @@ impl<T> Debug for AstPtr<T> {
 
 pub struct Program<'a> {
     pub loc: Loc,
-    pub toplevels: AstVec<'a, Toplevel<'a>>,
+    pub toplevels: AstSlice<'a, Toplevel<'a>>,
     pub kind: ProgramKind,
     /// Whether the function is in strict mode, which could be inherited from surrounding context
     /// (e.g. in a direct eval or module)
@@ -223,7 +267,7 @@ pub struct Program<'a> {
 impl<'a> Program<'a> {
     pub fn new(
         loc: Loc,
-        toplevels: AstVec<'a, Toplevel<'a>>,
+        toplevels: AstSlice<'a, Toplevel<'a>>,
         kind: ProgramKind,
         scope: AstPtr<AstScopeNode<'a>>,
         is_strict_mode: bool,
@@ -266,12 +310,12 @@ pub struct Identifier<'a> {
     pub scope: TaggedResolvedScope<'a>,
 }
 
-impl Identifier<'_> {
-    pub fn new(loc: Loc, name: AstString) -> Identifier {
+impl<'a> Identifier<'a> {
+    pub fn new(loc: Loc, name: AstString<'a>) -> Identifier<'a> {
         Identifier { loc, name, scope: TaggedResolvedScope::unresolved_global() }
     }
 
-    pub fn get_binding(&self) -> &Binding {
+    pub fn get_binding(&self) -> &Binding<'a> {
         self.scope.unwrap_resolved().get_binding(&self.name)
     }
 }
@@ -297,11 +341,11 @@ pub enum ResolvedScope {
 }
 
 impl<'a> TaggedResolvedScope<'a> {
-    pub const fn unresolved_global() -> TaggedResolvedScope<'static> {
+    pub const fn unresolved_global() -> TaggedResolvedScope<'a> {
         TaggedResolvedScope { ptr: ptr::null_mut(), data: PhantomData }
     }
 
-    pub const fn unresolved_dynamic() -> TaggedResolvedScope<'static> {
+    pub const fn unresolved_dynamic() -> TaggedResolvedScope<'a> {
         TaggedResolvedScope { ptr: 1 as *mut u8, data: PhantomData }
     }
 
@@ -377,7 +421,7 @@ pub enum VarKind {
 pub struct VariableDeclaration<'a> {
     pub loc: Loc,
     pub kind: VarKind,
-    pub declarations: AstVec<'a, VariableDeclarator<'a>>,
+    pub declarations: AstSlice<'a, VariableDeclarator<'a>>,
 }
 
 pub struct VariableDeclarator<'a> {
@@ -433,7 +477,7 @@ bitflags! {
 pub struct Function<'a> {
     pub loc: Loc,
     pub id: Option<P<'a, Identifier<'a>>>,
-    pub params: AstVec<'a, FunctionParam<'a>>,
+    pub params: AstSlice<'a, FunctionParam<'a>>,
     pub body: P<'a, FunctionBody<'a>>,
     pub flags: FunctionFlags,
 
@@ -445,7 +489,7 @@ impl<'a> Function<'a> {
     pub fn new_uninit(alloc: AstAlloc<'a>) -> Function<'a> {
         let body = FunctionBody::Block(FunctionBlockBody {
             loc: EMPTY_LOC,
-            body: alloc::vec![in alloc],
+            body: AstSlice::new_empty(),
             scope: None,
         });
 
@@ -453,7 +497,7 @@ impl<'a> Function<'a> {
             // Default values that will be overwritten by `init`
             loc: EMPTY_LOC,
             id: None,
-            params: alloc::vec![in alloc],
+            params: AstSlice::new_empty(),
             body: AstBox::new_in(body, alloc),
             flags: FunctionFlags::empty(),
             scope: AstPtr::uninit(),
@@ -464,7 +508,7 @@ impl<'a> Function<'a> {
         &mut self,
         loc: Loc,
         id: Option<P<'a, Identifier<'a>>>,
-        params: AstVec<'a, FunctionParam<'a>>,
+        params: AstSlice<'a, FunctionParam<'a>>,
         body: P<'a, FunctionBody<'a>>,
         flags: FunctionFlags,
         scope: AstPtr<AstScopeNode<'a>>,
@@ -480,7 +524,7 @@ impl<'a> Function<'a> {
     pub fn new(
         loc: Loc,
         id: Option<P<'a, Identifier<'a>>>,
-        params: AstVec<'a, FunctionParam<'a>>,
+        params: AstSlice<'a, FunctionParam<'a>>,
         body: P<'a, FunctionBody<'a>>,
         flags: FunctionFlags,
         scope: AstPtr<AstScopeNode<'a>>,
@@ -592,8 +636,8 @@ pub enum FunctionBody<'a> {
     Expression(OuterExpression<'a>),
 }
 
-impl FunctionBody<'_> {
-    pub fn unwrap_block(&self) -> &FunctionBlockBody {
+impl<'a> FunctionBody<'a> {
+    pub fn unwrap_block(&self) -> &FunctionBlockBody<'a> {
         match self {
             FunctionBody::Block(block) => block,
             _ => panic!("Expected block body"),
@@ -603,7 +647,7 @@ impl FunctionBody<'_> {
 
 pub struct FunctionBlockBody<'a> {
     pub loc: Loc,
-    pub body: AstVec<'a, Statement<'a>>,
+    pub body: AstSlice<'a, Statement<'a>>,
 
     /// Scope node for the function body, not including parameters. Only present if the function has
     /// parameter expressions, otherwise only the function's scope node is needed.
@@ -614,7 +658,7 @@ pub struct Class<'a> {
     pub loc: Loc,
     pub id: Option<P<'a, Identifier<'a>>>,
     pub super_class: Option<P<'a, OuterExpression<'a>>>,
-    pub body: AstVec<'a, ClassElement<'a>>,
+    pub body: AstSlice<'a, ClassElement<'a>>,
 
     pub constructor: Option<AstPtr<ClassMethod<'a>>>,
 
@@ -635,7 +679,7 @@ impl<'a> Class<'a> {
         loc: Loc,
         id: Option<P<'a, Identifier<'a>>>,
         super_class: Option<P<'a, OuterExpression<'a>>>,
-        body: AstVec<'a, ClassElement<'a>>,
+        body: AstSlice<'a, ClassElement<'a>>,
         scope: AstPtr<AstScopeNode<'a>>,
         fields_initializer_scope: Option<AstPtr<AstScopeNode<'a>>>,
         static_initializer_scope: Option<AstPtr<AstScopeNode<'a>>>,
@@ -720,7 +764,7 @@ pub struct ExpressionStatement<'a> {
 
 pub struct Block<'a> {
     pub loc: Loc,
-    pub body: AstVec<'a, Statement<'a>>,
+    pub body: AstSlice<'a, Statement<'a>>,
 
     /// Block scope node for the block.
     pub scope: AstPtr<AstScopeNode<'a>>,
@@ -736,7 +780,7 @@ pub struct IfStatement<'a> {
 pub struct SwitchStatement<'a> {
     pub loc: Loc,
     pub discriminant: P<'a, OuterExpression<'a>>,
-    pub cases: AstVec<'a, SwitchCase<'a>>,
+    pub cases: AstSlice<'a, SwitchCase<'a>>,
 
     /// Block scope node for the switch statement body.
     pub scope: AstPtr<AstScopeNode<'a>>,
@@ -745,7 +789,7 @@ pub struct SwitchStatement<'a> {
 pub struct SwitchCase<'a> {
     pub loc: Loc,
     pub test: Option<P<'a, OuterExpression<'a>>>,
-    pub body: AstVec<'a, Statement<'a>>,
+    pub body: AstSlice<'a, Statement<'a>>,
 }
 
 pub struct ForStatement<'a> {
@@ -794,12 +838,12 @@ pub enum ForEachInit<'a> {
     },
 }
 
-impl ForEachInit<'_> {
+impl<'a> ForEachInit<'a> {
     pub fn new_pattern(pattern: Pattern) -> ForEachInit {
         ForEachInit::Pattern { pattern, has_assign_expr: false }
     }
 
-    pub fn pattern(&self) -> &Pattern {
+    pub fn pattern(&self) -> &Pattern<'a> {
         match self {
             ForEachInit::VarDecl(decl) => &decl.declarations[0].id,
             ForEachInit::Pattern { pattern, .. } => pattern,
@@ -974,7 +1018,7 @@ pub enum Expression<'a> {
 }
 
 impl<'a> Expression<'a> {
-    pub fn to_id(&self) -> &Identifier {
+    pub fn to_id(&self) -> &Identifier<'a> {
         match self {
             Expression::Id(id) => id,
             _ => panic!("Expected identifier expression"),
@@ -1052,7 +1096,7 @@ pub struct BigIntLiteral<'a> {
     /// Sign of the BigInt value.
     sign: Sign,
     /// Digits of the BigInt value.
-    digits: AstVec<'a, u32>,
+    digits: AstSlice<'a, u32>,
 }
 
 impl<'a> BigIntLiteral<'a> {
@@ -1060,7 +1104,7 @@ impl<'a> BigIntLiteral<'a> {
         let (sign, unsigned) = value.into_parts();
         let digits = slice_to_alloc_vec(&unsigned.to_u32_digits(), alloc);
 
-        BigIntLiteral { loc, sign, digits }
+        BigIntLiteral { loc, sign, digits: AstSliceBuilder::new(digits).build() }
     }
 
     /// Return a clone of the BigInt value.
@@ -1231,7 +1275,7 @@ pub struct ConditionalExpression<'a> {
 pub struct CallExpression<'a> {
     pub loc: Loc,
     pub callee: P<'a, Expression<'a>>,
-    pub arguments: AstVec<'a, CallArgument<'a>>,
+    pub arguments: AstSlice<'a, CallArgument<'a>>,
     pub is_optional: bool,
 
     // The reamining fields are only set if the call expression is potentially a direct eval.
@@ -1260,7 +1304,7 @@ impl<'a> CallExpression<'a> {
     pub fn new(
         loc: Loc,
         callee: P<'a, Expression<'a>>,
-        arguments: AstVec<'a, CallArgument<'a>>,
+        arguments: AstSlice<'a, CallArgument<'a>>,
         is_optional: bool,
     ) -> CallExpression<'a> {
         CallExpression {
@@ -1286,17 +1330,17 @@ pub enum CallArgument<'a> {
 pub struct NewExpression<'a> {
     pub loc: Loc,
     pub callee: P<'a, Expression<'a>>,
-    pub arguments: AstVec<'a, CallArgument<'a>>,
+    pub arguments: AstSlice<'a, CallArgument<'a>>,
 }
 
 pub struct SequenceExpression<'a> {
     pub loc: Loc,
-    pub expressions: AstVec<'a, Expression<'a>>,
+    pub expressions: AstSlice<'a, Expression<'a>>,
 }
 
 pub struct ArrayExpression<'a> {
     pub loc: Loc,
-    pub elements: AstVec<'a, ArrayElement<'a>>,
+    pub elements: AstSlice<'a, ArrayElement<'a>>,
     // Needed for reparsing into a pattern
     pub is_parenthesized: bool,
 }
@@ -1315,7 +1359,7 @@ pub struct SpreadElement<'a> {
 
 pub struct ObjectExpression<'a> {
     pub loc: Loc,
-    pub properties: AstVec<'a, Property<'a>>,
+    pub properties: AstSlice<'a, Property<'a>>,
     // Needed for reparsing into a pattern
     pub is_parenthesized: bool,
 
@@ -1420,7 +1464,7 @@ impl<'a> SuperMemberExpression<'a> {
 pub struct SuperCallExpression<'a> {
     pub loc: Loc,
     pub super_: Loc,
-    pub arguments: AstVec<'a, CallArgument<'a>>,
+    pub arguments: AstSlice<'a, CallArgument<'a>>,
 
     /// Reference to the function scope that contains the binding for the containing derived
     /// constructor, or tagged as unresolved dynamic if the scope could not be statically determined.
@@ -1436,7 +1480,7 @@ pub struct SuperCallExpression<'a> {
 }
 
 impl<'a> SuperCallExpression<'a> {
-    pub fn new(loc: Loc, super_loc: Loc, arguments: AstVec<'a, CallArgument<'a>>) -> Self {
+    pub fn new(loc: Loc, super_loc: Loc, arguments: AstSlice<'a, CallArgument<'a>>) -> Self {
         Self {
             loc,
             super_: super_loc,
@@ -1450,8 +1494,8 @@ impl<'a> SuperCallExpression<'a> {
 
 pub struct TemplateLiteral<'a> {
     pub loc: Loc,
-    pub quasis: AstVec<'a, TemplateElement<'a>>,
-    pub expressions: AstVec<'a, Expression<'a>>,
+    pub quasis: AstSlice<'a, TemplateElement<'a>>,
+    pub expressions: AstSlice<'a, Expression<'a>>,
 }
 
 pub struct TemplateElement<'a> {
@@ -1507,7 +1551,7 @@ pub enum Pattern<'a> {
 }
 
 impl<'a> Pattern<'a> {
-    pub fn to_id(&self) -> &Identifier {
+    pub fn to_id(&self) -> &Identifier<'a> {
         match self {
             Pattern::Id(id) => id,
             _ => panic!("Expected identifier pattern"),
@@ -1524,7 +1568,7 @@ impl<'a> Pattern<'a> {
         match &self {
             Pattern::Id(_) => {}
             Pattern::Array(patt) => {
-                for element in &patt.elements {
+                for element in patt.elements.iter() {
                     match element {
                         ArrayPatternElement::Pattern(pattern) => pattern.iter_patterns(f),
                         ArrayPatternElement::Rest(rest) => rest.argument.iter_patterns(f),
@@ -1533,7 +1577,7 @@ impl<'a> Pattern<'a> {
                 }
             }
             Pattern::Object(patt) => {
-                for prop in &patt.properties {
+                for prop in patt.properties.iter() {
                     prop.value.iter_patterns(f)
                 }
             }
@@ -1574,7 +1618,7 @@ impl<'a> Pattern<'a> {
 
 pub struct ArrayPattern<'a> {
     pub loc: Loc,
-    pub elements: AstVec<'a, ArrayPatternElement<'a>>,
+    pub elements: AstSlice<'a, ArrayPatternElement<'a>>,
 }
 
 pub enum ArrayPatternElement<'a> {
@@ -1588,7 +1632,7 @@ impl<'a> ArrayPattern<'a> {
         &self,
         f: &mut F,
     ) -> EvalResult<()> {
-        for element in &self.elements {
+        for element in self.elements.iter() {
             match element {
                 ArrayPatternElement::Pattern(pattern) => pattern.iter_bound_names(f)?,
                 ArrayPatternElement::Rest(RestElement { argument, .. }) => {
@@ -1609,7 +1653,7 @@ pub struct RestElement<'a> {
 
 pub struct ObjectPattern<'a> {
     pub loc: Loc,
-    pub properties: AstVec<'a, ObjectPatternProperty<'a>>,
+    pub properties: AstSlice<'a, ObjectPatternProperty<'a>>,
 }
 
 impl<'a> ObjectPattern<'a> {
@@ -1617,7 +1661,7 @@ impl<'a> ObjectPattern<'a> {
         &self,
         f: &mut F,
     ) -> EvalResult<()> {
-        for prop in &self.properties {
+        for prop in self.properties.iter() {
             prop.value.iter_bound_names(f)?
         }
 
@@ -1651,13 +1695,13 @@ impl<'a> AssignmentPattern<'a> {
 
 pub struct ImportDeclaration<'a> {
     pub loc: Loc,
-    pub specifiers: AstVec<'a, ImportSpecifier<'a>>,
+    pub specifiers: AstSlice<'a, ImportSpecifier<'a>>,
     pub source: P<'a, StringLiteral<'a>>,
     pub attributes: Option<P<'a, ImportAttributes<'a>>>,
 }
 
 pub struct ImportAttributes<'a> {
-    pub attributes: AstVec<'a, ImportAttribute<'a>>,
+    pub attributes: AstSlice<'a, ImportAttribute<'a>>,
 }
 
 pub struct ImportAttribute<'a> {
@@ -1693,7 +1737,7 @@ pub struct ExportNamedDeclaration<'a> {
     pub loc: Loc,
     // Must be variable declaration, function declaration, or class declaration
     pub declaration: Option<P<'a, Statement<'a>>>,
-    pub specifiers: AstVec<'a, ExportSpecifier<'a>>,
+    pub specifiers: AstSlice<'a, ExportSpecifier<'a>>,
     pub source: Option<P<'a, StringLiteral<'a>>>,
     pub source_attributes: Option<P<'a, ImportAttributes<'a>>>,
 }
@@ -1703,7 +1747,7 @@ impl<'a> ExportNamedDeclaration<'a> {
         if let Some(declaration) = self.declaration.as_deref() {
             match declaration {
                 Statement::VarDecl(VariableDeclaration { declarations, .. }) => {
-                    for decl in declarations {
+                    for decl in declarations.iter() {
                         let _ = decl.iter_bound_names(&mut |id| {
                             f(id);
                             Ok(())
@@ -1769,7 +1813,7 @@ pub enum ExportName<'a> {
 }
 
 impl<'a> ExportName<'a> {
-    pub fn to_id(&self) -> &Identifier {
+    pub fn to_id(&self) -> &Identifier<'a> {
         match self {
             ExportName::Id(id) => id,
             _ => panic!("Expected identifier export name"),

--- a/src/js/parser/ast_visitor.rs
+++ b/src/js/parser/ast_visitor.rs
@@ -410,7 +410,7 @@ pub trait AstVisitor<'a>: Sized {
 #[macro_export]
 macro_rules! visit_vec {
     ($visitor:expr, $field:expr, $func:ident) => {
-        for node in &mut $field {
+        for node in $field.iter_mut() {
             $visitor.$func(node)
         }
     };
@@ -780,7 +780,7 @@ pub fn default_visit_array_expression<'a, V: AstVisitor<'a>>(
     visitor: &mut V,
     expr: &mut ArrayExpression<'a>,
 ) {
-    for element in &mut expr.elements {
+    for element in expr.elements.iter_mut() {
         match element {
             ArrayElement::Expression(expr) => visitor.visit_expression(expr),
             ArrayElement::Spread(spread) => visitor.visit_spread_element(spread),
@@ -895,7 +895,7 @@ pub fn default_visit_array_pattern<'a, V: AstVisitor<'a>>(
     visitor: &mut V,
     patt: &mut ArrayPattern<'a>,
 ) {
-    for element in &mut patt.elements {
+    for element in patt.elements.iter_mut() {
         match element {
             ArrayPatternElement::Pattern(pattern) => visitor.visit_pattern(pattern),
             ArrayPatternElement::Rest(rest) => visitor.visit_rest_element(rest),

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -365,7 +365,7 @@ impl<'a> Printer<'a> {
         self.end_node();
     }
 
-    fn print_for_init<'b>(&'b mut self, init: Option<&P<'b, ForInit<'b>>>) {
+    fn print_for_init(&mut self, init: Option<&P<'_, ForInit>>) {
         match init {
             None => self.print_null(),
             Some(init) => match init.as_ref() {
@@ -813,7 +813,7 @@ impl<'a> Printer<'a> {
         self.end_node();
     }
 
-    fn print_property<'b>(&'b mut self, prop: &Property<'b>) {
+    fn print_property(&mut self, prop: &Property) {
         if let PropertyKind::Spread(_) = prop.kind {
             self.start_node("SpreadElement", &prop.loc);
             self.property("argument", prop.key.as_ref(), Printer::print_expression);
@@ -1037,10 +1037,7 @@ impl<'a> Printer<'a> {
         self.end_node();
     }
 
-    fn print_import_attributes_property<'b>(
-        &'b mut self,
-        attributes: Option<&P<'b, ImportAttributes<'b>>>,
-    ) {
+    fn print_import_attributes_property(&mut self, attributes: Option<&P<'_, ImportAttributes>>) {
         if let Some(attributes) = attributes {
             self.array_property(
                 "attributes",
@@ -1137,28 +1134,28 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn print_optional_expression<'b>(&'b mut self, expr: Option<&'b P<'b, Expression<'b>>>) {
+    fn print_optional_expression(&mut self, expr: Option<&P<'_, Expression>>) {
         match expr {
             None => self.print_null(),
             Some(expr) => self.print_expression(expr),
         }
     }
 
-    fn print_optional_outer_expression<'b>(&'b mut self, expr: Option<&'b P<'b, OuterExpression>>) {
+    fn print_optional_outer_expression(&mut self, expr: Option<&P<'_, OuterExpression>>) {
         match expr {
             None => self.print_null(),
             Some(expr) => self.print_outer_expression(expr),
         }
     }
 
-    fn print_optional_statement<'b>(&'b mut self, stmt: Option<&'b P<'b, Statement<'b>>>) {
+    fn print_optional_statement(&mut self, stmt: Option<&P<'_, Statement>>) {
         match stmt {
             None => self.print_null(),
             Some(stmt) => self.print_statement(stmt),
         }
     }
 
-    fn print_optional_identifier<'b>(&'b mut self, id: Option<&'b P<'b, Identifier<'b>>>) {
+    fn print_optional_identifier(&mut self, id: Option<&P<'_, Identifier>>) {
         match id {
             None => self.print_null(),
             Some(id) => self.print_identifier(id),
@@ -1172,21 +1169,21 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn print_optional_block<'b>(&'b mut self, block: Option<&'b P<'b, Block<'b>>>) {
+    fn print_optional_block(&mut self, block: Option<&P<'_, Block>>) {
         match block {
             None => self.print_null(),
             Some(block) => self.print_block(block),
         }
     }
 
-    fn print_optional_pattern<'b>(&'b mut self, pattern: Option<&'b P<'b, Pattern<'b>>>) {
+    fn print_optional_pattern(&mut self, pattern: Option<&P<'_, Pattern>>) {
         match pattern {
             None => self.print_null(),
             Some(pattern) => self.print_pattern(pattern),
         }
     }
 
-    fn print_optional_string_literal<'b>(&'b mut self, lit: Option<&'b P<'b, StringLiteral<'b>>>) {
+    fn print_optional_string_literal(&mut self, lit: Option<&P<'_, StringLiteral>>) {
         match lit {
             None => self.print_null(),
             Some(lit) => self.print_string_literal(lit),
@@ -1207,7 +1204,7 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn print_optional_export_name<'b>(&'b mut self, export_name: Option<&P<'b, ExportName<'b>>>) {
+    fn print_optional_export_name(&mut self, export_name: Option<&P<'_, ExportName>>) {
         match export_name {
             None => self.print_null(),
             Some(export_name) => self.print_export_name(export_name),

--- a/src/js/parser/regexp.rs
+++ b/src/js/parser/regexp.rs
@@ -2,14 +2,14 @@ use bitflags::bitflags;
 
 use crate::js::common::unicode_property::UnicodeProperty;
 
-use super::ast::{AstString, AstVec, P};
+use super::ast::{AstSlice, AstString, P};
 
 pub struct RegExp<'a> {
     pub disjunction: Disjunction<'a>,
     pub flags: RegExpFlags,
     pub has_duplicate_named_capture_groups: bool,
     // All capture groups with their names if one was provided
-    pub capture_groups: AstVec<'a, Option<AstString<'a>>>,
+    pub capture_groups: AstSlice<'a, Option<AstString<'a>>>,
 }
 
 bitflags! {
@@ -87,12 +87,12 @@ impl RegExpFlags {
 pub struct Disjunction<'a> {
     /// List of alternatives separated by `|`. This list is non-empty, empty disjunctions are
     /// represented by a single empty alternative.
-    pub alternatives: AstVec<'a, Alternative<'a>>,
+    pub alternatives: AstSlice<'a, Alternative<'a>>,
 }
 
 pub struct Alternative<'a> {
     /// Sequence of terms that make up this alternative. May be empty in which case it always matches.
-    pub terms: AstVec<'a, Term<'a>>,
+    pub terms: AstSlice<'a, Term<'a>>,
 }
 
 pub enum Term<'a> {
@@ -201,12 +201,12 @@ pub struct CharacterClass<'a> {
     /// Whether to only match characters not listed in this class
     pub is_inverted: bool,
     /// Collection of operands to this classes expression
-    pub operands: AstVec<'a, ClassRange<'a>>,
+    pub operands: AstSlice<'a, ClassRange<'a>>,
 }
 
 pub struct StringDisjunction<'a> {
     /// The individual options in this disjunction, e.g. `[a, b, c]` for `\q{a|b|c}`
-    pub alternatives: AstVec<'a, AstString<'a>>,
+    pub alternatives: AstSlice<'a, AstString<'a>>,
 }
 
 pub struct Lookaround<'a> {

--- a/src/js/parser/regexp_parser.rs
+++ b/src/js/parser/regexp_parser.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 use super::{
-    ast::{ArenaVec, AstAlloc, AstPtr, AstStr, AstString, AstVecBuilder},
+    ast::{ArenaVec, AstAlloc, AstPtr, AstSlice, AstSliceBuilder, AstStr, AstString},
     lexer_stream::{LexerStream, SavedLexerStreamState},
     loc::Pos,
     regexp::{
@@ -188,14 +188,14 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
         AstString::from_str_in(string, self.alloc)
     }
 
-    fn alloc_vec<U>(&self) -> AstVecBuilder<'a, U> {
-        AstVecBuilder::new(alloc::Vec::new_in(self.alloc))
+    fn alloc_vec<U>(&self) -> AstSliceBuilder<'a, U> {
+        AstSliceBuilder::new(alloc::Vec::new_in(self.alloc))
     }
 
-    fn alloc_vec_with_element<U>(&self, element: U) -> AstVecBuilder<'a, U> {
+    fn alloc_vec_with_element<U>(&self, element: U) -> AstSliceBuilder<'a, U> {
         let mut vec = alloc::Vec::new_in(self.alloc);
         vec.push(element);
-        AstVecBuilder::new(vec)
+        AstSliceBuilder::new(vec)
     }
 
     #[inline]
@@ -277,7 +277,7 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
         Ok(RegExp {
             disjunction,
             flags,
-            capture_groups: AstVecBuilder::new(capture_groups).build(),
+            capture_groups: AstSliceBuilder::new(capture_groups).build(),
             has_duplicate_named_capture_groups,
         })
     }
@@ -345,7 +345,7 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
 
             // A trailing `|` means there is a final empty alternative
             if self.is_end() {
-                alternatives.push(Alternative { terms: &[] });
+                alternatives.push(Alternative { terms: AstSlice::new_empty() });
                 break;
             }
         }
@@ -1049,7 +1049,7 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
                 CharacterClass {
                     expression_type: ClassExpressionType::Union,
                     is_inverted,
-                    operands: &[],
+                    operands: AstSlice::new_empty(),
                 },
                 false,
             ));

--- a/src/js/parser/regexp_parser.rs
+++ b/src/js/parser/regexp_parser.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 use super::{
-    ast::{AstAlloc, AstPtr, AstStr, AstString, AstVec},
+    ast::{ArenaVec, AstAlloc, AstPtr, AstStr, AstString, AstVecBuilder},
     lexer_stream::{LexerStream, SavedLexerStreamState},
     loc::Pos,
     regexp::{
@@ -46,7 +46,7 @@ pub struct RegExpParser<'a, T: LexerStream> {
     /// Number of capture groups seen so far
     num_capture_groups: usize,
     /// All capture groups seen so far, with name if a name was specified
-    capture_groups: AstVec<'a, Option<AstString<'a>>>,
+    capture_groups: ArenaVec<'a, Option<AstString<'a>>>,
     /// Map of capture group names that have been encountered so far to the index of their last
     /// occurrence in the RegExp.
     capture_group_names: HashMap<AstStr<'a>, CaptureGroupIndex>,
@@ -188,14 +188,14 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
         AstString::from_str_in(string, self.alloc)
     }
 
-    fn alloc_vec<U>(&self) -> AstVec<'a, U> {
-        AstVec::new_in(self.alloc)
+    fn alloc_vec<U>(&self) -> AstVecBuilder<'a, U> {
+        AstVecBuilder::new(alloc::Vec::new_in(self.alloc))
     }
 
-    fn alloc_vec_with_element<U>(&self, element: U) -> AstVec<'a, U> {
-        let mut vec = AstVec::new_in(self.alloc);
+    fn alloc_vec_with_element<U>(&self, element: U) -> AstVecBuilder<'a, U> {
+        let mut vec = alloc::Vec::new_in(self.alloc);
         vec.push(element);
-        vec
+        AstVecBuilder::new(vec)
     }
 
     #[inline]
@@ -270,16 +270,16 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
             }
         };
 
-        let regexp = RegExp {
-            disjunction,
-            flags,
-            capture_groups: parser.capture_groups.clone(),
-            has_duplicate_named_capture_groups: parser.has_duplicate_named_capture_groups,
-        };
-
         parser.resolve_backreferences()?;
 
-        Ok(regexp)
+        let RegExpParser { capture_groups, has_duplicate_named_capture_groups, .. } = parser;
+
+        Ok(RegExp {
+            disjunction,
+            flags,
+            capture_groups: AstVecBuilder::new(capture_groups).build(),
+            has_duplicate_named_capture_groups,
+        })
     }
 
     // On failure return the error along with the offset into the input buffer
@@ -345,12 +345,12 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
 
             // A trailing `|` means there is a final empty alternative
             if self.is_end() {
-                alternatives.push(Alternative { terms: self.alloc_vec() });
+                alternatives.push(Alternative { terms: &[] });
                 break;
             }
         }
 
-        Ok(Disjunction { alternatives })
+        Ok(Disjunction { alternatives: alternatives.build() })
     }
 
     fn parse_alternative(&mut self) -> ParseResult<Alternative<'a>> {
@@ -393,7 +393,7 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
             }
         }
 
-        Ok(Alternative { terms })
+        Ok(Alternative { terms: terms.build() })
     }
 
     fn parse_term(&mut self) -> ParseResult<Term<'a>> {
@@ -556,13 +556,12 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
     }
 
     fn character_class_from_shorthand(&self, shorthand: ClassRange<'a>) -> CharacterClass<'a> {
-        let mut operands = alloc::vec![in self.alloc];
-        operands.push(shorthand);
+        let operands = self.alloc_vec_with_element(shorthand);
 
         CharacterClass {
             expression_type: ClassExpressionType::Union,
             is_inverted: false,
-            operands,
+            operands: operands.build(),
         }
     }
 
@@ -942,7 +941,7 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
         Ok(Term::CharacterClass(CharacterClass {
             expression_type: ClassExpressionType::Union,
             is_inverted,
-            operands: ranges,
+            operands: ranges.build(),
         }))
     }
 
@@ -1050,7 +1049,7 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
                 CharacterClass {
                     expression_type: ClassExpressionType::Union,
                     is_inverted,
-                    operands: self.alloc_vec(),
+                    operands: &[],
                 },
                 false,
             ));
@@ -1141,7 +1140,10 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
             return self.error(first_operand_pos, ParseError::InvertedCharacterClassContainStrings);
         }
 
-        Ok((CharacterClass { expression_type, is_inverted, operands }, may_contain_strings))
+        Ok((
+            CharacterClass { expression_type, is_inverted, operands: operands.build() },
+            may_contain_strings,
+        ))
     }
 
     /// Parse a single ClassSetOperand, returning whether it MayContainStrings.
@@ -1426,7 +1428,7 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
 
         self.expect('}')?;
 
-        Ok((StringDisjunction { alternatives }, may_contain_strings))
+        Ok((StringDisjunction { alternatives: alternatives.build() }, may_contain_strings))
     }
 
     /// Parse a single alternative in a class string disjunction. Return both the string and its

--- a/src/js/runtime/regexp/compiler.rs
+++ b/src/js/runtime/regexp/compiler.rs
@@ -351,7 +351,7 @@ impl CompiledRegExpBuilder {
             }
             let mut alternative_blocks: Vec<AlternativeBlock> = vec![];
 
-            for alternative in &disjunction.alternatives {
+            for alternative in disjunction.alternatives.iter() {
                 let alternative_block_id = self.new_block();
                 self.set_current_block(alternative_block_id);
 
@@ -470,9 +470,9 @@ impl CompiledRegExpBuilder {
         }
     }
 
-    fn emit_alternative_terms<'a>(
+    fn emit_alternative_terms<'a, 'b: 'a>(
         &mut self,
-        iter: impl Iterator<Item = &'a Term<'a>>,
+        iter: impl Iterator<Item = &'a Term<'b>>,
     ) -> SubExpressionInfo {
         // If any term always consumes then the alternative always consumes
         let mut always_consumes = false;
@@ -1012,7 +1012,7 @@ impl CompiledRegExpBuilder {
         let set = match character_class.expression_type {
             ClassExpressionType::Union => {
                 // Add code points and strings that are in any operand
-                for class_range in &character_class.operands {
+                for class_range in character_class.operands.iter() {
                     self.add_character_class_range_to_set(
                         class_range,
                         &mut set_builder,
@@ -1212,7 +1212,7 @@ impl CompiledRegExpBuilder {
                 strings_set_builder.extend(string_set.iter());
             }
             ClassRange::StringDisjunction(disjunction) => {
-                for string in &disjunction.alternatives {
+                for string in disjunction.alternatives.iter() {
                     // Check if the string has exactly one code point (only need to check at most
                     // the first two code points to be sure).
                     if string.iter_code_points().take(2).count() == 1 {

--- a/tests/harness/src/runner.rs
+++ b/tests/harness/src/runner.rs
@@ -382,9 +382,9 @@ fn load_harness_test_file(cx: Context, test262_root: &str, file: &str) {
     }
 }
 
-fn execute_script_as_bytecode(
+fn execute_script_as_bytecode<'a>(
     mut cx: Context,
-    analyzed_result: &js::parser::analyze::AnalyzedProgramResult,
+    analyzed_result: &'a js::parser::analyze::AnalyzedProgramResult<'a>,
 ) -> EvalResult<()> {
     let realm = cx.initial_realm();
     let generate_result =
@@ -400,9 +400,9 @@ fn execute_script_as_bytecode(
     cx.run_script(bytecode_script)
 }
 
-fn execute_module_as_bytecode(
+fn execute_module_as_bytecode<'a>(
     mut cx: Context,
-    analyzed_result: &js::parser::analyze::AnalyzedProgramResult,
+    analyzed_result: &'a js::parser::analyze::AnalyzedProgramResult<'a>,
 ) -> EvalResult<()> {
     let realm = cx.initial_realm();
     let generate_result =


### PR DESCRIPTION
## Summary

Shrink the size of the AST by using a custom `AstBox` and `AstSlice` type which do not contain a reference to the allocator. The switch to arena allocation for the AST in https://github.com/Hans-Halverson/brimstone/pull/166 introduced some size regressions due to the use of `allocator_api2::{Box, Vec}` which contain a reference to the allocator.

In addition to removing the unnecessary reference to the allocator, `AstSlice` cannot change in size and does not hold a capacity, halving it's size.

This speeds up parsing both due to the reduced memory use and due to no longer running destructors for the AST. The changes for some parsing benchmarks:
- `fixtures/acorn.js > parse`: -5.4%
- `fixtures/react.js > parse`: -4.6%
- `fixtures/typescript.js > parse`: -5.9%

## Tests

All tests pass.