### PR TITLE
[parser] Option to print parse stats including AST size

### DIFF
--- a/src/js/common/options.rs
+++ b/src/js/common/options.rs
@@ -44,6 +44,10 @@ pub struct Args {
     #[arg(long, default_value_t = false)]
     pub no_color: bool,
 
+    /// Print statistics about the parse phase
+    #[arg(long, default_value_t = false)]
+    pub parse_stats: bool,
+
     #[arg(required = true)]
     pub files: Vec<String>,
 }
@@ -70,6 +74,9 @@ pub struct Options {
 
     /// Whether to use colors when printing to the terminal
     pub no_color: bool,
+
+    /// Print statistics about the parse phase
+    pub parse_stats: bool,
 }
 
 impl Options {
@@ -82,6 +89,7 @@ impl Options {
             .print_regexp_bytecode(args.print_regexp_bytecode)
             .min_heap_size(args.min_heap_size.unwrap_or(DEFAULT_HEAP_SIZE))
             .no_color(args.no_color)
+            .parse_stats(args.parse_stats)
             .build()
     }
 
@@ -113,6 +121,7 @@ impl OptionsBuilder {
             dump_buffer: None,
             min_heap_size: DEFAULT_HEAP_SIZE,
             no_color: false,
+            parse_stats: false,
         })
     }
 
@@ -154,6 +163,11 @@ impl OptionsBuilder {
 
     pub fn no_color(mut self, no_color: bool) -> Self {
         self.0.no_color = no_color;
+        self
+    }
+
+    pub fn parse_stats(mut self, parse_stats: bool) -> Self {
+        self.0.parse_stats = parse_stats;
         self
     }
 }

--- a/src/js/parser/context.rs
+++ b/src/js/parser/context.rs
@@ -24,4 +24,24 @@ impl ParseContext {
     pub fn alloc(&self) -> &Bump {
         &self.alloc
     }
+
+    pub fn stats(&self) -> ParseStats {
+        ParseStats {
+            name: self.source.display_name().to_owned(),
+            source_size: self.source.contents.len(),
+            total_arena_size: self.alloc.allocated_bytes_including_metadata(),
+        }
+    }
+}
+
+#[allow(unused)]
+#[derive(Debug)]
+pub struct ParseStats {
+    /// Display name of the source file
+    name: String,
+    /// Size of the source file in bytes
+    source_size: usize,
+    /// Total size of the arena allocated for the AST in bytes. Includes arena metadata and space
+    /// allocated for the arena but not yet used.
+    total_arena_size: usize,
 }

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -214,6 +214,10 @@ impl Context {
             println!("{}", print_program(&parse_result));
         }
 
+        if self.options.parse_stats {
+            println!("{:#?}", pcx.stats());
+        }
+
         let analyzed_result = analyze(parse_result)?;
 
         // Generate bytecode for the program
@@ -236,6 +240,10 @@ impl Context {
 
         if self.options.print_ast {
             println!("{}", print_program(&parse_result));
+        }
+
+        if self.options.parse_stats {
+            println!("{:#?}", pcx.stats());
         }
 
         let analyzed_result = analyze(parse_result)?;


### PR DESCRIPTION
## Summary

Introduce a `--parse-stats` CLI option which prints out assorted statistics from the parser phase. Currently only the source size and total arena size are printed.

## Tests

All tests pass.