### PR TITLE
[parser] AST nodes use AstStrs which directly reference source without copying when possible

### DIFF
--- a/src/js/common/wtf_8.rs
+++ b/src/js/common/wtf_8.rs
@@ -95,12 +95,6 @@ impl<A: Allocator + Clone> Wtf8String<A> {
     }
 
     #[inline]
-    pub fn clone_in<A2: Allocator + Clone>(&self, alloc: A2) -> Wtf8String<A2> {
-        #[allow(unstable_name_collisions)]
-        Wtf8String { buf: self.buf.to_vec_in(alloc) }
-    }
-
-    #[inline]
     pub fn len(&self) -> usize {
         self.buf.len()
     }
@@ -275,13 +269,13 @@ pub struct Wtf8Str {
 
 impl Wtf8Str {
     #[inline]
-    pub fn from_bytes_unchecked(bytes: &[u8]) -> &Wtf8Str {
+    pub const fn from_bytes_unchecked(bytes: &[u8]) -> &Wtf8Str {
         unsafe { std::mem::transmute::<&[u8], &Wtf8Str>(bytes) }
     }
 
     #[allow(clippy::should_implement_trait)]
     #[inline]
-    pub fn from_str(str: &str) -> &Wtf8Str {
+    pub const fn from_str(str: &str) -> &Wtf8Str {
         Self::from_bytes_unchecked(str.as_bytes())
     }
 

--- a/src/js/common/wtf_8.rs
+++ b/src/js/common/wtf_8.rs
@@ -300,6 +300,10 @@ impl Wtf8Str {
         Wtf8CodePointsIterator::new(&self.buf)
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.buf.is_empty()
+    }
+
     /// Returns true if the string does not have any unpaired surrogates.
     ///
     /// IsWellFormedUnicode (https://tc39.es/ecma262/#sec-isstringwellformedunicode)

--- a/src/js/common/wtf_8.rs
+++ b/src/js/common/wtf_8.rs
@@ -152,37 +152,6 @@ impl<A: Allocator + Clone> Wtf8String<A> {
         self.buf.truncate(new_length);
     }
 
-    /// Returns true if the string does not have any unpaired surrogates.
-    ///
-    /// IsWellFormedUnicode (https://tc39.es/ecma262/#sec-isstringwellformedunicode)
-    pub fn is_well_formed(&self) -> bool {
-        let mut iter = self.iter_code_points();
-
-        let mut is_well_formed = true;
-
-        while let Some(code_point) = iter.next() {
-            if is_surrogate_code_point(code_point) {
-                // Only way to be well formed at this point is to be a high surrogate followed by
-                // a low surrogate.
-                if is_high_surrogate_code_point(code_point) {
-                    if let Some(next_code_point) = iter.next() {
-                        if is_low_surrogate_code_point(next_code_point) {
-                            // A surrogate pair is well formed so proceed to next code point
-                            continue;
-                        }
-                    }
-                }
-
-                is_well_formed = false;
-                break;
-            }
-
-            // Not a surrogate, proceed to next code point
-        }
-
-        is_well_formed
-    }
-
     #[inline]
     pub fn iter_code_points(&self) -> Wtf8CodePointsIterator<'_> {
         Wtf8CodePointsIterator::new(&self.buf)
@@ -330,6 +299,42 @@ impl Wtf8Str {
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         &self.buf
+    }
+
+    #[inline]
+    pub fn iter_code_points(&self) -> Wtf8CodePointsIterator<'_> {
+        Wtf8CodePointsIterator::new(&self.buf)
+    }
+
+    /// Returns true if the string does not have any unpaired surrogates.
+    ///
+    /// IsWellFormedUnicode (https://tc39.es/ecma262/#sec-isstringwellformedunicode)
+    pub fn is_well_formed(&self) -> bool {
+        let mut iter = self.iter_code_points();
+
+        let mut is_well_formed = true;
+
+        while let Some(code_point) = iter.next() {
+            if is_surrogate_code_point(code_point) {
+                // Only way to be well formed at this point is to be a high surrogate followed by
+                // a low surrogate.
+                if is_high_surrogate_code_point(code_point) {
+                    if let Some(next_code_point) = iter.next() {
+                        if is_low_surrogate_code_point(next_code_point) {
+                            // A surrogate pair is well formed so proceed to next code point
+                            continue;
+                        }
+                    }
+                }
+
+                is_well_formed = false;
+                break;
+            }
+
+            // Not a surrogate, proceed to next code point
+        }
+
+        is_well_formed
     }
 }
 

--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -1642,7 +1642,7 @@ impl<'a> Analyzer<'a> {
     }
 
     fn resolve_identifier_use(&mut self, id: &mut Identifier<'a>) {
-        self.resolve_use(&mut id.scope, &id.name, id.loc);
+        self.resolve_use(&mut id.scope, id.name, id.loc);
     }
 
     fn resolve_private_identifier_use(&mut self, private_id: &mut Identifier<'a>) {

--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -1627,7 +1627,7 @@ impl<'a> Analyzer<'a> {
                 self.add_export(id.loc, id.name.as_arena_str());
             }
             ExportName::String(string) => {
-                self.add_export(string.loc, string.value.as_arena_str());
+                self.add_export(string.loc, string.value);
             }
         }
     }

--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -785,7 +785,7 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
         // If a potential direct eval is ever seen, conservatively force all visible bindings to
         // have VM scope locations instead of local registers so they can be dynamically looked up.
         match expr.callee.as_ref() {
-            Expression::Id(Identifier { name, .. }) if name == "eval" && !expr.is_optional => {
+            Expression::Id(Identifier { name, .. }) if *name == "eval" && !expr.is_optional => {
                 let current_scope_id = self.current_scope_id();
                 self.scope_tree
                     .support_dynamic_access_in_visible_bindings(current_scope_id);
@@ -983,7 +983,7 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
         // Mark local bindings as exported
         export.iter_declaration_ids(&mut |id| {
             id.get_binding().set_is_exported(true);
-            self.add_export(id.loc, id.name.as_arena_str());
+            self.add_export(id.loc, id.name);
         });
 
         for specifier in export.specifiers.iter_mut() {
@@ -1123,7 +1123,7 @@ impl<'a> Analyzer<'a> {
             // directly by index. This may be overriden later if captured.
             if let Some(id) = toplevel_id {
                 let scope = id.scope.unwrap_resolved_mut();
-                let binding = scope.get_binding_mut(id.name.as_arena_str());
+                let binding = scope.get_binding_mut(id.name);
 
                 // Allow later arguments to overwrite earlier ones but do not overwrite a WithVar.
                 if !binding.needs_tdz_check()
@@ -1227,11 +1227,11 @@ impl<'a> Analyzer<'a> {
                     let private_id = key.expr.to_id_mut();
 
                     // If this name has been used at all so far it is a duplicate name
-                    if private_names.contains_key(private_id.name.as_str()) {
+                    if private_names.contains_key(private_id.name) {
                         self.emit_error(
                             private_id.loc,
                             ParseError::new_duplicate_private_name(
-                                private_id.name.clone_in(Global),
+                                private_id.name.to_owned_in(Global),
                             ),
                         );
                     } else {
@@ -1241,7 +1241,7 @@ impl<'a> Analyzer<'a> {
                             has_getter: true,
                             has_setter: true,
                         };
-                        private_names.insert(private_id.name.clone_in(Global), usage);
+                        private_names.insert(private_id.name.to_owned_in(Global), usage);
                     }
 
                     private_id
@@ -1258,7 +1258,7 @@ impl<'a> Analyzer<'a> {
 
                     // Check for duplicate name definitions. Only allow multiple definitions if
                     // there is exactly one getter and setter that have the same static property.
-                    match private_names.get_mut(private_id.name.as_str()) {
+                    match private_names.get_mut(private_id.name) {
                         // Mark usage for private name and its method type
                         None => {
                             let is_static = *is_static;
@@ -1270,7 +1270,7 @@ impl<'a> Analyzer<'a> {
                                 PrivateNameUsage { is_static, has_getter: true, has_setter: true }
                             };
 
-                            private_names.insert(private_id.name.clone_in(Global), usage);
+                            private_names.insert(private_id.name.to_owned_in(Global), usage);
                         }
                         // This private name has already been seen. Only avoid erroring if this use
                         // is a getter or setter which has not yet been seen.
@@ -1292,7 +1292,7 @@ impl<'a> Analyzer<'a> {
                             }
 
                             if is_duplicate {
-                                let private_name = private_id.name.clone_in(Global);
+                                let private_name = private_id.name.to_owned_in(Global);
                                 self.emit_error(
                                     private_id.loc,
                                     ParseError::new_duplicate_private_name(private_name),
@@ -1327,7 +1327,7 @@ impl<'a> Analyzer<'a> {
                 }) = element
                 {
                     let private_id = key.expr.to_id();
-                    let usage = private_names.get(private_id.name.as_str()).unwrap();
+                    let usage = private_names.get(private_id.name).unwrap();
                     if usage.has_getter && usage.has_setter {
                         if marked_pairs.insert(&private_id.name) {
                             *is_private_pair_start = true;
@@ -1490,14 +1490,12 @@ impl<'a> Analyzer<'a> {
         let mut labels = vec![];
         // Keep track of duplicate labels so that we don't pop the duplicate labels at the end
         let is_label_duplicate = self.visit_label_def(stmt, label_id);
-        let label_name = stmt.label.name.as_arena_str();
-        labels.push((label_name, is_label_duplicate));
+        labels.push((stmt.label.name, is_label_duplicate));
 
         let mut inner_stmt = stmt.body.as_mut();
         while let Statement::Labeled(stmt) = inner_stmt {
             let is_label_duplicate = self.visit_label_def(stmt, label_id);
-            let label_name = stmt.label.name.as_arena_str();
-            labels.push((label_name, is_label_duplicate));
+            labels.push((stmt.label.name, is_label_duplicate));
 
             inner_stmt = stmt.body.as_mut()
         }
@@ -1533,7 +1531,7 @@ impl<'a> Analyzer<'a> {
     }
 
     fn visit_label_def(&mut self, stmt: &mut LabeledStatement<'a>, label_id: LabelId) -> bool {
-        let label_name = &stmt.label.name.as_arena_str();
+        let label_name = stmt.label.name;
         let is_duplicate = self.labels.contains_key(label_name);
 
         if is_duplicate {
@@ -1575,7 +1573,7 @@ impl<'a> Analyzer<'a> {
 
     fn visit_label_use(&mut self, label: Option<&mut Label<'a>>, is_continue: bool) {
         if let Some(label) = label {
-            match self.labels.get(label.name.as_arena_str()) {
+            match self.labels.get(label.name) {
                 None => self.emit_error(label.loc, ParseError::LabelNotFound),
                 Some(label_info) if is_continue && !label_info.is_continue_target => {
                     self.emit_error(label.loc, ParseError::LabelNotFound)
@@ -1596,7 +1594,7 @@ impl<'a> Analyzer<'a> {
             // Check if private name is defined in this class or a parent class in its scope
             let mut is_defined = false;
             for class_entry in self.class_stack.iter().rev() {
-                if class_entry.private_names.contains_key(id.name.as_str()) {
+                if class_entry.private_names.contains_key(id.name) {
                     is_defined = true;
                     break;
                 }
@@ -1605,7 +1603,7 @@ impl<'a> Analyzer<'a> {
             self.resolve_private_identifier_use(id);
 
             if !is_defined {
-                let private_name = id.name.clone_in(Global);
+                let private_name = id.name.to_owned_in(Global);
                 self.emit_error(id.loc, ParseError::new_private_name_not_defined(private_name));
             }
         }
@@ -1624,7 +1622,7 @@ impl<'a> Analyzer<'a> {
     fn add_exported_name(&mut self, export_name: &ExportName<'a>) {
         match export_name {
             ExportName::Id(id) => {
-                self.add_export(id.loc, id.name.as_arena_str());
+                self.add_export(id.loc, id.name);
             }
             ExportName::String(string) => {
                 self.add_export(string.loc, string.value);

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -1120,9 +1120,9 @@ impl<'a> BigIntLiteral<'a> {
 
 pub struct RegExpLiteral<'a> {
     pub loc: Loc,
-    pub raw: P<'a, AstString<'a>>,
-    pub pattern: P<'a, AstString<'a>>,
-    pub flags: P<'a, AstString<'a>>,
+    pub raw: AstStr<'a>,
+    pub pattern: AstStr<'a>,
+    pub flags: AstStr<'a>,
     pub regexp: P<'a, RegExp<'a>>,
 }
 

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -321,7 +321,7 @@ impl<'a> Identifier<'a> {
     }
 
     pub fn get_binding(&self) -> &Binding<'a> {
-        self.scope.unwrap_resolved().get_binding(&self.name)
+        self.scope.unwrap_resolved().get_binding(self.name)
     }
 }
 

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -1505,9 +1505,9 @@ pub struct TemplateLiteral<'a> {
 
 pub struct TemplateElement<'a> {
     pub loc: Loc,
-    pub raw: AstString<'a>,
+    pub raw: AstStr<'a>,
     /// Guaranteed to exist for template literals. Tagged templates allow this to be None.
-    pub cooked: Option<AstString<'a>>,
+    pub cooked: Option<AstStr<'a>>,
 }
 
 pub struct TaggedTemplateExpression<'a> {

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -175,6 +175,11 @@ impl<'a> AstString<'a> {
     pub fn as_arena_str(&self) -> AstStr<'a> {
         unsafe { std::mem::transmute(<AstString<'a> as std::ops::Deref>::deref(self)) }
     }
+
+    pub fn into_arena_str(self) -> AstStr<'a> {
+        // Prevent destructor so that we can keep reference to memory in the arena
+        std::mem::ManuallyDrop::new(self).as_arena_str()
+    }
 }
 
 /// False positive from clippy
@@ -1088,7 +1093,7 @@ pub struct NumberLiteral {
 
 pub struct StringLiteral<'a> {
     pub loc: Loc,
-    pub value: AstString<'a>,
+    pub value: AstStr<'a>,
 }
 
 pub struct BigIntLiteral<'a> {

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -306,7 +306,7 @@ pub enum Toplevel<'a> {
 
 pub struct Identifier<'a> {
     pub loc: Loc,
-    pub name: AstString<'a>,
+    pub name: AstStr<'a>,
 
     /// Reference to the scope that contains the binding for this identifier, or tagged as
     /// unresolved if the scope could not be statically determined.
@@ -316,7 +316,7 @@ pub struct Identifier<'a> {
 }
 
 impl<'a> Identifier<'a> {
-    pub fn new(loc: Loc, name: AstString<'a>) -> Identifier<'a> {
+    pub fn new(loc: Loc, name: AstStr<'a>) -> Identifier<'a> {
         Identifier { loc, name, scope: TaggedResolvedScope::unresolved_global() }
     }
 
@@ -959,12 +959,12 @@ pub type LabelId = u16;
 
 pub struct Label<'a> {
     pub loc: Loc,
-    pub name: AstString<'a>,
+    pub name: AstStr<'a>,
     pub id: LabelId,
 }
 
 impl<'a> Label<'a> {
-    pub fn new(loc: Loc, name: AstString<'a>) -> Label<'a> {
+    pub fn new(loc: Loc, name: AstStr<'a>) -> Label<'a> {
         Label { loc, name, id: 0 }
     }
 }

--- a/src/js/parser/lexer.rs
+++ b/src/js/parser/lexer.rs
@@ -1149,13 +1149,9 @@ impl<'a> Lexer<'a> {
             }
         }
 
-        let pattern = AstString::from_bytes_unchecked_in(
-            &self.buf[pattern_start_pos..pattern_end_pos],
-            self.alloc,
-        );
-        let flags =
-            AstString::from_bytes_unchecked_in(&self.buf[flags_start_pos..self.pos], self.alloc);
-        let raw = AstString::from_bytes_unchecked_in(&self.buf[start_pos..self.pos], self.alloc);
+        let pattern = Wtf8Str::from_bytes_unchecked(&self.buf[pattern_start_pos..pattern_end_pos]);
+        let flags = Wtf8Str::from_bytes_unchecked(&self.buf[flags_start_pos..self.pos]);
+        let raw = Wtf8Str::from_bytes_unchecked(&self.buf[start_pos..self.pos]);
 
         self.emit(Token::RegExpLiteral { raw, pattern, flags }, start_pos)
     }

--- a/src/js/parser/lexer.rs
+++ b/src/js/parser/lexer.rs
@@ -1531,15 +1531,13 @@ impl<'a> Lexer<'a> {
             }
         }
 
-        // Same since this slice is ASCII only and therefore valid UTF-8
-        let id_string =
-            unsafe { String::from_utf8_unchecked(self.buf[start_pos..self.pos].to_vec()) };
+        // Safe since this slice is ASCII only and therefore valid UTF-8
+        let id_str = unsafe { std::str::from_utf8_unchecked(&self.buf[start_pos..self.pos]) };
 
-        if let Some(keyword_token) = self.ascii_id_to_keyword(&id_string) {
+        if let Some(keyword_token) = self.ascii_id_to_keyword(id_str) {
             self.emit(keyword_token, start_pos)
         } else {
-            let wtf8_id_string = AstString::from_string_in(id_string, self.alloc);
-            self.emit(Token::Identifier(wtf8_id_string), start_pos)
+            self.emit(Token::Identifier(Wtf8Str::from_str(id_str)), start_pos)
         }
     }
 
@@ -1586,7 +1584,7 @@ impl<'a> Lexer<'a> {
             }
         }
 
-        self.emit(Token::Identifier(string_builder), start_pos)
+        self.emit(Token::Identifier(string_builder.into_arena_str()), start_pos)
     }
 
     fn lex_identifier_unicode_escape_sequence(&mut self) -> ParseResult<CodePoint> {

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -743,7 +743,7 @@ impl<'a> Parser<'a> {
     }
 
     fn set_id_binding_init_pos(id: &Identifier, pos: Pos) {
-        let binding = id.scope.unwrap_resolved().get_binding(&id.name);
+        let binding = id.scope.unwrap_resolved().get_binding(id.name);
         match binding.kind() {
             BindingKind::Const { init_pos }
             | BindingKind::Let { init_pos }
@@ -2397,7 +2397,7 @@ impl<'a> Parser<'a> {
 
                 let quasi = p!(
                     self,
-                    self.parse_template_literal(*raw, cooked, *is_tail, /* is_tagged */ true,)?
+                    self.parse_template_literal(raw, cooked, *is_tail, /* is_tagged */ true,)?
                 );
                 let loc = self.mark_loc(start_pos);
 
@@ -2827,8 +2827,8 @@ impl<'a> Parser<'a> {
                     Err(loc) => return self.error(*loc, ParseError::MalformedEscapeSeqence),
                 };
 
-                let template_literal = self
-                    .parse_template_literal(*raw, cooked, *is_tail, /* is_tagged */ false)?;
+                let template_literal =
+                    self.parse_template_literal(raw, cooked, *is_tail, /* is_tagged */ false)?;
                 Ok(p!(self, Expression::Template(template_literal)))
             }
             _ => {
@@ -4526,7 +4526,7 @@ impl<'a> Parser<'a> {
 
             // String literal must be the start of an import as specifier
             let spec = if let Token::StringLiteral(value) = &self.token {
-                let imported = self.create_export_name_string(self.loc, *value)?;
+                let imported = self.create_export_name_string(self.loc, value)?;
                 self.advance()?;
 
                 self.expect(Token::As)?;
@@ -4740,7 +4740,7 @@ impl<'a> Parser<'a> {
 
     fn parse_export_name(&mut self) -> ParseResult<ExportName<'a>> {
         if let Token::StringLiteral(value) = &self.token {
-            let export_name = self.create_export_name_string(self.loc, *value)?;
+            let export_name = self.create_export_name_string(self.loc, value)?;
             self.advance()?;
 
             Ok(export_name)

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -435,7 +435,8 @@ impl<'a> Parser<'a> {
 
         while let Token::StringLiteral(str) = &self.token {
             // Use strict directive cannot have any escape characters in it, so check length
-            let is_unscaped_use_strict = str == "use strict" && self.loc.end - self.loc.start == 12;
+            let is_unscaped_use_strict =
+                *str == "use strict" && self.loc.end - self.loc.start == 12;
 
             self.advance()?;
 
@@ -2886,7 +2887,7 @@ impl<'a> Parser<'a> {
     fn parse_string_literal(&mut self) -> ParseResult<StringLiteral<'a>> {
         if let Token::StringLiteral(value) = &self.token {
             let loc = self.loc;
-            let value = value.clone();
+            let value = *value;
             self.advance()?;
 
             Ok(StringLiteral { loc, value })
@@ -4541,7 +4542,7 @@ impl<'a> Parser<'a> {
 
             // String literal must be the start of an import as specifier
             let spec = if let Token::StringLiteral(value) = &self.token {
-                let imported = self.create_export_name_string(self.loc, value.clone())?;
+                let imported = self.create_export_name_string(self.loc, *value)?;
                 self.advance()?;
 
                 self.expect(Token::As)?;
@@ -4755,7 +4756,7 @@ impl<'a> Parser<'a> {
 
     fn parse_export_name(&mut self) -> ParseResult<ExportName<'a>> {
         if let Token::StringLiteral(value) = &self.token {
-            let export_name = self.create_export_name_string(self.loc, value.clone())?;
+            let export_name = self.create_export_name_string(self.loc, *value)?;
             self.advance()?;
 
             Ok(export_name)
@@ -4769,7 +4770,7 @@ impl<'a> Parser<'a> {
     fn create_export_name_string(
         &mut self,
         loc: Loc,
-        value: AstString<'a>,
+        value: AstStr<'a>,
     ) -> ParseResult<ExportName<'a>> {
         if !value.is_well_formed() {
             return self.error(loc, ParseError::ExportNameNotWellFormed);

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -3093,9 +3093,9 @@ impl<'a> Parser<'a> {
         self.advance_regexp_literal()?;
 
         if let Token::RegExpLiteral { raw, pattern, flags } = &self.token {
-            let raw = p!(self, raw.clone());
-            let pattern = p!(self, pattern.clone());
-            let flags_string = p!(self, flags.clone());
+            let raw = *raw;
+            let pattern = *pattern;
+            let flags_string = *flags;
 
             self.advance()?;
             let loc = self.mark_loc(start_pos);

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -746,7 +746,7 @@ impl<'a> Printer<'a> {
         let id = expr.to_id();
 
         self.start_node("PrivateIdentifier", &id.loc);
-        self.property("name", &id.name, Printer::print_wtf8_string);
+        self.property("name", &id.name, Printer::print_wtf8_str);
         self.end_node();
     }
 
@@ -960,9 +960,9 @@ impl<'a> Printer<'a> {
         self.print_identifier_parts(&id.loc, &id.name);
     }
 
-    fn print_identifier_parts(&mut self, loc: &Loc, name: &AstString) {
+    fn print_identifier_parts(&mut self, loc: &Loc, name: &AstStr) {
         self.start_node("Identifier", loc);
-        self.property("name", name, Printer::print_wtf8_string);
+        self.property("name", name, Printer::print_wtf8_str);
         self.end_node();
     }
 

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -41,10 +41,14 @@ impl<'a> Printer<'a> {
         self.buf.push_str(str);
     }
 
-    fn print_wtf8_string(&mut self, string: &AstString) {
+    fn print_wtf8_str(&mut self, string: &AstStr) {
         self.buf.push('\"');
         self.buf.push_str(&string.to_string());
         self.buf.push('\"');
+    }
+
+    fn print_wtf8_string(&mut self, string: &AstString) {
+        self.print_wtf8_str(&string.as_str())
     }
 
     fn print_str(&mut self, string: &str) {
@@ -561,7 +565,7 @@ impl<'a> Printer<'a> {
 
     fn print_string_literal(&mut self, lit: &StringLiteral) {
         self.start_node("Literal", &lit.loc);
-        self.property("value", &lit.value, Printer::print_wtf8_string);
+        self.property("value", &lit.value, Printer::print_wtf8_str);
         self.end_node();
     }
 

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -906,8 +906,8 @@ impl<'a> Printer<'a> {
         self.string("{\n");
         self.inc_indent();
 
-        self.property("cooked", element.cooked.as_ref(), Printer::print_optional_wtf8_string);
-        self.property("raw", &element.raw, Printer::print_wtf8_string);
+        self.property("cooked", element.cooked.as_ref(), Printer::print_optional_wtf8_str);
+        self.property("raw", &element.raw, Printer::print_wtf8_str);
 
         self.dec_indent();
         self.indent();
@@ -1191,6 +1191,13 @@ impl<'a> Printer<'a> {
         match lit {
             None => self.print_null(),
             Some(lit) => self.print_string_literal(lit),
+        }
+    }
+
+    fn print_optional_wtf8_str(&mut self, string: Option<&AstStr>) {
+        match string {
+            None => self.print_null(),
+            Some(string) => self.print_wtf8_str(string),
         }
     }
 

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -578,7 +578,7 @@ impl<'a> Printer<'a> {
 
     fn print_regexp_literal(&mut self, lit: &RegExpLiteral) {
         self.start_node("Literal", &lit.loc);
-        self.property("raw", lit.raw.as_ref(), Printer::print_wtf8_string);
+        self.property("raw", &lit.raw, Printer::print_wtf8_str);
         self.property("value", lit, Printer::print_regex_value);
         self.property("regexp", lit.regexp.as_ref(), Printer::print_regexp);
         self.end_node();
@@ -588,8 +588,8 @@ impl<'a> Printer<'a> {
         self.string("{\n");
         self.inc_indent();
 
-        self.property("pattern", lit.pattern.as_ref(), Printer::print_wtf8_string);
-        self.property("flags", lit.flags.as_ref(), Printer::print_wtf8_string);
+        self.property("pattern", &lit.pattern, Printer::print_wtf8_str);
+        self.property("flags", &lit.flags, Printer::print_wtf8_str);
 
         self.dec_indent();
         self.indent();

--- a/src/js/parser/token.rs
+++ b/src/js/parser/token.rs
@@ -9,7 +9,7 @@ use super::{
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token<'a> {
-    Identifier(AstString<'a>),
+    Identifier(AstStr<'a>),
     NumberLiteral(f64),
     StringLiteral(AstStr<'a>),
     BigIntLiteral(BigInt),

--- a/src/js/parser/token.rs
+++ b/src/js/parser/token.rs
@@ -14,9 +14,9 @@ pub enum Token<'a> {
     StringLiteral(AstStr<'a>),
     BigIntLiteral(BigInt),
     RegExpLiteral {
-        raw: AstString<'a>,
-        pattern: AstString<'a>,
-        flags: AstString<'a>,
+        raw: AstStr<'a>,
+        pattern: AstStr<'a>,
+        flags: AstStr<'a>,
     },
     TemplatePart {
         raw: AstString<'a>,

--- a/src/js/parser/token.rs
+++ b/src/js/parser/token.rs
@@ -2,13 +2,16 @@ use std::fmt;
 
 use num_bigint::BigInt;
 
-use super::{ast::AstString, loc::Loc};
+use super::{
+    ast::{AstStr, AstString},
+    loc::Loc,
+};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token<'a> {
     Identifier(AstString<'a>),
     NumberLiteral(f64),
-    StringLiteral(AstString<'a>),
+    StringLiteral(AstStr<'a>),
     BigIntLiteral(BigInt),
     RegExpLiteral {
         raw: AstString<'a>,

--- a/src/js/parser/token.rs
+++ b/src/js/parser/token.rs
@@ -2,10 +2,7 @@ use std::fmt;
 
 use num_bigint::BigInt;
 
-use super::{
-    ast::{AstStr, AstString},
-    loc::Loc,
-};
+use super::{ast::AstStr, loc::Loc};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token<'a> {
@@ -19,9 +16,9 @@ pub enum Token<'a> {
         flags: AstStr<'a>,
     },
     TemplatePart {
-        raw: AstString<'a>,
+        raw: AstStr<'a>,
         // Either a successful string, or a malformed escape sequence error at the given loc
-        cooked: Result<AstString<'a>, Loc>,
+        cooked: Result<AstStr<'a>, Loc>,
         is_head: bool,
         is_tail: bool,
     },

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -319,7 +319,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
         for toplevel in program.toplevels.iter() {
             match toplevel {
                 ast::Toplevel::Import(import) => {
-                    let module_specifier = self.cx.alloc_wtf8_str(&import.source.value);
+                    let module_specifier = self.cx.alloc_wtf8_str(import.source.value);
 
                     let module_request =
                         self.gen_module_request(module_specifier, import.attributes.as_deref());
@@ -335,12 +335,12 @@ impl<'a> BytecodeProgramGenerator<'a> {
                                     .imported
                                     .as_ref()
                                     .map(|imported| self.alloc_export_name_string(imported))
-                                    .unwrap_or_else(|| self.cx.alloc_wtf8_str(&import.local.name));
+                                    .unwrap_or_else(|| self.cx.alloc_wtf8_str(import.local.name));
                                 (&import.local, Some(imported))
                             }
                         };
 
-                        let local_name = self.cx.alloc_wtf8_str(&local_id.name);
+                        let local_name = self.cx.alloc_wtf8_str(local_id.name);
                         let slot_index = Self::id_module_slot_index(local_id);
                         let is_exported = local_id.get_binding().is_exported();
 
@@ -364,7 +364,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
                     source_attributes,
                     ..
                 }) => {
-                    let module_specifier = self.cx.alloc_wtf8_str(&source.value);
+                    let module_specifier = self.cx.alloc_wtf8_str(source.value);
                     let module_request =
                         self.gen_module_request(module_specifier, source_attributes.as_deref());
 
@@ -409,11 +409,11 @@ impl<'a> BytecodeProgramGenerator<'a> {
                     let module_specifier = export
                         .source
                         .as_ref()
-                        .map(|source| self.cx.alloc_wtf8_str(&source.value));
+                        .map(|source| self.cx.alloc_wtf8_str(source.value));
 
                     // Exporting a full named declaration adds export entries for each exported id
                     export.iter_declaration_ids(&mut |id| {
-                        let local_name = self.cx.alloc_wtf8_str(&id.name);
+                        let local_name = self.cx.alloc_wtf8_str(id.name);
                         let slot_index = Self::id_module_slot_index(id);
 
                         local_exports.push(LocalExportEntry {
@@ -479,7 +479,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
                     }
                 }
                 ast::Toplevel::ExportAll(export) => {
-                    let module_specifier = self.cx.alloc_wtf8_str(&export.source.value);
+                    let module_specifier = self.cx.alloc_wtf8_str(export.source.value);
                     let module_request = self
                         .gen_module_request(module_specifier, export.source_attributes.as_deref());
 
@@ -556,7 +556,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
                 }
                 _ => unreachable!("expected string or identifier"),
             };
-            let value = InternedStrings::get_wtf8_str(self.cx, &attribute.value.value).as_flat();
+            let value = InternedStrings::get_wtf8_str(self.cx, attribute.value.value).as_flat();
 
             attribute_pairs.push((key, value));
         }
@@ -604,8 +604,8 @@ impl<'a> BytecodeProgramGenerator<'a> {
 
     fn alloc_export_name_string(&mut self, module_name: &ast::ExportName) -> Handle<FlatString> {
         match module_name {
-            ast::ExportName::Id(id) => self.cx.alloc_wtf8_str(&id.name),
-            ast::ExportName::String(lit) => self.cx.alloc_wtf8_str(&lit.value),
+            ast::ExportName::Id(id) => self.cx.alloc_wtf8_str(id.name),
+            ast::ExportName::String(lit) => self.cx.alloc_wtf8_str(lit.value),
         }
     }
 
@@ -1760,7 +1760,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 // overwritten and the function name does not need to be stored.
                 let binding = id.get_binding();
                 if binding.kind().is_function_expression_name() {
-                    self.gen_initialize_binding(&id.name, binding, Register::closure())?;
+                    self.gen_initialize_binding(id.name, binding, Register::closure())?;
                 }
             }
         }
@@ -2356,11 +2356,11 @@ impl<'a> BytecodeFunctionGenerator<'a> {
     ) -> EmitResult<GenRegister> {
         let pos = id.loc.start;
         match id.scope.kind() {
-            ResolvedScope::UnresolvedGlobal => self.gen_load_global_identifier(&id.name, pos, dest),
+            ResolvedScope::UnresolvedGlobal => self.gen_load_global_identifier(id.name, pos, dest),
             ResolvedScope::UnresolvedDynamic => {
-                self.gen_load_dynamic_identifier(&id.name, pos, dest)
+                self.gen_load_dynamic_identifier(id.name, pos, dest)
             }
-            ResolvedScope::Resolved => self.gen_load_binding(&id.name, id.get_binding(), pos, dest),
+            ResolvedScope::Resolved => self.gen_load_binding(id.name, id.get_binding(), pos, dest),
         }
     }
 
@@ -2570,14 +2570,14 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         let pos = id.loc.start;
         match id.scope.kind() {
             ResolvedScope::UnresolvedGlobal => {
-                self.gen_store_global_identifier(&id.name, value, pos)
+                self.gen_store_global_identifier(id.name, value, pos)
             }
             ResolvedScope::UnresolvedDynamic => {
-                self.gen_store_dynamic_identifier(&id.name, value, pos)
+                self.gen_store_dynamic_identifier(id.name, value, pos)
             }
             ResolvedScope::Resolved => {
                 let binding = id.get_binding();
-                self.gen_store_binding(&id.name, binding, value, flags, pos)
+                self.gen_store_binding(id.name, binding, value, flags, pos)
             }
         }
     }
@@ -2893,7 +2893,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         let dest = self.allocate_destination(dest)?;
 
         // All string literals are loaded from the constant table
-        let constant_index = self.add_wtf8_string_constant(&expr.value)?;
+        let constant_index = self.add_wtf8_string_constant(expr.value)?;
         self.writer.load_constant_instruction(dest, constant_index);
 
         Ok(dest)
@@ -2923,7 +2923,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         dest: ExprDest,
     ) -> EmitResult<GenRegister> {
         // Can use source directly as "escaped" pattern source string
-        let source = InternedStrings::get_wtf8_str(self.cx, &lit.pattern);
+        let source = InternedStrings::get_wtf8_str(self.cx, lit.pattern);
 
         // Compile regexp and store compiled regexp in constant table
         let compiled_regexp = compile_regexp(self.cx, &lit.regexp, source);
@@ -3084,7 +3084,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 // Special instruction for unresolved global bindings
                 ResolvedScope::UnresolvedGlobal => {
                     let argument = self.register_allocator.allocate()?;
-                    let constant_index = self.add_wtf8_string_constant(&id.name)?;
+                    let constant_index = self.add_wtf8_string_constant(id.name)?;
 
                     self.writer.load_global_or_unresolved_instruction(
                         argument,
@@ -3097,7 +3097,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 ResolvedScope::UnresolvedDynamic => {
                     // Special instruction for unresolved dynamic bindings
                     let argument = self.register_allocator.allocate()?;
-                    let constant_index = self.add_wtf8_string_constant(&id.name)?;
+                    let constant_index = self.add_wtf8_string_constant(id.name)?;
 
                     self.writer.load_dynamic_or_unresolved_instruction(
                         argument,
@@ -3233,7 +3233,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     }
                 }
 
-                let name_constant_index = self.add_wtf8_string_constant(&id.name)?;
+                let name_constant_index = self.add_wtf8_string_constant(id.name)?;
                 self.writer
                     .delete_binding_instruction(dest, name_constant_index, delete_pos);
 
@@ -3275,7 +3275,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         } else {
             let key = self.register_allocator.allocate()?;
             let name_id = member_expr.property.to_id();
-            let constant_index = self.add_wtf8_string_constant(&name_id.name)?;
+            let constant_index = self.add_wtf8_string_constant(name_id.name)?;
             self.writer.load_constant_instruction(key, constant_index);
             Ok(key)
         }
@@ -4012,15 +4012,15 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             } else {
                 match property.key.as_ref() {
                     ast::Expression::Id(id) => {
-                        let constant_index = self.add_wtf8_string_constant(&id.name)?;
+                        let constant_index = self.add_wtf8_string_constant(id.name)?;
                         let name = AnyStr::from_id(id);
                         let is_proto = id.name == "__proto__";
 
                         Property::Named { constant_index, name, is_proto }
                     }
                     ast::Expression::String(string) => {
-                        let constant_index = self.add_wtf8_string_constant(&string.value)?;
-                        let name = AnyStr::Wtf8(&string.value);
+                        let constant_index = self.add_wtf8_string_constant(string.value)?;
+                        let name = AnyStr::Wtf8(string.value);
                         let is_proto = string.value == "__proto__";
 
                         Property::Named { constant_index, name, is_proto }
@@ -4281,7 +4281,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         } else {
             // Must be a named access
             let name = expr.property.to_id();
-            let name_constant_index = self.add_wtf8_string_constant(&name.name)?;
+            let name_constant_index = self.add_wtf8_string_constant(name.name)?;
 
             if release_object {
                 self.register_allocator.release(object);
@@ -4310,7 +4310,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         match binding.vm_location().unwrap() {
             VMLocation::Scope { scope_id, index } => {
                 // Add the name to the constant table (without the "#" prefix)
-                let name_index = self.add_wtf8_string_constant(&private_id.name)?;
+                let name_index = self.add_wtf8_string_constant(private_id.name)?;
 
                 // Create a new private symbol
                 let dest = self.register_allocator.allocate()?;
@@ -4542,7 +4542,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                         // Must be a super named access, but we do not have a SetNamedSuperProperty
                         // instruction so load to a register.
                         let name = member.property.to_id();
-                        let name_constant_index = self.add_wtf8_string_constant(&name.name)?;
+                        let name_constant_index = self.add_wtf8_string_constant(name.name)?;
 
                         let key = self.register_allocator.allocate()?;
                         self.writer
@@ -4564,7 +4564,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     } else {
                         // Must be a named access
                         let name = member.property.to_id();
-                        let name_constant_index = self.add_wtf8_string_constant(&name.name)?;
+                        let name_constant_index = self.add_wtf8_string_constant(name.name)?;
                         Property::Named(name_constant_index)
                     }
                 };
@@ -4807,7 +4807,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     // Must be a super named access, but we do not have a SetNamedSuperProperty
                     // instruction so load to a register.
                     let name = member.property.to_id();
-                    let name_constant_index = self.add_wtf8_string_constant(&name.name)?;
+                    let name_constant_index = self.add_wtf8_string_constant(name.name)?;
 
                     let key = self.register_allocator.allocate()?;
                     self.writer
@@ -4842,7 +4842,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 } else {
                     // Must be a named access
                     let name = member.property.to_id();
-                    let name_constant_index = self.add_wtf8_string_constant(&name.name)?;
+                    let name_constant_index = self.add_wtf8_string_constant(name.name)?;
                     self.writer.get_named_property_instruction(
                         temp,
                         object,
@@ -4932,7 +4932,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 // operations may be performed directly on a local register, which would be
                 // observable.
                 if self.is_immutable_reassignment(binding, store_flags) {
-                    let name_constant_index = self.add_wtf8_string_constant(&id.name)?;
+                    let name_constant_index = self.add_wtf8_string_constant(id.name)?;
                     self.writer
                         .error_const_instruction(name_constant_index, id.loc.start);
                 }
@@ -5628,7 +5628,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         } else {
             // Must be a named access
             let name = expr.property.to_id();
-            let name_constant_index = self.add_wtf8_string_constant(&name.name)?;
+            let name_constant_index = self.add_wtf8_string_constant(name.name)?;
 
             self.register_allocator.release(home_object);
             if release_receiver {
@@ -6108,7 +6108,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         } else {
             // Must be a named access
             let name = member.property.to_id();
-            let property = self.add_wtf8_string_constant(&name.name)?;
+            let property = self.add_wtf8_string_constant(name.name)?;
             Ok(Reference::new(ReferenceKind::NamedProperty { object, property, operator_pos }))
         }
     }
@@ -6127,7 +6127,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         } else {
             // Must be a named access
             let name = member.property.to_id();
-            let name_constant_index = self.add_wtf8_string_constant(&name.name)?;
+            let name_constant_index = self.add_wtf8_string_constant(name.name)?;
 
             let property = self.register_allocator.allocate()?;
             self.writer
@@ -6282,7 +6282,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
             match &key {
                 Property::Named(id) => {
-                    let name_constant_index = self.add_wtf8_string_constant(&id.name)?;
+                    let name_constant_index = self.add_wtf8_string_constant(id.name)?;
 
                     // If there is a rest element name must be saved in the reserved registers. Can
                     // load directly to the temporary register since name is already a property key.
@@ -7094,7 +7094,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         } else {
             match &method.key.expr {
                 ast::Expression::Id(id) => Name::Named(AnyStr::from_id(id)),
-                ast::Expression::String(string) => Name::Named(AnyStr::Wtf8(&string.value)),
+                ast::Expression::String(string) => Name::Named(AnyStr::Wtf8(string.value)),
                 expr @ (ast::Expression::Number(_) | ast::Expression::BigInt(_)) => {
                     Name::Computed(self.gen_expression(expr)?, expr.pos())
                 }
@@ -9240,7 +9240,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         };
 
         if let Some(id) = id {
-            cx.alloc_wtf8_str(&id.name)
+            cx.alloc_wtf8_str(id.name)
         } else {
             cx.names.default_name().as_string().as_flat()
         }
@@ -9745,7 +9745,7 @@ enum AnyStr<'a> {
 
 impl<'a> AnyStr<'a> {
     fn from_id(id: &'a ast::Identifier<'a>) -> AnyStr<'a> {
-        AnyStr::Wtf8(&id.name)
+        AnyStr::Wtf8(id.name)
     }
 
     fn to_wtf8_string(self) -> Wtf8String {

--- a/src/js/runtime/eval/expression.rs
+++ b/src/js/runtime/eval/expression.rs
@@ -55,7 +55,7 @@ pub fn generate_template_object(
         let cooked_desc = PropertyDescriptor::data(cooked_value, false, true, false);
         must!(define_property_or_throw(cx, template_object, index_key, cooked_desc));
 
-        let raw_value = InternedStrings::get_wtf8_str(cx, &quasi.raw);
+        let raw_value = InternedStrings::get_wtf8_str(cx, quasi.raw);
         let raw_desc = PropertyDescriptor::data(raw_value.into(), false, true, false);
         must!(define_property_or_throw(cx, raw_object, index_key, raw_desc));
     }


### PR DESCRIPTION
## Summary

The AST currently holds many `AstString`s, which requires copying from the source buffer into an owned `AstString`. Instead the AST should hold `AstStr`s which are smaller and can directly reference the source buffer without copying.

It is not always possible to directly reference the source buffer, for example when escape sequences are encountered. In this case we must fall back to a slow path where we build an owned `AstString` value by value. Alternatively we start out in the fast path which will not allocate until a problematic byte is encountered.

This causes significant parse time reductions across all benchmarks.
- `acorn`: -28.9%
- `react`: -31.5%
- `typescript`: -28.2%

## Tests

All tests pass.