### PR TITLE
[regexp] RegExp AST nodes store AstStrs instead of AstStrings

### DIFF
--- a/src/js/common/wtf_8.rs
+++ b/src/js/common/wtf_8.rs
@@ -137,7 +137,7 @@ impl<A: Allocator + Clone> Wtf8String<A> {
     }
 
     #[inline]
-    pub fn push_wtf8_str<A2: Allocator + Clone>(&mut self, string: &Wtf8String<A2>) {
+    pub fn push_wtf8_str(&mut self, string: &Wtf8Str) {
         self.push_bytes_unchecked(string.as_bytes())
     }
 

--- a/src/js/common/wtf_8.rs
+++ b/src/js/common/wtf_8.rs
@@ -71,12 +71,6 @@ impl<A: Allocator + Clone> Wtf8String<A> {
     }
 
     #[inline]
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str_in(string: &str, alloc: A) -> Self {
-        Self::from_bytes_unchecked_in(string.as_bytes(), alloc)
-    }
-
-    #[inline]
     pub fn from_bytes_unchecked_in(bytes: &[u8], alloc: A) -> Self {
         #[allow(unstable_name_collisions)]
         Wtf8String { buf: bytes.to_vec_in(alloc) }

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -47,10 +47,6 @@ impl<'a> Printer<'a> {
         self.buf.push('\"');
     }
 
-    fn print_wtf8_string(&mut self, string: &AstString) {
-        self.print_wtf8_str(&string.as_str())
-    }
-
     fn print_str(&mut self, string: &str) {
         self.buf.push('\"');
         self.buf.push_str(string);
@@ -1201,13 +1197,6 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn print_optional_wtf8_string(&mut self, string: Option<&AstString>) {
-        match string {
-            None => self.print_null(),
-            Some(string) => self.print_wtf8_string(string),
-        }
-    }
-
     fn print_optional_number(&mut self, number: Option<impl ToString>) {
         match number {
             None => self.print_null(),
@@ -1299,7 +1288,7 @@ impl<'a> Printer<'a> {
     fn print_regexp_capture_group(&mut self, group: &CaptureGroup) {
         self.start_regexp_node("CaptureGroup");
         self.property("index", group.index, Printer::print_number);
-        self.property("name", group.name.as_ref(), Printer::print_optional_wtf8_string);
+        self.property("name", group.name.as_ref(), Printer::print_optional_wtf8_str);
         self.print_disjunction(&group.disjunction);
         self.end_node();
     }
@@ -1397,7 +1386,7 @@ impl<'a> Printer<'a> {
 
     fn print_regexp_string_disjunction(&mut self, disjunction: &StringDisjunction) {
         self.start_regexp_node("StringDisjunction");
-        self.array_property("alternatives", &disjunction.alternatives, Printer::print_wtf8_string);
+        self.array_property("alternatives", &disjunction.alternatives, Printer::print_wtf8_str);
         self.end_node();
     }
 

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -1252,9 +1252,9 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn print_regexp_literal_pattern(&mut self, literal: &AstString) {
+    fn print_regexp_literal_pattern(&mut self, literal: &AstStr) {
         self.start_regexp_node("Literal");
-        self.property("value", literal, Printer::print_wtf8_string);
+        self.property("value", literal, Printer::print_wtf8_str);
         self.end_node();
     }
 

--- a/src/js/parser/regexp.rs
+++ b/src/js/parser/regexp.rs
@@ -2,7 +2,7 @@ use bitflags::bitflags;
 
 use crate::js::common::unicode_property::UnicodeProperty;
 
-use super::ast::{AstSlice, AstString, P};
+use super::ast::{AstSlice, AstStr, AstString, P};
 
 pub struct RegExp<'a> {
     pub disjunction: Disjunction<'a>,
@@ -97,7 +97,7 @@ pub struct Alternative<'a> {
 
 pub enum Term<'a> {
     /// A literal string of characters with escape codes decoded into code points. Must be nonempty.
-    Literal(AstString<'a>),
+    Literal(AstStr<'a>),
     /// The wildcard which matches any single character: `.`
     Wildcard,
     /// A repition of a pattern: `a*`, `a+`, `a?`, `a{x,y}`, etc.

--- a/src/js/parser/regexp.rs
+++ b/src/js/parser/regexp.rs
@@ -2,14 +2,14 @@ use bitflags::bitflags;
 
 use crate::js::common::unicode_property::UnicodeProperty;
 
-use super::ast::{AstSlice, AstStr, AstString, P};
+use super::ast::{AstSlice, AstStr, P};
 
 pub struct RegExp<'a> {
     pub disjunction: Disjunction<'a>,
     pub flags: RegExpFlags,
     pub has_duplicate_named_capture_groups: bool,
     // All capture groups with their names if one was provided
-    pub capture_groups: AstSlice<'a, Option<AstString<'a>>>,
+    pub capture_groups: AstSlice<'a, Option<AstStr<'a>>>,
 }
 
 bitflags! {
@@ -143,7 +143,7 @@ pub type CaptureGroupIndex = u32;
 
 pub struct CaptureGroup<'a> {
     /// Optional capture group name
-    pub name: Option<AstString<'a>>,
+    pub name: Option<AstStr<'a>>,
     /// Index of the capture group in the RegExp
     pub index: CaptureGroupIndex,
     pub disjunction: Disjunction<'a>,
@@ -206,7 +206,7 @@ pub struct CharacterClass<'a> {
 
 pub struct StringDisjunction<'a> {
     /// The individual options in this disjunction, e.g. `[a, b, c]` for `\q{a|b|c}`
-    pub alternatives: AstSlice<'a, AstString<'a>>,
+    pub alternatives: AstSlice<'a, AstStr<'a>>,
 }
 
 pub struct Lookaround<'a> {


### PR DESCRIPTION
## Summary

All RegExp AST nodes now store `AstStr` instead of `AstString`. This affects literal terms, capture group names, and string disjunctions.

## Tests

All tests pass.