### PR TITLE
[parser] Refactor Expression, Statement, and Pattern nodes to be enum of pointers to AST nodes

### DIFF
--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -394,26 +394,26 @@ impl<'a> TaggedResolvedScope<'a> {
 }
 
 pub enum Statement<'a> {
-    VarDecl(VariableDeclaration<'a>),
+    VarDecl(P<'a, VariableDeclaration<'a>>),
     FuncDecl(P<'a, Function<'a>>),
     ClassDecl(P<'a, Class<'a>>),
-    Expr(ExpressionStatement<'a>),
-    Block(Block<'a>),
-    If(IfStatement<'a>),
-    Switch(SwitchStatement<'a>),
-    For(ForStatement<'a>),
-    ForEach(ForEachStatement<'a>),
-    While(WhileStatement<'a>),
-    DoWhile(DoWhileStatement<'a>),
-    With(WithStatement<'a>),
-    Try(TryStatement<'a>),
-    Throw(ThrowStatement<'a>),
-    Return(ReturnStatement<'a>),
-    Break(BreakStatement<'a>),
-    Continue(ContinueStatement<'a>),
-    Labeled(LabeledStatement<'a>),
-    Empty(Loc),
-    Debugger(Loc),
+    Expr(P<'a, ExpressionStatement<'a>>),
+    Block(P<'a, Block<'a>>),
+    If(P<'a, IfStatement<'a>>),
+    Switch(P<'a, SwitchStatement<'a>>),
+    For(P<'a, ForStatement<'a>>),
+    ForEach(P<'a, ForEachStatement<'a>>),
+    While(P<'a, WhileStatement<'a>>),
+    DoWhile(P<'a, DoWhileStatement<'a>>),
+    With(P<'a, WithStatement<'a>>),
+    Try(P<'a, TryStatement<'a>>),
+    Throw(P<'a, ThrowStatement<'a>>),
+    Return(P<'a, ReturnStatement<'a>>),
+    Break(P<'a, BreakStatement<'a>>),
+    Continue(P<'a, ContinueStatement<'a>>),
+    Labeled(P<'a, LabeledStatement<'a>>),
+    Empty(P<'a, Loc>),
+    Debugger(P<'a, Loc>),
 }
 
 #[derive(PartialEq)]
@@ -431,8 +431,8 @@ pub struct VariableDeclaration<'a> {
 
 pub struct VariableDeclarator<'a> {
     pub loc: Loc,
-    pub id: P<'a, Pattern<'a>>,
-    pub init: Option<P<'a, OuterExpression<'a>>>,
+    pub id: Pattern<'a>,
+    pub init: Option<OuterExpression<'a>>,
     /// Whether an assignment expression appears in the pattern.
     pub id_has_assign_expr: bool,
 }
@@ -440,8 +440,8 @@ pub struct VariableDeclarator<'a> {
 impl<'a> VariableDeclarator<'a> {
     pub fn new(
         loc: Loc,
-        id: P<'a, Pattern<'a>>,
-        init: Option<P<'a, OuterExpression<'a>>>,
+        id: Pattern<'a>,
+        init: Option<OuterExpression<'a>>,
     ) -> VariableDeclarator<'a> {
         VariableDeclarator { loc, id, init, id_has_assign_expr: false }
     }
@@ -662,7 +662,7 @@ pub struct FunctionBlockBody<'a> {
 pub struct Class<'a> {
     pub loc: Loc,
     pub id: Option<P<'a, Identifier<'a>>>,
-    pub super_class: Option<P<'a, OuterExpression<'a>>>,
+    pub super_class: Option<OuterExpression<'a>>,
     pub body: AstSlice<'a, ClassElement<'a>>,
 
     pub constructor: Option<AstPtr<ClassMethod<'a>>>,
@@ -683,7 +683,7 @@ impl<'a> Class<'a> {
     pub fn new(
         loc: Loc,
         id: Option<P<'a, Identifier<'a>>>,
-        super_class: Option<P<'a, OuterExpression<'a>>>,
+        super_class: Option<OuterExpression<'a>>,
         body: AstSlice<'a, ClassElement<'a>>,
         scope: AstPtr<AstScopeNode<'a>>,
         fields_initializer_scope: Option<AstPtr<AstScopeNode<'a>>>,
@@ -709,7 +709,7 @@ pub enum ClassElement<'a> {
 
 pub struct ClassMethod<'a> {
     pub loc: Loc,
-    pub key: P<'a, OuterExpression<'a>>,
+    pub key: OuterExpression<'a>,
     pub value: P<'a, Function<'a>>,
     pub kind: ClassMethodKind,
     pub is_computed: bool,
@@ -723,7 +723,7 @@ pub struct ClassMethod<'a> {
 impl<'a> ClassMethod<'a> {
     pub fn new(
         loc: Loc,
-        key: P<'a, OuterExpression<'a>>,
+        key: OuterExpression<'a>,
         value: P<'a, Function<'a>>,
         kind: ClassMethodKind,
         is_computed: bool,
@@ -755,8 +755,8 @@ pub enum ClassMethodKind {
 
 pub struct ClassProperty<'a> {
     pub loc: Loc,
-    pub key: P<'a, OuterExpression<'a>>,
-    pub value: Option<P<'a, OuterExpression<'a>>>,
+    pub key: OuterExpression<'a>,
+    pub value: Option<OuterExpression<'a>>,
     pub is_computed: bool,
     pub is_static: bool,
     pub is_private: bool,
@@ -764,7 +764,7 @@ pub struct ClassProperty<'a> {
 
 pub struct ExpressionStatement<'a> {
     pub loc: Loc,
-    pub expr: P<'a, OuterExpression<'a>>,
+    pub expr: OuterExpression<'a>,
 }
 
 pub struct Block<'a> {
@@ -777,14 +777,14 @@ pub struct Block<'a> {
 
 pub struct IfStatement<'a> {
     pub loc: Loc,
-    pub test: P<'a, OuterExpression<'a>>,
-    pub conseq: P<'a, Statement<'a>>,
-    pub altern: Option<P<'a, Statement<'a>>>,
+    pub test: OuterExpression<'a>,
+    pub conseq: Statement<'a>,
+    pub altern: Option<Statement<'a>>,
 }
 
 pub struct SwitchStatement<'a> {
     pub loc: Loc,
-    pub discriminant: P<'a, OuterExpression<'a>>,
+    pub discriminant: OuterExpression<'a>,
     pub cases: AstSlice<'a, SwitchCase<'a>>,
 
     /// Block scope node for the switch statement body.
@@ -793,16 +793,16 @@ pub struct SwitchStatement<'a> {
 
 pub struct SwitchCase<'a> {
     pub loc: Loc,
-    pub test: Option<P<'a, OuterExpression<'a>>>,
+    pub test: Option<OuterExpression<'a>>,
     pub body: AstSlice<'a, Statement<'a>>,
 }
 
 pub struct ForStatement<'a> {
     pub loc: Loc,
     pub init: Option<P<'a, ForInit<'a>>>,
-    pub test: Option<P<'a, OuterExpression<'a>>>,
-    pub update: Option<P<'a, OuterExpression<'a>>>,
-    pub body: P<'a, Statement<'a>>,
+    pub test: Option<OuterExpression<'a>>,
+    pub update: Option<OuterExpression<'a>>,
+    pub body: Statement<'a>,
 
     /// Block scope node that contains the for statement variable declarations and the body.
     pub scope: AstPtr<AstScopeNode<'a>>,
@@ -817,8 +817,8 @@ pub struct ForEachStatement<'a> {
     pub loc: Loc,
     pub kind: ForEachKind,
     pub left: P<'a, ForEachInit<'a>>,
-    pub right: P<'a, OuterExpression<'a>>,
-    pub body: P<'a, Statement<'a>>,
+    pub right: OuterExpression<'a>,
+    pub body: Statement<'a>,
     pub is_await: bool,
 
     /// Source position of start of the `in` or `of` keyword.
@@ -870,20 +870,20 @@ impl<'a> ForEachInit<'a> {
 
 pub struct WhileStatement<'a> {
     pub loc: Loc,
-    pub test: P<'a, OuterExpression<'a>>,
-    pub body: P<'a, Statement<'a>>,
+    pub test: OuterExpression<'a>,
+    pub body: Statement<'a>,
 }
 
 pub struct DoWhileStatement<'a> {
     pub loc: Loc,
-    pub test: P<'a, OuterExpression<'a>>,
-    pub body: P<'a, Statement<'a>>,
+    pub test: OuterExpression<'a>,
+    pub body: Statement<'a>,
 }
 
 pub struct WithStatement<'a> {
     pub loc: Loc,
-    pub object: P<'a, OuterExpression<'a>>,
-    pub body: P<'a, Statement<'a>>,
+    pub object: OuterExpression<'a>,
+    pub body: Statement<'a>,
 
     /// Scope node for the with statement body
     pub scope: AstPtr<AstScopeNode<'a>>,
@@ -898,7 +898,7 @@ pub struct TryStatement<'a> {
 
 pub struct CatchClause<'a> {
     pub loc: Loc,
-    pub param: Option<P<'a, Pattern<'a>>>,
+    pub param: Option<Pattern<'a>>,
     pub body: P<'a, Block<'a>>,
     /// Whether the parameter is a pattern with an assignment expression.
     pub param_has_assign_expr: bool,
@@ -910,7 +910,7 @@ pub struct CatchClause<'a> {
 impl<'a> CatchClause<'a> {
     pub fn new(
         loc: Loc,
-        param: Option<P<'a, Pattern<'a>>>,
+        param: Option<Pattern<'a>>,
         body: P<'a, Block<'a>>,
         scope: AstPtr<AstScopeNode<'a>>,
     ) -> CatchClause<'a> {
@@ -920,12 +920,12 @@ impl<'a> CatchClause<'a> {
 
 pub struct ThrowStatement<'a> {
     pub loc: Loc,
-    pub argument: P<'a, OuterExpression<'a>>,
+    pub argument: OuterExpression<'a>,
 }
 
 pub struct ReturnStatement<'a> {
     pub loc: Loc,
-    pub argument: Option<P<'a, OuterExpression<'a>>>,
+    pub argument: Option<OuterExpression<'a>>,
 
     /// Reference to the scope that contains the binding for `this`. Similar to the scope in the
     /// `ThisExpression` node, but only set if this return is in a derived constructor (meaning the
@@ -934,7 +934,7 @@ pub struct ReturnStatement<'a> {
 }
 
 impl<'a> ReturnStatement<'a> {
-    pub fn new(loc: Loc, argument: Option<P<'a, OuterExpression<'a>>>) -> ReturnStatement<'a> {
+    pub fn new(loc: Loc, argument: Option<OuterExpression<'a>>) -> ReturnStatement<'a> {
         ReturnStatement { loc, argument, this_scope: None }
     }
 }
@@ -952,7 +952,7 @@ pub struct ContinueStatement<'a> {
 pub struct LabeledStatement<'a> {
     pub loc: Loc,
     pub label: P<'a, Label<'a>>,
-    pub body: P<'a, Statement<'a>>,
+    pub body: Statement<'a>,
 }
 
 pub type LabelId = u16;
@@ -988,38 +988,38 @@ impl OuterExpression<'_> {
 }
 
 pub enum Expression<'a> {
-    Id(Identifier<'a>),
-    Null(Loc),
-    Boolean(BooleanLiteral),
-    Number(NumberLiteral),
-    String(StringLiteral<'a>),
-    BigInt(BigIntLiteral<'a>),
+    Id(P<'a, Identifier<'a>>),
+    Null(P<'a, Loc>),
+    Boolean(P<'a, BooleanLiteral>),
+    Number(P<'a, NumberLiteral>),
+    String(P<'a, StringLiteral<'a>>),
+    BigInt(P<'a, BigIntLiteral<'a>>),
     RegExp(P<'a, RegExpLiteral<'a>>),
-    Unary(UnaryExpression<'a>),
-    Binary(BinaryExpression<'a>),
-    Logical(LogicalExpression<'a>),
-    Assign(AssignmentExpression<'a>),
-    Update(UpdateExpression<'a>),
-    Member(MemberExpression<'a>),
-    Chain(ChainExpression<'a>),
-    Conditional(ConditionalExpression<'a>),
-    Call(CallExpression<'a>),
-    New(NewExpression<'a>),
-    Sequence(SequenceExpression<'a>),
-    Array(ArrayExpression<'a>),
-    Object(ObjectExpression<'a>),
+    Unary(P<'a, UnaryExpression<'a>>),
+    Binary(P<'a, BinaryExpression<'a>>),
+    Logical(P<'a, LogicalExpression<'a>>),
+    Assign(P<'a, AssignmentExpression<'a>>),
+    Update(P<'a, UpdateExpression<'a>>),
+    Member(P<'a, MemberExpression<'a>>),
+    Chain(P<'a, ChainExpression<'a>>),
+    Conditional(P<'a, ConditionalExpression<'a>>),
+    Call(P<'a, CallExpression<'a>>),
+    New(P<'a, NewExpression<'a>>),
+    Sequence(P<'a, SequenceExpression<'a>>),
+    Array(P<'a, ArrayExpression<'a>>),
+    Object(P<'a, ObjectExpression<'a>>),
     Function(P<'a, Function<'a>>),
     ArrowFunction(P<'a, Function<'a>>),
     Class(P<'a, Class<'a>>),
-    This(ThisExpression<'a>),
-    Await(AwaitExpression<'a>),
-    Yield(YieldExpression<'a>),
+    This(P<'a, ThisExpression<'a>>),
+    Await(P<'a, AwaitExpression<'a>>),
+    Yield(P<'a, YieldExpression<'a>>),
     SuperMember(P<'a, SuperMemberExpression<'a>>),
     SuperCall(P<'a, SuperCallExpression<'a>>),
-    Template(TemplateLiteral<'a>),
-    TaggedTemplate(TaggedTemplateExpression<'a>),
-    MetaProperty(MetaProperty<'a>),
-    Import(ImportExpression<'a>),
+    Template(P<'a, TemplateLiteral<'a>>),
+    TaggedTemplate(P<'a, TaggedTemplateExpression<'a>>),
+    MetaProperty(P<'a, MetaProperty<'a>>),
+    Import(P<'a, ImportExpression<'a>>),
 }
 
 impl<'a> Expression<'a> {
@@ -1140,7 +1140,7 @@ pub enum UnaryOperator {
 pub struct UnaryExpression<'a> {
     pub loc: Loc,
     pub operator: UnaryOperator,
-    pub argument: P<'a, Expression<'a>>,
+    pub argument: Expression<'a>,
 }
 
 #[derive(PartialEq)]
@@ -1175,8 +1175,8 @@ pub enum BinaryOperator {
 pub struct BinaryExpression<'a> {
     pub loc: Loc,
     pub operator: BinaryOperator,
-    pub left: P<'a, Expression<'a>>,
-    pub right: P<'a, Expression<'a>>,
+    pub left: Expression<'a>,
+    pub right: Expression<'a>,
 
     /// Source position of the start of the operator
     pub operator_pos: Pos,
@@ -1192,8 +1192,8 @@ pub enum LogicalOperator {
 pub struct LogicalExpression<'a> {
     pub loc: Loc,
     pub operator: LogicalOperator,
-    pub left: P<'a, Expression<'a>>,
-    pub right: P<'a, Expression<'a>>,
+    pub left: Expression<'a>,
+    pub right: Expression<'a>,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -1230,8 +1230,8 @@ impl AssignmentOperator {
 pub struct AssignmentExpression<'a> {
     pub loc: Loc,
     pub operator: AssignmentOperator,
-    pub left: P<'a, Pattern<'a>>,
-    pub right: P<'a, Expression<'a>>,
+    pub left: Pattern<'a>,
+    pub right: Expression<'a>,
 
     /// Source position of the start of the operator
     pub operator_pos: Pos,
@@ -1249,14 +1249,14 @@ pub enum UpdateOperator {
 pub struct UpdateExpression<'a> {
     pub loc: Loc,
     pub operator: UpdateOperator,
-    pub argument: P<'a, Expression<'a>>,
+    pub argument: Expression<'a>,
     pub is_prefix: bool,
 }
 
 pub struct MemberExpression<'a> {
     pub loc: Loc,
-    pub object: P<'a, Expression<'a>>,
-    pub property: P<'a, Expression<'a>>,
+    pub object: Expression<'a>,
+    pub property: Expression<'a>,
     pub is_computed: bool,
     pub is_optional: bool,
     pub is_private: bool,
@@ -1267,19 +1267,19 @@ pub struct MemberExpression<'a> {
 
 pub struct ChainExpression<'a> {
     pub loc: Loc,
-    pub expression: P<'a, Expression<'a>>,
+    pub expression: Expression<'a>,
 }
 
 pub struct ConditionalExpression<'a> {
     pub loc: Loc,
-    pub test: P<'a, Expression<'a>>,
-    pub altern: P<'a, Expression<'a>>,
-    pub conseq: P<'a, Expression<'a>>,
+    pub test: Expression<'a>,
+    pub altern: Expression<'a>,
+    pub conseq: Expression<'a>,
 }
 
 pub struct CallExpression<'a> {
     pub loc: Loc,
-    pub callee: P<'a, Expression<'a>>,
+    pub callee: Expression<'a>,
     pub arguments: AstSlice<'a, CallArgument<'a>>,
     pub is_optional: bool,
 
@@ -1308,7 +1308,7 @@ pub struct CallExpression<'a> {
 impl<'a> CallExpression<'a> {
     pub fn new(
         loc: Loc,
-        callee: P<'a, Expression<'a>>,
+        callee: Expression<'a>,
         arguments: AstSlice<'a, CallArgument<'a>>,
         is_optional: bool,
     ) -> CallExpression<'a> {
@@ -1334,7 +1334,7 @@ pub enum CallArgument<'a> {
 
 pub struct NewExpression<'a> {
     pub loc: Loc,
-    pub callee: P<'a, Expression<'a>>,
+    pub callee: Expression<'a>,
     pub arguments: AstSlice<'a, CallArgument<'a>>,
 }
 
@@ -1358,7 +1358,7 @@ pub enum ArrayElement<'a> {
 
 pub struct SpreadElement<'a> {
     pub loc: Loc,
-    pub argument: P<'a, Expression<'a>>,
+    pub argument: Expression<'a>,
     pub has_trailing_comma: bool,
 }
 
@@ -1374,8 +1374,8 @@ pub struct ObjectExpression<'a> {
 
 pub struct Property<'a> {
     pub loc: Loc,
-    pub key: P<'a, Expression<'a>>,
-    pub value: Option<P<'a, Expression<'a>>>,
+    pub key: Expression<'a>,
+    pub value: Option<Expression<'a>>,
     pub is_computed: bool,
     pub is_method: bool,
     pub kind: PropertyKind<'a>,
@@ -1391,7 +1391,7 @@ pub enum PropertyKind<'a> {
     // A pattern initializer that is not valid in a final AST, but can be reparsed into an object
     // pattern property with an initializer. The single expression argument is the initializer. If
     // a PatternInitializer is found during analysis the analyzer will error.
-    PatternInitializer(P<'a, Expression<'a>>),
+    PatternInitializer(Expression<'a>),
 }
 
 pub struct ThisExpression<'a> {
@@ -1406,19 +1406,19 @@ pub struct ThisExpression<'a> {
 
 pub struct AwaitExpression<'a> {
     pub loc: Loc,
-    pub argument: P<'a, Expression<'a>>,
+    pub argument: Expression<'a>,
 }
 
 pub struct YieldExpression<'a> {
     pub loc: Loc,
-    pub argument: Option<P<'a, Expression<'a>>>,
+    pub argument: Option<Expression<'a>>,
     pub is_delegate: bool,
 }
 
 pub struct SuperMemberExpression<'a> {
     pub loc: Loc,
     pub super_: Loc,
-    pub property: P<'a, Expression<'a>>,
+    pub property: Expression<'a>,
     pub is_computed: bool,
 
     /// Whether this super member expression is in a static method. Set during analysis.
@@ -1442,7 +1442,7 @@ impl<'a> SuperMemberExpression<'a> {
         loc: Loc,
         super_: Loc,
         operator_pos: Pos,
-        property: P<'a, Expression<'a>>,
+        property: Expression<'a>,
         is_computed: bool,
     ) -> Self {
         Self {
@@ -1512,7 +1512,7 @@ pub struct TemplateElement<'a> {
 
 pub struct TaggedTemplateExpression<'a> {
     pub loc: Loc,
-    pub tag: P<'a, Expression<'a>>,
+    pub tag: Expression<'a>,
     pub quasi: P<'a, TemplateLiteral<'a>>,
 }
 
@@ -1542,17 +1542,17 @@ pub enum MetaPropertyKind<'a> {
 
 pub struct ImportExpression<'a> {
     pub loc: Loc,
-    pub source: P<'a, Expression<'a>>,
-    pub options: Option<P<'a, Expression<'a>>>,
+    pub source: Expression<'a>,
+    pub options: Option<Expression<'a>>,
 }
 
 pub enum Pattern<'a> {
-    Id(Identifier<'a>),
-    Array(ArrayPattern<'a>),
-    Object(ObjectPattern<'a>),
-    Assign(AssignmentPattern<'a>),
-    Member(MemberExpression<'a>),
-    SuperMember(SuperMemberExpression<'a>),
+    Id(P<'a, Identifier<'a>>),
+    Array(P<'a, ArrayPattern<'a>>),
+    Object(P<'a, ObjectPattern<'a>>),
+    Assign(P<'a, AssignmentPattern<'a>>),
+    Member(P<'a, MemberExpression<'a>>),
+    SuperMember(P<'a, SuperMemberExpression<'a>>),
 }
 
 impl<'a> Pattern<'a> {
@@ -1653,7 +1653,7 @@ impl<'a> ArrayPattern<'a> {
 
 pub struct RestElement<'a> {
     pub loc: Loc,
-    pub argument: P<'a, Pattern<'a>>,
+    pub argument: Pattern<'a>,
 }
 
 pub struct ObjectPattern<'a> {
@@ -1676,8 +1676,8 @@ impl<'a> ObjectPattern<'a> {
 
 pub struct ObjectPatternProperty<'a> {
     pub loc: Loc,
-    pub key: Option<P<'a, Expression<'a>>>,
-    pub value: P<'a, Pattern<'a>>,
+    pub key: Option<Expression<'a>>,
+    pub value: Pattern<'a>,
     pub is_computed: bool,
     // For rest properties the value is the argument and must be an id. All other fields are ignored.
     pub is_rest: bool,
@@ -1685,8 +1685,8 @@ pub struct ObjectPatternProperty<'a> {
 
 pub struct AssignmentPattern<'a> {
     pub loc: Loc,
-    pub left: P<'a, Pattern<'a>>,
-    pub right: P<'a, Expression<'a>>,
+    pub left: Pattern<'a>,
+    pub right: Expression<'a>,
 }
 
 impl<'a> AssignmentPattern<'a> {
@@ -1712,7 +1712,7 @@ pub struct ImportAttributes<'a> {
 pub struct ImportAttribute<'a> {
     pub loc: Loc,
     // Must be a string literal or identifier
-    pub key: P<'a, Expression<'a>>,
+    pub key: Expression<'a>,
     pub value: P<'a, StringLiteral<'a>>,
 }
 
@@ -1741,7 +1741,7 @@ pub struct ImportNamespaceSpecifier<'a> {
 pub struct ExportNamedDeclaration<'a> {
     pub loc: Loc,
     // Must be variable declaration, function declaration, or class declaration
-    pub declaration: Option<P<'a, Statement<'a>>>,
+    pub declaration: Option<Statement<'a>>,
     pub specifiers: AstSlice<'a, ExportSpecifier<'a>>,
     pub source: Option<P<'a, StringLiteral<'a>>>,
     pub source_attributes: Option<P<'a, ImportAttributes<'a>>>,
@@ -1800,7 +1800,7 @@ impl<'a> ExportDefaultDeclaration<'a> {
 pub enum ExportDefaultKind<'a> {
     Function(P<'a, Function<'a>>),
     Class(P<'a, Class<'a>>),
-    Expression(P<'a, OuterExpression<'a>>),
+    Expression(OuterExpression<'a>),
 }
 
 pub struct ExportAllDeclaration<'a> {

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -275,7 +275,7 @@ impl<'a> Printer<'a> {
         if method.is_private {
             self.property("key", &method.key.expr, Printer::print_private_identifier);
         } else {
-            self.property("key", method.key.as_ref(), Printer::print_outer_expression);
+            self.property("key", &method.key, Printer::print_outer_expression);
         }
 
         self.property("value", method.value.as_ref(), Printer::print_function_expression);
@@ -302,7 +302,7 @@ impl<'a> Printer<'a> {
         if prop.is_private {
             self.property("key", &prop.key.expr, Printer::print_private_identifier);
         } else {
-            self.property("key", prop.key.as_ref(), Printer::print_outer_expression);
+            self.property("key", &prop.key, Printer::print_outer_expression);
         }
 
         self.property("value", prop.value.as_ref(), Printer::print_optional_outer_expression);
@@ -324,7 +324,7 @@ impl<'a> Printer<'a> {
 
     fn print_expression_statement(&mut self, expr: &ExpressionStatement) {
         self.start_node("ExpressionStatement", &expr.loc);
-        self.property("kind", expr.expr.as_ref(), Printer::print_outer_expression);
+        self.property("kind", &expr.expr, Printer::print_outer_expression);
         self.end_node();
     }
 
@@ -336,15 +336,15 @@ impl<'a> Printer<'a> {
 
     fn print_if_statement(&mut self, stmt: &IfStatement) {
         self.start_node("IfStatement", &stmt.loc);
-        self.property("test", stmt.test.as_ref(), Printer::print_outer_expression);
-        self.property("consequent", stmt.conseq.as_ref(), Printer::print_statement);
+        self.property("test", &stmt.test, Printer::print_outer_expression);
+        self.property("consequent", &stmt.conseq, Printer::print_statement);
         self.property("alternate", stmt.altern.as_ref(), Printer::print_optional_statement);
         self.end_node();
     }
 
     fn print_switch_statement(&mut self, stmt: &SwitchStatement) {
         self.start_node("SwitchStatement", &stmt.loc);
-        self.property("discriminant", stmt.discriminant.as_ref(), Printer::print_outer_expression);
+        self.property("discriminant", &stmt.discriminant, Printer::print_outer_expression);
         self.array_property("cases", stmt.cases.as_ref(), Printer::print_switch_case);
         self.end_node();
     }
@@ -361,7 +361,7 @@ impl<'a> Printer<'a> {
         self.property("init", stmt.init.as_ref(), Printer::print_for_init);
         self.property("test", stmt.test.as_ref(), Printer::print_optional_outer_expression);
         self.property("update", stmt.update.as_ref(), Printer::print_optional_outer_expression);
-        self.property("body", stmt.body.as_ref(), Printer::print_statement);
+        self.property("body", &stmt.body, Printer::print_statement);
         self.end_node();
     }
 
@@ -382,8 +382,8 @@ impl<'a> Printer<'a> {
         };
         self.start_node(name, &stmt.loc);
         self.property("left", stmt.left.as_ref(), Printer::print_for_each_init);
-        self.property("right", stmt.right.as_ref(), Printer::print_outer_expression);
-        self.property("body", stmt.body.as_ref(), Printer::print_statement);
+        self.property("right", &stmt.right, Printer::print_outer_expression);
+        self.property("body", &stmt.body, Printer::print_statement);
 
         if stmt.kind == ForEachKind::Of {
             self.property("await", stmt.is_await, Printer::print_bool);
@@ -401,22 +401,22 @@ impl<'a> Printer<'a> {
 
     fn print_while_statement(&mut self, stmt: &WhileStatement) {
         self.start_node("WhileStatement", &stmt.loc);
-        self.property("test", stmt.test.as_ref(), Printer::print_outer_expression);
-        self.property("body", stmt.body.as_ref(), Printer::print_statement);
+        self.property("test", &stmt.test, Printer::print_outer_expression);
+        self.property("body", &stmt.body, Printer::print_statement);
         self.end_node();
     }
 
     fn print_do_while_statement(&mut self, stmt: &DoWhileStatement) {
         self.start_node("DoWhileStatement", &stmt.loc);
-        self.property("test", stmt.test.as_ref(), Printer::print_outer_expression);
-        self.property("body", stmt.body.as_ref(), Printer::print_statement);
+        self.property("test", &stmt.test, Printer::print_outer_expression);
+        self.property("body", &stmt.body, Printer::print_statement);
         self.end_node();
     }
 
     fn print_with_statement(&mut self, stmt: &WithStatement) {
         self.start_node("WithStatement", &stmt.loc);
-        self.property("object", stmt.object.as_ref(), Printer::print_outer_expression);
-        self.property("body", stmt.body.as_ref(), Printer::print_statement);
+        self.property("object", &stmt.object, Printer::print_outer_expression);
+        self.property("body", &stmt.body, Printer::print_statement);
         self.end_node();
     }
 
@@ -441,7 +441,7 @@ impl<'a> Printer<'a> {
 
     fn print_throw_statement(&mut self, stmt: &ThrowStatement) {
         self.start_node("ThrowStatement", &stmt.loc);
-        self.property("argument", stmt.argument.as_ref(), Printer::print_outer_expression);
+        self.property("argument", &stmt.argument, Printer::print_outer_expression);
         self.end_node();
     }
 
@@ -466,7 +466,7 @@ impl<'a> Printer<'a> {
     fn print_labeled_statement(&mut self, stmt: &LabeledStatement) {
         self.start_node("LabeledStatement", &stmt.loc);
         self.property("label", stmt.label.as_ref(), Printer::print_label);
-        self.property("body", stmt.body.as_ref(), Printer::print_statement);
+        self.property("body", &stmt.body, Printer::print_statement);
         self.end_node();
     }
 
@@ -495,7 +495,7 @@ impl<'a> Printer<'a> {
 
     fn print_variable_declarator(&mut self, var_decl: &VariableDeclarator) {
         self.start_node("VariableDeclarator", &var_decl.loc);
-        self.property("id", var_decl.id.as_ref(), Printer::print_pattern);
+        self.property("id", &var_decl.id, Printer::print_pattern);
         self.property("init", var_decl.init.as_ref(), Printer::print_optional_outer_expression);
         self.end_node();
     }
@@ -608,7 +608,7 @@ impl<'a> Printer<'a> {
     fn print_unary_expression(&mut self, unary: &UnaryExpression) {
         self.start_node("UnaryExpression", &unary.loc);
         self.property("operator", &unary.operator, Printer::print_unary_operator);
-        self.property("argument", unary.argument.as_ref(), Printer::print_expression);
+        self.property("argument", &unary.argument, Printer::print_expression);
         self.end_node();
     }
 
@@ -645,12 +645,12 @@ impl<'a> Printer<'a> {
         self.property("operator", &binary.operator, Printer::print_binary_operator);
 
         if binary.operator == BinaryOperator::InPrivate {
-            self.property("left", binary.left.as_ref(), Printer::print_private_identifier);
+            self.property("left", &binary.left, Printer::print_private_identifier);
         } else {
-            self.property("left", binary.left.as_ref(), Printer::print_expression);
+            self.property("left", &binary.left, Printer::print_expression);
         }
 
-        self.property("right", binary.right.as_ref(), Printer::print_expression);
+        self.property("right", &binary.right, Printer::print_expression);
         self.end_node();
     }
 
@@ -666,8 +666,8 @@ impl<'a> Printer<'a> {
     fn print_logical_expression(&mut self, logical: &LogicalExpression) {
         self.start_node("LogicalExpression", &logical.loc);
         self.property("operator", &logical.operator, Printer::print_logical_operator);
-        self.property("left", logical.left.as_ref(), Printer::print_expression);
-        self.property("right", logical.right.as_ref(), Printer::print_expression);
+        self.property("left", &logical.left, Printer::print_expression);
+        self.property("right", &logical.right, Printer::print_expression);
         self.end_node();
     }
 
@@ -696,8 +696,8 @@ impl<'a> Printer<'a> {
     fn print_assignment_expression(&mut self, assign: &AssignmentExpression) {
         self.start_node("AssignmentExpression", &assign.loc);
         self.property("operator", &assign.operator, Printer::print_assignment_operator);
-        self.property("left", assign.left.as_ref(), Printer::print_pattern);
-        self.property("right", assign.right.as_ref(), Printer::print_expression);
+        self.property("left", &assign.left, Printer::print_pattern);
+        self.property("right", &assign.right, Printer::print_expression);
         self.end_node();
     }
 
@@ -712,19 +712,19 @@ impl<'a> Printer<'a> {
     fn print_update_expression(&mut self, update: &UpdateExpression) {
         self.start_node("UpdateExpression", &update.loc);
         self.property("operator", &update.operator, Printer::print_update_operator);
-        self.property("argument", update.argument.as_ref(), Printer::print_expression);
+        self.property("argument", &update.argument, Printer::print_expression);
         self.property("prefix", update.is_prefix, Printer::print_bool);
         self.end_node();
     }
 
     fn print_member_expression(&mut self, member: &MemberExpression) {
         self.start_node("MemberExpression", &member.loc);
-        self.property("object", member.object.as_ref(), Printer::print_expression);
+        self.property("object", &member.object, Printer::print_expression);
 
         if member.is_private {
-            self.property("property", member.property.as_ref(), Printer::print_private_identifier);
+            self.property("property", &member.property, Printer::print_private_identifier);
         } else {
-            self.property("property", member.property.as_ref(), Printer::print_expression);
+            self.property("property", &member.property, Printer::print_expression);
         }
 
         self.property("computed", member.is_computed, Printer::print_bool);
@@ -734,7 +734,7 @@ impl<'a> Printer<'a> {
 
     fn print_chain_expression(&mut self, chain: &ChainExpression) {
         self.start_node("ChainExpression", &chain.loc);
-        self.property("expression", chain.expression.as_ref(), Printer::print_expression);
+        self.property("expression", &chain.expression, Printer::print_expression);
         self.end_node();
     }
 
@@ -748,15 +748,15 @@ impl<'a> Printer<'a> {
 
     fn print_conditional_expression(&mut self, cond: &ConditionalExpression) {
         self.start_node("ConditionalExpression", &cond.loc);
-        self.property("test", cond.test.as_ref(), Printer::print_expression);
-        self.property("consequent", cond.conseq.as_ref(), Printer::print_expression);
-        self.property("alternate", cond.altern.as_ref(), Printer::print_expression);
+        self.property("test", &cond.test, Printer::print_expression);
+        self.property("consequent", &cond.conseq, Printer::print_expression);
+        self.property("alternate", &cond.altern, Printer::print_expression);
         self.end_node();
     }
 
     fn print_call_expression(&mut self, call: &CallExpression) {
         self.start_node("CallExpression", &call.loc);
-        self.property("callee", call.callee.as_ref(), Printer::print_expression);
+        self.property("callee", &call.callee, Printer::print_expression);
         self.array_property("arguments", call.arguments.as_ref(), Printer::print_call_argument);
         self.property("optional", call.is_optional, Printer::print_bool);
         self.end_node();
@@ -771,14 +771,14 @@ impl<'a> Printer<'a> {
 
     fn print_new_expression(&mut self, new: &NewExpression) {
         self.start_node("NewExpression", &new.loc);
-        self.property("callee", new.callee.as_ref(), Printer::print_expression);
+        self.property("callee", &new.callee, Printer::print_expression);
         self.array_property("arguments", new.arguments.as_ref(), Printer::print_call_argument);
         self.end_node();
     }
 
     fn print_sequence_expression(&mut self, seq: &SequenceExpression) {
         self.start_node("SequenceExpression", &seq.loc);
-        self.array_property("expressions", seq.expressions.as_ref(), Printer::print_expression);
+        self.array_property("expressions", &seq.expressions, Printer::print_expression);
         self.end_node();
     }
 
@@ -803,7 +803,7 @@ impl<'a> Printer<'a> {
 
     fn print_spread_element(&mut self, spread: &SpreadElement) {
         self.start_node("SpreadElement", &spread.loc);
-        self.property("argument", spread.argument.as_ref(), Printer::print_expression);
+        self.property("argument", &spread.argument, Printer::print_expression);
         self.end_node()
     }
 
@@ -816,13 +816,13 @@ impl<'a> Printer<'a> {
     fn print_property(&mut self, prop: &Property) {
         if let PropertyKind::Spread(_) = prop.kind {
             self.start_node("SpreadElement", &prop.loc);
-            self.property("argument", prop.key.as_ref(), Printer::print_expression);
+            self.property("argument", &prop.key, Printer::print_expression);
             self.end_node();
             return;
         }
 
         self.start_node("Property", &prop.loc);
-        self.property("key", prop.key.as_ref(), Printer::print_expression);
+        self.property("key", &prop.key, Printer::print_expression);
         self.property("value", prop.value.as_ref(), Printer::print_optional_expression);
         self.property("computed", prop.is_computed, Printer::print_bool);
         self.property("shorthand", prop.value.is_none(), Printer::print_bool);
@@ -844,7 +844,7 @@ impl<'a> Printer<'a> {
 
     fn print_await_expression(&mut self, expr: &AwaitExpression) {
         self.start_node("AwaitExpression", &expr.loc);
-        self.property("argument", expr.argument.as_ref(), Printer::print_expression);
+        self.property("argument", &expr.argument, Printer::print_expression);
         self.end_node();
     }
 
@@ -863,7 +863,7 @@ impl<'a> Printer<'a> {
     fn print_super_member_expression(&mut self, member: &SuperMemberExpression) {
         self.start_node("MemberExpression", &member.loc);
         self.property("object", &member.super_, Printer::print_super);
-        self.property("property", member.property.as_ref(), Printer::print_expression);
+        self.property("property", &member.property, Printer::print_expression);
         self.property("computed", member.is_computed, Printer::print_bool);
         self.end_node();
     }
@@ -887,7 +887,7 @@ impl<'a> Printer<'a> {
             .collect::<Vec<_>>();
 
         self.array_property("quasis", &quasis_with_is_tail, Printer::print_template_element);
-        self.array_property("expressions", lit.expressions.as_ref(), Printer::print_expression);
+        self.array_property("expressions", &lit.expressions, Printer::print_expression);
         self.end_node();
     }
 
@@ -912,7 +912,7 @@ impl<'a> Printer<'a> {
 
     fn print_tagged_template_expression(&mut self, expr: &TaggedTemplateExpression) {
         self.start_node("TaggedTemplateExpression", &expr.loc);
-        self.property("tag", expr.tag.as_ref(), Printer::print_expression);
+        self.property("tag", &expr.tag, Printer::print_expression);
         self.property("quasi", expr.quasi.as_ref(), Printer::print_template_literal);
         self.end_node();
     }
@@ -936,7 +936,7 @@ impl<'a> Printer<'a> {
 
     fn print_import_expression(&mut self, expr: &ImportExpression) {
         self.start_node("ImportExpression", &expr.loc);
-        self.property("source", expr.source.as_ref(), Printer::print_expression);
+        self.property("source", &expr.source, Printer::print_expression);
         self.property("options", expr.options.as_ref(), Printer::print_optional_expression);
         self.end_node();
     }
@@ -988,7 +988,7 @@ impl<'a> Printer<'a> {
 
     fn print_rest_element(&mut self, rest: &RestElement) {
         self.start_node("RestElement", &rest.loc);
-        self.property("argument", rest.argument.as_ref(), Printer::print_pattern);
+        self.property("argument", &rest.argument, Printer::print_pattern);
         self.end_node();
     }
 
@@ -1005,22 +1005,22 @@ impl<'a> Printer<'a> {
     fn print_object_pattern_property(&mut self, prop: &ObjectPatternProperty) {
         if prop.is_rest {
             self.start_node("RestElement", &prop.loc);
-            self.property("property", prop.value.as_ref(), Printer::print_pattern);
+            self.property("property", &prop.value, Printer::print_pattern);
             self.end_node();
             return;
         }
 
         self.start_node("Property", &prop.loc);
         self.property("key", prop.key.as_ref(), Printer::print_optional_expression);
-        self.property("value", prop.value.as_ref(), Printer::print_pattern);
+        self.property("value", &prop.value, Printer::print_pattern);
         self.property("computed", prop.is_computed, Printer::print_bool);
         self.end_node();
     }
 
     fn print_assign_pattern(&mut self, patt: &AssignmentPattern) {
         self.start_node("AssignmentPattern", &patt.loc);
-        self.property("left", patt.left.as_ref(), Printer::print_pattern);
-        self.property("right", patt.right.as_ref(), Printer::print_expression);
+        self.property("left", &patt.left, Printer::print_pattern);
+        self.property("right", &patt.right, Printer::print_expression);
         self.end_node();
     }
 
@@ -1049,7 +1049,7 @@ impl<'a> Printer<'a> {
 
     fn print_import_attribute(&mut self, attribute: &ImportAttribute) {
         self.start_node("ImportAttribute", &attribute.loc);
-        self.property("key", attribute.key.as_ref(), Printer::print_expression);
+        self.property("key", &attribute.key, Printer::print_expression);
         self.property("value", attribute.value.as_ref(), Printer::print_string_literal);
         self.end_node();
     }
@@ -1134,21 +1134,21 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn print_optional_expression(&mut self, expr: Option<&P<'_, Expression>>) {
+    fn print_optional_expression(&mut self, expr: Option<&Expression>) {
         match expr {
             None => self.print_null(),
             Some(expr) => self.print_expression(expr),
         }
     }
 
-    fn print_optional_outer_expression(&mut self, expr: Option<&P<'_, OuterExpression>>) {
+    fn print_optional_outer_expression(&mut self, expr: Option<&OuterExpression>) {
         match expr {
             None => self.print_null(),
             Some(expr) => self.print_outer_expression(expr),
         }
     }
 
-    fn print_optional_statement(&mut self, stmt: Option<&P<'_, Statement>>) {
+    fn print_optional_statement(&mut self, stmt: Option<&Statement>) {
         match stmt {
             None => self.print_null(),
             Some(stmt) => self.print_statement(stmt),
@@ -1176,7 +1176,7 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn print_optional_pattern(&mut self, pattern: Option<&P<'_, Pattern>>) {
+    fn print_optional_pattern(&mut self, pattern: Option<&Pattern>) {
         match pattern {
             None => self.print_null(),
             Some(pattern) => self.print_pattern(pattern),


### PR DESCRIPTION
## Summary

The current AST structure results in a lot of wasted space. Expression, Statement, and Pattern nodes are all represented as enums which take the size of their largest variant, wasting space for the more commonly used, smaller variants. In the past we kept the size down by placing the largest variants behind a pointer, but let's go ahead and move to placing all variants behind a pointer instead. This means that Expression, Statement, and Pattern effectively become a typed pair of the tag and a pointer to the node itself. Each variant now only needs to allocate the precise size of the corresponding AST node, resulting in no wasted space inside these enums.

This refactoring also reduces the amount of copying within the parser, particularly in converting Expression to OuterExpression.

The reduction in memory use and copying results in ~5% parse time reductions across all benchmarks.

## Tests

All tests pass.