### PR TITLE
[runtime] Register all rust vtables with the runtime

### DIFF
--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -23,6 +23,7 @@ use super::{
     },
     property_descriptor::PropertyDescriptor,
     property_key::PropertyKey,
+    rust_vtables::extract_virtual_object_vtable,
     scope::Scope,
     type_utilities::same_object_value_handles,
     Context, EvalResult, HeapPtr, Value,
@@ -63,6 +64,8 @@ extend_object! {
 }
 
 impl MappedArgumentsObject {
+    pub const VIRTUAL_OBJECT_VTABLE: *const () = extract_virtual_object_vtable::<Self>();
+
     pub fn new(
         cx: Context,
         callee: Handle<Closure>,

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -19,6 +19,7 @@ use super::{
     },
     property_descriptor::PropertyDescriptor,
     property_key::PropertyKey,
+    rust_vtables::extract_virtual_object_vtable,
     type_utilities::{is_constructor_value, same_object_value, to_number, to_uint32},
     Context, EvalResult, Handle, HeapPtr, Realm, Value,
 };
@@ -33,6 +34,8 @@ extend_object! {
 }
 
 impl ArrayObject {
+    pub const VIRTUAL_OBJECT_VTABLE: *const () = extract_virtual_object_vtable::<Self>();
+
     pub fn new(cx: Context, proto: Handle<ObjectValue>) -> Handle<ArrayObject> {
         let mut array = object_create_with_proto::<ArrayObject>(cx, ObjectKind::ArrayObject, proto);
 

--- a/src/js/runtime/intrinsics/typed_array.rs
+++ b/src/js/runtime/intrinsics/typed_array.rs
@@ -25,6 +25,7 @@ use crate::{
         property_descriptor::PropertyDescriptor,
         property_key::PropertyKey,
         realm::Realm,
+        rust_vtables::{extract_typed_array_vtable, extract_virtual_object_vtable},
         string_value::StringValue,
         type_utilities::{
             to_big_int64, to_big_uint64, to_index, to_int16, to_int32, to_int8, to_number,
@@ -100,7 +101,13 @@ pub trait TypedArray {
     ) -> EvalResult<()>;
 }
 
-heap_trait_object!(TypedArray, DynTypedArray, HeapDynTypedArray, into_dyn_typed_array);
+heap_trait_object!(
+    TypedArray,
+    DynTypedArray,
+    HeapDynTypedArray,
+    into_dyn_typed_array,
+    extract_typed_array_vtable
+);
 
 impl DynTypedArray {
     pub fn into_object_value(self) -> Handle<ObjectValue> {

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -211,6 +211,9 @@ macro_rules! create_typed_array_constructor {
         }
 
         impl $typed_array {
+            pub const VIRTUAL_OBJECT_VTABLE: *const () = extract_virtual_object_vtable::<Self>();
+            pub const TYPED_ARRAY_VTABLE: *const () = extract_typed_array_vtable::<Self>();
+
             fn new_with_proto(
                 cx: Context,
                 proto: Handle<ObjectValue>,

--- a/src/js/runtime/mod.rs
+++ b/src/js/runtime/mod.rs
@@ -39,6 +39,7 @@ mod property_key;
 mod proxy_object;
 mod realm;
 mod regexp;
+mod rust_vtables;
 pub mod scope;
 pub mod scope_names;
 mod source_file;

--- a/src/js/runtime/module/module.rs
+++ b/src/js/runtime/module/module.rs
@@ -7,7 +7,8 @@ use crate::{
     heap_trait_object,
     runtime::{
         boxed_value::BoxedValue, gc::HeapItem, promise_object::PromiseObject,
-        string_value::FlatString, Context, EvalResult, Handle, HeapPtr,
+        rust_vtables::extract_module_vtable, string_value::FlatString, Context, EvalResult, Handle,
+        HeapPtr,
     },
 };
 
@@ -68,7 +69,7 @@ pub enum ResolveExportName {
     Local { name: HeapPtr<FlatString>, boxed_value: HeapPtr<BoxedValue> },
 }
 
-heap_trait_object!(Module, DynModule, HeapDynModule, into_dyn_module);
+heap_trait_object!(Module, DynModule, HeapDynModule, into_dyn_module, extract_module_vtable);
 
 impl DynModule {
     pub fn as_heap_item(self) -> Handle<HeapItem> {

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -15,6 +15,7 @@ use crate::{
             ordinary_own_string_symbol_property_keys,
         },
         property::Property,
+        rust_vtables::extract_virtual_object_vtable,
         type_utilities::same_value,
         Context, EvalResult, Handle, HeapPtr, PropertyDescriptor, PropertyKey, Value,
     },
@@ -37,6 +38,8 @@ extend_object! {
 }
 
 impl ModuleNamespaceObject {
+    pub const VIRTUAL_OBJECT_VTABLE: *const () = extract_virtual_object_vtable::<Self>();
+
     pub fn new(cx: Context, module: DynModule) -> HeapPtr<ModuleNamespaceObject> {
         // Module namespace object does not have a prototype. This satisfies:
         // - [[GetPrototypeOf]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getprototypeof)

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -16,6 +16,7 @@ use crate::{
         object_value::ObjectValue,
         ordinary_object::object_create_with_optional_proto,
         promise_object::{PromiseCapability, PromiseObject},
+        rust_vtables::extract_module_vtable,
         scope::Scope,
         string_value::FlatString,
         Context, EvalResult, Handle, HeapPtr, PropertyKey, Value,
@@ -105,6 +106,8 @@ type ModuleOptionArray = BsArray<Option<HeapDynModule>>;
 pub type ExportMap = BsHashMap<PropertyKey, HeapPtr<HeapItem>>;
 
 impl SourceTextModule {
+    pub const MODULE_VTABLE: *const () = extract_module_vtable::<Self>();
+
     pub fn new(
         cx: Context,
         program_function: Handle<BytecodeFunction>,

--- a/src/js/runtime/module/synthetic_module.rs
+++ b/src/js/runtime/module/synthetic_module.rs
@@ -11,6 +11,7 @@ use crate::{
         module::module::next_module_id,
         object_descriptor::{ObjectDescriptor, ObjectKind},
         promise_object::{coerce_to_ordinary_promise, PromiseCapability, PromiseObject},
+        rust_vtables::extract_module_vtable,
         scope::Scope,
         scope_names::{ScopeFlags, ScopeNameFlags, ScopeNames},
         string_value::FlatString,
@@ -44,6 +45,8 @@ pub enum SyntheticModuleKind {
 }
 
 impl SyntheticModule {
+    pub const MODULE_VTABLE: *const () = extract_module_vtable::<Self>();
+
     /// Create a new SyntheticModule with the given exported names. Caller is responsible for
     /// initializing the kind field.
     fn new(

--- a/src/js/runtime/object_descriptor.rs
+++ b/src/js/runtime/object_descriptor.rs
@@ -6,7 +6,7 @@ use crate::{
     runtime::{
         arguments_object::MappedArgumentsObject,
         module::module_namespace_object::ModuleNamespaceObject, ordinary_object::OrdinaryObject,
-        Value,
+        rust_vtables::extract_virtual_object_vtable, Value,
     },
     set_uninit,
 };
@@ -18,7 +18,7 @@ use super::{
         BigInt64Array, BigUInt64Array, Float16Array, Float32Array, Float64Array, Int16Array,
         Int32Array, Int8Array, UInt16Array, UInt32Array, UInt8Array, UInt8ClampedArray,
     },
-    object_value::{extract_object_vtable, VirtualObject, VirtualObjectVtable},
+    object_value::{VirtualObject, VirtualObjectVtable},
     proxy_object::ProxyObject,
     string_object::StringObject,
     Context,
@@ -192,7 +192,7 @@ impl ObjectDescriptor {
         let mut desc = cx.alloc_uninit::<ObjectDescriptor>();
 
         set_uninit!(desc.descriptor, *descriptor);
-        set_uninit!(desc.vtable, extract_object_vtable::<Handle<T>>());
+        set_uninit!(desc.vtable, extract_virtual_object_vtable::<T>());
         set_uninit!(desc.kind, kind);
         set_uninit!(desc.flags, flags);
 

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -1,7 +1,7 @@
 use rand::Rng;
 
 use std::{
-    mem::{size_of, transmute, transmute_copy},
+    mem::{size_of, transmute_copy},
     num::NonZeroU32,
 };
 
@@ -721,19 +721,6 @@ impl BsIndexMapField<PropertyKey, HeapProperty> for NamedPropertiesMapField {
 struct ObjectTraitObject {
     data: *const Handle<ObjectValue>,
     vtable: *const (),
-}
-
-/// Compile time shenanigans to extract the trait object vtable for a particular type that
-/// implements Object so that we can construct our own trait objects manually.
-pub const fn extract_object_vtable<T: VirtualObject>() -> *const () {
-    unsafe {
-        let example_ptr: *const T = std::ptr::null();
-        let example_trait_object: *const dyn VirtualObject = example_ptr;
-        let object_trait_object =
-            transmute::<*const dyn VirtualObject, ObjectTraitObject>(example_trait_object);
-
-        object_trait_object.vtable
-    }
 }
 
 impl HeapObject for HeapPtr<ObjectValue> {

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -11,6 +11,7 @@ use super::{
     property::Property,
     property_descriptor::PropertyDescriptor,
     property_key::PropertyKey,
+    rust_vtables::extract_virtual_object_vtable,
     type_utilities::{same_object_value_handles, same_opt_object_value, same_value},
     value::Value,
     Context,
@@ -92,6 +93,10 @@ impl Handle<ObjectValue> {
 
         Ok(true)
     }
+}
+
+impl OrdinaryObject {
+    pub const VIRTUAL_OBJECT_VTABLE: *const () = extract_virtual_object_vtable::<Self>();
 }
 
 impl VirtualObject for Handle<OrdinaryObject> {

--- a/src/js/runtime/proxy_object.rs
+++ b/src/js/runtime/proxy_object.rs
@@ -16,6 +16,7 @@ use super::{
     ordinary_object::{is_compatible_property_descriptor, object_create},
     property_descriptor::{from_property_descriptor, to_property_descriptor, PropertyDescriptor},
     property_key::PropertyKey,
+    rust_vtables::extract_virtual_object_vtable,
     type_utilities::{
         is_callable_object, is_constructor_object_value, same_opt_object_value_handles, same_value,
         to_boolean,
@@ -34,6 +35,8 @@ extend_object! {
 }
 
 impl ProxyObject {
+    pub const VIRTUAL_OBJECT_VTABLE: *const () = extract_virtual_object_vtable::<Self>();
+
     pub fn new(
         cx: Context,
         proxy_target: Handle<ObjectValue>,

--- a/src/js/runtime/rust_vtables.rs
+++ b/src/js/runtime/rust_vtables.rs
@@ -1,0 +1,173 @@
+use std::sync::LazyLock;
+
+use super::{
+    arguments_object::MappedArgumentsObject,
+    array_object::ArrayObject,
+    intrinsics::typed_array::{
+        BigInt64Array, BigUInt64Array, Float16Array, Float32Array, Float64Array, Int16Array,
+        Int32Array, Int8Array, TypedArray, UInt16Array, UInt32Array, UInt8Array, UInt8ClampedArray,
+    },
+    module::{
+        module::Module, module_namespace_object::ModuleNamespaceObject,
+        source_text_module::SourceTextModule, synthetic_module::SyntheticModule,
+    },
+    object_value::VirtualObject,
+    ordinary_object::OrdinaryObject,
+    proxy_object::ProxyObject,
+    string_object::StringObject,
+};
+
+/// Every Rust trait vtable that can appear in the heap.
+///
+/// This occurs due to the implementation of dynamic dispatch where the corresponding Rust trait
+/// vtable is stored in the heap and used to reconstruct a Rust trait object.
+#[allow(unused)]
+#[derive(Clone, Copy)]
+#[repr(u8)]
+pub enum RustVtable {
+    // VirtualObjects
+    OrdinaryVirtualObject,
+    ArrayVirtualObject,
+    StringVirtualObject,
+    ProxyVirtualObject,
+    ModuleNamespaceVirtualObject,
+    MappedArgumentsVirtualObject,
+    Int8ArrayVirtualObject,
+    UInt8ArrayVirtualObject,
+    UInt8ClampedArrayVirtualObject,
+    Int16ArrayVirtualObject,
+    UInt16ArrayVirtualObject,
+    Int32ArrayVirtualObject,
+    Uint32ArrayVirtualObject,
+    Float16ArrayVirtualObject,
+    Float32ArrayVirtualObject,
+    Float64ArrayVirtualObject,
+    BigInt64ArrayVirtualObject,
+    BigUInt64ArrayVirtualObject,
+    // Modules
+    SourceTextModule,
+    SyntheticModule,
+    // TypedArrays
+    Int8TypedArray,
+    UInt8TypedArray,
+    UInt8ClampedTypedArray,
+    Int16TypedArray,
+    UInt16TypedArray,
+    Int32TypedArray,
+    UInt32TypedArray,
+    Float16TypedArray,
+    Float32TypedArray,
+    Float64TypedArray,
+    BigInt64TypedArray,
+    BigUInt64TypedArray,
+    // Last entry for the number of vtables registered
+    Last,
+}
+
+/// The vtables stored in order. Can be indexed with the RustVtable enum to find the vtable pointer
+/// of a particular type.
+const RUST_VTABLES: [*const (); RustVtable::Last as usize] = [
+    // VirtualObjects
+    OrdinaryObject::VIRTUAL_OBJECT_VTABLE,
+    ArrayObject::VIRTUAL_OBJECT_VTABLE,
+    StringObject::VIRTUAL_OBJECT_VTABLE,
+    ProxyObject::VIRTUAL_OBJECT_VTABLE,
+    ModuleNamespaceObject::VIRTUAL_OBJECT_VTABLE,
+    MappedArgumentsObject::VIRTUAL_OBJECT_VTABLE,
+    Int8Array::VIRTUAL_OBJECT_VTABLE,
+    UInt8Array::VIRTUAL_OBJECT_VTABLE,
+    UInt8ClampedArray::VIRTUAL_OBJECT_VTABLE,
+    Int16Array::VIRTUAL_OBJECT_VTABLE,
+    UInt16Array::VIRTUAL_OBJECT_VTABLE,
+    Int32Array::VIRTUAL_OBJECT_VTABLE,
+    UInt32Array::VIRTUAL_OBJECT_VTABLE,
+    Float16Array::VIRTUAL_OBJECT_VTABLE,
+    Float32Array::VIRTUAL_OBJECT_VTABLE,
+    Float64Array::VIRTUAL_OBJECT_VTABLE,
+    BigInt64Array::VIRTUAL_OBJECT_VTABLE,
+    BigUInt64Array::VIRTUAL_OBJECT_VTABLE,
+    // Modules
+    SourceTextModule::MODULE_VTABLE,
+    SyntheticModule::MODULE_VTABLE,
+    // TypedArrays
+    Int8Array::TYPED_ARRAY_VTABLE,
+    UInt8Array::TYPED_ARRAY_VTABLE,
+    UInt8ClampedArray::TYPED_ARRAY_VTABLE,
+    Int16Array::TYPED_ARRAY_VTABLE,
+    UInt16Array::TYPED_ARRAY_VTABLE,
+    Int32Array::TYPED_ARRAY_VTABLE,
+    UInt32Array::TYPED_ARRAY_VTABLE,
+    Float16Array::TYPED_ARRAY_VTABLE,
+    Float32Array::TYPED_ARRAY_VTABLE,
+    Float64Array::TYPED_ARRAY_VTABLE,
+    BigInt64Array::TYPED_ARRAY_VTABLE,
+    BigUInt64Array::TYPED_ARRAY_VTABLE,
+];
+
+thread_local! {
+    /// Array of (vtable, enum) pairs sorted by vtable pointer. This is used to look up the enum for a
+    /// particular vtable pointer in O(log n) time.
+    static RUST_VTABLES_SORTED_BY_POINTER: LazyLock<Vec<(*const (), RustVtable)>> =
+        LazyLock::new(|| {
+            let mut vtables = Vec::with_capacity(RustVtable::Last as usize);
+
+            for (i, &vtable) in RUST_VTABLES.iter().enumerate() {
+                let enum_value = unsafe { std::mem::transmute::<u8, RustVtable>(i as u8) };
+                vtables.push((vtable, enum_value));
+            }
+
+            vtables.sort_by_key(|&(ptr, _)| ptr);
+
+            vtables
+        });
+}
+
+/// Return the vtable pointer for a particular type.
+#[allow(unused)]
+pub const fn get_vtable(vtable: RustVtable) -> *const () {
+    RUST_VTABLES[vtable as usize]
+}
+
+/// Lookup the RustVtable enum value for a particular vtable pointer. If the vtable pointer is not
+/// registered then return None.
+#[allow(unused)]
+pub fn lookup_vtable_enum(vtable: *const ()) -> Option<RustVtable> {
+    RUST_VTABLES_SORTED_BY_POINTER.with(|vtables_sorted_by_pointer| {
+        let index = vtables_sorted_by_pointer
+            .binary_search_by_key(&vtable, |&(ptr, _)| ptr)
+            .ok()?;
+
+        Some(vtables_sorted_by_pointer[index].1)
+    })
+}
+
+/// Rust representation of a fat pointer. Used to extract vtable pointer.
+#[repr(C)]
+struct FatPointer {
+    data: *const (),
+    vtable: *const (),
+}
+
+/// Compile time shenanigans to extract the trait object vtable for a particular type that
+/// implements the trait so that we can construct our own trait objects manually.
+macro_rules! extract_vtable_function {
+    ($method_name:ident, $trait:ident) => {
+        pub const fn $method_name<T>() -> *const ()
+        where
+            $crate::runtime::Handle<T>: $trait,
+        {
+            unsafe {
+                let example_ptr: *const $crate::runtime::Handle<T> =
+                    std::ptr::NonNull::dangling().as_ptr();
+                let example_fat_ptr: *const dyn $trait = example_ptr;
+                let fat_ptr = std::mem::transmute::<*const dyn $trait, FatPointer>(example_fat_ptr);
+
+                fat_ptr.vtable
+            }
+        }
+    };
+}
+
+extract_vtable_function!(extract_virtual_object_vtable, VirtualObject);
+extract_vtable_function!(extract_module_vtable, Module);
+extract_vtable_function!(extract_typed_array_vtable, TypedArray);

--- a/src/js/runtime/string_object.rs
+++ b/src/js/runtime/string_object.rs
@@ -28,6 +28,7 @@ use crate::{
 use super::{
     gc::{HeapObject, HeapVisitor},
     property::Property,
+    rust_vtables::extract_virtual_object_vtable,
     string_value::FlatString,
 };
 
@@ -40,6 +41,8 @@ extend_object! {
 }
 
 impl StringObject {
+    pub const VIRTUAL_OBJECT_VTABLE: *const () = extract_virtual_object_vtable::<Self>();
+
     pub fn new_from_value(
         cx: Context,
         string_data_handle: Handle<StringValue>,


### PR DESCRIPTION
## Summary

In preparation for serializing the heap we need some additional structure around Rust vtables placed in the heap. This occurs due to a couple sites using Rust trait objects for dynamic dispatch: object method dispatch, modules, and typed arrays.

This PR registers all Rust vtables that appear in the heap to a top level collection and pairs each with a value in the new `RustVtable` enum. This allows you to map between the `RustVtable` enum and the true value of the vtable pointer, meaning in the future we can serialize to `RustVtable` and deserialize to the vtable pointer in the new address space.

## Tests

All tests pass.