### PR TITLE
[runtime] Eliminate WTF-8 cached interned strings map outside bytecode generator

### DIFF
--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -73,7 +73,7 @@ impl MappedArgumentsObject {
         scope: Handle<Scope>,
         num_parameters: usize,
     ) -> Handle<MappedArgumentsObject> {
-        let shadowed_name = InternedStrings::get_wtf8_str(cx, &SHADOWED_SCOPE_SLOT_NAME).as_flat();
+        let shadowed_name = InternedStrings::alloc_wtf8_str(cx, &SHADOWED_SCOPE_SLOT_NAME);
 
         let size = Self::calculate_size_in_bytes(num_parameters);
         let mut object = object_create_with_size::<MappedArgumentsObject>(

--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -45,7 +45,12 @@ macro_rules! builtin_names {
 
 builtin_names!(
     (empty_string, ""),
+    (space, " "),
+    (comma, ","),
+    (slash, "/"),
+    (zero, "0"),
     (negative_zero, "-0"),
+    (negative_infinity_literal, "-Infinity"),
     (default_name, "*default*"),
     (__define_getter__, "__defineGetter__"),
     (__define_setter__, "__defineSetter__"),

--- a/src/js/runtime/eval/eval.rs
+++ b/src/js/runtime/eval/eval.rs
@@ -210,7 +210,7 @@ fn eval_declaration_instantiation(mut cx: Context, program: &ast::Program) -> Ev
     let mut eval_var_names = vec![];
     let mut eval_func_names = vec![];
     for (name, binding) in program.scope.as_ref().iter_var_decls() {
-        let name = InternedStrings::get_wtf8_str(cx, name).as_flat();
+        let name = InternedStrings::alloc_wtf8_str(cx, name);
         match binding.kind() {
             BindingKind::Var => eval_var_names.push(name),
             BindingKind::Function { .. } => eval_func_names.push(name),
@@ -222,7 +222,7 @@ fn eval_declaration_instantiation(mut cx: Context, program: &ast::Program) -> Ev
     let eval_scope = program.scope.as_ref();
     let eval_var_names = eval_scope
         .iter_var_decls()
-        .map(|(name, _)| InternedStrings::get_wtf8_str(cx, name).as_flat())
+        .map(|(name, _)| InternedStrings::alloc_wtf8_str(cx, name))
         .collect::<Vec<_>>();
 
     check_eval_var_name_conflicts(cx, &eval_var_names, &eval_func_names)?;

--- a/src/js/runtime/eval/expression.rs
+++ b/src/js/runtime/eval/expression.rs
@@ -13,7 +13,6 @@ use crate::{
         array_object::array_create_in_realm,
         error::{range_error, type_error},
         eval_result::EvalResult,
-        interned_strings::InternedStrings,
         numeric_operations::number_exponentiate,
         object_descriptor::ObjectKind,
         object_value::ObjectValue,
@@ -31,7 +30,7 @@ use crate::{
 
 /// GetTemplateObject (https://tc39.es/ecma262/#sec-gettemplateobject)
 pub fn generate_template_object(
-    cx: Context,
+    mut cx: Context,
     realm: Handle<Realm>,
     lit: &ast::TemplateLiteral,
 ) -> Handle<ObjectValue> {
@@ -48,12 +47,12 @@ pub fn generate_template_object(
 
         let cooked_value = match &quasi.cooked {
             None => cx.undefined(),
-            Some(cooked) => InternedStrings::get_wtf8_str(cx, cooked).into(),
+            Some(cooked) => cx.alloc_wtf8_str(cooked).as_value(),
         };
         let cooked_desc = PropertyDescriptor::data(cooked_value, false, true, false);
         must!(define_property_or_throw(cx, template_object, index_key, cooked_desc));
 
-        let raw_value = InternedStrings::get_wtf8_str(cx, quasi.raw);
+        let raw_value = cx.alloc_wtf8_str(quasi.raw);
         let raw_desc = PropertyDescriptor::data(raw_value.into(), false, true, false);
         must!(define_property_or_throw(cx, raw_object, index_key, raw_desc));
     }

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -22,7 +22,7 @@ use crate::runtime::{
     for_in_iterator::ForInIterator,
     generator_object::GeneratorObject,
     global_names::GlobalNames,
-    interned_strings::{InternedStringsMapField, InternedStringsSetField},
+    interned_strings::InternedStringsSetField,
     intrinsics::{
         array_buffer_constructor::ArrayBufferObject,
         array_iterator::ArrayIterator,
@@ -188,7 +188,6 @@ impl HeapObject for HeapPtr<HeapItem> {
             ObjectKind::GlobalSymbolRegistryMap => {
                 GlobalSymbolRegistryField::byte_size(&self.cast())
             }
-            ObjectKind::InternedStringsMap => InternedStringsMapField::byte_size(&self.cast()),
             ObjectKind::InternedStringsSet => InternedStringsSetField::byte_size(&self.cast()),
             ObjectKind::LexicalNamesMap => LexicalNamesMapField::byte_size(&self.cast()),
             ObjectKind::ModuleCacheMap => ModuleCacheField::byte_size(&self.cast()),
@@ -333,9 +332,6 @@ impl HeapObject for HeapPtr<HeapItem> {
             }
             ObjectKind::GlobalSymbolRegistryMap => {
                 GlobalSymbolRegistryField::visit_pointers(self.cast_mut(), visitor)
-            }
-            ObjectKind::InternedStringsMap => {
-                InternedStringsMapField::visit_pointers(self.cast_mut(), visitor)
             }
             ObjectKind::InternedStringsSet => {
                 InternedStringsSetField::visit_pointers(self.cast_mut(), visitor)

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -12,7 +12,6 @@ use crate::{
         error::{range_error, type_error},
         function::get_argument,
         get,
-        interned_strings::InternedStrings,
         numeric_constants::MAX_SAFE_INTEGER_U64,
         object_descriptor::ObjectKind,
         object_value::ObjectValue,
@@ -835,7 +834,7 @@ impl ArrayPrototype {
 
         let separator = get_argument(cx, arguments, 0);
         let separator = if separator.is_undefined() {
-            InternedStrings::get_str(cx, ",")
+            cx.names.comma().as_string()
         } else {
             to_string(cx, separator)?
         };
@@ -1492,7 +1491,7 @@ impl ArrayPrototype {
         let length = length_of_array_like(cx, object)?;
 
         let mut result = cx.names.empty_string().as_string();
-        let separator = InternedStrings::get_str(cx, ",");
+        let separator = cx.names.comma().as_string();
 
         // Shared between iterations
         let mut key = PropertyKey::uninit().to_handle(cx);

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -3,7 +3,6 @@ use crate::runtime::{
     builtin_function::BuiltinFunction,
     error::{range_error, type_error},
     function::get_argument,
-    interned_strings::InternedStrings,
     intrinsics::date_object::{day, make_date, make_time, time_clip},
     object_value::ObjectValue,
     property::Property,
@@ -1215,7 +1214,7 @@ impl DatePrototype {
 
     fn to_date_string_shared(mut cx: Context, date_value: f64) -> EvalResult<Handle<Value>> {
         if date_value.is_nan() {
-            return Ok(InternedStrings::get_str(cx, "Invalid Date").as_value());
+            return Ok(cx.alloc_string("Invalid Date").as_value());
         }
 
         let date_value = local_time(date_value);
@@ -1374,7 +1373,7 @@ impl DatePrototype {
 
     fn to_time_string_shared(mut cx: Context, date_value: f64) -> EvalResult<Handle<Value>> {
         if date_value.is_nan() {
-            return Ok(InternedStrings::get_str(cx, "Invalid Date").as_value());
+            return Ok(cx.alloc_string("Invalid Date").as_value());
         }
 
         let local_date_value = local_time(date_value);
@@ -1403,7 +1402,7 @@ impl DatePrototype {
         };
 
         if date_value.is_nan() {
-            return Ok(InternedStrings::get_str(cx, "Invalid Date").as_value());
+            return Ok(cx.alloc_string("Invalid Date").as_value());
         }
 
         let year = year_from_time(date_value);
@@ -1546,7 +1545,7 @@ fn time_zone_string(string: &mut String, _time_value: f64) {
 /// ToDateString (https://tc39.es/ecma262/#sec-todatestring)
 pub fn to_date_string(mut cx: Context, time_value: f64) -> Handle<StringValue> {
     if time_value.is_nan() {
-        return InternedStrings::get_str(cx, "Invalid Date");
+        return cx.alloc_string("Invalid Date").as_string();
     }
 
     let local_time_value = local_time(time_value);

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -11,7 +11,6 @@ use crate::{
         eval_result::EvalResult,
         function::{get_argument, set_function_length_maybe_infinity, set_function_name},
         get,
-        interned_strings::InternedStrings,
         object_descriptor::ObjectKind,
         object_value::ObjectValue,
         ordinary_object::{object_create_with_optional_proto, object_ordinary_init},
@@ -206,11 +205,11 @@ impl FunctionPrototype {
 
             // Builtin functions have special formatting using the function name
             if function.rust_runtime_function_id().is_some() {
-                let mut string_parts = vec![InternedStrings::get_str(cx, "function ")];
+                let mut string_parts = vec![cx.alloc_string("function ").as_string()];
                 if let Some(name) = function.name() {
                     string_parts.push(name);
                 }
-                string_parts.push(InternedStrings::get_str(cx, "() { [native code] }"));
+                string_parts.push(cx.alloc_string("() { [native code] }").as_string());
 
                 return Ok(StringValue::concat_all(cx, &string_parts).as_value());
             }

--- a/src/js/runtime/intrinsics/number_prototype.rs
+++ b/src/js/runtime/intrinsics/number_prototype.rs
@@ -2,7 +2,6 @@ use crate::runtime::{
     error::{range_error, type_error},
     eval_result::EvalResult,
     function::get_argument,
-    interned_strings::InternedStrings,
     object_value::ObjectValue,
     realm::Realm,
     string_value::FlatString,
@@ -285,12 +284,12 @@ impl NumberPrototype {
         if number_value.is_nan() {
             return Ok(cx.names.nan().as_string().as_value());
         } else if number_value.is_zero() {
-            return Ok(InternedStrings::get_str(cx, "0").as_value());
+            return Ok(cx.names.zero().as_string().as_value());
         } else if number_value.is_infinity() {
             return if number_value.as_number() == f64::INFINITY {
                 Ok(cx.names.infinity().as_string().as_value())
             } else {
-                Ok(InternedStrings::get_str(cx, "-Infinity").as_value())
+                Ok(cx.names.negative_infinity_literal().as_string().as_value())
             };
         }
 

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -29,7 +29,6 @@ use crate::{
         function::get_argument,
         gc::{Handle, HeapObject, HeapVisitor},
         get,
-        interned_strings::InternedStrings,
         object_descriptor::ObjectKind,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -424,7 +423,7 @@ fn escape_pattern_string(
 ) -> Handle<StringValue> {
     // Special case the empty pattern string - equivalent to an empty non-capturing group
     if pattern_string.is_empty() {
-        return InternedStrings::get_str(cx, "(?:)");
+        return cx.alloc_string("(?:)").as_string();
     }
 
     // Only need to escape line terminators and forward slash

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -14,7 +14,6 @@ use crate::{
         eval_result::EvalResult,
         function::get_argument,
         get,
-        interned_strings::InternedStrings,
         intrinsics::{
             regexp_string_iterator::RegExpStringIterator,
             string_prototype::SubstitutionTemplateParser,
@@ -555,7 +554,7 @@ impl RegExpPrototype {
 
     /// RegExp.prototype [ @@split ] (https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.split%)
     pub fn split(
-        cx: Context,
+        mut cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
@@ -586,7 +585,7 @@ impl RegExpPrototype {
 
         // Make sure the sticky flag is included in the flags string
         if !is_sticky {
-            let y_string = InternedStrings::get_str(cx, "y");
+            let y_string = cx.alloc_string("y").as_string();
             flags_string = StringValue::concat(cx, flags_string, y_string);
         }
 
@@ -741,7 +740,7 @@ impl RegExpPrototype {
         let flags_value = get(cx, this_object, cx.names.flags())?;
         let flags_string = to_string(cx, flags_value)?;
 
-        let slash_string = InternedStrings::get_str(cx, "/");
+        let slash_string = cx.names.slash().as_string();
 
         let full_string = StringValue::concat_all(
             cx,

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -17,7 +17,6 @@ use crate::{
         eval_result::EvalResult,
         function::get_argument,
         get,
-        interned_strings::InternedStrings,
         intrinsics::{
             intrinsics::Intrinsic,
             regexp_constructor::{regexp_create, RegExpSource},
@@ -587,7 +586,7 @@ impl StringPrototype {
         let int_max_length = int_max_length as u32;
 
         let fill_string = if fill_string_arg.is_undefined() {
-            InternedStrings::get_str(cx, " ")
+            cx.names.space().as_string()
         } else {
             to_string(cx, fill_string_arg)?
         };

--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -13,7 +13,6 @@ use crate::{
         error::{range_error, type_error},
         function::get_argument,
         get,
-        interned_strings::InternedStrings,
         intrinsics::{
             array_buffer_constructor::clone_array_buffer,
             array_iterator::{ArrayIterator, ArrayIteratorKind},
@@ -743,7 +742,7 @@ impl TypedArrayPrototype {
 
         let separator = get_argument(cx, arguments, 0);
         let separator = if separator.is_undefined() {
-            InternedStrings::get_str(cx, ",")
+            cx.names.comma().as_string()
         } else {
             to_string(cx, separator)?
         };
@@ -1438,7 +1437,7 @@ impl TypedArrayPrototype {
         let length = typed_array_length(&typed_array_record);
 
         let mut result = cx.names.empty_string().as_string();
-        let separator = InternedStrings::get_str(cx, ",");
+        let separator = cx.names.comma().as_string();
 
         for i in 0..length {
             if i > 0 {

--- a/src/js/runtime/object_descriptor.rs
+++ b/src/js/runtime/object_descriptor.rs
@@ -143,7 +143,6 @@ pub enum ObjectKind {
     WeakSetObjectWeakValueSet,
     WeakMapObjectWeakValueMap,
     GlobalSymbolRegistryMap,
-    InternedStringsMap,
     InternedStringsSet,
     LexicalNamesMap,
     ModuleCacheMap,
@@ -373,7 +372,6 @@ impl BaseDescriptors {
         other_heap_object_descriptor!(ObjectKind::WeakMapObjectWeakValueMap);
         other_heap_object_descriptor!(ObjectKind::WeakSetObjectWeakValueSet);
         other_heap_object_descriptor!(ObjectKind::GlobalSymbolRegistryMap);
-        other_heap_object_descriptor!(ObjectKind::InternedStringsMap);
         other_heap_object_descriptor!(ObjectKind::InternedStringsSet);
         other_heap_object_descriptor!(ObjectKind::LexicalNamesMap);
         other_heap_object_descriptor!(ObjectKind::ModuleCacheMap);

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -263,7 +263,7 @@ impl Handle<Realm> {
         self.lexical_names = LexicalNamesMap::new_initial(cx, ObjectKind::LexicalNamesMap);
 
         // All global scopes have the realm in their first slot
-        let binding_names = &[InternedStrings::get_wtf8_str(cx, &REALM_SCOPE_SLOT_NAME).as_flat()];
+        let binding_names = &[InternedStrings::alloc_wtf8_str(cx, &REALM_SCOPE_SLOT_NAME)];
         let binding_flags = &[ScopeNameFlags::empty()];
         let scope_names =
             ScopeNames::new(cx, ScopeFlags::IS_VAR_SCOPE, binding_names, binding_flags);


### PR DESCRIPTION
## Summary

In preparation for heap serialization we are reducing usage of the `InternedStrings::str_cache` map from `Wtf8String` to heap strings.

The only remaining uses of the WTF-8 map are in the bytecode generator. All other uses have been changed to either use a new builtin name or always allocate first before checking if interned.

## Tests

All tests pass.