### PR TITLE
[runtime] Serialize heap and embed in binary, use to initialize heap at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,9 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "brimstone"
 version = "0.1.0"
 dependencies = [
+ "bitflags 2.9.0",
  "brimstone_core",
+ "brimstone_serialized_heap",
  "clap",
  "criterion",
 ]
@@ -104,6 +106,7 @@ name = "brimstone_integration_test_harness"
 version = "0.1.0"
 dependencies = [
  "brimstone_core",
+ "brimstone_serialized_heap",
  "clap",
  "regex",
  "serde",
@@ -121,10 +124,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "brimstone_serialized_heap"
+version = "0.1.0"
+dependencies = [
+ "brimstone_core",
+]
+
+[[package]]
 name = "brimstone_tests"
 version = "0.1.0"
 dependencies = [
  "brimstone_core",
+ "brimstone_serialized_heap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "src/brimstone_icu_collections",
   "src/brimstone_macros",
   "src/js",
+  "src/brimstone_serialized_heap",
   "tests",
   "tests/harness",
 ]
@@ -20,6 +21,7 @@ brimstone = { path = "src" }
 brimstone_core = { path = "src/js" }
 brimstone_icu_collections = { path = "src/brimstone_icu_collections" }
 brimstone_macros = { path = "src/brimstone_macros" }
+brimstone_serialized_heap = { path = "src/brimstone_serialized_heap" }
 
 # External Crates
 allocator-api2 = "0.2.21"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -10,9 +10,11 @@ name = "bs"
 path = "main.rs"
 
 [dependencies]
+bitflags.workspace = true
 clap = { workspace = true, features = ["derive"] }
 
 brimstone_core.workspace = true
+brimstone_serialized_heap.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/src/brimstone_serialized_heap/Cargo.toml
+++ b/src/brimstone_serialized_heap/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "brimstone_serialized_heap"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+brimstone_core.workspace = true
+
+[build-dependencies]
+brimstone_core.workspace = true

--- a/src/brimstone_serialized_heap/build.rs
+++ b/src/brimstone_serialized_heap/build.rs
@@ -1,0 +1,96 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
+
+use brimstone_core::{
+    common::options::OptionsBuilder,
+    runtime::{gc::HeapSerializer, ContextBuilder},
+};
+
+/// Generate the default serialized heap and embed into the binary.
+fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let out_path = Path::new(&out_dir);
+    let dest_path = out_path.join("generated_serialized_heap.rs");
+
+    let serialized_heap_file = gen_serialized_heap_file(out_path);
+
+    fs::write(&dest_path, &serialized_heap_file).unwrap();
+}
+
+/// A 4 MB heap is sufficient
+const HEAP_SIZE: usize = 4 * 1024 * 1024;
+
+fn gen_serialized_heap_file(out_path: &Path) -> String {
+    let options = OptionsBuilder::new().min_heap_size(HEAP_SIZE).build();
+    let cx = ContextBuilder::new().set_options(Rc::new(options)).build();
+
+    let serializer = HeapSerializer::serialize(cx);
+    let serialized_heap = serializer.as_serialized();
+
+    let permanent_space_file =
+        write_bytes_to_file(serialized_heap.permanent_space.bytes, out_path, "permanent_space.in");
+    let current_space_file =
+        write_bytes_to_file(serialized_heap.current_space.bytes, out_path, "current_space.in");
+
+    let root_offsets_file = write_bytes_to_file(
+        usize_slice_to_u8_slice(serialized_heap.root_offsets),
+        out_path,
+        "root_offsets.in",
+    );
+
+    format!(
+        r#"
+use brimstone_core::common::serialized_heap::{{SerializedHeap, SerializedSemispace}};
+
+/// Align a sequence of bytes to a the alignment of the given type.
+/// 
+/// Needs #[repr(C)] to guarantee that bytes comes after `_align`.
+#[repr(C)]
+struct AlignedBytes<Align, Bytes: ?Sized = [u8]> {{
+    _align: [Align; 0],
+    bytes: Bytes, 
+}}
+
+const SERIALIZED_PERMANENT_SPACE: &[u8] = include_bytes!("{}");
+const SERIALIZED_CURRENT_SPACE: &[u8] = include_bytes!("{}");
+const SERIALIZED_ROOT_OFFSETS: &[usize] = u8_slice_to_usize_slice(&ALIGNED_SERIALIZED_ROOT_OFFSETS.bytes);
+
+const fn u8_slice_to_usize_slice(slice: &[u8]) -> &[usize] {{
+    let num_usizes = slice.len() / std::mem::size_of::<usize>();
+    unsafe {{ std::slice::from_raw_parts(slice.as_ptr().cast(), num_usizes) }}
+}}
+
+/// Must make sure that byte sequence has the right alignment so that it can be read as a &[usize].
+static ALIGNED_SERIALIZED_ROOT_OFFSETS: &AlignedBytes<usize> = &AlignedBytes {{
+    _align: [],
+    bytes: *include_bytes!("{}"),
+}};
+
+/// The default serialized heap embedded in the binary.
+pub const SERIALIZED_HEAP: SerializedHeap<'static> = SerializedHeap {{
+    permanent_space: SerializedSemispace {{ bytes: SERIALIZED_PERMANENT_SPACE, start_offset: {} }},
+    current_space: SerializedSemispace {{ bytes: SERIALIZED_CURRENT_SPACE, start_offset: {} }},
+    root_offsets: SERIALIZED_ROOT_OFFSETS,
+}};
+"#,
+        permanent_space_file.to_string_lossy(),
+        current_space_file.to_string_lossy(),
+        root_offsets_file.to_string_lossy(),
+        serialized_heap.permanent_space.start_offset,
+        serialized_heap.current_space.start_offset,
+    )
+}
+
+fn write_bytes_to_file(bytes: &[u8], out_path: &Path, file_name: &str) -> PathBuf {
+    let file = out_path.join(file_name).to_path_buf();
+    fs::write(&file, bytes).unwrap();
+    file
+}
+
+const fn usize_slice_to_u8_slice(slice: &[usize]) -> &[u8] {
+    let num_bytes = std::mem::size_of::<usize>() * slice.len();
+    unsafe { std::slice::from_raw_parts(slice.as_ptr().cast(), num_bytes) }
+}

--- a/src/brimstone_serialized_heap/src/lib.rs
+++ b/src/brimstone_serialized_heap/src/lib.rs
@@ -1,0 +1,12 @@
+mod generated_serialized_heap {
+    include!(concat!(env!("OUT_DIR"), "/generated_serialized_heap.rs"));
+}
+
+use brimstone_core::common::serialized_heap::set_default_serialized_heap;
+
+/// Initialize the default serialized heap. Must be called before a Context is created.
+///
+/// Can be safely called any number of times.
+pub fn init() {
+    set_default_serialized_heap(generated_serialized_heap::SERIALIZED_HEAP);
+}

--- a/src/js/common/mod.rs
+++ b/src/js/common/mod.rs
@@ -7,6 +7,7 @@ pub mod macros;
 pub mod math;
 pub mod memory;
 pub mod options;
+pub mod serialized_heap;
 pub mod terminal;
 pub mod time;
 pub mod unicode;

--- a/src/js/common/serialized_heap.rs
+++ b/src/js/common/serialized_heap.rs
@@ -1,0 +1,33 @@
+use std::sync::OnceLock;
+
+/// A serialized version of the heap containing enough information to initialize a new heap from.
+///
+/// Non-owning, references a `HeapSerializer` with lifetime `'a`.
+pub struct SerializedHeap<'a> {
+    /// Copy of the heap's semispaces with pointers rewritten to offsets. Contains the full
+    /// permanent semispace, and only the used portion of the current semispace.
+    pub permanent_space: SerializedSemispace<'a>,
+    pub current_space: SerializedSemispace<'a>,
+    /// Offsets of all roots to the heap, in traversal order
+    pub root_offsets: &'a [usize],
+}
+
+/// The serialized form of an individual semispace.
+pub struct SerializedSemispace<'a> {
+    /// Compressed bytes of the serialized semispace
+    pub bytes: &'a [u8],
+    /// Start offset of the semispace, relative to the heap start
+    pub start_offset: usize,
+}
+
+static DEFAULT_SERIALIZED_HEAP: OnceLock<Option<SerializedHeap<'static>>> = OnceLock::new();
+
+/// Get the current default serialized heap, if it has been set.
+pub fn get_default_serialized_heap() -> Option<&'static SerializedHeap<'static>> {
+    DEFAULT_SERIALIZED_HEAP.get().unwrap_or(&None).as_ref()
+}
+
+/// Set the heap to use as the default serialized heap.
+pub fn set_default_serialized_heap(serialized_heap: SerializedHeap<'static>) {
+    let _ = DEFAULT_SERIALIZED_HEAP.set(Some(serialized_heap));
+}

--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -1,6 +1,8 @@
 use crate::handle_scope_guard;
 
-use super::{context::Context, property_key::PropertyKey, value::SymbolValue, Handle};
+use super::{
+    context::Context, gc::HeapVisitor, property_key::PropertyKey, value::SymbolValue, Handle,
+};
 
 // All built-in string property keys referenced in the spec
 macro_rules! builtin_names {
@@ -27,6 +29,12 @@ macro_rules! builtin_names {
                     Handle::<PropertyKey>::from_fixed_non_heap_ptr(&self.$rust_name)
                 }
             )*
+
+            pub fn visit_roots(&mut self, visitor: &mut impl HeapVisitor) {
+                $(
+                    visitor.visit_property_key(&mut self.$rust_name);
+                )*
+            }
         }
 
         impl Context {
@@ -482,6 +490,12 @@ macro_rules! builtin_symbols {
                     Handle::<PropertyKey>::from_fixed_non_heap_ptr(&self.$rust_name)
                 }
             )*
+
+            pub fn visit_roots(&mut self, visitor: &mut impl HeapVisitor) {
+                $(
+                    visitor.visit_property_key(&mut self.$rust_name);
+                )*
+            }
         }
 
         impl Context {

--- a/src/js/runtime/gc/garbage_collector.rs
+++ b/src/js/runtime/gc/garbage_collector.rs
@@ -75,7 +75,7 @@ impl GarbageCollector {
         let mut gc = Self::new(cx);
 
         // First visit roots in the context and copy their objects to the to-heap
-        cx.visit_roots(&mut gc);
+        cx.visit_roots_for_gc(&mut gc);
 
         // Then visit all the roots in the permanent heap and copy their objects to the to-heap
         gc.visit_permanent_heap_roots();

--- a/src/js/runtime/gc/heap_object.rs
+++ b/src/js/runtime/gc/heap_object.rs
@@ -30,13 +30,35 @@ where
 }
 
 pub trait HeapVisitor {
-    fn visit(&mut self, ptr: &mut HeapPtr<HeapItem>);
+    /// Visit a strongly held pointer.
+    fn visit(&mut self, ptr: &mut HeapPtr<HeapItem>) {
+        self.visit_common(ptr);
+    }
 
+    /// Visit a weakly held pointer.
+    fn visit_weak(&mut self, ptr: &mut HeapPtr<HeapItem>) {
+        self.visit_common(ptr);
+    }
+
+    /// Visit any pointer (which may be either strong or weak).
+    fn visit_common(&mut self, _ptr: &mut HeapPtr<HeapItem>) {}
+
+    /// Visit a pointer a Rust vtable.
+    fn visit_rust_vtable_pointer(&mut self, _ptr: &mut *const ()) {}
+
+    /// Visit a strongly held pointer of any type.
     #[inline]
     fn visit_pointer<T>(&mut self, ptr: &mut HeapPtr<T>) {
         unsafe { self.visit(transmute::<&mut HeapPtr<T>, &mut HeapPtr<HeapItem>>(ptr)) };
     }
 
+    /// Visit a weakly held pointer of any type.
+    #[inline]
+    fn visit_weak_pointer<T>(&mut self, ptr: &mut HeapPtr<T>) {
+        unsafe { self.visit_weak(transmute::<&mut HeapPtr<T>, &mut HeapPtr<HeapItem>>(ptr)) };
+    }
+
+    /// Visit an optional strongly held pointer.
     #[inline]
     fn visit_pointer_opt<T>(&mut self, ptr: &mut Option<HeapPtr<T>>) {
         if ptr.is_some() {
@@ -46,6 +68,7 @@ pub trait HeapVisitor {
         }
     }
 
+    /// Visit a strongly held value.
     #[inline]
     fn visit_value(&mut self, value: &mut Value) {
         if value.is_pointer() {
@@ -53,6 +76,15 @@ pub trait HeapVisitor {
         }
     }
 
+    /// Visit a weakly held value.
+    #[inline]
+    fn visit_weak_value(&mut self, value: &mut Value) {
+        if value.is_pointer() {
+            unsafe { self.visit_weak(transmute::<&mut Value, &mut HeapPtr<HeapItem>>(value)) };
+        }
+    }
+
+    /// Visit a strongly held property key.
     #[inline]
     fn visit_property_key(&mut self, property_key: &mut PropertyKey) {
         unsafe { self.visit_value(transmute::<&mut PropertyKey, &mut Value>(property_key)) };

--- a/src/js/runtime/gc/heap_serializer.rs
+++ b/src/js/runtime/gc/heap_serializer.rs
@@ -1,0 +1,257 @@
+/// A Context along with its heap can be converted to a serialized form and then deserialized back
+/// later. This allows for embedding an entire pre-initialized heap with all builtin objects into
+/// the binary itself, then initializing a Context from the serialized heap at runtime.
+///
+/// The serialization strategy is described below:
+///
+/// The serialized form of the heap has all absolute pointers rewritten as offsets from the start of
+/// the heap. In addition all root pointers in the Context must also have been rewritten as offsets.
+/// To deserialize we simply traverse the heap and root pointers and rewrite back to an absolute
+/// pointer by adding the base pointer of the heap. Roots offsets are saved in a vector following
+/// traversal order which is the same during serialization and deserialization.
+///
+/// There are also some non-heap pointers contained within the heap, namely Rust vtable pointers
+/// for dynamic dispatch. These are serialized to their RustVtable enum value and then
+/// deserialized to the true value of the vtable pointer in the loaded program.
+use crate::{
+    common::serialized_heap::{SerializedHeap, SerializedSemispace},
+    runtime::{
+        object_descriptor::ObjectDescriptor,
+        rust_vtables::{get_vtable, lookup_vtable_enum, RustVtable},
+        Context, Value,
+    },
+};
+
+use super::{Heap, HeapItem, HeapPtr, HeapVisitor};
+
+pub struct HeapSerializer {
+    cx: Context,
+    /// Copy of a slice of the heap's semispaces, will have pointers rewritten to offsets.
+    permanent_space: Vec<u8>,
+    current_space: Vec<u8>,
+    /// Offsets of all roots to the heap, in traversal order.
+    roots: Vec<usize>,
+    /// Base pointer for the heap. Offset of all pointers is calculated relative to this.
+    base: *const u8,
+    /// Whether we are collecting roots, and should collect each offset in the roots list.
+    is_collecting_roots: bool,
+}
+
+enum Space {
+    Permanent,
+    Current,
+}
+
+impl HeapSerializer {
+    fn new(cx: Context) -> Self {
+        // Copy the semispace slices to be serialized
+        let permanent_space = cx.heap.permanent_heap().to_owned();
+        let current_space = cx.heap.current_used_heap().to_owned();
+
+        Self {
+            cx,
+            permanent_space,
+            current_space,
+            roots: vec![],
+            base: cx.heap.heap_start(),
+            is_collecting_roots: false,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn serialize(mut cx: Context) -> Self {
+        // Clear the WTF-8 to interned string cache, since it is transient
+        cx.interned_strings.generator_cache_mut().clear();
+
+        // First run a GC to only serialize live data in heap
+        Heap::run_gc(cx);
+
+        // Then must ensure that the current semispace is adjacent to the permanent semispace,
+        // running another GC if necessary to swap the semispaces.
+        if !cx.heap.is_current_before_next() {
+            Heap::run_gc(cx);
+        }
+
+        let mut serializer = Self::new(cx);
+
+        // Visit all roots in order, rewriting pointers to be offsets from the start of the heap
+        // and collecting the offsets in traversal order.
+        serializer.collect_roots();
+
+        // Then rewrite pointers to offsets in all copied semispaces
+        serializer.rewrite_pointers_to_offsets_in_space(Space::Permanent);
+        serializer.rewrite_pointers_to_offsets_in_space(Space::Current);
+
+        serializer
+    }
+
+    fn collect_roots(&mut self) {
+        self.is_collecting_roots = true;
+        self.cx.clone().visit_roots_for_serialization(self);
+        self.is_collecting_roots = false;
+    }
+
+    /// Traverse a slice of a semispace, rewriting all pointers to be offsets from the heap start.
+    fn rewrite_pointers_to_offsets_in_space(&mut self, space: Space) {
+        let space = match space {
+            Space::Permanent => &mut self.permanent_space,
+            Space::Current => &mut self.current_space,
+        };
+
+        let space_len = space.len();
+        let space_start_ptr = space.as_mut_ptr();
+
+        let mut item_offset = 0;
+        while item_offset < space_len {
+            // Start of an object - cast to HeapItem and rewrite its pointers to be offsets from the
+            // start of the heap.
+            let item_ptr = unsafe { space_start_ptr.add(item_offset) };
+            let mut heap_item = HeapPtr::from_ptr(item_ptr).cast::<HeapItem>();
+            let kind = heap_item.descriptor().kind();
+
+            heap_item.visit_pointers_for_kind(self, kind);
+
+            // Increment fix pointer to point to next new heap object
+            item_offset += Heap::alloc_size_for_request_size(heap_item.byte_size_for_kind(kind));
+        }
+    }
+
+    pub fn as_serialized(&self) -> SerializedHeap {
+        let permanent_start = self.cx.heap.permanent_heap_bounds().0;
+        let current_start = self.cx.heap.current_used_heap_bounds().0;
+
+        let permanent_offset = permanent_start as usize - self.base as usize;
+        let current_offset = current_start as usize - self.base as usize;
+
+        SerializedHeap {
+            permanent_space: SerializedSemispace {
+                bytes: self.permanent_space.as_slice(),
+                start_offset: permanent_offset,
+            },
+            current_space: SerializedSemispace {
+                bytes: self.current_space.as_slice(),
+                start_offset: current_offset,
+            },
+            root_offsets: self.roots.as_slice(),
+        }
+    }
+}
+
+impl HeapVisitor for HeapSerializer {
+    fn visit_common(&mut self, ptr: &mut HeapPtr<HeapItem>) {
+        // Find the pointer's offset from the start of the heap
+        let offset = ptr.as_ptr() as usize - self.base as usize;
+
+        if self.is_collecting_roots {
+            // When collecting roots do not modify the Context's pointers
+            self.roots.push(offset);
+        } else {
+            // Rewrite the pointer if within the heap
+            *ptr = HeapPtr::from_ptr(offset as *mut HeapItem);
+        }
+    }
+
+    fn visit_rust_vtable_pointer(&mut self, ptr: &mut *const ()) {
+        // Rust vtable pointers are replaced with their enum value
+        let enum_value = lookup_vtable_enum(*ptr).unwrap();
+        *ptr = enum_value as usize as *const ();
+    }
+}
+
+pub struct HeapSpaceDeserializer {
+    /// Base pointer for the heap. Offset of all pointers is calculated relative to this.
+    base: *const u8,
+}
+
+impl HeapSpaceDeserializer {
+    fn new(cx: Context) -> Self {
+        Self { base: cx.heap.heap_start() }
+    }
+
+    pub fn deserialize(cx: Context, bytes: &mut [u8]) {
+        let mut deserializer = Self::new(cx);
+
+        let mut item_offset = 0;
+        while item_offset < bytes.len() {
+            // Start of an object is a descriptor pointer, encoded as an offset;
+            let heap_item_ptr = unsafe { bytes.as_mut_ptr().add(item_offset) };
+
+            // Decode the descriptor and read its kind
+            let descriptor_offset = unsafe { *heap_item_ptr.cast::<usize>() };
+            let descriptor_ptr = unsafe {
+                deserializer
+                    .base
+                    .add(descriptor_offset)
+                    .cast::<ObjectDescriptor>()
+            };
+            let descriptor_kind = unsafe { (*descriptor_ptr).kind() };
+
+            let mut heap_item = HeapPtr::from_ptr(heap_item_ptr).cast::<HeapItem>();
+            heap_item.visit_pointers_for_kind(&mut deserializer, descriptor_kind);
+
+            // Increment fix pointer to point to next new heap object
+            let byte_size = heap_item.byte_size_for_kind(descriptor_kind);
+            item_offset += Heap::alloc_size_for_request_size(byte_size);
+        }
+    }
+}
+
+impl HeapVisitor for HeapSpaceDeserializer {
+    fn visit_common(&mut self, ptr: &mut HeapPtr<HeapItem>) {
+        // Decode by adding the heap base pointer to each stored offset
+        let decoded_ptr = unsafe { self.base.add(ptr.as_ptr() as usize) };
+        *ptr = HeapPtr::from_ptr(decoded_ptr as *mut HeapItem);
+    }
+
+    fn visit_rust_vtable_pointer(&mut self, ptr: &mut *const ()) {
+        // Rust vtable pointers were encoded as their enum value, so lookup the true vtable pointer
+        let enum_value = unsafe { std::mem::transmute::<u8, RustVtable>(*ptr as usize as u8) };
+        *ptr = get_vtable(enum_value);
+    }
+}
+
+pub struct HeapRootsDeserializer<'a> {
+    /// Base pointer for the heap. Offset of all pointers is calculated relative to this.
+    base: *const u8,
+    /// Index of the next root to deserialize.
+    root_index: usize,
+    /// Offsets of all roots to the heap, in traversal order.
+    root_offsets: &'a [usize],
+}
+
+impl<'a> HeapRootsDeserializer<'a> {
+    fn new(cx: Context, serialized: &'a SerializedHeap) -> Self {
+        Self {
+            base: cx.heap.heap_start(),
+            root_index: 0,
+            root_offsets: serialized.root_offsets,
+        }
+    }
+
+    pub fn deserialize(mut cx: Context, serialized: &'a SerializedHeap) {
+        let mut deserializer = Self::new(cx, serialized);
+        cx.visit_roots_for_serialization(&mut deserializer);
+
+        // Make sure that the correct number of roots were deserialized
+        debug_assert!(deserializer.root_index == serialized.root_offsets.len());
+    }
+}
+
+impl HeapVisitor for HeapRootsDeserializer<'_> {
+    fn visit_common(&mut self, ptr: &mut HeapPtr<HeapItem>) {
+        // Find the next root offset in traversal order and decode it
+        let root_offset = self.root_offsets[self.root_index];
+        let root_ptr = unsafe { self.base.add(root_offset).cast::<HeapItem>() };
+
+        *ptr = HeapPtr::from_ptr(root_ptr.cast_mut());
+
+        self.root_index += 1;
+    }
+
+    fn visit_value(&mut self, value: &mut Value) {
+        // All values should be rewritten regardless of whether they are pointers, since only
+        // pointers were visited when serializing. This includes uninitialized values which may be
+        // represented as the empty value.
+        unsafe { self.visit(std::mem::transmute::<&mut Value, &mut HeapPtr<HeapItem>>(value)) };
+    }
+}

--- a/src/js/runtime/gc/heap_trait_object.rs
+++ b/src/js/runtime/gc/heap_trait_object.rs
@@ -47,6 +47,7 @@ macro_rules! heap_trait_object {
             #[allow(dead_code)]
             pub fn visit_pointers(&mut self, visitor: &mut impl $crate::runtime::gc::HeapVisitor) {
                 visitor.visit_pointer(&mut self.data);
+                visitor.visit_rust_vtable_pointer(&mut self.vtable);
             }
         }
 

--- a/src/js/runtime/gc/mod.rs
+++ b/src/js/runtime/gc/mod.rs
@@ -3,6 +3,7 @@ mod handle;
 mod heap;
 mod heap_item;
 mod heap_object;
+mod heap_serializer;
 mod heap_trait_object;
 mod pointer;
 
@@ -12,4 +13,6 @@ pub use handle::{
 pub use heap::{Heap, HeapInfo};
 pub use heap_item::HeapItem;
 pub use heap_object::{HeapObject, HeapVisitor, IsHeapObject};
+#[allow(unused)]
+pub use heap_serializer::{HeapRootsDeserializer, HeapSerializer};
 pub use pointer::HeapPtr;

--- a/src/js/runtime/interned_strings.rs
+++ b/src/js/runtime/interned_strings.rs
@@ -115,7 +115,10 @@ impl InternedStrings {
     pub fn visit_roots(&mut self, visitor: &mut impl HeapVisitor) {
         visitor.visit_pointer(&mut self.strings);
 
-        // Intentionally do not visit generator cache as all heap strings are weak references
+        // Interned strings are weak references
+        for (_, string) in self.generator_cache.iter_mut() {
+            visitor.visit_weak_pointer(string);
+        }
     }
 }
 
@@ -144,6 +147,9 @@ impl InternedStringsSetField {
     pub fn visit_pointers(set: &mut HeapPtr<InternedStringsSet>, visitor: &mut impl HeapVisitor) {
         set.visit_pointers(visitor);
 
-        // Intentionally do not visit interned strings as they are treated as weak references
+        // Interned strings are weak references
+        for string in set.iter_mut_gc_unsafe() {
+            visitor.visit_weak_pointer(string);
+        }
     }
 }

--- a/src/js/runtime/intrinsics/finalization_registry_object.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_object.rs
@@ -241,7 +241,11 @@ impl HeapObject for HeapPtr<FinalizationRegistryCells> {
             if let Some(cell) = self.cells.get_unchecked_mut(i) {
                 visitor.visit_value(&mut cell.held_value);
 
-                // Intentionally do not visit target and unregister_token
+                visitor.visit_weak_value(&mut cell.target);
+
+                if let Some(unregister_token) = cell.unregister_token.as_mut() {
+                    visitor.visit_weak_value(unregister_token);
+                }
             }
         }
     }

--- a/src/js/runtime/intrinsics/weak_map_object.rs
+++ b/src/js/runtime/intrinsics/weak_map_object.rs
@@ -115,6 +115,9 @@ impl WeakMapObjectMapField {
     pub fn visit_pointers(map: &mut HeapPtr<WeakValueMap>, visitor: &mut impl HeapVisitor) {
         map.visit_pointers(visitor);
 
-        // Intentionally do not visit entries
+        for (key, value) in map.iter_mut_gc_unsafe() {
+            visitor.visit_weak_value(key.value_mut());
+            visitor.visit_weak_value(value);
+        }
     }
 }

--- a/src/js/runtime/intrinsics/weak_ref_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_ref_constructor.rs
@@ -132,7 +132,8 @@ impl HeapObject for HeapPtr<WeakRefObject> {
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
         self.visit_object_pointers(visitor);
+        visitor.visit_weak_value(&mut self.weak_ref_target);
 
-        // Intentionally do not visit weak_ref_target and next_weak_ref
+        // Intentionally do not visit next_weak_ref
     }
 }

--- a/src/js/runtime/intrinsics/weak_set_object.rs
+++ b/src/js/runtime/intrinsics/weak_set_object.rs
@@ -115,6 +115,8 @@ impl WeakSetObjectSetField {
     pub fn visit_pointers(set: &mut HeapPtr<WeakValueSet>, visitor: &mut impl HeapVisitor) {
         set.visit_pointers(visitor);
 
-        // Intentionally do not visit elements
+        for value in set.iter_mut_gc_unsafe() {
+            visitor.visit_weak_value(value.value_mut());
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,9 @@ fn evaluate(mut cx: Context, args: &Args) -> BsResult<()> {
 
 /// Wrapper to pretty print errors
 fn main() {
+    // Global initialization
+    brimstone_serialized_heap::init();
+
     let args = Args::parse();
     let cx = create_context(&args);
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dev-dependencies]
 brimstone_core.workspace = true
+brimstone_serialized_heap.workspace = true
 
 [[test]]
 name = "snapshot_tests"

--- a/tests/harness/Cargo.toml
+++ b/tests/harness/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 
 [dependencies]
 brimstone_core.workspace = true
+brimstone_serialized_heap.workspace = true
 
 clap = { workspace = true, features = ["derive"] }
 regex.workspace = true

--- a/tests/harness/src/main.rs
+++ b/tests/harness/src/main.rs
@@ -66,6 +66,9 @@ struct Args {
 }
 
 fn main_impl() -> GenericResult {
+    // Global initialization
+    brimstone_serialized_heap::init();
+
     let args = Args::parse();
 
     let manifest_path = args

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -37,12 +37,18 @@ struct TestEnv {
     errors: Vec<String>,
 }
 
+fn init() {
+    brimstone_serialized_heap::init();
+}
+
 fn get_test_root(dirname: &str) -> PathBuf {
     std::env::current_dir().unwrap().join(dirname)
 }
 
 #[test]
 fn js_parser_snapshot_tests() -> GenericResult<()> {
+    init();
+
     let parser_tests_dir = get_test_root("js_parser");
     run_snapshot_tests(&parser_tests_dir, &mut |path| print_ast(path))
 }
@@ -60,6 +66,8 @@ fn print_ast(path: &str) -> GenericResult<String> {
 
 #[test]
 fn js_error_snapshot_tests() -> GenericResult<()> {
+    init();
+
     let error_tests_dir = get_test_root("js_error");
     run_snapshot_tests(&error_tests_dir, &mut |path| print_error(path))
 }
@@ -89,12 +97,16 @@ fn print_error(path: &str) -> GenericResult<String> {
 
 #[test]
 fn js_bytecode_snapshot_tests() -> GenericResult<()> {
+    init();
+
     let bytecode_tests_dir = get_test_root("js_bytecode");
     run_snapshot_tests(&bytecode_tests_dir, &mut |path| print_bytecode(path))
 }
 
 #[test]
 fn js_regexp_bytecode_snapshot_tests() -> GenericResult<()> {
+    init();
+
     let regexp_bytecode_tests_dir = get_test_root("js_regexp_bytecode");
     run_snapshot_tests(&regexp_bytecode_tests_dir, &mut |path| print_regexp_bytecode(path))
 }


### PR DESCRIPTION
## Summary

Starting up the VM requires creating creating a heap and then initializing a large number of objects to create all builtins. We can greatly speed this up by initializing from a serialized version of the heap instead of actually running all this builtin setup logic. This serialized heap is generated at compile time and embedded in the binary itself. The serialied heap to use is set in the `Options`.

The serialized form of the heap has all absolute pointers rewritten as offsets from the start of the heap. In addition all root pointers in the `Context` must also have been rewritten as offsets. To deserialize we simply traverse the heap and root pointers and rewrite back to an absolute pointer by adding the base pointer of the heap. Roots offsets are saved in a vector following traversal order which is the same during serialization and deserialization. We also now visit weak pointers during generic `HeapVisitor` traversal so that they can be rewritten during serialization/deserialization.

There are also some non-heap pointers contained within the heap, namely Rust vtable pointers for dynamic dispatch. These are serialized to their `RustVtable` enum value and then deserialized to the true value of the vtable pointer in the loaded program. We also now must visit these Rust vtable pointers during generic `HeapVisitor` traversal.

Embedding the serialized heap requires some changes to the build and module system. The core library (aka the `common`, `parser`, and `runtime` directories) have been converted into a `brimstone_core` crate, which is consumed by the `brimstone` executable crate. There is a new `brimstone_serialized_heap` crate which provides the default serialized heap, which can be set as the default with `brimstone_serialized_heap::init()`. The `brimstone_serialized_heap` crate contains a `build.rs` script to create a Context using `brimstone_core` as a build dependency, serializes it, then writes the serialized heap into a codegenned file which is used by the crate.

This significantly improves startup time.
- A benchmark comparing manual `Context` initialization vs initializing a `Context` from the embedded serialized form found a 90.6 vs 35.4 ms runtime, or a 61% reduction
- Running all test262 and integration tests with `brimstone-test -r` went from to 5.24 to 4.31 seconds, an 18% reduction


## Test Plan

All tests pass. Added a benchmark test for initializing the Context from a serialized heap.