### PR TITLE
[parser] Refactor parser to have no dependencies on runtime modules

### DIFF
--- a/src/js/common/mod.rs
+++ b/src/js/common/mod.rs
@@ -8,6 +8,8 @@ pub mod math;
 pub mod memory;
 pub mod options;
 pub mod serialized_heap;
+pub mod string;
+pub mod string_iterators;
 pub mod terminal;
 pub mod time;
 pub mod unicode;

--- a/src/js/common/string.rs
+++ b/src/js/common/string.rs
@@ -1,0 +1,7 @@
+/// Strings are represented as a sequence of u8s representing code points or a sequence of u16s
+/// representing code units.
+#[derive(Clone, Copy, PartialEq)]
+pub enum StringWidth {
+    OneByte,
+    TwoByte,
+}

--- a/src/js/common/string_iterators.rs
+++ b/src/js/common/string_iterators.rs
@@ -1,0 +1,254 @@
+use super::{
+    string::StringWidth,
+    unicode::{
+        code_point_from_surrogate_pair, is_high_surrogate_code_unit, is_low_surrogate_code_unit,
+        CodePoint, CodeUnit,
+    },
+};
+
+/// Methods necessary to treat as a peekable stream of code units.
+pub trait GenericCodeUnitIterator: Iterator<Item = CodeUnit> {
+    fn peek(&self) -> Option<Self::Item>;
+}
+
+/// An iterator over the code units of a string. Is not GC-safe.
+#[derive(Clone)]
+pub struct CodeUnitIterator {
+    ptr: *const u8,
+    end: *const u8,
+    width: StringWidth,
+}
+
+impl CodeUnitIterator {
+    pub fn new_one_byte(ptr: *const u8, end: *const u8) -> Self {
+        CodeUnitIterator { ptr, end, width: StringWidth::OneByte }
+    }
+
+    pub fn new_two_byte(ptr: *const u16, end: *const u16) -> Self {
+        CodeUnitIterator {
+            ptr: ptr as *const u8,
+            end: end as *const u8,
+            width: StringWidth::TwoByte,
+        }
+    }
+
+    pub fn from_raw_one_byte_slice(slice: &[u8]) -> Self {
+        let range = slice.as_ptr_range();
+        Self::new_one_byte(range.start, range.end)
+    }
+
+    pub fn from_raw_two_byte_slice(slice: &[CodeUnit]) -> Self {
+        let range = slice.as_ptr_range();
+        Self::new_two_byte(range.start, range.end)
+    }
+
+    #[inline]
+    pub fn is_end(&self) -> bool {
+        std::ptr::eq(self.ptr, self.end)
+    }
+
+    pub fn ptr(&self) -> *const u8 {
+        self.ptr
+    }
+
+    pub fn ptr_back(&self) -> *const u8 {
+        self.end
+    }
+
+    pub fn width(&self) -> StringWidth {
+        self.width
+    }
+
+    #[inline]
+    pub fn consume_equals(&mut self, other: &mut CodeUnitIterator) -> bool {
+        loop {
+            match (self.next(), other.next()) {
+                (None, None) => return true,
+                (None, Some(_)) | (Some(_), None) => return false,
+                (Some(code_unit_1), Some(code_unit_2)) => {
+                    if code_unit_1 != code_unit_2 {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn peek_back(&self) -> Option<CodeUnit> {
+        if self.is_end() {
+            None
+        } else {
+            unsafe {
+                if self.width == StringWidth::OneByte {
+                    Some(self.end.sub(1).read() as u16)
+                } else {
+                    Some((self.end.sub(2) as *const u16).read())
+                }
+            }
+        }
+    }
+}
+
+impl Iterator for CodeUnitIterator {
+    type Item = CodeUnit;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.is_end() {
+            None
+        } else {
+            unsafe {
+                if self.width == StringWidth::OneByte {
+                    let item = self.ptr.read() as u16;
+                    self.ptr = self.ptr.add(1);
+                    Some(item)
+                } else {
+                    let item = (self.ptr as *const u16).read();
+                    self.ptr = (self.ptr as *const u16).add(1) as *const u8;
+                    Some(item)
+                }
+            }
+        }
+    }
+}
+
+impl DoubleEndedIterator for CodeUnitIterator {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.is_end() {
+            None
+        } else {
+            unsafe {
+                if self.width == StringWidth::OneByte {
+                    self.end = self.end.sub(1);
+                    Some(self.end.read() as u16)
+                } else {
+                    self.end = self.end.sub(2);
+                    Some((self.end as *const u16).read())
+                }
+            }
+        }
+    }
+}
+
+impl GenericCodeUnitIterator for CodeUnitIterator {
+    fn peek(&self) -> Option<CodeUnit> {
+        if self.is_end() {
+            None
+        } else {
+            unsafe {
+                if self.width == StringWidth::OneByte {
+                    Some(self.ptr.read() as u16)
+                } else {
+                    Some((self.ptr as *const u16).read())
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct GenericCodePointIterator<I: GenericCodeUnitIterator> {
+    iter: I,
+}
+
+impl<I: GenericCodeUnitIterator> GenericCodePointIterator<I> {
+    pub fn new(iter: I) -> Self {
+        Self { iter }
+    }
+
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.iter
+    }
+
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.iter
+    }
+}
+
+impl<I: GenericCodeUnitIterator> Iterator for GenericCodePointIterator<I> {
+    type Item = CodePoint;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.iter.next() {
+            None => None,
+            Some(code_unit) => {
+                // High surrogate may be followed by a low surrogate, in which case the surrogate
+                // pair encodes the full code point.
+                if is_high_surrogate_code_unit(code_unit) {
+                    match self.iter.peek() {
+                        Some(next_code_unit) if is_low_surrogate_code_unit(next_code_unit) => {
+                            self.iter.next();
+                            Some(code_point_from_surrogate_pair(code_unit, next_code_unit))
+                        }
+                        // High surrogate was not the start of a surrogate pair so return it directly
+                        _ => Some(code_unit as CodePoint),
+                    }
+                } else {
+                    // Both non-surrogate and high surrogate code points are returned directly as
+                    // they are not the start of a surrogate pair.
+                    Some(code_unit as CodePoint)
+                }
+            }
+        }
+    }
+}
+
+/// An iterator over the code points of a string. Is not GC-safe.
+pub type CodePointIterator = GenericCodePointIterator<CodeUnitIterator>;
+
+impl CodePointIterator {
+    pub fn new_one_byte(ptr: *const u8, end: *const u8) -> Self {
+        Self::new(CodeUnitIterator::new_one_byte(ptr, end))
+    }
+
+    pub fn new_two_byte(ptr: *const u16, end: *const u16) -> Self {
+        Self::new(CodeUnitIterator::new_two_byte(ptr, end))
+    }
+
+    pub fn from_raw_one_byte_slice(slice: &[u8]) -> Self {
+        Self::new(CodeUnitIterator::from_raw_one_byte_slice(slice))
+    }
+
+    pub fn from_raw_two_byte_slice(slice: &[CodeUnit]) -> Self {
+        Self::new(CodeUnitIterator::from_raw_two_byte_slice(slice))
+    }
+
+    pub fn ptr(&self) -> *const u8 {
+        self.iter.ptr()
+    }
+
+    pub fn ptr_back(&self) -> *const u8 {
+        self.iter.ptr_back()
+    }
+
+    pub fn width(&self) -> StringWidth {
+        self.iter.width()
+    }
+}
+
+impl DoubleEndedIterator for CodePointIterator {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self.iter.next_back() {
+            None => None,
+            Some(code_unit) => {
+                // Low surrogate may follow a high surrogate, in which case the surrogate pair
+                // encodes the full code point.
+                if is_low_surrogate_code_unit(code_unit) {
+                    match self.iter.peek_back() {
+                        Some(prev_code_unit) if is_high_surrogate_code_unit(prev_code_unit) => {
+                            self.iter.next();
+                            Some(code_point_from_surrogate_pair(prev_code_unit, code_unit))
+                        }
+                        // Low surrogate was not the start of a surrogate pair so return it directly
+                        _ => Some(code_unit as CodePoint),
+                    }
+                } else {
+                    // Both non-surrogate and low surrogate code points are returned directly as
+                    // they are not the start of a surrogate pair.
+                    Some(code_unit as CodePoint)
+                }
+            }
+        }
+    }
+}

--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -7,7 +7,6 @@ use allocator_api2::alloc::Global;
 
 use crate::{
     common::wtf_8::{Wtf8Cow, Wtf8Str},
-    must,
     parser::{
         parse_error::InvalidDuplicateParametersReason,
         scope_tree::{VMLocation, ARGUMENTS_NAME},
@@ -1462,13 +1461,11 @@ impl<'a> Analyzer<'a> {
             }
 
             // Check for invalid names depending on context
-            must!(declaration.iter_bound_names(&mut |id| {
+            declaration.iter_bound_names(&mut |id| {
                 if var_decl.kind != VarKind::Var && id.name == "let" {
                     self.emit_error(id.loc, ParseError::LetNameInLexicalDeclaration);
                 }
-
-                Ok(())
-            }));
+            });
         }
 
         default_visit_variable_declaration(self, var_decl);

--- a/src/js/parser/lexer_stream.rs
+++ b/src/js/parser/lexer_stream.rs
@@ -1,11 +1,11 @@
 use std::rc::Rc;
 
-use crate::{
-    common::unicode::{
+use crate::common::{
+    string_iterators::{CodePointIterator, CodeUnitIterator},
+    unicode::{
         code_point_from_surrogate_pair, decode_wtf8_codepoint, is_ascii,
         is_high_surrogate_code_unit, is_low_surrogate_code_unit, needs_surrogate_pair, CodeUnit,
     },
-    runtime::string_value::{CodePointIterator, CodeUnitIterator},
 };
 
 use super::{
@@ -235,7 +235,7 @@ impl LexerStream for Utf8LexerStream<'_> {
     #[allow(refining_impl_trait)]
     fn iter_slice<'b>(&self, _: Pos, _: Pos) -> impl 'b + DoubleEndedIterator<Item = u32> {
         // Stub implementation
-        CodePointIterator::from_raw_one_byte_slice(&[])
+        [].iter().copied()
     }
 
     fn slice(&self, _: Pos, _: Pos) -> &[u8] {

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -755,10 +755,9 @@ impl<'a> Parser<'a> {
     }
 
     fn set_binding_init_pos(pattern: &Pattern, pos: Pos) {
-        let _ = pattern.iter_bound_names(&mut |id| {
+        pattern.iter_bound_names(&mut |id| {
             Self::set_id_binding_init_pos(id, pos);
-            Ok(())
-        });
+        })
     }
 
     fn set_id_binding_init_pos(id: &Identifier, pos: Pos) {

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -5,6 +5,7 @@ use bumpalo::Bump;
 
 use crate::{
     common::{
+        string::StringWidth,
         unicode::{
             is_ascii_alphabetic, is_decimal_digit, is_latin1, is_newline, is_surrogate_code_point,
             is_whitespace,
@@ -34,7 +35,7 @@ use crate::{
         ordinary_object::object_create_from_constructor,
         realm::Realm,
         regexp::{compiled_regexp::CompiledRegExpObject, compiler::compile_regexp},
-        string_value::{StringValue, StringWidth},
+        string_value::StringValue,
         to_string,
         type_utilities::{is_regexp, same_value},
         Context, HeapPtr, PropertyDescriptor, Value,

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use crate::{
     common::{
         icu::ICU,
+        string::StringWidth,
         unicode::{
             is_decimal_digit, is_high_surrogate_code_unit, is_low_surrogate_code_unit, CodePoint,
         },
@@ -27,7 +28,7 @@ use crate::{
         object_value::ObjectValue,
         realm::Realm,
         string_object::StringObject,
-        string_value::{CodePointIterator, FlatString, StringValue, StringWidth},
+        string_value::{FlatString, StringValue, UnsafeCodePointIterator},
         to_string,
         type_utilities::{
             is_callable, is_regexp, require_object_coercible, to_integer_or_infinity, to_length,
@@ -1473,14 +1474,14 @@ fn to_valid_string_parts(string: HeapPtr<FlatString>) -> Vec<StringPart> {
     }
 }
 
-/// Wrapper around CodePointIterator that returns chars. Must only be created for CodePointIterators
-/// over valid unicode code points.
+/// Wrapper around UnsafeCodePointIterator that returns chars. Must only be created for an
+/// UnsafeCodePointIterator over valid unicode code points.
 struct CharIterator {
-    iter: CodePointIterator,
+    iter: UnsafeCodePointIterator,
 }
 
 impl CharIterator {
-    pub fn new(iter: CodePointIterator) -> Self {
+    pub fn new(iter: UnsafeCodePointIterator) -> Self {
         Self { iter }
     }
 }

--- a/src/js/runtime/regexp/matcher.rs
+++ b/src/js/runtime/regexp/matcher.rs
@@ -1,17 +1,14 @@
 use crate::{
     common::{
         icu::ICU,
+        string::StringWidth,
         unicode::{is_newline, CodePoint},
     },
     parser::lexer_stream::{
         HeapOneByteLexerStream, HeapTwoByteCodePointLexerStream, HeapTwoByteCodeUnitLexerStream,
         LexerStream, SavedLexerStreamState,
     },
-    runtime::{
-        regexp::instruction::OpCode,
-        string_value::{StringValue, StringWidth},
-        Handle, HeapPtr,
-    },
+    runtime::{regexp::instruction::OpCode, string_value::StringValue, Handle, HeapPtr},
 };
 
 use super::{

--- a/src/js/runtime/string_parsing.rs
+++ b/src/js/runtime/string_parsing.rs
@@ -3,8 +3,12 @@ use std::str::FromStr;
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 
-use crate::common::unicode::{
-    is_ascii_newline, is_ascii_whitespace, is_unicode_newline, is_unicode_whitespace, CodeUnit,
+use crate::common::{
+    string::StringWidth,
+    string_iterators::GenericCodeUnitIterator,
+    unicode::{
+        is_ascii_newline, is_ascii_whitespace, is_unicode_newline, is_unicode_whitespace, CodeUnit,
+    },
 };
 
 use super::{
@@ -12,12 +16,12 @@ use super::{
         year_month_day_to_days_since_unix_epoch, MAX_TIME_VALUE, MS_PER_DAY, MS_PER_HOUR,
         MS_PER_MINUTE, MS_PER_SECOND,
     },
-    string_value::{CodeUnitIterator, GenericCodeUnitIterator, StringValue, StringWidth},
+    string_value::{StringValue, UnsafeCodeUnitIterator},
     Handle,
 };
 
 pub struct StringLexer {
-    iter: CodeUnitIterator,
+    iter: UnsafeCodeUnitIterator,
     // Pointer to start of the previously read character (aka the character in the current field)
     prev_ptr: *const u8,
     current: Option<CodeUnit>,


### PR DESCRIPTION
## Summary

In preparation for breaking `brimstone_core` into separate crates we must break any cycles between these future crates. This PR removes any dependencies on runtime modules from the parser. This includes:

- Removing an unnecessary dependency on `EvalResult` in `iter_bound_names`
- Moving all string iteration utilities into the parser module, as they are needed by the generic `LexerStream`. This includes all one and two byte string iteration utilities over both code units and code points. The runtime `string_value` module now wraps these utilities in `UnsafeCodeUnitIterator` and `UnsafeCodePointIterator` to avoid duplicating code.

## Tests

All tests pass.