### PR TITLE
[runtime] Make random number generation deterministic during heap initialization

### DIFF
--- a/src/js/runtime/intrinsics/math_object.rs
+++ b/src/js/runtime/intrinsics/math_object.rs
@@ -510,8 +510,12 @@ impl MathObject {
     }
 
     /// Math.random (https://tc39.es/ecma262/#sec-math.random)
-    pub fn random(cx: Context, _: Handle<Value>, _: &[Handle<Value>]) -> EvalResult<Handle<Value>> {
-        let n = rand::thread_rng().gen::<f64>();
+    pub fn random(
+        mut cx: Context,
+        _: Handle<Value>,
+        _: &[Handle<Value>],
+    ) -> EvalResult<Handle<Value>> {
+        let n = cx.rand.gen::<f64>();
         Ok(cx.number(n))
     }
 

--- a/src/js/runtime/string_value.rs
+++ b/src/js/runtime/string_value.rs
@@ -103,6 +103,8 @@ impl StringValue {
         self.kind != StringKind::Concat
     }
 
+    /// Return the Context for this heap object. Only use when absolutely necessary - prefer to
+    /// instead explicitly pass in the Context.
     fn cx(&self) -> Context {
         HeapInfo::from_raw_heap_ptr(self as *const _).cx()
     }

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -567,7 +567,7 @@ pub struct SymbolValue {
 
 impl SymbolValue {
     pub fn new(
-        cx: Context,
+        mut cx: Context,
         description: Option<Handle<StringValue>>,
         is_private: bool,
     ) -> Handle<SymbolValue> {
@@ -576,7 +576,7 @@ impl SymbolValue {
 
         set_uninit!(symbol.descriptor, cx.base_descriptors.get(ObjectKind::Symbol));
         set_uninit!(symbol.description, description.map(|desc| *desc));
-        set_uninit!(symbol.hash_code, rand::thread_rng().gen::<u32>());
+        set_uninit!(symbol.hash_code, cx.rand.gen::<u32>());
         set_uninit!(symbol.is_private, is_private);
 
         symbol.to_handle()


### PR DESCRIPTION
## Summary

We want to make heap serialization totally deterministic and reproducible. One source of non-determinism in the serialized output is random number generation during heap initialization. Instead let's use a deterministic seeded PRNG during heap initialization, then switch to a randomly seeded PRNG after heap initialization is complete.

This means the `Context` should own the PRNG since the PRNG state is now tied to the `Context`'s lifecycle.

## Tests

All tests pass.