### PR TITLE
[parser] Private identifier names include the leading # symbol

### DIFF
--- a/src/js/common/wtf_8.rs
+++ b/src/js/common/wtf_8.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Borrow,
     fmt,
     hash::{self, Hash},
-    ops::Deref,
+    ops::{Deref, Index, Range, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive},
 };
 
 use allocator_api2::{
@@ -351,6 +351,51 @@ impl fmt::Display for Wtf8Str {
 impl fmt::Debug for Wtf8Str {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.to_string())
+    }
+}
+
+impl Index<Range<usize>> for Wtf8Str {
+    type Output = Wtf8Str;
+
+    #[inline]
+    fn index(&self, index: Range<usize>) -> &Self::Output {
+        Wtf8Str::from_bytes_unchecked(&self.buf[index])
+    }
+}
+
+impl Index<RangeFrom<usize>> for Wtf8Str {
+    type Output = Wtf8Str;
+
+    #[inline]
+    fn index(&self, index: RangeFrom<usize>) -> &Self::Output {
+        Wtf8Str::from_bytes_unchecked(&self.buf[index])
+    }
+}
+
+impl Index<RangeTo<usize>> for Wtf8Str {
+    type Output = Wtf8Str;
+
+    #[inline]
+    fn index(&self, index: RangeTo<usize>) -> &Self::Output {
+        Wtf8Str::from_bytes_unchecked(&self.buf[index])
+    }
+}
+
+impl Index<RangeInclusive<usize>> for Wtf8Str {
+    type Output = Wtf8Str;
+
+    #[inline]
+    fn index(&self, index: RangeInclusive<usize>) -> &Self::Output {
+        Wtf8Str::from_bytes_unchecked(&self.buf[index])
+    }
+}
+
+impl Index<RangeToInclusive<usize>> for Wtf8Str {
+    type Output = Wtf8Str;
+
+    #[inline]
+    fn index(&self, index: RangeToInclusive<usize>) -> &Self::Output {
+        Wtf8Str::from_bytes_unchecked(&self.buf[index])
     }
 }
 

--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -1302,11 +1302,11 @@ impl<'a> Analyzer<'a> {
                 _ => continue,
             };
 
-            if private_id.name == "constructor" {
+            if private_id.name == "#constructor" {
                 self.emit_error(private_id.loc, ParseError::PrivateNameConstructor);
             }
 
-            self.resolve_private_identifier_use(private_id);
+            self.resolve_identifier_use(private_id);
         }
 
         // If any private accessor pair was encountered then mark the first part of every pair in
@@ -1599,7 +1599,7 @@ impl<'a> Analyzer<'a> {
                 }
             }
 
-            self.resolve_private_identifier_use(id);
+            self.resolve_identifier_use(id);
 
             if !is_defined {
                 let private_name = id.name.to_owned_in(Global);
@@ -1642,12 +1642,6 @@ impl<'a> Analyzer<'a> {
 
     fn resolve_identifier_use(&mut self, id: &mut Identifier<'a>) {
         self.resolve_use(&mut id.scope, id.name, id.loc);
-    }
-
-    fn resolve_private_identifier_use(&mut self, private_id: &mut Identifier<'a>) {
-        // Private name has a "#" prefix
-        let private_name = &format!("#{}", &private_id.name);
-        self.resolve_use(&mut private_id.scope, Wtf8Str::from_str(private_name), private_id.loc);
     }
 
     fn resolve_this_use(&mut self, loc: Loc, mut set_scope: impl FnMut(AstPtr<AstScopeNode<'a>>)) {

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -303,6 +303,8 @@ pub enum Toplevel<'a> {
 
 pub struct Identifier<'a> {
     pub loc: Loc,
+
+    /// Name of the identifier. May begin with a '#' if it is a private name.
     pub name: AstStr<'a>,
 
     /// Reference to the scope that contains the binding for this identifier, or tagged as

--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -341,13 +341,13 @@ impl fmt::Display for ParseError {
                 write!(f, "Object property initializers do not use `=`")
             }
             ParseError::DuplicatePrivateName(name) => {
-                write!(f, "Redeclaration of private name #{}", name)
+                write!(f, "Redeclaration of private name {}", name)
             }
             ParseError::PrivateNameOutsideClass => {
                 write!(f, "Private name outside class")
             }
             ParseError::PrivateNameNotDefined(name) => {
-                write!(f, "Reference to undeclared private name #{}", name)
+                write!(f, "Reference to undeclared private name {}", name)
             }
             ParseError::PrivateNameConstructor => {
                 write!(f, "Private name not allowed to be #constructor")

--- a/src/js/parser/token.rs
+++ b/src/js/parser/token.rs
@@ -5,6 +5,7 @@ use super::{ast::AstStr, loc::Loc};
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token<'a> {
     Identifier(AstStr<'a>),
+    PrivateIdentifier(AstStr<'a>),
     NumberLiteral(f64),
     StringLiteral(AstStr<'a>),
     BigIntLiteral {
@@ -77,7 +78,6 @@ pub enum Token<'a> {
     Colon,
     Arrow,
     Spread,
-    Hash,
     // Keywords
     Var,
     Let,
@@ -148,7 +148,9 @@ pub struct TemplatePartToken<'a> {
 impl Token<'_> {
     pub fn as_cow(&self) -> Cow<'static, str> {
         let str = match self {
-            Token::Identifier(name) => return Cow::Owned(name.to_string()),
+            Token::Identifier(name) | Token::PrivateIdentifier(name) => {
+                return Cow::Owned(name.to_string())
+            }
             Token::NumberLiteral(lit) => return Cow::Owned(lit.to_string()),
             Token::StringLiteral(lit) => return Cow::Owned(lit.to_string()),
             Token::BigIntLiteral { digits_slice, .. } => {
@@ -187,7 +189,6 @@ impl Token<'_> {
             Token::Semicolon => ";",
             Token::Arrow => "=>",
             Token::Spread => "...",
-            Token::Hash => "#",
             Token::LeftParen => "(",
             Token::RightParen => ")",
             Token::LeftBrace => "{",

--- a/src/js/runtime/eval/eval.rs
+++ b/src/js/runtime/eval/eval.rs
@@ -128,10 +128,7 @@ fn get_private_names_from_scopes(
 
             for (i, name) in scope_names.name_ptrs().iter().enumerate() {
                 if scope_names.is_private_name(i) {
-                    // Exclude the "#" prefix
-                    let prefixed_private_name = name.to_string();
-                    let private_name = Wtf8String::from_str(&prefixed_private_name[1..]);
-
+                    let private_name = Wtf8String::from_string(name.to_string());
                     private_names
                         .as_mut()
                         .unwrap()

--- a/tests/js_parser/class/property.exp
+++ b/tests/js_parser/class/property.exp
@@ -148,8 +148,8 @@
             loc: "11:12-11:20",
             key: {
               type: "PrivateIdentifier",
-              loc: "11:13-11:16",
-              name: "key",
+              loc: "11:12-11:16",
+              name: "#key",
             },
             value: {
               type: "Identifier",
@@ -320,8 +320,8 @@
             loc: "23:13-23:17",
             key: {
               type: "PrivateIdentifier",
-              loc: "23:14-23:17",
-              name: "key",
+              loc: "23:13-23:17",
+              name: "#key",
             },
             value: null,
             computed: false,
@@ -674,8 +674,8 @@
             loc: "43:3-43:10",
             key: {
               type: "PrivateIdentifier",
-              loc: "43:4-43:5",
-              name: "a",
+              loc: "43:3-43:5",
+              name: "#a",
             },
             value: {
               type: "FunctionExpression",
@@ -1252,8 +1252,8 @@
             loc: "85:3-85:14",
             key: {
               type: "PrivateIdentifier",
-              loc: "85:8-85:9",
-              name: "a",
+              loc: "85:7-85:9",
+              name: "#a",
             },
             value: {
               type: "FunctionExpression",
@@ -1470,8 +1470,8 @@
             loc: "101:3-101:16",
             key: {
               type: "PrivateIdentifier",
-              loc: "101:11-101:12",
-              name: "a",
+              loc: "101:10-101:12",
+              name: "#a",
             },
             value: {
               type: "Literal",
@@ -1512,8 +1512,8 @@
             loc: "103:3-103:17",
             key: {
               type: "PrivateIdentifier",
-              loc: "103:11-103:12",
-              name: "a",
+              loc: "103:10-103:12",
+              name: "#a",
             },
             value: {
               type: "FunctionExpression",

--- a/tests/js_parser/expression/binary.exp
+++ b/tests/js_parser/expression/binary.exp
@@ -620,8 +620,8 @@
         operator: "in",
         left: {
           type: "PrivateIdentifier",
-          loc: "43:2-43:3",
-          name: "a",
+          loc: "43:1-43:3",
+          name: "#a",
         },
         right: {
           type: "Identifier",

--- a/tests/js_parser/expression/chain.exp
+++ b/tests/js_parser/expression/chain.exp
@@ -145,8 +145,8 @@
           },
           property: {
             type: "PrivateIdentifier",
-            loc: "9:5-9:6",
-            name: "b",
+            loc: "9:4-9:6",
+            name: "#b",
           },
           computed: false,
           optional: true,

--- a/tests/js_parser/expression/member.exp
+++ b/tests/js_parser/expression/member.exp
@@ -139,8 +139,8 @@
         },
         property: {
           type: "PrivateIdentifier",
-          loc: "9:4-9:7",
-          name: "foo",
+          loc: "9:3-9:7",
+          name: "#foo",
         },
         computed: false,
         optional: false,


### PR DESCRIPTION
## Summary

Refactor private identifier nodes in the AST to consist of an Identifier node that contains the leading "#" character. The full name including the "#" is already what was used almost everywhere else, notably during analysis. This lets us remove many special cases and places where we had to reallocated a `Wtf8String` just to include the leading "#".

The lexer now emits a single `Token::PrivateIdentifier` instead of `Token::Hash` followed by a `Token::Identifier`. This required breaking out private identifier parsing, reusing existing identifier parsing utilities as much as possible.

## Tests

Recorded parser snapshot tests to now include "#" in private identifiers. All tests pass.