### PR TITLE
[tests] Use smaller heap for integration tests

### DIFF
--- a/src/benches/benches.rs
+++ b/src/benches/benches.rs
@@ -65,7 +65,7 @@ fn setup_step(file: &str, flags: TestFlags) -> (Context, ParseContext) {
     // Use a 10 MB heap size
     let options = OptionsBuilder::new()
         .annex_b(flags.contains(TestFlags::ANNEX_B))
-        .min_heap_size(10 * 1024 * 1024)
+        .heap_size(10 * 1024 * 1024)
         .build();
     let cx = ContextBuilder::new().set_options(Rc::new(options)).build();
     let source = Rc::new(Source::new_from_file(&format!("benches/{}", file)).unwrap());

--- a/src/brimstone_serialized_heap/build.rs
+++ b/src/brimstone_serialized_heap/build.rs
@@ -24,7 +24,7 @@ fn main() {
 const HEAP_SIZE: usize = 4 * 1024 * 1024;
 
 fn gen_serialized_heap_file(out_path: &Path) -> String {
-    let options = OptionsBuilder::new().min_heap_size(HEAP_SIZE).build();
+    let options = OptionsBuilder::new().heap_size(HEAP_SIZE).build();
     let cx = ContextBuilder::new().set_options(Rc::new(options)).build();
 
     let serializer = HeapSerializer::serialize(cx);

--- a/src/js/common/options.rs
+++ b/src/js/common/options.rs
@@ -41,7 +41,7 @@ pub struct Args {
 
     /// The starting heap size, in bytes.
     #[arg(long)]
-    pub min_heap_size: Option<usize>,
+    pub heap_size: Option<usize>,
 
     /// Do not use colors when printing to terminal. Otherwise use colors if supported.
     #[arg(long, default_value_t = false)]
@@ -72,8 +72,8 @@ pub struct Options {
     /// Buffer to write all dumped output into instead of stdout
     pub dump_buffer: Option<Mutex<String>>,
 
-    /// The starting heap size in bytes, if set.
-    pub min_heap_size: usize,
+    /// The heap size to use in bytes.
+    pub heap_size: usize,
 
     /// Whether to use colors when printing to the terminal
     pub no_color: bool,
@@ -116,7 +116,7 @@ impl OptionsBuilder {
             print_bytecode: false,
             print_regexp_bytecode: false,
             dump_buffer: None,
-            min_heap_size: DEFAULT_HEAP_SIZE,
+            heap_size: DEFAULT_HEAP_SIZE,
             no_color: false,
             parse_stats: false,
             serialized_heap: get_default_serialized_heap(),
@@ -130,7 +130,7 @@ impl OptionsBuilder {
             .print_ast(args.print_ast)
             .print_bytecode(args.print_bytecode)
             .print_regexp_bytecode(args.print_regexp_bytecode)
-            .min_heap_size(args.min_heap_size.unwrap_or(DEFAULT_HEAP_SIZE))
+            .heap_size(args.heap_size.unwrap_or(DEFAULT_HEAP_SIZE))
             .no_color(args.no_color)
             .parse_stats(args.parse_stats)
     }
@@ -160,8 +160,8 @@ impl OptionsBuilder {
         self
     }
 
-    pub fn min_heap_size(mut self, min_heap_size: usize) -> Self {
-        self.0.min_heap_size = min_heap_size;
+    pub fn heap_size(mut self, heap_size: usize) -> Self {
+        self.0.heap_size = heap_size;
         self
     }
 

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -124,7 +124,7 @@ type GlobalSymbolRegistry = BsHashMap<HeapPtr<FlatString>, HeapPtr<SymbolValue>>
 impl Context {
     fn new(options: Rc<Options>) -> Context {
         let cx_cell = Box::new(ContextCell {
-            heap: Heap::new(options.min_heap_size),
+            heap: Heap::new(options.heap_size),
             global_symbol_registry: HeapPtr::uninit(),
             names: BuiltinNames::uninit(),
             well_known_symbols: BuiltinSymbols::uninit(),

--- a/tests/harness/src/runner.rs
+++ b/tests/harness/src/runner.rs
@@ -45,6 +45,9 @@ pub struct TestRunner {
 // Runner threads have an 8MB stack
 const RUNNER_THREAD_STACK_SIZE: usize = 1 << 23;
 
+/// Size of the heap for each test. Use a low value that is sufficient for running all tests.
+const HEAP_SIZE: usize = 10 * 1024 * 1024;
+
 impl TestRunner {
     pub fn new(
         manifest: TestManifest,
@@ -224,7 +227,10 @@ fn run_single_test(
     start_timestamp: SystemTime,
 ) -> TestResult {
     // Set up options for test
-    let options = OptionsBuilder::new().annex_b(test.is_annex_b).build();
+    let options = OptionsBuilder::new()
+        .annex_b(test.is_annex_b)
+        .heap_size(HEAP_SIZE)
+        .build();
 
     // Each test is executed in its own realm
     let cx = ContextBuilder::new().set_options(Rc::new(options)).build();


### PR DESCRIPTION
## Summary

We can set a much smaller heap size to greatly speed up our integration tests. A 10MB heap is sufficient for all test262 and first party integration tests.

This speeds up full integration test runs by ~32%, from 4.31 to 2.93 seconds.

## Tests

All tests pass.