### PR TITLE
[runtime] Heap serialization accounts for differences in heap layout due to features enabled

### DIFF
--- a/src/brimstone_serialized_heap/build.rs
+++ b/src/brimstone_serialized_heap/build.rs
@@ -74,6 +74,7 @@ pub const SERIALIZED_HEAP: SerializedHeap<'static> = SerializedHeap {{
     permanent_space: SerializedSemispace {{ bytes: SERIALIZED_PERMANENT_SPACE, start_offset: {} }},
     current_space: SerializedSemispace {{ bytes: SERIALIZED_CURRENT_SPACE, start_offset: {} }},
     root_offsets: SERIALIZED_ROOT_OFFSETS,
+    heap_info_size: {},
 }};
 "#,
         permanent_space_file.to_string_lossy(),
@@ -81,6 +82,7 @@ pub const SERIALIZED_HEAP: SerializedHeap<'static> = SerializedHeap {{
         root_offsets_file.to_string_lossy(),
         serialized_heap.permanent_space.start_offset,
         serialized_heap.current_space.start_offset,
+        serialized_heap.heap_info_size,
     )
 }
 

--- a/src/js/common/serialized_heap.rs
+++ b/src/js/common/serialized_heap.rs
@@ -10,6 +10,8 @@ pub struct SerializedHeap<'a> {
     pub current_space: SerializedSemispace<'a>,
     /// Offsets of all roots to the heap, in traversal order
     pub root_offsets: &'a [usize],
+    /// Size of the HeapInfo struct
+    pub heap_info_size: usize,
 }
 
 /// The serialized form of an individual semispace.


### PR DESCRIPTION
## Summary

There is a bug in our heap serialization system due to the fact that the set of Cargo features enabled can change the heap layout, e.g. due to differences in `HeapInfo` size when the `handle_stats` flag is enabled. This breaks heap deserialization as the encoded offsets are from the start of the heap (and the `HeapInfo` is stored at the start of the heap), so changes to `HeapInfo` size should be added as an extra offset while deserializing pointers.

We can fix this by storing the size of the `HeapInfo` in the serialized heap, then comparing this to the size of the `HeapInfo` when deserializing. The heap's base pointer is then adjusted by this difference when deserializing. 

## Tests

All tests pass. Reduced heap size in integration tests with `handle_stats` feature now passes all tests instead of segfaulting.