### PR TITLE
[runtime] RustRuntimeFunctionRegistry does not create HashMap during initialization

### DIFF
--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -303,7 +303,7 @@ impl BytecodeFunction {
         is_constructor: bool,
         name: Option<Handle<StringValue>>,
     ) -> Handle<BytecodeFunction> {
-        let function_id = *cx.rust_runtime_functions.get_id(builtin_func).unwrap();
+        let function_id = cx.rust_runtime_functions.get_id(builtin_func).unwrap();
 
         let size = Self::calculate_size_in_bytes(0);
         let mut object = cx.alloc_uninit_with_size::<BytecodeFunction>(size);

--- a/src/js/runtime/stack_trace.rs
+++ b/src/js/runtime/stack_trace.rs
@@ -62,7 +62,7 @@ fn gather_current_stack_frames(mut cx: Context, skip_current_frame: bool) -> Vec
         if stack_frame.previous_frame().is_none() {
             let function = stack_frame.closure().function_ptr();
             if let Some(id) = function.rust_runtime_function_id() {
-                if id == *cx.rust_runtime_functions.get_id(return_undefined).unwrap() {
+                if id == cx.rust_runtime_functions.get_id(return_undefined).unwrap() {
                     break;
                 }
             }


### PR DESCRIPTION
## Summary

There are ~500 rust functions which can be called by the runtime. Currently these are registered in an array stored in the `Context` called the `RustRuntimeFunctionRegistry`. This registry also stores a `HashMap` from function pointer to the id used to reference the function which must be filled when creating a `Context.

Setting up this registry to create a `Context`  takes a surprising amount of time. For example setting up this registry takes ~1.3% of the total time to run all integration tests with `cargo brimstone-test`.

Lets remove this `HashMap` and instead adopt the same strategy for Rust vtables to look up function ids. We now lazily generated a sorted array of function pointers which is binary searched to find the function id.

Context creation from serialized now takes ~9% less time while context creation from scratch takes ~3.5% less time according to benchmarks. With this change `cargo brimstone-test -r` runtime decreases from ~2.93 to 2.88 seconds.

There are some other optimizations that were tried but abandoned as they had a negative effect on runtime performance. Particularly surprising was using a `const RUST_RUNTIME_FUNCTIONS` array instead of the `RustRuntimeFunctionRegistry` which consistently reduced performance across the board. Additionally storing the rust runtime function into the heap instead of storing the index had a small negative effect on runtime performance and non-serialized `Context` creation.

## Tests

All tests pass.