### PR TITLE
[runtime] Resizable heap that grows during garbage collections

### DIFF
--- a/src/js/common/constants.rs
+++ b/src/js/common/constants.rs
@@ -1,2 +1,5 @@
-/// Default size of the heap, in bytes.
+/// Default size of the heap, in bytes. 256 MB.
 pub const DEFAULT_HEAP_SIZE: usize = 256 * 1024 * 1024;
+
+/// Maximum size of the heap, in bytes. 1GB.
+pub const MAX_HEAP_SIZE: usize = 1024 * 1024 * 1024;

--- a/src/js/runtime/gc/mod.rs
+++ b/src/js/runtime/gc/mod.rs
@@ -7,6 +7,7 @@ mod heap_serializer;
 mod heap_trait_object;
 mod pointer;
 
+pub use garbage_collector::{GarbageCollector, GcType};
 pub use handle::{
     Escapable, Handle, HandleContents, HandleScope, HandleScopeGuard, ToHandleContents,
 };

--- a/src/js/runtime/gc_object.rs
+++ b/src/js/runtime/gc_object.rs
@@ -4,8 +4,12 @@ use crate::{
 };
 
 use super::{
-    eval_result::EvalResult, gc::Heap, intrinsics::intrinsics::Intrinsic,
-    object_value::ObjectValue, realm::Realm, Context, Handle, Value,
+    eval_result::EvalResult,
+    gc::{GcType, Heap},
+    intrinsics::intrinsics::Intrinsic,
+    object_value::ObjectValue,
+    realm::Realm,
+    Context, Handle, Value,
 };
 
 pub struct GcObject;
@@ -30,7 +34,7 @@ impl GcObject {
     }
 
     pub fn run(cx: Context, _: Handle<Value>, _: &[Handle<Value>]) -> EvalResult<Handle<Value>> {
-        Heap::run_gc(cx);
+        Heap::run_gc(cx, GcType::Normal);
         Ok(cx.undefined())
     }
 }

--- a/tests/harness/src/runner.rs
+++ b/tests/harness/src/runner.rs
@@ -45,8 +45,8 @@ pub struct TestRunner {
 // Runner threads have an 8MB stack
 const RUNNER_THREAD_STACK_SIZE: usize = 1 << 23;
 
-/// Size of the heap for each test. Use a low value that is sufficient for running all tests.
-const HEAP_SIZE: usize = 10 * 1024 * 1024;
+/// Size of the heap for each test. Use a small value since most tests do not require a large heap.
+const HEAP_SIZE: usize = 1024 * 1024;
 
 impl TestRunner {
     pub fn new(


### PR DESCRIPTION
## Summary

Previously the heap had a fixed size. Let's take the first step of moving towards a resizable heap by implementing a simple strategy where the heap doubles in size on GCs up until a cap. This required refactoring parts of the garbage collector to support arbitrary resizing, with the biggest change being allowing the permanent heap to be moved during a resizing GC.

The current resizing strategy is very naive and will always eventually reach the maximum allowed heap size instead of staying near the size of the live set, nor will the the heap ever shrink.

With these changes we reduce the size of the heap during integration tests to start at 1MB. This reduces time to run all integration tests with `cargo brimstone-test -r` by ~50%, down to 1.44 seconds locally.

## Tests

All tests pass.