### PR TITLE
[ci] Ensure necessary rust toolchain components are installed in lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
 
+      - name: Install toolchain components
+        run: rustup component add rustfmt clippy
+
       - name: Check formatting
         run: cargo fmt -- --check
 


### PR DESCRIPTION
## Summary

The CI environment has regressed and some components (namely `rustfmt` and `clippy`) cannot be found for the current toolchain. Avoid this going forwards by adding an explicit step to install `rustfmt` and `clippy` in the lint job.

## Tests

Lint job in CI now passes.