### PR TITLE
[runtime] Misc code cleanup in garbage collector

### DIFF
--- a/src/js/runtime/gc/heap.rs
+++ b/src/js/runtime/gc/heap.rs
@@ -290,12 +290,12 @@ impl Heap {
         self.heap_start
     }
 
-    pub fn current_heap_bounds(&self) -> (*const u8, *const u8) {
-        (self.start, self.end)
+    pub fn current_heap_bounds(&self) -> Range<*const u8> {
+        self.start..self.end
     }
 
-    pub fn next_heap_bounds(&self) -> (*const u8, *const u8) {
-        (self.next_heap_start, self.next_heap_end)
+    pub fn next_heap_bounds(&self) -> Range<*const u8> {
+        self.next_heap_start..self.next_heap_end
     }
 
     pub fn permanent_heap_bounds(&self) -> Range<*const u8> {


### PR DESCRIPTION
## Summary

Perform some miscellaneous code cleanup in the garbage collector.

- Refactor garbage collection process for clarity, creating and commenting helper functions
- Use a pointer range instead of holding a pair of pointers for heap bounds in some locations
- Remove unnecessary function parameters that can be replaced by GC field accesses


## Tests

All tests pass.