### PR TITLE
[runtime] Add additional annex B methods after deserializing heap

### DIFF
--- a/src/js/runtime/annex_b.rs
+++ b/src/js/runtime/annex_b.rs
@@ -1,0 +1,11 @@
+use crate::runtime::{
+    intrinsics::{intrinsics::Intrinsic, string_prototype::StringPrototype},
+    Context, Handle, Realm,
+};
+
+/// Annex B methods are not guaranteed to be part of the serialized heap so we must initialize them
+/// separately.
+pub fn init_annex_b_methods(cx: Context, realm: Handle<Realm>) {
+    let string_prototype = realm.get_intrinsic(Intrinsic::StringPrototype);
+    StringPrototype::init_annex_b_methods(string_prototype, cx, realm);
+}

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -18,7 +18,7 @@ use crate::{
     parser::{
         analyze::analyze, parse_module, parse_script, print_program, source::Source, ParseContext,
     },
-    runtime::gc::GarbageCollector,
+    runtime::{annex_b::init_annex_b_methods, gc::GarbageCollector},
 };
 
 use super::{
@@ -168,6 +168,12 @@ impl Context {
 
         // Stop using deterministic PRNG
         cx.rand = StdRng::from_entropy();
+
+        // Annex B methods may not be included in the serialized heap so they must be initialized
+        // separately.
+        if options.annex_b {
+            init_annex_b_methods(cx, cx.initial_realm());
+        }
 
         cx
     }

--- a/src/js/runtime/intrinsics/mod.rs
+++ b/src/js/runtime/intrinsics/mod.rs
@@ -63,7 +63,7 @@ pub mod set_object;
 mod set_prototype;
 pub mod string_constructor;
 pub mod string_iterator;
-mod string_prototype;
+pub mod string_prototype;
 pub mod symbol_constructor;
 mod symbol_prototype;
 pub mod typed_array;

--- a/src/js/runtime/mod.rs
+++ b/src/js/runtime/mod.rs
@@ -1,5 +1,6 @@
 pub mod abstract_operations;
 mod accessor;
+mod annex_b;
 mod arguments_object;
 mod array_object;
 mod array_properties;


### PR DESCRIPTION
## Summary

In Annex B mode some additional methods are added to builtin objects, e.g. `String.prototype.substr`. These regressed after heap serialization since the serialized heap never contained the Annex B flag at build time and the methods were never actually added.

Since we cannot guarantee that the Annex B methods will be included in the serialized heap we should instead always add all Annex B methods after heap deserialization. This may perform unnecessary work or overwrite methods with these same names in the serialized heap but at least guarantees Annex B functionality. Currently only `String.prototype` methods are added but for completeness this can be extended to `Date.prototype` and `RegExp.prototype` methods as well.

## Tests

- `cargo brimstone-test -- --all annexB/built-ins/String` now passes for all implemented `String.prototype.*` Annex B methods.
- All CI tests pass