### PR TITLE
[bytecode] Store intermediate object or array in temporary while building to avoid clobbering observable register

### DIFF
--- a/tests/integration/language/expression/array/element_throws_does_not_clobber_dest.js
+++ b/tests/integration/language/expression/array/element_throws_does_not_clobber_dest.js
@@ -1,0 +1,19 @@
+/*---
+description: Throwing while evaluating an element in an array literal does not clobber the array's destination.
+---*/
+
+function throws() {
+  throw new Error();
+}
+
+function test() {
+  var x = 1;
+  try {
+    x = [ throws() ];
+  } catch {}
+
+  // Register is not clobbered by array value
+  assert.sameValue(x, 1);
+}
+
+test();

--- a/tests/integration/language/expression/object/property_throws_does_not_clobber_dest.js
+++ b/tests/integration/language/expression/object/property_throws_does_not_clobber_dest.js
@@ -1,0 +1,19 @@
+/*---
+description: Throwing while evaluating a property in an object literal does not clobber the object's destination.
+---*/
+
+function throws() {
+  throw new Error();
+}
+
+function test() {
+  var x = 1;
+  try {
+    x = { prop: throws() };
+  } catch {}
+
+  // Register is not clobbered by object value
+  assert.sameValue(x, 1);
+}
+
+test();

--- a/tests/js_bytecode/expression/array.exp
+++ b/tests/js_bytecode/expression/array.exp
@@ -14,8 +14,12 @@
     33: StoreGlobal r0, c11
     36: NewClosure r0, c12
     39: StoreGlobal r0, c13
-    42: LoadUndefined r0
-    44: Ret r0
+    42: NewClosure r0, c14
+    45: StoreGlobal r0, c15
+    48: NewClosure r0, c16
+    51: StoreGlobal r0, c17
+    54: LoadUndefined r0
+    56: Ret r0
   Constant Table:
     0: [BytecodeFunction: testEmptyArray]
     1: [String: testEmptyArray]
@@ -31,6 +35,10 @@
     11: [String: onlySpread]
     12: [BytecodeFunction: multipleSpreads]
     13: [String: multipleSpreads]
+    14: [BytecodeFunction: temporaryRegisterToAvoidClobbering]
+    15: [String: temporaryRegisterToAvoidClobbering]
+    16: [BytecodeFunction: noTemporaryRegisterNeededForEmptyObject]
+    17: [String: noTemporaryRegisterNeededForEmptyObject]
 }
 
 [BytecodeFunction: testEmptyArray] {
@@ -152,4 +160,24 @@
     72: Jump -14 (.L4)
   .L5:
     74: Ret r0
+}
+
+[BytecodeFunction: temporaryRegisterToAvoidClobbering] {
+  Parameters: 0, Registers: 4
+     0: LoadImmediate r0, 1
+     3: NewArray r1
+     5: LoadImmediate r2, 0
+     8: LoadImmediate r3, 2
+    11: SetArrayProperty r1, r2, r3
+    15: Mov r0, r1
+    18: LoadUndefined r1
+    20: Ret r1
+}
+
+[BytecodeFunction: noTemporaryRegisterNeededForEmptyObject] {
+  Parameters: 0, Registers: 2
+    0: LoadImmediate r0, 1
+    3: NewArray r0
+    5: LoadUndefined r1
+    7: Ret r1
 }

--- a/tests/js_bytecode/expression/array.js
+++ b/tests/js_bytecode/expression/array.js
@@ -25,3 +25,15 @@ function onlySpread(p) {
 function multipleSpreads(p1, p2, p3) {
   return [...p1, ...p2, 1, ...p3];
 }
+
+function temporaryRegisterToAvoidClobbering() {
+  var local = 1;
+  // Intermediate array is written to a temporary to avoid clobbering
+  local = [ 2 ];
+}
+
+function noTemporaryRegisterNeededForEmptyObject() {
+  var local = 1;
+  // Intermediate array is not needed if array is empty since no observable clobbering can occur
+  local = [];
+}

--- a/tests/js_bytecode/expression/object/basic.exp
+++ b/tests/js_bytecode/expression/object/basic.exp
@@ -16,10 +16,14 @@
     39: StoreGlobal r0, c13
     42: NewClosure r0, c14
     45: StoreGlobal r0, c15
-    48: LoadImmediate r0, 0
-    51: StoreGlobal r0, c16
-    54: LoadUndefined r0
-    56: Ret r0
+    48: NewClosure r0, c16
+    51: StoreGlobal r0, c17
+    54: NewClosure r0, c18
+    57: StoreGlobal r0, c19
+    60: LoadImmediate r0, 0
+    63: StoreGlobal r0, c20
+    66: LoadUndefined r0
+    68: Ret r0
   Constant Table:
     0: [BytecodeFunction: emptyObject]
     1: [String: emptyObject]
@@ -37,7 +41,11 @@
     13: [String: proto]
     14: [BytecodeFunction: propertyNamesNotResolved]
     15: [String: propertyNamesNotResolved]
-    16: [String: global]
+    16: [BytecodeFunction: temporaryRegisterToAvoidClobbering]
+    17: [String: temporaryRegisterToAvoidClobbering]
+    18: [BytecodeFunction: noTemporaryRegisterNeededForEmptyObject]
+    19: [String: noTemporaryRegisterNeededForEmptyObject]
+    20: [String: global]
 }
 
 [BytecodeFunction: emptyObject] {
@@ -153,4 +161,25 @@
     1: [String: b]
     2: [String: d]
     3: [String: c]
+}
+
+[BytecodeFunction: temporaryRegisterToAvoidClobbering] {
+  Parameters: 0, Registers: 3
+     0: LoadImmediate r0, 1
+     3: NewObject r1
+     5: LoadImmediate r2, 2
+     8: DefineNamedProperty r1, c0, r2
+    12: Mov r0, r1
+    15: LoadUndefined r1
+    17: Ret r1
+  Constant Table:
+    0: [String: prop]
+}
+
+[BytecodeFunction: noTemporaryRegisterNeededForEmptyObject] {
+  Parameters: 0, Registers: 2
+    0: LoadImmediate r0, 1
+    3: NewObject r0
+    5: LoadUndefined r1
+    7: Ret r1
 }

--- a/tests/js_bytecode/expression/object/basic.js
+++ b/tests/js_bytecode/expression/object/basic.js
@@ -36,3 +36,15 @@ function propertyNamesNotResolved() {
   // TDZ check needed
   const { b, c } = { b, d: c };
 }
+
+function temporaryRegisterToAvoidClobbering() {
+  var local = 1;
+  // Intermediate object is written to a temporary to avoid clobbering
+  local = { prop: 2 };
+}
+
+function noTemporaryRegisterNeededForEmptyObject() {
+  var local = 1;
+  // Intermediate object is not needed if object is empty since no observable clobbering can occur
+  local = {};
+}


### PR DESCRIPTION
## Summary

When building object and array literals we start by creating an empty object/array then evaluate and add its properties/elements. However evaluating these properties/elements can throw, in which case we need to make sure that the destination register for the object/array has not been clobbered by the intermediate object/array value.

This is the same general pattern used in other cases that can lead to observable register clobbering like logical assignments and template expressions.

Note that we can make a small optimization to avoid the unnecessary temporary if there are no properties or elements of the literal.

## Tests

- Added integration tests that catch this case.
- Added bytecode snapshot tests to confirm that temporary is only used when needed.