### PR TITLE
[bytecode] EFix missing exit of catch VM scope

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -8425,6 +8425,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         // No need to write a jump from catch to next block after body, since either the finally
         // or join block will be emitted directly after the catch.
         let catch_completion = self.gen_block_statement(&catch_clause.body)?;
+        self.gen_scope_end(catch_scope);
+
         let catch_handler_end = self.writer.current_offset();
 
         let catch_handler = ExceptionHandlerBuilder::new(catch_handler_start, catch_handler_end);

--- a/tests/integration/regression/000001.js
+++ b/tests/integration/regression/000001.js
@@ -1,0 +1,23 @@
+/*---
+description: Catch VM scope is properly exited after the catch block.
+---*/
+
+function outer() {
+  var inOuterScope = 100;
+
+  function inner() {
+    try {
+      // Does not throw so catch is not encountered
+    } catch (thrown) {
+      // Capture `thrown` to force catch VM scope to exist
+      (() => thrown);
+    }
+
+    // Catch scope is properly exited, allowing for accessing outer scope at correct parent index
+    assert.sameValue(inOuterScope, 100);
+  }
+
+  inner();
+}
+
+outer();

--- a/tests/js_bytecode/scope/catch.exp
+++ b/tests/js_bytecode/scope/catch.exp
@@ -54,7 +54,7 @@
   Parameters: 0, Registers: 4
      0: Mov r1, <scope>
      3: LoadImmediate r2, 1
-     6: Jump 36 (.L0)
+     6: Jump 37 (.L0)
      8: Mov <scope>, r1
     11: PushLexicalScope c0
     13: LoadEmpty r3
@@ -67,9 +67,10 @@
     34: LoadImmediate r2, 1
     37: StoreToScope r2, 0, 0
     41: PopScope 
+    42: PopScope 
   .L0:
-    42: LoadUndefined r1
-    44: Ret r1
+    43: LoadUndefined r1
+    45: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]


### PR DESCRIPTION
## Summary

## Tests

- Added an integration regression test for this case
- Bytecode snapshot tests covering catch VM scopes is updated with new pop