### PR TITLE
[bytecode] Fix scope exit at end of block statement with abrupt completion

### DIFF
--- a/tests/integration/regression/000002.js
+++ b/tests/integration/regression/000002.js
@@ -1,0 +1,25 @@
+/*---
+description: Block VM scope is properly exited when block ends in abrupt completion.
+---*/
+
+function outer() {
+  var inOuterScope = 100;
+
+  function inner() {
+    label: {
+      // Capture to force VM scope to exist
+      let captured = 1;
+      (() => captured);
+
+      // Abrupt completion at end of block
+      break label;
+    }
+
+    // Block scope is properly cleaned up, allowing for accessing outer scope
+    assert.sameValue(inOuterScope, 100);
+  }
+
+  inner();
+}
+
+outer();

--- a/tests/js_bytecode/scope/block.exp
+++ b/tests/js_bytecode/scope/block.exp
@@ -4,13 +4,27 @@
      3: StoreGlobal r0, c1
      6: NewClosure r0, c2
      9: StoreGlobal r0, c3
-    12: LoadUndefined r0
-    14: Ret r0
+    12: NewClosure r0, c4
+    15: StoreGlobal r0, c5
+    18: NewClosure r0, c6
+    21: StoreGlobal r0, c7
+    24: NewClosure r0, c8
+    27: StoreGlobal r0, c9
+    30: LoadImmediate r0, 1
+    33: StoreToScope r0, 1, 0
+    37: LoadUndefined r0
+    39: Ret r0
   Constant Table:
     0: [BytecodeFunction: startScope]
     1: [String: startScope]
     2: [BytecodeFunction: captures]
     3: [String: captures]
+    4: [BytecodeFunction: abruptEndReturn]
+    5: [String: abruptEndReturn]
+    6: [BytecodeFunction: abruptEndThrow]
+    7: [String: abruptEndThrow]
+    8: [BytecodeFunction: abruptEndBreak]
+    9: [String: abruptEndBreak]
 }
 
 [BytecodeFunction: startScope] {
@@ -45,6 +59,106 @@
 }
 
 [BytecodeFunction: foo] {
+  Parameters: 0, Registers: 1
+    0: LoadFromScope r0, 0, 0
+    4: CheckTdz r0, c0
+    7: Ret r0
+  Constant Table:
+    0: [String: x]
+}
+
+[BytecodeFunction: abruptEndReturn] {
+  Parameters: 0, Registers: 1
+     0: PushLexicalScope c0
+     2: LoadEmpty r0
+     4: StoreToScope r0, 0, 0
+     8: LoadImmediate r0, 1
+    11: StoreToScope r0, 0, 0
+    15: NewClosure r0, c1
+    18: LoadTrue r0
+    20: JumpFalse r0, 6 (.L0)
+    23: PopScope 
+    24: Jump 6 (.L1)
+  .L0:
+    26: LoadUndefined r0
+    28: Ret r0
+  .L1:
+    30: LoadFromScope r0, 1, 0
+    34: CheckTdz r0, c2
+    37: LoadUndefined r0
+    39: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [BytecodeFunction: <anonymous>]
+    2: [String: outerScope]
+}
+
+[BytecodeFunction: <anonymous>] {
+  Parameters: 0, Registers: 1
+    0: LoadFromScope r0, 0, 0
+    4: CheckTdz r0, c0
+    7: Ret r0
+  Constant Table:
+    0: [String: x]
+}
+
+[BytecodeFunction: abruptEndThrow] {
+  Parameters: 0, Registers: 1
+     0: PushLexicalScope c0
+     2: LoadEmpty r0
+     4: StoreToScope r0, 0, 0
+     8: LoadImmediate r0, 1
+    11: StoreToScope r0, 0, 0
+    15: NewClosure r0, c1
+    18: LoadTrue r0
+    20: JumpFalse r0, 6 (.L0)
+    23: PopScope 
+    24: Jump 7 (.L1)
+  .L0:
+    26: LoadImmediate r0, 2
+    29: Throw r0
+  .L1:
+    31: LoadFromScope r0, 1, 0
+    35: CheckTdz r0, c2
+    38: LoadUndefined r0
+    40: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [BytecodeFunction: <anonymous>]
+    2: [String: outerScope]
+}
+
+[BytecodeFunction: <anonymous>] {
+  Parameters: 0, Registers: 1
+    0: LoadFromScope r0, 0, 0
+    4: CheckTdz r0, c0
+    7: Ret r0
+  Constant Table:
+    0: [String: x]
+}
+
+[BytecodeFunction: abruptEndBreak] {
+  Parameters: 0, Registers: 1
+     0: PushLexicalScope c0
+     2: LoadEmpty r0
+     4: StoreToScope r0, 0, 0
+     8: LoadImmediate r0, 1
+    11: StoreToScope r0, 0, 0
+    15: NewClosure r0, c1
+    18: PopScope 
+    19: Jump 2 (.L0)
+  .L0:
+    21: LoadFromScope r0, 1, 0
+    25: CheckTdz r0, c2
+    28: LoadUndefined r0
+    30: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [BytecodeFunction: <anonymous>]
+    2: [String: outerScope]
+}
+
+[BytecodeFunction: <anonymous>] {
   Parameters: 0, Registers: 1
     0: LoadFromScope r0, 0, 0
     4: CheckTdz r0, c0

--- a/tests/js_bytecode/scope/block.js
+++ b/tests/js_bytecode/scope/block.js
@@ -17,3 +17,55 @@ function captures() {
     }
   }
 }
+
+let outerScope = 1;
+
+function abruptEndReturn() {
+  block: {
+    let x = 1;
+    (() => x);
+
+    // Force a path that leaves the block
+    if (true) {
+      break block;
+    }
+
+    // Abrupt (return) completion
+    return;
+  }
+
+  // Correct outer scope
+  outerScope;
+}
+
+
+function abruptEndThrow() {
+  block: {
+    let x = 1;
+    (() => x);
+
+    // Force a path that leaves the block
+    if (true) {
+      break block;
+    }
+
+    // Abrupt (throw) completion
+    throw 2;
+  }
+
+  // Correct outer scope
+  outerScope;
+}
+
+function abruptEndBreak() {
+  block: {
+    let x = 1;
+    (() => x);
+
+    // Abrupt (break) completion
+    break block;
+  }
+
+  // Correct outer scope
+  outerScope;
+}


### PR DESCRIPTION
## Summary

During bytecode generation we only need to emit instructions to pop VM scopes at the end of a block statement if the block statement has a potential normal completion. If the block statement has an abrupt completion then the pop instructions are handled separately (none for return, restoring saved scope for throw, handled by jump target machinery for break and continue).

However despite not needing to emit explicit pop instructions at the end of the block we still need to unwind the scope within the bytecode generator. Otherwise the simulated state of the VM scope chain in the bytecode generator will not match the true VM scope chain at runtime past this point.

## Tests

- Added an integration regression test for this case
- Added bytecode snapshot tests covering the VM scopes for block statements with abrupt completions