### PR TITLE
[runtime] Don't call well-known Symbol methods for RegExp on primitive values

### DIFF
--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -426,7 +426,7 @@ impl StringPrototype {
         let this_object = require_object_coercible(cx, this_value)?;
 
         let regexp_arg = get_argument(cx, arguments, 0);
-        if !regexp_arg.is_nullish() {
+        if regexp_arg.is_object() {
             let matcher = get_method(cx, regexp_arg, cx.well_known_symbols.match_())?;
             if let Some(matcher) = matcher {
                 return call_object(cx, matcher, regexp_arg, &[this_object]);
@@ -454,7 +454,7 @@ impl StringPrototype {
         let this_object = require_object_coercible(cx, this_value)?;
 
         let regexp_arg = get_argument(cx, arguments, 0);
-        if !regexp_arg.is_nullish() {
+        if regexp_arg.is_object() {
             if is_regexp(cx, regexp_arg)? {
                 let regexp_object = regexp_arg.as_object();
 
@@ -654,7 +654,7 @@ impl StringPrototype {
         let replace_arg = get_argument(cx, arguments, 1);
 
         // Use the @@replace method of the argument if one exists
-        if !search_arg.is_nullish() {
+        if search_arg.is_object() {
             let replacer = get_method(cx, search_arg, cx.well_known_symbols.replace())?;
             if let Some(replacer) = replacer {
                 return call_object(cx, replacer, search_arg, &[object, replace_arg]);
@@ -734,7 +734,7 @@ impl StringPrototype {
         let replace_arg = get_argument(cx, arguments, 1);
 
         // Use the @@replace method of the argument if one exists
-        if !search_arg.is_nullish() {
+        if search_arg.is_object() {
             // If search argument is a RegExp, check that it has the global flag
             if is_regexp(cx, search_arg)? {
                 let search_regexp = search_arg.as_object();
@@ -846,7 +846,7 @@ impl StringPrototype {
 
         // Use the @@search method of the argument if one exists
         let regexp_arg = get_argument(cx, arguments, 0);
-        if !regexp_arg.is_nullish() {
+        if regexp_arg.is_object() {
             let searcher = get_method(cx, regexp_arg, cx.well_known_symbols.search())?;
             if let Some(searcher) = searcher {
                 return call_object(cx, searcher, regexp_arg, &[object]);
@@ -924,7 +924,7 @@ impl StringPrototype {
         let limit_argument = get_argument(cx, arguments, 1);
 
         // Use the @@split method of the separator if one exists
-        if !separator_argument.is_nullish() {
+        if separator_argument.is_object() {
             let split_key = cx.well_known_symbols.split();
             let splitter = get_method(cx, separator_argument, split_key)?;
 

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -8,31 +8,6 @@
       //
       ////////////////////////////////////////
 
-      // Do not call well-known symbols on primitives for string methods (https://github.com/tc39/test262/pull/4404)
-      "built-ins/String/prototype/match/cstm-matcher-on-bigint-primitive.js",
-      "built-ins/String/prototype/match/cstm-matcher-on-boolean-primitive.js",
-      "built-ins/String/prototype/match/cstm-matcher-on-number-primitive.js",
-      "built-ins/String/prototype/match/cstm-matcher-on-string-primitive.js",
-      "built-ins/String/prototype/matchAll/cstm-matchall-on-bigint-primitive.js",
-      "built-ins/String/prototype/matchAll/cstm-matchall-on-number-primitive.js",
-      "built-ins/String/prototype/matchAll/cstm-matchall-on-string-primitive.js",
-      "built-ins/String/prototype/replace/cstm-replace-on-bigint-primitive.js",
-      "built-ins/String/prototype/replace/cstm-replace-on-boolean-primitive.js",
-      "built-ins/String/prototype/replace/cstm-replace-on-number-primitive.js",
-      "built-ins/String/prototype/replace/cstm-replace-on-string-primitive.js",
-      "built-ins/String/prototype/replaceAll/cstm-replaceall-on-bigint-primitive.js",
-      "built-ins/String/prototype/replaceAll/cstm-replaceall-on-boolean-primitive.js",
-      "built-ins/String/prototype/replaceAll/cstm-replaceall-on-number-primitive.js",
-      "built-ins/String/prototype/replaceAll/cstm-replaceall-on-string-primitive.js",
-      "built-ins/String/prototype/search/cstm-search-on-bigint-primitive.js",
-      "built-ins/String/prototype/search/cstm-search-on-boolean-primitive.js",
-      "built-ins/String/prototype/search/cstm-search-on-number-primitive.js",
-      "built-ins/String/prototype/search/cstm-search-on-string-primitive.js",
-      "built-ins/String/prototype/split/cstm-split-on-bigint-primitive.js",
-      "built-ins/String/prototype/split/cstm-split-on-boolean-primitive.js",
-      "built-ins/String/prototype/split/cstm-split-on-number-primitive.js",
-      "built-ins/String/prototype/split/cstm-split-on-string-primitive.js",
-
       // The newTarget getter must not be evaluated if argument processing throws an error before AllocateTypedArray is reached
       "built-ins/TypedArrayConstructors/ctors/typedarray-arg/throw-type-error-before-custom-proto-access.js",
 


### PR DESCRIPTION
## Summary

Implement the normative change in https://github.com/tc39/ecma262/pull/3009 where well-known Symbol methods for RegExps are no longer called on primitive values in `String.prototype.{match, matchAll, replace, replaceAll, search, split}`. These methods now verify that the target value is a object before looking for methods instead of just checking that the target value is non-nullish.

## Tests

test262 tests for this case now pass.