### PR TITLE
[runtime] URI decoding checks for more invalid UTF8 sequences

### DIFF
--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -11,9 +11,6 @@
       // The newTarget getter must not be evaluated if argument processing throws an error before AllocateTypedArray is reached
       "built-ins/TypedArrayConstructors/ctors/typedarray-arg/throw-type-error-before-custom-proto-access.js",
 
-      // decodeURIComponent should throw URIError for various invalid UTF-8 sequences
-      "built-ins/decodeURIComponent/throw-URIError.js",
-
       // A variety of failures in introduced SpiderMonkey tests
       "staging/sm/*",
 


### PR DESCRIPTION
## Summary

We were missing some explicit checks for invalid UTF8 sequences while URI decoding. The following checks have been added:
- Throw if decoding to a surrogate code point
- Throw if decoding to a value outside the code point range
- Throw on overlong encoding (i.e. if the leading byte holds no information and is unnecessary)

## Tests

test262 test for invalid UTF8 while URI decoding now passes.