### PR TITLE
[runtime] Typed array constructors do not look up prototype too early

### DIFF
--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -628,13 +628,13 @@ macro_rules! create_typed_array_constructor {
                     return Self::allocate_with_length(cx, new_target, 0);
                 }
 
-                let proto = get_prototype_from_constructor(cx, new_target, Intrinsic::$prototype)?;
-
                 let argument = get_argument(cx, arguments, 0);
                 if !argument.is_object() {
                     let length = to_index(cx, argument)?;
                     return Self::allocate_with_length(cx, new_target, length);
                 }
+
+                let proto = get_prototype_from_constructor(cx, new_target, Intrinsic::$prototype)?;
 
                 let argument = argument.as_object();
                 if argument.is_typed_array() {

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -8,9 +8,6 @@
       //
       ////////////////////////////////////////
 
-      // The newTarget getter must not be evaluated if argument processing throws an error before AllocateTypedArray is reached
-      "built-ins/TypedArrayConstructors/ctors/typedarray-arg/throw-type-error-before-custom-proto-access.js",
-
       // A variety of failures in introduced SpiderMonkey tests
       "staging/sm/*",
 


### PR DESCRIPTION
## Summary

Typed array constructors should only look up the prototype when necessary. We were doing this lookup too early, causing an observable difference if this lookup threw in the case of a non-object first argument. Instead the argument should first have `ToIndex` applied which could throw instead.

## Tests

test262 test for this case now passes.