### PR TITLE
[runtime] Implement Error.isError

### DIFF
--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -283,6 +283,7 @@ builtin_names!(
     (is, "is"),
     (is_array, "isArray"),
     (is_concat_spreadable, "isConcatSpreadable"),
+    (is_error, "isError"),
     (is_extensible, "isExtensible"),
     (is_finite, "isFinite"),
     (is_frozen, "isFrozen"),

--- a/src/js/runtime/intrinsics/error_constructor.rs
+++ b/src/js/runtime/intrinsics/error_constructor.rs
@@ -133,6 +133,8 @@ impl ErrorConstructor {
             realm.get_intrinsic(Intrinsic::ErrorPrototype).into(),
         );
 
+        func.intrinsic_func(cx, cx.names.is_error(), Self::is_error, 1, realm);
+
         func
     }
 
@@ -170,6 +172,21 @@ impl ErrorConstructor {
         install_error_cause(cx, object, options_arg)?;
 
         Ok(object.as_value())
+    }
+
+    /// Error.isError (https://tc39.es/ecma262/#sec-error.iserror)
+    pub fn is_error(
+        cx: Context,
+        _: Handle<Value>,
+        arguments: &[Handle<Value>],
+    ) -> EvalResult<Handle<Value>> {
+        let arg = get_argument(cx, arguments, 0);
+
+        if !arg.is_object() {
+            return Ok(cx.bool(false));
+        }
+
+        Ok(cx.bool(arg.as_object().is_error()))
     }
 }
 

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -297,6 +297,7 @@ rust_runtime_functions!(
     DatePrototype::to_utc_string,
     DatePrototype::value_of,
     ErrorConstructor::construct,
+    ErrorConstructor::is_error,
     ErrorPrototype::get_stack,
     ErrorPrototype::to_string,
     EvalErrorConstructor::construct,

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -242,7 +242,6 @@
       "upsert",
       "Array.fromAsync",
       "Atomics.pause",
-      "Error.isError",
       "FinalizationRegistry.prototype.cleanupSome",
       "Intl.DurationFormat",
       "Intl.Locale-info",


### PR DESCRIPTION
## Summary

Implement the `Error.isError` proposal (https://github.com/tc39/proposal-is-error).

## Tests

All test262 `Error.isError` tests pass.