### PR TITLE
[analyze] Error on labeled function outside Annex B mode

### DIFF
--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -431,7 +431,12 @@ impl<'a> Parser<'a> {
         let scope_tree = p!(self, self.scope_builder.finish_ast_scope_tree());
         let source = self.lexer.source.clone();
 
-        Ok(ParseProgramResult { program: p!(self, program), scope_tree, source })
+        Ok(ParseProgramResult {
+            program: p!(self, program),
+            scope_tree,
+            source,
+            options: self.options.clone(),
+        })
     }
 
     fn parse_directive_prologue(&mut self) -> ParseResult<bool> {
@@ -495,7 +500,12 @@ impl<'a> Parser<'a> {
         let scope_tree = p!(self, self.scope_builder.finish_ast_scope_tree());
         let source = self.lexer.source.clone();
 
-        Ok(ParseProgramResult { program: p!(self, program), scope_tree, source })
+        Ok(ParseProgramResult {
+            program: p!(self, program),
+            scope_tree,
+            source,
+            options: self.options.clone(),
+        })
     }
 
     fn parse_toplevel(&mut self) -> ParseResult<Toplevel<'a>> {
@@ -4947,11 +4957,13 @@ pub struct ParseProgramResult<'a> {
     pub program: P<'a, Program<'a>>,
     pub scope_tree: P<'a, ScopeTree<'a>>,
     pub source: Rc<Source>,
+    pub options: Rc<Options>,
 }
 
 pub struct ParseFunctionResult<'a> {
     pub function: P<'a, Function<'a>>,
     pub scope_tree: P<'a, ScopeTree<'a>>,
+    pub options: Rc<Options>,
 }
 
 pub fn parse_script(pcx: &ParseContext, options: Rc<Options>) -> ParseResult<ParseProgramResult> {
@@ -5050,11 +5062,11 @@ pub fn parse_function_for_function_constructor(
     let source = pcx.source();
 
     let lexer = Lexer::new(source, alloc);
-    let mut parser = Parser::new(lexer, ScopeTree::new_global(alloc), options, alloc);
+    let mut parser = Parser::new(lexer, ScopeTree::new_global(alloc), options.clone(), alloc);
     parser.advance()?;
 
     let func_node = parser.parse_function_declaration(FunctionContext::TOPLEVEL)?;
     let scope_tree = p!(parser, parser.scope_builder.finish_ast_scope_tree());
 
-    Ok(ParseFunctionResult { function: func_node, scope_tree })
+    Ok(ParseFunctionResult { function: func_node, scope_tree, options })
 }

--- a/tests/js_error/parser/labeled_function.exp
+++ b/tests/js_error/parser/labeled_function.exp
@@ -1,0 +1,5 @@
+SyntaxError: Functions cannot be labeled
+  ┌ tests/js_error/parser/labeled_function.js:2:1
+  |
+2 | label: function test() {}
+  | ^

--- a/tests/js_error/parser/labeled_function.js
+++ b/tests/js_error/parser/labeled_function.js
@@ -1,0 +1,2 @@
+// Labeled function in non-Annex B mode
+label: function test() {}


### PR DESCRIPTION
## Summary

Labeled function declarations are only allowed in non-strict Annex B mode. Error if not in Annex B mode. This required adding the set of compiler options to the analyzer.

## Tests

Added error snapshot test for the non-Annex B case.