### PR TITLE
[bytecode] Fix miscompilation for class methods with computed names generating discontiguous NewClass arguments

### DIFF
--- a/src/js/runtime/bytecode/operand.rs
+++ b/src/js/runtime/bytecode/operand.rs
@@ -257,6 +257,12 @@ impl<W: Width> fmt::Display for Register<W> {
     }
 }
 
+impl<W: Width> fmt::Debug for Register<W> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
 impl<W: Width> UInt<W> {
     #[inline]
     pub fn new(value: W::UInt) -> Self {

--- a/tests/integration/regression/000003.js
+++ b/tests/integration/regression/000003.js
@@ -1,0 +1,23 @@
+/*---
+description: Class with computed method names, where computed name is a direct use of a binding.
+---*/
+
+function test(key2) {
+  const key1 = "foo";
+
+  class C {
+    [key1]() {
+      return 11;
+    }
+    [key2]() {
+      return 12;
+    }
+  }
+
+  const c = new C();
+
+  assert.sameValue(c.foo(), 11);
+  assert.sameValue(c.bar(), 12);
+}
+
+test("bar");

--- a/tests/js_bytecode/class/new_class_contiguous_range.exp
+++ b/tests/js_bytecode/class/new_class_contiguous_range.exp
@@ -1,0 +1,49 @@
+[BytecodeFunction: <global>] {
+  Parameters: 0, Registers: 1
+    0: NewClosure r0, c0
+    3: StoreGlobal r0, c1
+    6: LoadUndefined r0
+    8: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: test]
+    1: [String: test]
+}
+
+[BytecodeFunction: test] {
+  Parameters: 1, Registers: 7
+     0: LoadConstant r0, c0
+     3: LoadEmpty r2
+     5: Mov r3, r0
+     8: ToPropertyKey r3, r3
+    11: NewClosure r4, c1
+    14: Mov r5, a0
+    17: ToPropertyKey r5, r5
+    20: NewClosure r6, c2
+    23: NewClass r1, c4, c3, r2, r3
+    29: LoadUndefined r2
+    31: Ret r2
+  Constant Table:
+    0: [String: foo]
+    1: [BytecodeFunction: <anonymous>]
+    2: [BytecodeFunction: <anonymous>]
+    3: [BytecodeFunction: C]
+    4: [ClassNames]
+}
+
+[BytecodeFunction: C] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: <anonymous>] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: <anonymous>] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}

--- a/tests/js_bytecode/class/new_class_contiguous_range.js
+++ b/tests/js_bytecode/class/new_class_contiguous_range.js
@@ -1,0 +1,10 @@
+function test(bar) {
+  var foo = "foo";
+
+  // Use bindings directly in computed property names. These must be moved to a temporary so that
+  // they appear in the contiguous range of registers passed to NewClass.
+  class C {
+    [foo]() {}
+    get [bar]() {}
+  }
+}


### PR DESCRIPTION
# Description

Fixes: https://github.com/Hans-Halverson/brimstone/issues/210

We are currently miscompiling class methods with computed names, when the computed name's expression is a direct use a binding defined earlier before the body of the class.

The NewClass instruction expects its arguments (containing methods and computed method names) to be in a contiguous range of registers. A discontiguous range was being generated in this case because we weren't enforcing that each computed name must be generated into a new temporary register. The binding was resolved to a direct reference of a local/argument register, breaking the contiguous range.

We now make sure to place computed name results in a temporary register. We also add a debug assertion that the NewClass arguments list is contiguous.

# Tests

- Added regression test for this case, testing computed method names coming from a local and from an argument
- Added bytecode snapshot test
- Verified that all cases reported in https://github.com/Hans-Halverson/brimstone/issues/210 now pass