### PR TITLE
[runtime] JSON.parse does not allow trailing commas

### DIFF
--- a/src/js/runtime/intrinsics/json_object.rs
+++ b/src/js/runtime/intrinsics/json_object.rs
@@ -357,6 +357,11 @@ fn parse_json_object(lexer: &mut StringLexer) -> Option<JSONValue> {
 
         // There may be whitespace after the comma and before the next property
         skip_json_whitespace(lexer);
+
+        // Trailing comma is not allowed
+        if lexer.current_equals('}') {
+            return None;
+        }
     }
 
     lexer.expect('}')?;
@@ -384,6 +389,11 @@ fn parse_json_array(lexer: &mut StringLexer) -> Option<JSONValue> {
 
         // There may be whitespace after the comma and before the next value
         skip_json_whitespace(lexer);
+
+        // Trailing comma is not allowed
+        if lexer.current_equals(']') {
+            return None;
+        }
     }
 
     lexer.expect(']')?;

--- a/tests/integration/built-ins/JSON/parse_trailing_comma.js
+++ b/tests/integration/built-ins/JSON/parse_trailing_comma.js
@@ -1,0 +1,9 @@
+/*---
+description: JSON.parse does not allow trailing commas in objects or arrays.
+---*/
+
+assert.throws(SyntaxError, () => JSON.parse('{"a":1,}'));
+assert.throws(SyntaxError, () => JSON.parse('{"a":1 ,}'));
+
+assert.throws(SyntaxError, () => JSON.parse('[1,]'));
+assert.throws(SyntaxError, () => JSON.parse('[1 ,]'));


### PR DESCRIPTION
# Description

Fixes https://github.com/Hans-Halverson/brimstone/issues/211.

`JSON.parse` should not have been accepting trailing commas. Let's makes sure to error when this case appears in objects and arrays.

# Tests

Added integration tests verifying that `JSON.parse` does not accept trailing commas in objects or arrays, including when separated by whitespace.