### PR TITLE
[test] Bump test262 to latest version

### DIFF
--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -7,6 +7,15 @@
       // Bugs (We intend to fix these)
       //
       ////////////////////////////////////////
+      // Bug in iterator close order for some Set methods
+      "built-ins/Set/prototype/isDisjointFrom/set-like-iter-return.js",
+      "built-ins/Set/prototype/isSupersetOf/set-like-iter-return.js",
+
+      // Bug when copying within resizable array that resizes during evaluation
+      "built-ins/TypedArray/prototype/copyWithin/coerced-target-start-end-shrink.js",
+
+      // Different rejection order for promises when evaluating modules with top-level await
+      "language/module-code/top-level-await/rejection-order.js",
 
       // A variety of failures in introduced SpiderMonkey tests
       "staging/sm/*",
@@ -162,6 +171,11 @@
   // Tests for unimplemented features. Counts against test262 progress.
   "unimplemented": {
     "features": [
+      // Stage 4 proposals which need to be implemented
+      "iterator-sequencing",
+      "uint8array-base64",
+      "Math.sumPrecise",
+
       // Other unimplemented features
       "SharedArrayBuffer",
       "Atomics"
@@ -192,11 +206,11 @@
       "explicit-resource-management",
       "import-assertions",
       "import-defer",
-      "iterator-sequencing",
+      "immutable-arraybuffer",
       "json-parse-with-source",
       "legacy-regexp",
+      "nonextensible-applies-to-private",
       "source-phase-imports",
-      "uint8array-base64",
       "upsert",
       "Array.fromAsync",
       "Atomics.pause",
@@ -204,7 +218,6 @@
       "Intl.DurationFormat",
       "Intl.Locale-info",
       "Intl.NumberFormat-v3",
-      "Math.sumPrecise",
       "Temporal",
       "ShadowRealm"
     ]

--- a/tests/test262/install_test262.sh
+++ b/tests/test262/install_test262.sh
@@ -6,8 +6,8 @@ CURRENT_DIR=$(cd "$(dirname "$0")" && pwd)
 TEST262_REPO_DIR="$CURRENT_DIR/test262"
 
 # Pinned commit hash of test262 repo that we test off of. Be sure to also update README.md.
-# Last updated on 2025-07-12
-TEST262_COMMIT_SHA="f0dc15c6c7ec095ba3caf3acc0f8665394665841"
+# Last updated on 2025-11-18
+TEST262_COMMIT_SHA="cff568602848f8d083074c45a72b1503c1e00bad"
 
 # Clone the test262 repo if it is not already present
 if [ ! -d "$TEST262_REPO_DIR" ]; then


### PR DESCRIPTION
## Summary

Bumps test262 to the latest version (https://github.com/tc39/test262/commit/cff568602848f8d083074c45a72b1503c1e00bad).

- Categorize and add ignores for newly failing tests.
- Promotes three proposals that have reached Stage 4

## Tests

All non-ignored tests pass.