### PR TITLE
[common] Bump rust toolchain to 1.91.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.91.1"

--- a/src/brimstone_serialized_heap/build.rs
+++ b/src/brimstone_serialized_heap/build.rs
@@ -93,6 +93,6 @@ fn write_bytes_to_file(bytes: &[u8], out_path: &Path, file_name: &str) -> PathBu
 }
 
 const fn usize_slice_to_u8_slice(slice: &[usize]) -> &[u8] {
-    let num_bytes = std::mem::size_of::<usize>() * slice.len();
+    let num_bytes = std::mem::size_of_val(slice);
     unsafe { std::slice::from_raw_parts(slice.as_ptr().cast(), num_bytes) }
 }

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -4966,7 +4966,10 @@ pub struct ParseFunctionResult<'a> {
     pub options: Rc<Options>,
 }
 
-pub fn parse_script(pcx: &ParseContext, options: Rc<Options>) -> ParseResult<ParseProgramResult> {
+pub fn parse_script(
+    pcx: &ParseContext,
+    options: Rc<Options>,
+) -> ParseResult<ParseProgramResult<'_>> {
     // Create and prime parser
     let alloc = pcx.alloc();
     let lexer = Lexer::new(pcx.source(), alloc);
@@ -4978,7 +4981,10 @@ pub fn parse_script(pcx: &ParseContext, options: Rc<Options>) -> ParseResult<Par
     parser.parse_script(initial_state)
 }
 
-pub fn parse_module(pcx: &ParseContext, options: Rc<Options>) -> ParseResult<ParseProgramResult> {
+pub fn parse_module(
+    pcx: &ParseContext,
+    options: Rc<Options>,
+) -> ParseResult<ParseProgramResult<'_>> {
     // Create and prime parser
     let alloc = pcx.alloc();
     let lexer = Lexer::new(pcx.source(), alloc);
@@ -4993,7 +4999,7 @@ pub fn parse_script_for_eval(
     options: Rc<Options>,
     is_direct: bool,
     inherit_strict_mode: bool,
-) -> ParseResult<ParseProgramResult> {
+) -> ParseResult<ParseProgramResult<'_>> {
     // Create and prime parser
     let alloc = pcx.alloc();
     let lexer = Lexer::new(pcx.source(), alloc);
@@ -5056,7 +5062,7 @@ pub fn parse_function_body_for_function_constructor(
 pub fn parse_function_for_function_constructor(
     pcx: &ParseContext,
     options: Rc<Options>,
-) -> ParseResult<ParseFunctionResult> {
+) -> ParseResult<ParseFunctionResult<'_>> {
     // Create and prime parser
     let alloc = pcx.alloc();
     let source = pcx.source();

--- a/src/js/runtime/bytecode/source_map.rs
+++ b/src/js/runtime/bytecode/source_map.rs
@@ -61,7 +61,7 @@ impl BytecodeSourceMap {
         Some(current_source_position)
     }
 
-    fn iter(source_map: &HeapPtr<ByteArray>) -> SourceMapIter {
+    fn iter(source_map: &HeapPtr<ByteArray>) -> SourceMapIter<'_> {
         SourceMapIter::new(source_map.as_slice())
     }
 }

--- a/src/js/runtime/collections/hash_map.rs
+++ b/src/js/runtime/collections/hash_map.rs
@@ -135,25 +135,25 @@ impl<K: Eq + Hash + Clone, V: Clone> BsHashMap<K, V> {
 
     /// Return iterator through the entries of the map. Iterator is not GC-safe, so make sure there
     /// are no allocations between construction and use.
-    pub fn iter_gc_unsafe(&self) -> GcUnsafeEntriesIter<K, V> {
+    pub fn iter_gc_unsafe(&self) -> GcUnsafeEntriesIter<'_, K, V> {
         GcUnsafeEntriesIter(self.entries.as_slice().iter())
     }
 
     /// Return iterator through the entries of the map. Iterator is not GC-safe, so make sure there
     /// are no allocations between construction and use.
-    pub fn iter_mut_gc_unsafe(&mut self) -> GcUnsafeEntriesIterMut<K, V> {
+    pub fn iter_mut_gc_unsafe(&mut self) -> GcUnsafeEntriesIterMut<'_, K, V> {
         GcUnsafeEntriesIterMut(self.entries.as_mut_slice().iter_mut())
     }
 
     /// Return iterator through the keys of the map. Iterator is not GC-safe, so make sure there
     /// are no allocations between construction and use.
-    pub fn keys_gc_unsafe(&self) -> GcUnsafeKeysIter<K, V> {
+    pub fn keys_gc_unsafe(&self) -> GcUnsafeKeysIter<'_, K, V> {
         GcUnsafeKeysIter(self.entries.as_slice().iter())
     }
 
     /// Return iterator through the keys of the map. Iterator is not GC-safe, so make sure there
     /// are no allocations between construction and use.
-    pub fn keys_mut_gc_unsafe(&mut self) -> GcUnsafeKeysIterMut<K, V> {
+    pub fn keys_mut_gc_unsafe(&mut self) -> GcUnsafeKeysIterMut<'_, K, V> {
         GcUnsafeKeysIterMut(self.entries.as_mut_slice().iter_mut())
     }
 

--- a/src/js/runtime/collections/hash_set.rs
+++ b/src/js/runtime/collections/hash_set.rs
@@ -55,7 +55,7 @@ impl<T: Eq + Hash + Clone> BsHashSet<T> {
 
     /// Return iterator through the elements of the set. Iterator is not GC-safe, so make sure there
     /// are no allocations between construction and use.
-    pub fn iter_mut_gc_unsafe(&mut self) -> GcUnsafeKeysIterMut<T, ()> {
+    pub fn iter_mut_gc_unsafe(&mut self) -> GcUnsafeKeysIterMut<'_, T, ()> {
         self.0.keys_mut_gc_unsafe()
     }
 

--- a/src/js/runtime/collections/index_map.rs
+++ b/src/js/runtime/collections/index_map.rs
@@ -165,14 +165,14 @@ impl<K: Eq + Hash + Clone, V: Clone> BsIndexMap<K, V> {
 
     /// Return iterator through the entries of the map. Iterator is not GC-safe, so make sure there
     /// are no allocations between construction and use.
-    pub fn iter_gc_unsafe(&self) -> GcUnsafeEntriesIter<K, V> {
+    pub fn iter_gc_unsafe(&self) -> GcUnsafeEntriesIter<'_, K, V> {
         // Only iterate through a slice of the entries that have been used
         GcUnsafeEntriesIter(self.entries_as_slice()[..self.num_entries_used()].iter())
     }
 
     /// Return iterator through the entries of the map. Iterator is not GC-safe, so make sure there
     /// are no allocations between construction and use.
-    pub fn iter_mut_gc_unsafe(&mut self) -> GcUnsafeEntriesIterMut<K, V> {
+    pub fn iter_mut_gc_unsafe(&mut self) -> GcUnsafeEntriesIterMut<'_, K, V> {
         // Only iterate through a slice of the entries that have been used
         let num_entries_used = self.num_entries_used();
         GcUnsafeEntriesIterMut(self.entries_as_slice_mut()[..num_entries_used].iter_mut())
@@ -180,13 +180,13 @@ impl<K: Eq + Hash + Clone, V: Clone> BsIndexMap<K, V> {
 
     /// Return iterator through the keys of the map. Iterator is not GC-safe, so make sure there
     /// are no allocations between construction and use.
-    pub fn keys_gc_unsafe(&self) -> GcUnsafeKeysIter<K, V> {
+    pub fn keys_gc_unsafe(&self) -> GcUnsafeKeysIter<'_, K, V> {
         GcUnsafeKeysIter(self.entries_as_slice()[..self.num_entries_used()].iter())
     }
 
     /// Return iterator through the keys of the map. Iterator is not GC-safe, so make sure there
     /// are no allocations between construction and use.
-    pub fn keys_mut_gc_unsafe(&mut self) -> GcUnsafeKeysIterMut<K, V> {
+    pub fn keys_mut_gc_unsafe(&mut self) -> GcUnsafeKeysIterMut<'_, K, V> {
         let num_entries_used = self.num_entries_used();
         GcUnsafeKeysIterMut(self.entries_as_slice_mut()[..num_entries_used].iter_mut())
     }

--- a/src/js/runtime/collections/index_set.rs
+++ b/src/js/runtime/collections/index_set.rs
@@ -58,7 +58,7 @@ impl<T: Eq + Hash + Clone> BsIndexSet<T> {
 
     /// Return iterator through the elements of the set. Iterator is not GC-safe, so make sure there
     /// are no allocations between construction and use.
-    pub fn iter_mut_gc_unsafe(&mut self) -> GcUnsafeKeysIterMut<T, ()> {
+    pub fn iter_mut_gc_unsafe(&mut self) -> GcUnsafeKeysIterMut<'_, T, ()> {
         self.0.keys_mut_gc_unsafe()
     }
 

--- a/src/js/runtime/gc/heap_serializer.rs
+++ b/src/js/runtime/gc/heap_serializer.rs
@@ -116,7 +116,7 @@ impl HeapSerializer {
         }
     }
 
-    pub fn as_serialized(&self) -> SerializedHeap {
+    pub fn as_serialized(&self) -> SerializedHeap<'_> {
         let permanent_start = self.cx.heap.permanent_heap_bounds().start;
         let current_start = self.cx.heap.current_used_heap_bounds().0;
 

--- a/src/js/runtime/intrinsics/finalization_registry_object.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_object.rs
@@ -208,7 +208,7 @@ impl FinalizationRegistryCells {
         self.num_deleted += 1;
     }
 
-    pub fn iter_mut_gc_unsafe(&mut self) -> slice::IterMut<Option<FinalizationRegistryCell>> {
+    pub fn iter_mut_gc_unsafe(&mut self) -> slice::IterMut<'_, Option<FinalizationRegistryCell>> {
         let num_cells_used = self.num_cells_used();
         let used_slice = &mut self.cells.as_mut_slice()[0..num_cells_used];
         used_slice.iter_mut()

--- a/src/js/runtime/proxy_object.rs
+++ b/src/js/runtime/proxy_object.rs
@@ -214,15 +214,15 @@ impl VirtualObject for Handle<ProxyObject> {
                     ),
                 );
             }
-        } else {
-            if !is_compatible_property_descriptor(cx, is_target_extensible, desc, target_desc) {
+        } else if let Some(target_desc) = target_desc {
+            if !is_compatible_property_descriptor(cx, is_target_extensible, desc, Some(target_desc))
+            {
                 return type_error(
                     cx,
                     &format!("proxy can't report an incompatible property descriptor for '{key}'"),
                 );
             }
 
-            let target_desc = target_desc.unwrap();
             if is_setting_non_configurable {
                 if let Some(true) = target_desc.is_configurable {
                     return type_error(cx, &format!("proxy can't define an existing configurable property '{key}' as non-configurable"));

--- a/src/js/runtime/string_value.rs
+++ b/src/js/runtime/string_value.rs
@@ -1280,7 +1280,7 @@ impl DebugPrint for HeapPtr<ConcatString> {
 }
 
 // Ensure that data will be aligned if placed after the rest of the fields
-static_assert!(FlatString::DATA_OFFSET % align_of::<u16>() == 0);
+static_assert!(FlatString::DATA_OFFSET.is_multiple_of(align_of::<u16>()));
 
 /// An iterator over the code units of a string. Is not GC-safe.
 #[derive(Clone)]


### PR DESCRIPTION
## Summary

Bump the rust toolchain to its latest version: 1.91.1.

Fixed a handful of new lint warnings.

## Tests

All tests pass.