### PR TITLE
[common] Enable Annex B extensions by default

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -20,7 +20,9 @@ brimstone_serialized_heap.workspace = true
 criterion.workspace = true
 
 [features]
-default = ["jemalloc"]
+default = ["annex_b", "jemalloc"]
+# Enable Annex B extensions by default
+annex_b = ["brimstone_core/annex_b"]
 # Run the garbage collector in stress test mode
 gc_stress_test = ["brimstone_core/gc_stress_test"]
 # Collect handle use statistics

--- a/src/js/Cargo.toml
+++ b/src/js/Cargo.toml
@@ -44,6 +44,8 @@ zerovec.workspace = true
 
 [features]
 default = ["jemalloc"]
+# Enable Annex B extensions by default
+annex_b = []
 # Run the garbage collector in stress test mode
 gc_stress_test = []
 # Collect handle use statistics

--- a/src/js/common/options.rs
+++ b/src/js/common/options.rs
@@ -27,8 +27,8 @@ pub struct Args {
     #[arg(short, long, default_value_t = false)]
     pub module: bool,
 
-    /// Enable Annex B extensions
-    #[arg(long, default_value_t = false)]
+    /// Whether to enable Annex B extensions
+    #[arg(long, default_value_t = cfg!(feature = "annex_b"))]
     pub annex_b: bool,
 
     /// Expose global gc methods
@@ -111,7 +111,7 @@ impl OptionsBuilder {
     /// Create new options with default values.
     pub fn new() -> Self {
         Self(Options {
-            annex_b: false,
+            annex_b: cfg!(feature = "annex_b"),
             print_ast: false,
             print_bytecode: false,
             print_regexp_bytecode: false,


### PR DESCRIPTION
## Summary

We keep encountering Annex B syntax. In the spirit of compatibility let's switch to supporting Annex B by default instead of requiring it to be opt in with a cli flag.

A new Rust feature is used to gate whether Annex B is enabled by default. You can still always manually configure Annex B regardless of whether this feature is enabled. To my knowledge Annex B support is not yet expensive, but if that changes we will consider conditional compilation.

Note that we only have partial support for Annex B at the moment.

## Tests

Verified that `cargo run` no parses Annex B syntax but`cargo run --no-default-features` does not parse Annex B syntax. All tests pass.