### PR TITLE
[bytecode] Fix clobber of for-in loop's lhs register by ForInNext result which signals the end of iteration

### DIFF
--- a/tests/integration/language/statement/for-in/left_hand_side_not_clobbered.js
+++ b/tests/integration/language/statement/for-in/left_hand_side_not_clobbered.js
@@ -1,0 +1,23 @@
+/*---
+description: The left hand side of a for-in loop is not clobbered if no iterations occur or after the final iteration.
+---*/
+
+var a1 = 10;
+for (a1 in {});
+assert.sameValue(a1, 10);
+
+var a2 = 20;
+for (a2 in { prop: 1 });
+assert.sameValue(a2, 'prop');
+
+(function() {
+  var a3 = 30;
+  for (a3 in {});
+  assert.sameValue(a3, 30);
+})();
+
+(function() {
+  var a4 = 40;
+  for (a4 in { prop: 1 });
+  assert.sameValue(a4, 'prop');
+})();

--- a/tests/js_bytecode/scope/for_in.exp
+++ b/tests/js_bytecode/scope/for_in.exp
@@ -24,19 +24,20 @@
 [BytecodeFunction: startScope] {
   Parameters: 0, Registers: 4
      0: NewObject r2
-     2: JumpNullish r2, 26 (.L1)
+     2: JumpNullish r2, 29 (.L1)
      5: NewForInIterator r2, r2
   .L0:
-     8: ForInNext r0, r2
-    11: JumpNullish r0, 17 (.L1)
-    14: LoadEmpty r1
-    16: CheckTdz r1, c0
-    19: Add r3, r0, r1
-    23: LoadImmediate r1, 0
-    26: Jump -18 (.L0)
+     8: ForInNext r3, r2
+    11: JumpNullish r3, 20 (.L1)
+    14: Mov r0, r3
+    17: LoadEmpty r1
+    19: CheckTdz r1, c0
+    22: Add r3, r0, r1
+    26: LoadImmediate r1, 0
+    29: Jump -21 (.L0)
   .L1:
-    28: LoadUndefined r2
-    30: Ret r2
+    31: LoadUndefined r2
+    33: Ret r2
   Constant Table:
     0: [String: inner]
 }
@@ -132,17 +133,18 @@
   Parameters: 0, Registers: 3
      0: LoadEmpty r0
      2: CheckTdz r0, c0
-     5: JumpNullish r0, 19 (.L1)
+     5: JumpNullish r0, 22 (.L1)
      8: NewForInIterator r1, r0
   .L0:
     11: LoadEmpty r0
-    13: ForInNext r0, r1
-    16: JumpNullish r0, 8 (.L1)
-    19: LoadImmediate r2, 1
-    22: Jump -11 (.L0)
+    13: ForInNext r2, r1
+    16: JumpNullish r2, 11 (.L1)
+    19: Mov r0, r2
+    22: LoadImmediate r2, 1
+    25: Jump -14 (.L0)
   .L1:
-    24: LoadUndefined r1
-    26: Ret r1
+    27: LoadUndefined r1
+    29: Ret r1
   Constant Table:
     0: [String: x]
 }

--- a/tests/js_bytecode/statement/for_in.exp
+++ b/tests/js_bytecode/statement/for_in.exp
@@ -37,84 +37,89 @@
   Parameters: 0, Registers: 3
      0: LoadImmediate r1, 1
      3: NewObject r1
-     5: JumpNullish r1, 17 (.L1)
+     5: JumpNullish r1, 20 (.L1)
      8: NewForInIterator r1, r1
   .L0:
-    11: ForInNext r0, r1
-    14: JumpNullish r0, 8 (.L1)
-    17: LoadImmediate r2, 2
-    20: Jump -9 (.L0)
+    11: ForInNext r2, r1
+    14: JumpNullish r2, 11 (.L1)
+    17: Mov r0, r2
+    20: LoadImmediate r2, 2
+    23: Jump -12 (.L0)
   .L1:
-    22: LoadImmediate r1, 3
-    25: LoadUndefined r1
-    27: Ret r1
+    25: LoadImmediate r1, 3
+    28: LoadUndefined r1
+    30: Ret r1
 }
 
 [BytecodeFunction: basicConstLet] {
   Parameters: 0, Registers: 4
      0: LoadImmediate r2, 1
      3: NewObject r2
-     5: JumpNullish r2, 17 (.L1)
+     5: JumpNullish r2, 20 (.L1)
      8: NewForInIterator r2, r2
   .L0:
-    11: ForInNext r1, r2
-    14: JumpNullish r1, 8 (.L1)
-    17: LoadImmediate r3, 2
-    20: Jump -9 (.L0)
+    11: ForInNext r3, r2
+    14: JumpNullish r3, 11 (.L1)
+    17: Mov r1, r3
+    20: LoadImmediate r3, 2
+    23: Jump -12 (.L0)
   .L1:
-    22: LoadImmediate r2, 3
-    25: NewObject r2
-    27: JumpNullish r2, 17 (.L3)
-    30: NewForInIterator r2, r2
+    25: LoadImmediate r2, 3
+    28: NewObject r2
+    30: JumpNullish r2, 20 (.L3)
+    33: NewForInIterator r2, r2
   .L2:
-    33: ForInNext r0, r2
-    36: JumpNullish r0, 8 (.L3)
-    39: LoadImmediate r3, 3
-    42: Jump -9 (.L2)
+    36: ForInNext r3, r2
+    39: JumpNullish r3, 11 (.L3)
+    42: Mov r0, r3
+    45: LoadImmediate r3, 3
+    48: Jump -12 (.L2)
   .L3:
-    44: LoadImmediate r2, 4
-    47: LoadUndefined r2
-    49: Ret r2
+    50: LoadImmediate r2, 4
+    53: LoadUndefined r2
+    55: Ret r2
 }
 
 [BytecodeFunction: testBreakAndContinue] {
   Parameters: 0, Registers: 3
      0: LoadImmediate r1, 1
      3: NewObject r1
-     5: JumpNullish r1, 30 (.L3)
+     5: JumpNullish r1, 33 (.L3)
      8: NewForInIterator r1, r1
   .L0:
-    11: ForInNext r0, r1
-    14: JumpNullish r0, 21 (.L3)
-    17: LoadImmediate r2, 2
-    20: JumpToBooleanFalse r2, 5 (.L1)
-    23: Jump 12 (.L3)
+    11: ForInNext r2, r1
+    14: JumpNullish r2, 24 (.L3)
+    17: Mov r0, r2
+    20: LoadImmediate r2, 2
+    23: JumpToBooleanFalse r2, 5 (.L1)
+    26: Jump 12 (.L3)
   .L1:
-    25: LoadImmediate r2, 3
-    28: JumpToBooleanFalse r2, 5 (.L2)
-    31: Jump -20 (.L0)
+    28: LoadImmediate r2, 3
+    31: JumpToBooleanFalse r2, 5 (.L2)
+    34: Jump -23 (.L0)
   .L2:
-    33: Jump -22 (.L0)
+    36: Jump -25 (.L0)
   .L3:
-    35: LoadImmediate r1, 4
-    38: LoadUndefined r1
-    40: Ret r1
+    38: LoadImmediate r1, 4
+    41: LoadUndefined r1
+    43: Ret r1
 }
 
 [BytecodeFunction: lhsIdentifier] {
-  Parameters: 1, Registers: 1
+  Parameters: 1, Registers: 2
      0: LoadImmediate r0, 1
      3: NewObject r0
-     5: JumpNullish r0, 14 (.L1)
+     5: JumpNullish r0, 17 (.L1)
      8: NewForInIterator r0, r0
   .L0:
-    11: ForInNext a0, r0
-    14: JumpNullish a0, 5 (.L1)
-    17: Jump -6 (.L0)
+    11: ForInNext r1, r0
+    14: JumpNullish r1, 8 (.L1)
+    17: Mov a0, r1
+    20: Jump -9 (.L0)
   .L1:
-    19: LoadImmediate r0, 2
-    22: LoadUndefined r0
-    24: Ret r0
+    22: LoadImmediate r0, 2
+    25: LoadUndefined r0
+    27: Ret r0
 }
 
 [BytecodeFunction: lhsMember] {


### PR DESCRIPTION
## Summary

Fixes a bug in bytecode generation where `ForInNext` was always clobbering the variable of a for-in statement when the `ForInNext` returns a result which signals the end of iteration. This is only observable when the variable is a `var` that can be read after the loop.

The problem is that the `ForInNext` returns `undefined` when the loop was done, but as an optimization we were storing this directly to the variable's register destination (if stored directly in a register). We should instead always be storing to a temporary first, checking if `undefined`, then only writing back to the variable if the iteration result was not `undefined`.

## Tests

- Added integration test verifying that for-in variable is not clobbered after last iteration (or if there are no iterations)
- Update snapshot tests to see temporary register now used for `ForInNext` result