### PR TITLE
[parser] Annex B allows var declarations within a catch body to have the same name as catch parameters

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -7451,6 +7451,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             ScopeNodeKind::Block
             | ScopeNodeKind::Switch
             | ScopeNodeKind::Class
+            | ScopeNodeKind::CatchBody
             | ScopeNodeKind::Eval { .. }
             | ScopeNodeKind::StaticInitializer => {
                 if let Some(vm_node_id) = scope.vm_scope_id() {

--- a/tests/js_bytecode/annex_b/catch_parameter_redeclaration.exp
+++ b/tests/js_bytecode/annex_b/catch_parameter_redeclaration.exp
@@ -1,0 +1,29 @@
+[BytecodeFunction: <global>] {
+  Parameters: 0, Registers: 1
+    0: NewClosure r0, c0
+    3: StoreGlobal r0, c1
+    6: LoadUndefined r0
+    8: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: test]
+    1: [String: test]
+}
+
+[BytecodeFunction: test] {
+  Parameters: 0, Registers: 4
+     0: LoadImmediate r0, 1
+     3: Mov r2, <scope>
+     6: LoadImmediate r3, 2
+     9: Jump 17 (.L0)
+    11: Mov <scope>, r2
+    14: LoadImmediate r3, 3
+    17: LoadImmediate r1, 4
+    20: LoadImmediate r1, 5
+    23: LoadImmediate r3, 6
+  .L0:
+    26: LoadImmediate r0, 6
+    29: LoadUndefined r2
+    31: Ret r2
+  Exception Handlers:
+    6-9 -> 11 (r1)
+}

--- a/tests/js_bytecode/annex_b/catch_parameter_redeclaration.js
+++ b/tests/js_bytecode/annex_b/catch_parameter_redeclaration.js
@@ -1,0 +1,21 @@
+function test() {
+  // Reference hoisted variable
+  foo = 1;
+
+  try {
+    2;
+  } catch (foo) {
+    3;
+    
+    // Store to catch paramter
+    var foo = 4;
+
+    // Load catch parameter
+    foo = 5;
+
+    6;
+  }
+
+  // Reference hoisted variable
+  foo = 6;
+}

--- a/tests/js_error/annex_b/statement/catch_parameter_conflict_leave_hoisted_var.exp
+++ b/tests/js_error/annex_b/statement/catch_parameter_conflict_leave_hoisted_var.exp
@@ -1,0 +1,5 @@
+SyntaxError: Redeclaration of const foo
+  ┌ tests/js_error/annex_b/statement/catch_parameter_conflict_leave_hoisted_var.js:9:9
+  |
+9 |     var foo = 4;
+  |         ^

--- a/tests/js_error/annex_b/statement/catch_parameter_conflict_leave_hoisted_var.js
+++ b/tests/js_error/annex_b/statement/catch_parameter_conflict_leave_hoisted_var.js
@@ -1,0 +1,11 @@
+function test() {
+  // Conflict with hoisted var in scope outside catch, even though var does not conflict within the
+  // catch body itself.
+  const foo = 1;
+
+  try {
+    2;
+  } catch (foo) {
+    var foo = 4;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the Annex B extension where var declarations in a catch body are allowed to have the same name as catch parameters without erroring. All references to this name within the catch clause will resolve to the catch parameter, including initialization of the var declaration. The var declaration itself is still hoisted outside the catch clause and can be accessed outside the catch.

We implement this by modifying `add_var_scoped_binding` to:
- Not error when a var conflicts with a catch parameter in this case
- Return the catch scope instead of the scope the var is hoisted to. This makes the var declaration identifier resolve to the catch parameter so that the catch parameter is stored to during initialization.
- Not add the var name to `extra_var_names` within the catch body scope, since this scope will be checked for name conflicts during analysis

Notes:
 - We now specify the `ScopeNodeKind` when parsing each block so that we can mark the catch body block
 - The options must be plumbed to the `ScopeTree` so we can check whether to use Annex B features

`eval` support not yet implemented.

## Tests

- Now passes all catch parameter test262 Annex B tests: `annexB/language/statements/try/*`
- Add bytecode snapshot test to confirm that loads and stores reference the catch parameter vs variable binding correctly
- Add parser snapshot tests to ensure that the hoisted var declaration can still cause redeclaration errors outside the catch clause