### PR TITLE
[test] Fix cargo bench and build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,14 @@ jobs:
         run: |
           cargo brimstone-test -- --reindex
           cargo brimstone-test --release --no-default-features --features nightly -- --ignore-unimplemented
+    
+  build-benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
+
+      - name: Build benchmarks
+        run: cargo bench --no-run

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.claude
+
 target
 node_modules
 tests/test262/test262

--- a/src/benches/benches.rs
+++ b/src/benches/benches.rs
@@ -67,7 +67,10 @@ fn setup_step(file: &str, flags: TestFlags) -> (Context, ParseContext) {
         .annex_b(flags.contains(TestFlags::ANNEX_B))
         .heap_size(10 * 1024 * 1024)
         .build();
-    let cx = ContextBuilder::new().set_options(Rc::new(options)).build();
+    let cx = ContextBuilder::new()
+        .set_options(Rc::new(options))
+        .build()
+        .unwrap();
     let source = Rc::new(Source::new_from_file(&format!("benches/{file}")).unwrap());
     let pcx = ParseContext::new(source);
     (cx, pcx)
@@ -202,7 +205,10 @@ fn context_benches(c: &mut Criterion) {
         || {},
         |_| {
             let options = OptionsBuilder::new().serialized_heap(None).build();
-            let cx = ContextBuilder::new().set_options(Rc::new(options)).build();
+            let cx = ContextBuilder::new()
+                .set_options(Rc::new(options))
+                .build()
+                .unwrap();
             (cx, ())
         },
         cleanup2_step,
@@ -217,7 +223,10 @@ fn context_benches(c: &mut Criterion) {
             let options = OptionsBuilder::new()
                 .serialized_heap(Some(serialized_heap))
                 .build();
-            let cx = ContextBuilder::new().set_options(Rc::new(options)).build();
+            let cx = ContextBuilder::new()
+                .set_options(Rc::new(options))
+                .build()
+                .unwrap();
             (cx, ())
         },
         cleanup2_step,


### PR DESCRIPTION
## Summary

`cargo bench` regressed during the allocation failure refactor. Fix `cargo bench` and build during CI to prevent future regressions.

## Tests

- CI