### PR TITLE
[test] Fix fuzzer build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,14 @@ jobs:
 
       - name: Build benchmarks
         run: cargo bench --no-run
+
+  build-fuzzer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
+
+      - name: Build fuzzer
+        run: ./tests/fuzz/build.sh

--- a/tests/fuzz/build.sh
+++ b/tests/fuzz/build.sh
@@ -17,14 +17,19 @@ clang -shared -o "$BUILD_DIR/libcoverage.so" "$BUILD_DIR/coverage.o"
 #
 # https://github.com/llvm/llvm-project/blob/31127b9e225c50ebadcdc268bccb16319b8db72d/llvm/lib/Transforms/Instrumentation/SanitizerCoverage.cpp#L95-L96
 
-RUSTFLAGS="\
+# Pass flags via CARGO_TARGET_<TRIPLE>_RUSTFLAGS (and an explicit --target) so that they only apply
+# to the target binary and not to build dependencies like proc macros.
+HOST_TRIPLE=$(rustc --print host-tuple)
+HOST_TRIPLE_ENV_VAR=$(tr 'a-z-' 'A-Z_' <<< "$HOST_TRIPLE")
+
+env "CARGO_TARGET_${HOST_TRIPLE_ENV_VAR}_RUSTFLAGS=\
   -C link-arg=-L$BUILD_DIR \
   -C link-arg=-lcoverage \
   -C codegen-units=1 \
   -C passes=sancov-module \
   -C llvm-args=-sanitizer-coverage-trace-pc-guard \
   -C llvm-args=-sanitizer-coverage-level=3" \
-  cargo build --features build_fuzz -p brimstone_fuzz
+  cargo build --features build_fuzz -p brimstone_fuzz --target "$HOST_TRIPLE"
 
 # Clone fuzzilli repo if not present
 FUZZILLI_DIR="$CURRENT_DIR/fuzzilli"

--- a/tests/fuzz/run.sh
+++ b/tests/fuzz/run.sh
@@ -13,6 +13,8 @@ RESULTS_DIR="$CURRENT_DIR/results"
 # Build brimstone for fuzzing and install dependencies
 "$CURRENT_DIR/build.sh"
 
+HOST_TRIPLE=$(rustc -vV | sed -n 's/host: //p')
+
 # Build and run fuzzilli
 cd "$FUZZILLI_DIR"
 
@@ -24,4 +26,4 @@ swift run \
   --storagePath="$RESULTS_DIR" \
   --jobs=4 \
   "$@" \
-  "$ROOT_DIR/target/debug/brimstone_fuzz"
+  "$ROOT_DIR/target/$HOST_TRIPLE/debug/brimstone_fuzz"


### PR DESCRIPTION
## Summary

The fuzzer build was crashing seemingly after the latest Rust toolchain upgrade. The crash was caused by `coverage.c` being initialized multiple times, which was happening when compiling proc macro dependencies.

To fix we should be only compiling the target binary with coverage, not proc macros. Rust doesn't provide a great way of only providing `RUSTFLAGS` for the target and not build dependencies on the host, but it can be accomplished with the `--target <triple>`  flag combined with `CARGO_TARGET_${TRIPLE}_RUSTFLAGS`.

Let's also add a CI job to build the fuzzer to prevent future regressions. If I recall correctly this very bug was happening in CI before and is the reason such a job didn't already exist.

## Tests

- `./tests/fuzz/run.sh` now builds and runs again
- New CI job `build-fuzzer` passes