### PR TITLE
[bytecode] Consolidate simple error throwing byte instructions into single instruction

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -64,7 +64,7 @@ use super::{
     constant_table_builder::{ConstantTableBuilder, ConstantTableIndex},
     exception_handlers::{ExceptionHandlerBuilder, ExceptionHandlersBuilder},
     function::Closure,
-    instruction::{DecodeInfo, DefinePrivatePropertyFlags, EvalFlags, OpCode},
+    instruction::{DecodeInfo, DefinePrivatePropertyFlags, EvalFlags, OpCode, ThrowNewErrorKind},
     operand::{min_width_for_signed, ConstantIndex, Operand, Register, SInt, UInt},
     register_allocator::TemporaryRegisterAllocator,
     width::{ExtraWide, Narrow, UnsignedWidthRepr, Wide, Width, WidthEnum},
@@ -3280,8 +3280,11 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     self.register_allocator.release(property);
                 }
 
-                self.writer
-                    .error_delete_super_property_instruction(delete_pos);
+                self.gen_throw_new_error(
+                    ThrowNewErrorKind::ReferenceError,
+                    "cannot delete super property",
+                    delete_pos,
+                )?;
 
                 // No need to initialize dest since it will not be used
                 self.allocate_destination(dest)
@@ -4800,8 +4803,11 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         dest: ExprDest,
     ) -> EmitResult<GenRegister> {
         let call_result = self.gen_call_expression(call, dest, None)?;
-        self.writer
-            .error_assign_to_call_expression_instruction(call.loc.start);
+        self.gen_throw_new_error(
+            ThrowNewErrorKind::ReferenceError,
+            "cannot assign to call expression",
+            call.loc.start,
+        )?;
 
         Ok(call_result)
     }
@@ -5505,7 +5511,11 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             self.writer.iterator_close_instruction(iterator, pos);
         }
 
-        self.writer.error_iterator_no_throw_method_instruction(pos);
+        self.gen_throw_new_error(
+            ThrowNewErrorKind::TypeError,
+            "iterator does not have a throw method",
+            pos,
+        )?;
 
         // If throw method does exist then call it
         self.start_block(has_throw_method_block);
@@ -9335,6 +9345,19 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         } else {
             Ok(cx.names.default_name().as_string().as_flat())
         }
+    }
+
+    fn gen_throw_new_error(
+        &mut self,
+        kind: ThrowNewErrorKind,
+        message: &str,
+        pos: usize,
+    ) -> EmitResult<()> {
+        let error_type = UInt::new(kind as u32);
+        let message_constant_index = self.add_string_constant(message)?;
+        self.writer
+            .throw_new_error_instruction(error_type, message_constant_index, pos);
+        Ok(())
     }
 }
 

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1682,29 +1682,15 @@ define_instructions!(
         }
     }
 
-    /// Throw a ReferenceError for attempting to delete a super property.
-    ErrorDeleteSuperProperty {
-        camel_case: ErrorDeleteSuperPropertyInstruction,
-        snake_case: error_delete_super_property_instruction,
+    /// Throw a new native error of the given type with a static message in the constant table.
+    ThrowNewError {
+        camel_case: ThrowNewErrorInstruction,
+        snake_case: throw_new_error_instruction,
         can_throw: true,
-        operands: {}
-    }
-
-    /// Throw a ReferenceError for attempting to assign to a call expression in Annex B.
-    ErrorAssignToCallExpression {
-        camel_case: ErrorAssignToCallExpressionInstruction,
-        snake_case: error_assign_to_call_expression_instruction,
-        can_throw: true,
-        operands: {}
-    }
-
-    /// Throw a TypeError for a throw completion in a yield* where the iterator does not have a
-    /// throw method.
-    ErrorIteratorNoThrowMethod {
-        camel_case: ErrorIteratorNoThrowMethodInstruction,
-        snake_case: error_iterator_no_throw_method_instruction,
-        can_throw: true,
-        operands: {}
+        operands: {
+            [0] error_type: UInt,
+            [1] message: ConstantIndex,
+        }
     }
 
     /// Create a new for-in iterator for the given object, storing in dest. Gathers all the iterable
@@ -1946,6 +1932,23 @@ bitflags! {
         const GETTER = 1 << 1;
         /// Whether to define a setter property.
         const SETTER = 1 << 2;
+    }
+}
+
+/// The kind of native error thrown by the `ThrowNewError` instruction.
+#[repr(u8)]
+pub enum ThrowNewErrorKind {
+    ReferenceError = 0,
+    TypeError = 1,
+}
+
+impl ThrowNewErrorKind {
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::ReferenceError),
+            1 => Some(Self::TypeError),
+            _ => None,
+        }
     }
 }
 

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -18,7 +18,6 @@ use crate::{
         array_object::{array_create, ArrayObject},
         async_generator_object::{async_generator_complete_step, AsyncGeneratorObject},
         boxed_value::BoxedValue,
-        bytecode::instruction::ErrorAssignToCallExpressionInstruction,
         class_names::{new_class, ClassNames},
         error::{
             err_assign_constant, err_cannot_set_property, err_not_defined, reference_error,
@@ -44,8 +43,10 @@ use crate::{
         heap_item_descriptor::HeapItemKind,
         intrinsics::{
             async_generator_prototype::AsyncGeneratorPrototype,
-            generator_prototype::GeneratorPrototype, intrinsics::Intrinsic,
-            native_error::TypeError, regexp_constructor::RegExpObject,
+            generator_prototype::GeneratorPrototype,
+            intrinsics::Intrinsic,
+            native_error::{ReferenceError, TypeError},
+            regexp_constructor::RegExpObject,
             rust_runtime::RuntimeFunctionId,
         },
         iterator::{get_iterator, iterator_complete, iterator_value, IteratorHint},
@@ -85,8 +86,7 @@ use super::{
         DefinePrivatePropertyFlags, DefinePrivatePropertyInstruction, DefinePropertyFlags,
         DefinePropertyInstruction, DeleteBindingInstruction, DeletePropertyInstruction,
         DivInstruction, DupScopeInstruction, DynamicImportInstruction, ErrorConstInstruction,
-        ErrorDeleteSuperPropertyInstruction, ErrorIteratorNoThrowMethodInstruction, EvalFlags,
-        ExpInstruction, ForInNextInstruction, GeneratorStartInstruction,
+        EvalFlags, ExpInstruction, ForInNextInstruction, GeneratorStartInstruction,
         GetAsyncIteratorInstruction, GetIteratorInstruction, GetMethodInstruction,
         GetNamedPropertyInstruction, GetNamedSuperPropertyInstruction,
         GetPrivatePropertyInstruction, GetPropertyInstruction, GetSuperConstructorInstruction,
@@ -119,8 +119,9 @@ use super::{
         ShiftRightArithmeticInstruction, ShiftRightLogicalInstruction, StoreDynamicInstruction,
         StoreGlobalInstruction, StoreToModuleInstruction, StoreToScopeInstruction,
         StrictEqualInstruction, StrictNotEqualInstruction, SubInstruction, ThrowInstruction,
-        ToNumberInstruction, ToNumericInstruction, ToObjectInstruction, ToPropertyKeyInstruction,
-        ToStringInstruction, TypeOfInstruction, YieldInstruction,
+        ThrowNewErrorInstruction, ThrowNewErrorKind, ToNumberInstruction, ToNumericInstruction,
+        ToObjectInstruction, ToPropertyKeyInstruction, ToStringInstruction, TypeOfInstruction,
+        YieldInstruction,
     },
     instruction_traits::{
         GenericCallArgs, GenericCallInstruction, GenericConstructInstruction,
@@ -1189,23 +1190,8 @@ impl VM {
                         OpCode::ErrorConst => {
                             dispatch_or_throw!(ErrorConstInstruction, execute_error_const)
                         }
-                        OpCode::ErrorDeleteSuperProperty => {
-                            dispatch_or_throw!(
-                                ErrorDeleteSuperPropertyInstruction,
-                                execute_error_delete_super_property
-                            )
-                        }
-                        OpCode::ErrorAssignToCallExpression => {
-                            dispatch_or_throw!(
-                                ErrorAssignToCallExpressionInstruction,
-                                execute_error_assign_to_call_expression
-                            )
-                        }
-                        OpCode::ErrorIteratorNoThrowMethod => {
-                            dispatch_or_throw!(
-                                ErrorIteratorNoThrowMethodInstruction,
-                                execute_error_iterator_no_throw_method
-                            )
+                        OpCode::ThrowNewError => {
+                            dispatch_or_throw!(ThrowNewErrorInstruction, execute_throw_new_error)
                         }
                         OpCode::NewForInIterator => {
                             dispatch_or_throw!(
@@ -4424,27 +4410,22 @@ impl VM {
     }
 
     #[inline]
-    fn execute_error_delete_super_property<W: Width>(
+    fn execute_throw_new_error<W: Width>(
         &mut self,
-        _: &ErrorDeleteSuperPropertyInstruction<W>,
+        instr: &ThrowNewErrorInstruction<W>,
     ) -> EvalResult<()> {
-        reference_error(self.cx(), "cannot delete super property")
-    }
+        let error_type_operand = instr.error_type().value().to_usize() as u8;
+        let kind = ThrowNewErrorKind::from_u8(error_type_operand).unwrap();
+        let message = self.get_constant(instr.message()).as_string().to_handle();
 
-    #[inline]
-    fn execute_error_assign_to_call_expression<W: Width>(
-        &mut self,
-        _: &ErrorAssignToCallExpressionInstruction<W>,
-    ) -> EvalResult<()> {
-        reference_error(self.cx(), "cannot assign to call expression")
-    }
+        let error_value = match kind {
+            ThrowNewErrorKind::ReferenceError => {
+                ReferenceError::new_with_message_value(self.cx(), message)?
+            }
+            ThrowNewErrorKind::TypeError => TypeError::new_with_message_value(self.cx(), message)?,
+        };
 
-    #[inline]
-    fn execute_error_iterator_no_throw_method<W: Width>(
-        &mut self,
-        _: &ErrorIteratorNoThrowMethodInstruction<W>,
-    ) -> EvalResult<()> {
-        type_error(self.cx(), "iterator does not have a throw method")
+        eval_err!(error_value.into())
     }
 
     #[inline]

--- a/src/js/runtime/intrinsics/native_error.rs
+++ b/src/js/runtime/intrinsics/native_error.rs
@@ -11,6 +11,7 @@ use crate::runtime::{
     },
     object_value::ObjectValue,
     realm::Realm,
+    string_value::StringValue,
     type_utilities::to_string,
     Context, Handle, HeapPtr, Value,
 };
@@ -26,8 +27,15 @@ macro_rules! create_native_error {
                 message: String,
             ) -> AllocResult<Handle<ErrorObject>> {
                 // Be sure to allocate before creating object
-                let message_value = cx.alloc_string(&message)?.into();
+                let message_value = cx.alloc_string(&message)?.as_string();
+                Self::new_with_message_value(cx, message_value)
+            }
 
+            #[allow(dead_code)]
+            pub fn new_with_message_value(
+                cx: Context,
+                message: Handle<StringValue>,
+            ) -> AllocResult<Handle<ErrorObject>> {
                 let object = ErrorObject::new(
                     cx,
                     Intrinsic::$prototype,
@@ -36,7 +44,7 @@ macro_rules! create_native_error {
 
                 object
                     .as_object()
-                    .intrinsic_data_prop(cx, cx.names.message(), message_value)?;
+                    .intrinsic_data_prop(cx, cx.names.message(), message.into())?;
 
                 Ok(object)
             }

--- a/tests/js_bytecode/annex_b/assign_to_call_expression.exp
+++ b/tests/js_bytecode/annex_b/assign_to_call_expression.exp
@@ -1,0 +1,114 @@
+[BytecodeFunction: <global>] {
+  Parameters: 0, Registers: 1
+     0: NewClosure r0, c0
+     3: StoreGlobal r0, c1
+     6: NewClosure r0, c2
+     9: StoreGlobal r0, c3
+    12: NewClosure r0, c4
+    15: StoreGlobal r0, c5
+    18: NewClosure r0, c6
+    21: StoreGlobal r0, c7
+    24: NewClosure r0, c8
+    27: StoreGlobal r0, c9
+    30: LoadUndefined r0
+    32: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: f]
+    1: [String: f]
+    2: [BytecodeFunction: assignmentExpression]
+    3: [String: assignmentExpression]
+    4: [BytecodeFunction: updateExpression]
+    5: [String: updateExpression]
+    6: [BytecodeFunction: forInInitializer]
+    7: [String: forInInitializer]
+    8: [BytecodeFunction: forOfInitializer]
+    9: [String: forOfInitializer]
+}
+
+[BytecodeFunction: f] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: assignmentExpression] {
+  Parameters: 0, Registers: 1
+     0: LoadGlobal r0, c0
+     3: Call r0, r0, r0, 0
+     8: ThrowNewError 0, c1
+    11: LoadUndefined r0
+    13: Ret r0
+  Constant Table:
+    0: [String: f]
+    1: [String: cannot assign to call expression]
+}
+
+[BytecodeFunction: updateExpression] {
+  Parameters: 0, Registers: 1
+     0: LoadGlobal r0, c0
+     3: Call r0, r0, r0, 0
+     8: ThrowNewError 0, c1
+    11: LoadGlobal r0, c0
+    14: Call r0, r0, r0, 0
+    19: ThrowNewError 0, c1
+    22: LoadGlobal r0, c0
+    25: Call r0, r0, r0, 0
+    30: ThrowNewError 0, c1
+    33: LoadGlobal r0, c0
+    36: Call r0, r0, r0, 0
+    41: ThrowNewError 0, c1
+    44: LoadUndefined r0
+    46: Ret r0
+  Constant Table:
+    0: [String: f]
+    1: [String: cannot assign to call expression]
+}
+
+[BytecodeFunction: forInInitializer] {
+  Parameters: 0, Registers: 3
+     0: NewObject r0
+     2: JumpNullish r0, 25 (.L1)
+     5: NewForInIterator r0, r0
+  .L0:
+     8: ForInNext r1, r0
+    11: JumpNullish r1, 16 (.L1)
+    14: LoadGlobal r2, c0
+    17: Call r2, r2, r2, 0
+    22: ThrowNewError 0, c1
+    25: Jump -17 (.L0)
+  .L1:
+    27: LoadUndefined r0
+    29: Ret r0
+  Constant Table:
+    0: [String: f]
+    1: [String: cannot assign to call expression]
+}
+
+[BytecodeFunction: forOfInitializer] {
+  Parameters: 0, Registers: 5
+     0: NewArray r2
+     2: GetIterator r0, r1, r2
+  .L0:
+     6: IteratorNext r2, r3, r0, r1
+    11: JumpTrue r3, 31 (.L2)
+    14: LoadGlobal r3, c0
+    17: Call r3, r3, r3, 0
+    22: ThrowNewError 0, c1
+    25: Mov r4, <scope>
+    28: Jump 12 (.L1)
+    30: LoadImmediate r2, 0
+    33: Mov <scope>, r4
+    36: IteratorClose r0
+    38: Throw r3
+  .L1:
+    40: Jump -34 (.L0)
+  .L2:
+    42: LoadUndefined r0
+    44: Ret r0
+  Constant Table:
+    0: [String: f]
+    1: [String: cannot assign to call expression]
+  Exception Handlers:
+    14-28 -> 30 (r3)
+    36-38 -> 38
+}

--- a/tests/js_bytecode/annex_b/assign_to_call_expression.js
+++ b/tests/js_bytecode/annex_b/assign_to_call_expression.js
@@ -1,0 +1,20 @@
+function f() {}
+
+function assignmentExpression() {
+  f() = 1 + 2;
+}
+
+function updateExpression() {
+  f()++;
+  f()--;
+  ++f();
+  --f();
+}
+
+function forInInitializer() {
+  for (f() in {}) {}
+}
+
+function forOfInitializer() {
+  for (f() of []) {}
+}

--- a/tests/js_bytecode/expression/delete.exp
+++ b/tests/js_bytecode/expression/delete.exp
@@ -224,8 +224,10 @@
 
 [BytecodeFunction: deleteNamedSuperProperty] {
   Parameters: 0, Registers: 1
-    0: ErrorDeleteSuperProperty 
-    1: Ret r0
+    0: ThrowNewError 0, c0
+    3: Ret r0
+  Constant Table:
+    0: [String: cannot delete super property]
 }
 
 [BytecodeFunction: deleteComputedSuperProperty] {
@@ -233,6 +235,8 @@
      0: LoadImmediate r0, 1
      3: LoadImmediate r1, 2
      6: Add r0, r0, r1
-    10: ErrorDeleteSuperProperty 
-    11: Ret r0
+    10: ThrowNewError 0, c0
+    13: Ret r0
+  Constant Table:
+    0: [String: cannot delete super property]
 }

--- a/tests/js_bytecode/expression/yield_star.exp
+++ b/tests/js_bytecode/expression/yield_star.exp
@@ -25,10 +25,10 @@
      19: CheckIteratorResultObject r6
      21: GetNamedProperty r7, r6, c0
      25: JumpTrue r7, 5 (.L1)
-     28: Jump 76 (.L8)
+     28: Jump 78 (.L8)
   .L1:
      30: GetNamedProperty r1, r6, c1
-     34: Jump 77 (.L9)
+     34: Jump 79 (.L9)
   .L2:
      36: JumpNotUndefined r5, 35 (.L5)
      39: GetMethod r8, r2, c3
@@ -39,34 +39,35 @@
      54: CheckIteratorResultObject r6
      56: GetNamedProperty r7, r6, c0
      60: JumpTrue r7, 5 (.L4)
-     63: Jump 41 (.L8)
+     63: Jump 43 (.L8)
   .L4:
      65: GetNamedProperty r8, r6, c1
      69: Ret r8
   .L5:
      71: GetMethod r8, r2, c2
-     75: JumpNotUndefined r8, 6 (.L6)
+     75: JumpNotUndefined r8, 8 (.L6)
      78: IteratorClose r2
-     80: ErrorIteratorNoThrowMethod 
+     80: ThrowNewError 1, c4
   .L6:
-     81: CallWithReceiver r6, r8, r2, r4, 1
-     87: CheckIteratorResultObject r6
-     89: GetNamedProperty r7, r6, c0
-     93: JumpTrue r7, 5 (.L7)
-     96: Jump 8 (.L8)
+     83: CallWithReceiver r6, r8, r2, r4, 1
+     89: CheckIteratorResultObject r6
+     91: GetNamedProperty r7, r6, c0
+     95: JumpTrue r7, 5 (.L7)
+     98: Jump 8 (.L8)
   .L7:
-     98: GetNamedProperty r1, r6, c1
-    102: Jump 9 (.L9)
+    100: GetNamedProperty r1, r6, c1
+    104: Jump 9 (.L9)
   .L8:
-    104: Yield r4, r5, r0, r6
-    109: Jump -99 (.L0)
+    106: Yield r4, r5, r0, r6
+    111: Jump -101 (.L0)
   .L9:
-    111: Ret r1
+    113: Ret r1
   Constant Table:
     0: [String: done]
     1: [String: value]
     2: [String: throw]
     3: [String: return]
+    4: [String: iterator does not have a throw method]
 }
 
 [BytecodeFunction: asyncYieldStar] {
@@ -85,12 +86,13 @@
      29: CheckIteratorResultObject r6
      31: GetNamedProperty r7, r6, c0
      35: JumpTrue r7, 5 (.L2)
-     38: Jump 123 (.L15)
+     38: Jump 125 (.L15)
   .L2:
      40: GetNamedProperty r1, r6, c1
-     44: JumpConstant c4 (.L4)
+     44: JumpConstant c5 (.L4)
   .L3:
      46: JumpNotUndefined r5, 55 (.L9)
+  .L4:
      49: GetMethod r8, r2, c3
      53: JumpNotUndefined r8, 15 (.L6)
      56: Await r4, r9, r0, r4
@@ -107,13 +109,13 @@
      84: CheckIteratorResultObject r6
      86: GetNamedProperty r7, r6, c0
      90: JumpTrue r7, 5 (.L8)
-     93: Jump 68 (.L15)
+     93: Jump 70 (.L15)
   .L8:
      95: GetNamedProperty r8, r6, c1
      99: Ret r8
   .L9:
     101: GetMethod r8, r2, c2
-    105: JumpNotUndefined r8, 23 (.L12)
+    105: JumpNotUndefined r8, 25 (.L12)
     108: AsyncIteratorCloseStart r10, r9, r2
     112: JumpFalse r9, 15 (.L11)
     115: Await r10, r11, r0, r10
@@ -122,38 +124,39 @@
   .L10:
     125: AsyncIteratorCloseFinish r10
   .L11:
-    127: ErrorIteratorNoThrowMethod 
+    127: ThrowNewError 1, c4
   .L12:
-    128: CallWithReceiver r6, r8, r2, r4, 1
-    134: Await r6, r8, r0, r6
-    139: JumpTrue r8, 5 (.L13)
-    142: Throw r6
+    130: CallWithReceiver r6, r8, r2, r4, 1
+    136: Await r6, r8, r0, r6
+    141: JumpTrue r8, 5 (.L13)
+    144: Throw r6
   .L13:
-    144: CheckIteratorResultObject r6
-    146: GetNamedProperty r7, r6, c0
-    150: JumpTrue r7, 5 (.L14)
-    153: Jump 8 (.L15)
+    146: CheckIteratorResultObject r6
+    148: GetNamedProperty r7, r6, c0
+    152: JumpTrue r7, 5 (.L14)
+    155: Jump 8 (.L15)
   .L14:
-    155: GetNamedProperty r1, r6, c1
-    159: Jump 35 (.L16)
+    157: GetNamedProperty r1, r6, c1
+    161: Jump 35 (.L16)
   .L15:
-    161: GetNamedProperty r8, r6, c1
-    165: Yield r4, r5, r0, r8
-    170: JumpNotUndefined (Wide) r5, -160 (.L0)
-    176: Await r4, r5, r0, r4
-    181: JumpNullish (Wide) r5, -171 (.L0)
-    188: LoadUndefined r5
-    190: Jump (Wide) -180 (.L0)
+    163: GetNamedProperty r8, r6, c1
+    167: Yield r4, r5, r0, r8
+    172: JumpNotUndefined (Wide) r5, -162 (.L0)
+    178: Await r4, r5, r0, r4
+    183: JumpNullish (Wide) r5, -173 (.L0)
+    190: LoadUndefined r5
+    192: Jump (Wide) -182 (.L0)
   .L16:
-    194: Await r1, r2, r0, r1
-    199: JumpTrue r2, 5 (.L17)
-    202: Throw r1
+    196: Await r1, r2, r0, r1
+    201: JumpTrue r2, 5 (.L17)
+    204: Throw r1
   .L17:
-    204: Ret r1
+    206: Ret r1
   Constant Table:
     0: [String: done]
     1: [String: value]
     2: [String: throw]
     3: [String: return]
-    4: 150
+    4: [String: iterator does not have a throw method]
+    5: 152
 }


### PR DESCRIPTION
## Summary

We had multiple bytecode instructions which simply threw a new native error with a static message. Let's consolidate these into a single `ThrowNewError` bytecode instruction. Native error type is specified as a uint operand and message is in the constant table.

## Tests

- Updated bytecode snapshot tests that used the affected instructions
- Added bytecode snapshot test for error thrown during assignment to a call expression in Annex B mode