### PR TITLE
[runtime] Prevent overflow in String.raw argument count check

### DIFF
--- a/src/js/runtime/intrinsics/string_constructor.rs
+++ b/src/js/runtime/intrinsics/string_constructor.rs
@@ -158,7 +158,7 @@ impl StringConstructor {
         _: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let substitution_count = arguments.len() - 1;
+        let substitution_count = arguments.len().saturating_sub(1);
 
         let template_arg = get_argument(cx, arguments, 0);
         let cooked = to_object(cx, template_arg)?;

--- a/tests/integration/regression/000009.js
+++ b/tests/integration/regression/000009.js
@@ -1,0 +1,5 @@
+/*---
+description: Crash due to overflow in number of `String.raw` arguments.
+---*/
+
+assert.throws(TypeError, () => String.raw());


### PR DESCRIPTION
## Summary

Fix integer overflow when checking `String.raw`'s argument count. Found by the fuzzer.

## Tests

- Added regression test for this case