### PR TITLE
[runtime] Add BsWeakVec collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.agents
 .claude
 
 target

--- a/src/js/runtime/collections/mod.rs
+++ b/src/js/runtime/collections/mod.rs
@@ -5,6 +5,7 @@ pub mod index_map;
 pub mod index_set;
 mod inline_array;
 pub mod vec;
+pub mod weak_vec;
 
 pub use array::BsArray;
 pub use hash_map::{BsHashMap, BsHashMapField};
@@ -13,3 +14,4 @@ pub use index_map::{BsIndexMap, BsIndexMapField};
 pub use index_set::{BsIndexSet, BsIndexSetField};
 pub use inline_array::InlineArray;
 pub use vec::{BsVec, BsVecField};
+pub use weak_vec::BsWeakVec;

--- a/src/js/runtime/collections/weak_vec.rs
+++ b/src/js/runtime/collections/weak_vec.rs
@@ -2,6 +2,7 @@ use crate::{
     field_offset,
     runtime::{
         alloc_error::AllocResult,
+        collections::InlineArray,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
         Context, HeapPtr, Value,
@@ -9,36 +10,43 @@ use crate::{
     set_uninit,
 };
 
-use super::InlineArray;
-
-/// A growable array of values.
+/// A growable array of weakly held values.
+///
+/// Garbage collector is aware of this type and compresses it in place during collection.
+///
+/// The intrusive `next_weak_vec` list used by the collector lives on the holder of the vec, not on
+/// the vec itself.
 #[repr(C)]
-pub struct BsVec<T> {
+pub struct BsWeakVec {
     descriptor: HeapPtr<HeapItemDescriptor>,
     /// The number of elements stored in the array.
     length: usize,
+    // Holds the address of the next weak list that has been visited during garbage collection.
+    // Unused outside of garbage collection.
+    next_weak_vec: Option<HeapPtr<BsWeakVec>>,
     /// The array along with its capacity, which is always a power of 2.
-    array: InlineArray<T>,
+    array: InlineArray<Value>,
 }
 
-impl<T: Clone + Copy> BsVec<T> {
-    /// Create a new BsVec with the given capacity.
-    pub fn new(cx: Context, kind: HeapItemKind, capacity: usize) -> AllocResult<HeapPtr<Self>> {
+impl BsWeakVec {
+    /// Create a new BsWeakVec with the given capacity.
+    pub fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
         let size = Self::calculate_size_in_bytes(capacity);
-        let mut vec = cx.alloc_uninit_with_size::<BsVec<T>>(size)?;
+        let mut vec = cx.alloc_uninit_with_size::<BsWeakVec>(size)?;
 
-        set_uninit!(vec.descriptor, cx.base_descriptors.get(kind));
+        set_uninit!(vec.descriptor, cx.base_descriptors.get(HeapItemKind::WeakVec));
         set_uninit!(vec.length, 0);
+        set_uninit!(vec.next_weak_vec, None);
         vec.array.init_with_uninit(capacity);
 
         Ok(vec)
     }
 
-    const ARRAY_FIELD_OFFSET: usize = field_offset!(BsVec<u8>, array);
+    const ARRAY_FIELD_OFFSET: usize = field_offset!(BsWeakVec, array);
 
     #[inline]
     fn calculate_size_in_bytes(capacity: usize) -> usize {
-        Self::ARRAY_FIELD_OFFSET + InlineArray::<T>::calculate_size_in_bytes(capacity)
+        Self::ARRAY_FIELD_OFFSET + InlineArray::<Value>::calculate_size_in_bytes(capacity)
     }
 
     #[inline]
@@ -56,49 +64,58 @@ impl<T: Clone + Copy> BsVec<T> {
         self.array.len()
     }
 
+    pub fn next_weak_vec(&self) -> Option<HeapPtr<BsWeakVec>> {
+        self.next_weak_vec
+    }
+
+    pub fn set_next_weak_vec(&mut self, next_weak_vec: Option<HeapPtr<BsWeakVec>>) {
+        self.next_weak_vec = next_weak_vec;
+    }
+
     #[inline]
-    pub fn as_slice(&self) -> &[T] {
+    pub fn as_slice(&self) -> &[Value] {
         &self.array.as_slice()[..self.len()]
     }
 
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [T] {
+    pub fn as_mut_slice(&mut self) -> &mut [Value] {
         let len = self.len();
         &mut self.array.as_mut_slice()[..len]
     }
 
-    /// Append an item to the BsVec. Should only be called if there is room to append an item.
-    pub fn push_without_growing(&mut self, item: T) {
+    /// Append an item to the BsWeakVec. Should only be called if there is room to append an item.
+    pub fn push_without_growing(&mut self, item: Value) {
         let len = self.len();
         self.array.as_mut_slice()[len] = item;
         self.length += 1;
     }
 }
 
-impl<T: Clone + Copy> HeapItem for HeapPtr<BsVec<T>> {
+impl HeapItem for HeapPtr<BsWeakVec> {
     fn byte_size(&self) -> usize {
-        BsVec::<T>::calculate_size_in_bytes(self.capacity())
+        BsWeakVec::calculate_size_in_bytes(self.capacity())
     }
 
-    /// Visit pointers intrinsic to all BsVecs. Do not visit elements as they could be of any type.
+    /// Visit pointers intrinsic to all BsWeakVec. Do not visit elements as they could be of any type.
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
         visitor.visit_pointer(&mut self.descriptor);
     }
 }
 
-/// A BsVec stored as the field of a heap item. Can create new BsVec objects and set the field to
-/// a new BsVec.
-pub trait BsVecField<T: Clone + Copy> {
-    fn new_vec(cx: Context, capacity: usize) -> AllocResult<HeapPtr<BsVec<T>>>;
+/// A BsWeakVec stored as the field of a heap item. Can create new BsWeakVec objects and set the
+/// field to a new BsWeakVec.
+#[allow(unused)]
+pub trait BsWeakVecField {
+    fn new_vec(cx: Context, capacity: usize) -> AllocResult<HeapPtr<BsWeakVec>>;
 
-    fn get(&self) -> HeapPtr<BsVec<T>>;
+    fn get(&self) -> HeapPtr<BsWeakVec>;
 
-    fn set(&mut self, vec: HeapPtr<BsVec<T>>);
+    fn set(&mut self, vec: HeapPtr<BsWeakVec>);
 
     /// Prepare vec for appending a single item. This will grow the vec and update container to
     /// point to new vec if there is no room to append another item to the vec.
     #[inline]
-    fn maybe_grow_for_push(&mut self, cx: Context) -> AllocResult<HeapPtr<BsVec<T>>> {
+    fn maybe_grow_for_push(&mut self, cx: Context) -> AllocResult<HeapPtr<BsWeakVec>> {
         let old_vec = self.get();
 
         // Check if we have room for another item in the vec
@@ -123,20 +140,5 @@ pub trait BsVecField<T: Clone + Copy> {
         new_vec.as_mut_slice().copy_from_slice(old_vec.as_slice());
 
         Ok(new_vec)
-    }
-}
-
-/// A generic vec of values. Corresponds to HeapItemKind::ValueVec.
-type ValueVec = BsVec<Value>;
-
-pub fn value_vec_byte_size(value_array: HeapPtr<ValueVec>) -> usize {
-    BsVec::<Value>::calculate_size_in_bytes(value_array.capacity())
-}
-
-pub fn value_vec_visit_pointers(value_vec: &mut HeapPtr<ValueVec>, visitor: &mut impl HeapVisitor) {
-    value_vec.visit_pointers(visitor);
-
-    for value in value_vec.as_mut_slice() {
-        visitor.visit_value(value);
     }
 }

--- a/src/js/runtime/gc/garbage_collector.rs
+++ b/src/js/runtime/gc/garbage_collector.rs
@@ -3,6 +3,7 @@ use std::{ops::Range, ptr::NonNull};
 use crate::{
     common::constants::MAX_HEAP_SIZE,
     runtime::{
+        collections::BsWeakVec,
         gc::Heap,
         heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
         interned_strings::InternedStrings,
@@ -40,17 +41,20 @@ pub struct GarbageCollector {
     // item.
     alloc_ptr: *const u8,
 
-    // Chain of pointers to all WeakRefs that have been visited during this gc cycle
+    // Intrusive list of all WeakRefs that have been visited during this gc cycle
     weak_ref_list: Option<HeapPtr<WeakRefObject>>,
 
-    // Chain of pointers to all WeakSets that have been visited during this gc cycle
+    // Intrusive list of all WeakSets that have been visited during this gc cycle
     weak_set_list: Option<HeapPtr<WeakSetObject>>,
 
-    // Chain of pointers to all WeakMaps that have been visited during this gc cycle
+    // Intrusive list of all WeakMaps that have been visited during this gc cycle
     weak_map_list: Option<HeapPtr<WeakMapObject>>,
 
-    // Chain of pointers to all FinalizationRegistries that have been visited during this gc cycle
+    // Intrusive list of all FinalizationRegistries that have been visited during this gc cycle
     finalization_registry_list: Option<HeapPtr<FinalizationRegistryObject>>,
+
+    // Intrusive list of all WeakVecs that have been visited during this gc cycle
+    weak_vec_list: Option<HeapPtr<BsWeakVec>>,
 }
 
 #[derive(Clone, Debug)]
@@ -83,6 +87,7 @@ impl GarbageCollector {
             weak_set_list: None,
             weak_map_list: None,
             finalization_registry_list: None,
+            weak_vec_list: None,
         }
     }
 
@@ -281,6 +286,7 @@ impl GarbageCollector {
             HeapItemKind::WeakMapObject => {
                 self.add_visited_weak_map(new_heap_item.cast::<WeakMapObject>())
             }
+            HeapItemKind::WeakVec => self.add_visited_weak_vec(new_heap_item.cast::<BsWeakVec>()),
             HeapItemKind::FinalizationRegistryObject => self.add_visited_finalization_registry(
                 new_heap_item.cast::<FinalizationRegistryObject>(),
             ),
@@ -357,10 +363,16 @@ impl GarbageCollector {
         self.weak_set_list = Some(weak_set);
     }
 
-    // Add a weak map to the linked list of weak map that are live during this garbage collection.
+    // Add a weak map to the linked list of weak maps that are live during this garbage collection.
     fn add_visited_weak_map(&mut self, mut weak_map: HeapPtr<WeakMapObject>) {
         weak_map.set_next_weak_map(self.weak_map_list);
         self.weak_map_list = Some(weak_map);
+    }
+
+    // Add a weak vec to the linked list of weak vecs that are live during this garbage collection.
+    fn add_visited_weak_vec(&mut self, mut weak_vec: HeapPtr<BsWeakVec>) {
+        weak_vec.set_next_weak_vec(self.weak_vec_list);
+        self.weak_vec_list = Some(weak_vec);
     }
 
     // Add a finalization registry to the linked list of finalization registries that are live
@@ -381,6 +393,7 @@ impl GarbageCollector {
         self.fix_weak_refs();
         self.fix_weak_sets();
         self.fix_weak_maps();
+        self.fix_weak_vecs();
         self.fix_finalization_registries(cx);
     }
 
@@ -600,6 +613,53 @@ impl GarbageCollector {
 
             next_finalization_registry = finalization_registry.next_finalization_registry();
         }
+    }
+
+    /// Walk the intrusive list of live weak vecs and compress each one.
+    fn fix_weak_vecs(&mut self) {
+        // Walk all live weak vecs in the list
+        let mut next_weak_vec = self.weak_vec_list;
+        while let Some(weak_vec) = next_weak_vec {
+            self.compress_weak_vec(weak_vec);
+            next_weak_vec = weak_vec.next_weak_vec();
+        }
+    }
+
+    /// Compress a `BsWeakVec` by removing elements that have been garbage collected.
+    ///
+    /// Vector is compressed in place by moving live elements down to fill the slots of dead
+    /// elements. Note that backing array is never shrunk.
+    fn compress_weak_vec(&self, mut weak_vec: HeapPtr<BsWeakVec>) {
+        let len = weak_vec.len();
+        let mut next_kept_index = 0;
+
+        for index in 0..len {
+            let element = weak_vec.as_mut_slice()[index];
+
+            let kept_element = if element.is_pointer() {
+                let element_ptr = element.as_pointer().as_ptr().cast::<u8>();
+                if self.is_in_moved_space(element_ptr) {
+                    let element_descriptor = element.as_pointer().descriptor();
+
+                    // Element is known to be live if it has already moved (and left a forwarding
+                    // pointer)
+                    decode_forwarding_pointer(element_descriptor).map(Value::heap_item)
+                } else {
+                    // Pointer is not from a GC'd space
+                    Some(element)
+                }
+            } else {
+                // Non-pointer values are never GC'd
+                Some(element)
+            };
+
+            if let Some(element) = kept_element {
+                weak_vec.as_mut_slice()[next_kept_index] = element;
+                next_kept_index += 1;
+            }
+        }
+
+        weak_vec.set_len(next_kept_index);
     }
 
     fn prune_weak_interned_strings(&mut self, cx: Context) {

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -17,6 +17,7 @@ use crate::runtime::{
             u32_array_visit_pointers, value_array_byte_size, value_array_visit_pointers,
         },
         vec::{value_vec_byte_size, value_vec_visit_pointers},
+        BsWeakVec,
     },
     context::{GlobalSymbolRegistryField, ModuleCacheField},
     for_in_iterator::ForInIterator,
@@ -217,6 +218,7 @@ impl HeapPtr<AnyHeapItem> {
             }
             HeapItemKind::GlobalScopes => self.cast::<GlobalScopes>().byte_size(),
             HeapItemKind::ValueVec => value_vec_byte_size(self.cast()),
+            HeapItemKind::WeakVec => self.cast::<BsWeakVec>().byte_size(),
             HeapItemKind::Last => unreachable!("No objects are created with this descriptor"),
         }
     }
@@ -380,6 +382,7 @@ impl HeapPtr<AnyHeapItem> {
                 .visit_pointers(visitor),
             HeapItemKind::GlobalScopes => self.cast::<GlobalScopes>().visit_pointers(visitor),
             HeapItemKind::ValueVec => value_vec_visit_pointers(self.cast_mut(), visitor),
+            HeapItemKind::WeakVec => self.cast::<BsWeakVec>().visit_pointers(visitor),
             HeapItemKind::Last => unreachable!("No objects are created with this descriptor"),
         }
     }

--- a/src/js/runtime/heap_item_descriptor.rs
+++ b/src/js/runtime/heap_item_descriptor.rs
@@ -158,6 +158,7 @@ pub enum HeapItemKind {
 
     // Vectors
     ValueVec,
+    WeakVec,
 
     // Numerical value is the number of kinds in the enum
     Last,
@@ -392,6 +393,7 @@ impl BaseDescriptors {
         other_heap_item_descriptor!(HeapItemKind::GlobalScopes);
 
         other_heap_item_descriptor!(HeapItemKind::ValueVec);
+        other_heap_item_descriptor!(HeapItemKind::WeakVec);
 
         Ok(base_descriptors)
     }


### PR DESCRIPTION
## Summary

Add a new runtime collection primitive - `BsWeakVec`. This is a growable array of weak `Values` that is compressed during garbage collection.

Mostly a copy of `BsVec` specialized for `Values`. Will try to refactor to share more code.

Not yet used but will be needed for prototype object backreferences in hidden classes.

## Tests

Not yet used.