### PR TITLE
[runtime] Fix debug crash when garbage collecting an already collected WeakRef

### DIFF
--- a/src/js/runtime/gc/garbage_collector.rs
+++ b/src/js/runtime/gc/garbage_collector.rs
@@ -391,23 +391,28 @@ impl GarbageCollector {
         let mut next_weak_ref = self.weak_ref_list;
         while let Some(mut weak_ref) = next_weak_ref {
             let target = weak_ref.weak_ref_target();
+            next_weak_ref = weak_ref.next_weak_ref();
 
-            debug_assert!(target.is_pointer());
-            let target_ptr = target.as_pointer().as_ptr().cast();
-
-            if self.is_in_moved_space(target_ptr) {
-                let target_descriptor = target.as_pointer().descriptor();
-
-                // Target is known to be live if it has already moved (and left a forwarding pointer)
-                if let Some(forwarding_ptr) = decode_forwarding_pointer(target_descriptor) {
-                    weak_ref.set_weak_ref_target(Value::heap_item(forwarding_ptr));
-                } else {
-                    // Otherwise target was garbage collected so reset target to undefined
-                    weak_ref.set_weak_ref_target(Value::undefined());
-                }
+            // Target may have already been cleared to undefined by a prior GC
+            if !target.is_pointer() {
+                continue;
             }
 
-            next_weak_ref = weak_ref.next_weak_ref();
+            let target_ptr = target.as_pointer().as_ptr().cast();
+
+            if !self.is_in_moved_space(target_ptr) {
+                continue;
+            }
+
+            let target_descriptor = target.as_pointer().descriptor();
+
+            // Target is known to be live if it has already moved (and left a forwarding pointer)
+            if let Some(forwarding_ptr) = decode_forwarding_pointer(target_descriptor) {
+                weak_ref.set_weak_ref_target(Value::heap_item(forwarding_ptr));
+            } else {
+                // Otherwise target was garbage collected so reset target to undefined
+                weak_ref.set_weak_ref_target(Value::undefined());
+            }
         }
     }
 

--- a/tests/integration/regression/000010.js
+++ b/tests/integration/regression/000010.js
@@ -1,0 +1,11 @@
+/*---
+description: Crashed when an already GC'd WeakRef was GC'd again.
+---*/
+
+const ref = new WeakRef({});
+
+$262.gc();
+assert.sameValue(ref.deref(), undefined);
+
+$262.gc();
+assert.sameValue(ref.deref(), undefined);


### PR DESCRIPTION
## Summary

We currently crash in debug mode when garbage collection encounters an already collected `WeakRef` since we assume it is a pointer not undefined.

Caught by the fuzzer.

## Tests

- Added minimal regression test