### PR TITLE
[runtime] Prevent overflow when storing i64::MIN into a BigInt64Array

### DIFF
--- a/src/js/runtime/intrinsics/typed_array.rs
+++ b/src/js/runtime/intrinsics/typed_array.rs
@@ -321,7 +321,8 @@ pub fn to_big_int64_element(cx: Context, value: Handle<Value>) -> EvalResult<i64
     match sign {
         Sign::Plus => Ok(digits[0] as i64),
         Sign::NoSign => Ok(0),
-        Sign::Minus => Ok(-(digits[0] as i64)),
+        // Wrapping negation correctly keeps i64::MIN as i64::MIN
+        Sign::Minus => Ok((digits[0] as i64).wrapping_neg()),
     }
 }
 

--- a/tests/integration/regression/000011.js
+++ b/tests/integration/regression/000011.js
@@ -1,0 +1,11 @@
+/*---
+description: Storing i64::MIN into a BigInt64Array crashed from integer overflow.
+---*/
+
+const a = new BigInt64Array(1);
+
+a[0] = -9223372036854775808n;
+assert.sameValue(a[0], -9223372036854775808n);
+
+a[0] = 9223372036854775808n;
+assert.sameValue(a[0], -9223372036854775808n);


### PR DESCRIPTION
## Summary

Storing `i64::MIN` into a `BigInt64Array` caused integer overflow due to negation.

Caught by the fuzzer.

## Tests

- Added regression test for this case