### PR TITLE
[runtime] Prevent overflow in Math.abs(i32::MIN)

### DIFF
--- a/src/js/runtime/intrinsics/math_object.rs
+++ b/src/js/runtime/intrinsics/math_object.rs
@@ -7,6 +7,7 @@ use crate::{
         eval_result::EvalResult,
         function::get_argument,
         intrinsics::rust_runtime::RuntimeFunction,
+        numeric_constants::MAX_I32_PLUS_ONE_AS_F64,
         numeric_operations::number_exponentiate,
         object_value::ObjectValue,
         property::Property,
@@ -129,10 +130,15 @@ impl MathObject {
         let n = to_number(cx, argument)?;
 
         if n.is_smi() {
-            Ok(cx.smi(i32::abs(n.as_smi())))
-        } else {
-            Ok(cx.number(f64::abs(n.as_double())))
+            if let Some(smi) = n.as_smi().checked_abs() {
+                return Ok(cx.smi(smi));
+            } else {
+                // Only possible if i32::MIN which is larger than an i32 can represent
+                return Ok(cx.number(MAX_I32_PLUS_ONE_AS_F64));
+            }
         }
+
+        Ok(cx.number(f64::abs(n.as_double())))
     }
 
     /// Math.acos (https://tc39.es/ecma262/#sec-math.acos)

--- a/src/js/runtime/numeric_constants.rs
+++ b/src/js/runtime/numeric_constants.rs
@@ -7,4 +7,6 @@ pub const MIN_POSITIVE_SUBNORMAL_F64: f64 = 5e-324;
 pub const MAX_U8_AS_F64: f64 = u8::MAX as f64;
 pub const MAX_U32_AS_F64: f64 = u32::MAX as f64;
 
+pub const MAX_I32_PLUS_ONE_AS_F64: f64 = (i32::MAX as i64 + 1) as f64;
+
 pub const MAX_SAFE_INTEGER_U64: u64 = 9007199254740991;

--- a/tests/integration/regression/0000012.js
+++ b/tests/integration/regression/0000012.js
@@ -1,0 +1,5 @@
+/*---
+description: Math.abs(i32::MIN) overflowed.
+---*/
+
+assert.sameValue(Math.abs(-2147483648), 2147483648);


### PR DESCRIPTION
## Summary

Fix overflow in `Math.abs(i32::MIN)` by using rust's `checked_abs` method and hardcoding the result for `i32::MIN`.

## Tests

- Added regression test for `Math.abs(i32::MIN)`