### PR TITLE
[runtime] Fix integer overflow in TypedArray.prototype.set

### DIFF
--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -1303,7 +1303,7 @@ impl TypedArrayPrototype {
         let source_element_size = source.element_size();
 
         if target_offset == f64::INFINITY
-            || source_length as u64 + target_offset as u64 > target_length
+            || (source_length as u64).saturating_add(target_offset as u64) > target_length
         {
             return range_error(cx, "TypedArray.prototype.set offset is out of range");
         }
@@ -1372,7 +1372,7 @@ impl TypedArrayPrototype {
         let source = to_object(cx, source)?;
         let source_length = length_of_array_like(cx, source)?;
 
-        if offset == f64::INFINITY || source_length + offset as u64 > target_length {
+        if offset == f64::INFINITY || source_length.saturating_add(offset as u64) > target_length {
             return range_error(cx, "TypedArray.prototype.set offset is out of range");
         }
         let offset = offset as u64;

--- a/tests/integration/regression/000015.js
+++ b/tests/integration/regression/000015.js
@@ -1,0 +1,9 @@
+/*---
+description: Overflow in TypedArray.prototype.set should not cause a crash
+---*/
+
+const ta1 = new Float32Array([0]);
+assert.throws(RangeError, () => ta1.set(ta1, 1.0e+100));
+
+const ta2 = new Float32Array([0]);
+assert.throws(RangeError, () => ta2.set({ length: 1 }, 1.0e+100));


### PR DESCRIPTION
## Summary

Integer overflow could occur in `TypedArray.prototype.set` when adding the source array's length to the specified offset. We can fix this with `saturating_add` since the results is only used in an upper bound comparison.

Caught by the fuzzer.

## Tests

- Added regression test for both cases of integer overflow found in `TypedArray.prototype.set`