### PR TITLE
[common] Constants for number of bytes in a megabyte and gigabyte

### DIFF
--- a/src/benches/benches.rs
+++ b/src/benches/benches.rs
@@ -5,7 +5,10 @@ use std::{
 
 use bitflags::bitflags;
 use brimstone_core::{
-    common::{options::OptionsBuilder, serialized_heap::get_default_serialized_heap},
+    common::{
+        constants::MEGABYTE_BYTES, options::OptionsBuilder,
+        serialized_heap::get_default_serialized_heap,
+    },
     parser::{
         analyze::{analyze, AnalyzedProgramResult},
         parse_module, parse_script,
@@ -65,7 +68,7 @@ fn setup_step(file: &str, flags: TestFlags) -> (Context, ParseContext) {
     // Use a 10 MB heap size
     let options = OptionsBuilder::new()
         .annex_b(flags.contains(TestFlags::ANNEX_B))
-        .min_heap_size(10 * 1024 * 1024)
+        .min_heap_size(10 * MEGABYTE_BYTES)
         .build()
         .unwrap();
     let cx = ContextBuilder::new()

--- a/src/brimstone_serialized_heap/build.rs
+++ b/src/brimstone_serialized_heap/build.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use brimstone_core::{
-    common::options::OptionsBuilder,
+    common::{constants::MEGABYTE_BYTES, options::OptionsBuilder},
     runtime::{gc::HeapSerializer, ContextBuilder},
 };
 
@@ -21,7 +21,7 @@ fn main() {
 }
 
 /// A 4 MB heap is sufficient
-const HEAP_SIZE: usize = 4 * 1024 * 1024;
+const HEAP_SIZE: usize = 4 * MEGABYTE_BYTES;
 
 fn gen_serialized_heap_file(out_path: &Path) -> String {
     let options = OptionsBuilder::new()

--- a/src/js/common/constants.rs
+++ b/src/js/common/constants.rs
@@ -1,11 +1,17 @@
-/// Default minimum size of the heap, in bytes. 64MB.
-pub const DEFAULT_MIN_HEAP_SIZE: usize = 64 * 1024 * 1024;
+/// Number of bytes in a megabyte.
+pub const MEGABYTE_BYTES: usize = 1024 * 1024;
 
-/// Default maximum size of the heap, in bytes. 1GB.
-pub const DEFAULT_MAX_HEAP_SIZE: usize = 1024 * 1024 * 1024;
+/// Number of bytes in a gigabyte.
+pub const GIGABYTE_BYTES: usize = 1024 * 1024 * 1024;
 
-/// The minimum size the heap can ever be, in bytes. 1MB.
-pub const MIN_HEAP_SIZE: usize = 1024 * 1024;
+/// Default minimum size of the heap in bytes.
+pub const DEFAULT_MIN_HEAP_SIZE: usize = 64 * MEGABYTE_BYTES;
 
-/// The maximum size the heap can ever be, in bytes. 4GB.
-pub const MAX_HEAP_SIZE: usize = 4 * 1024 * 1024 * 1024;
+/// Default maximum size of the heap in bytes.
+pub const DEFAULT_MAX_HEAP_SIZE: usize = GIGABYTE_BYTES;
+
+/// The minimum size the heap can ever be in bytes.
+pub const MIN_HEAP_SIZE: usize = MEGABYTE_BYTES;
+
+/// The maximum size the heap can ever be in bytes.
+pub const MAX_HEAP_SIZE: usize = 4 * GIGABYTE_BYTES;

--- a/src/js/common/options.rs
+++ b/src/js/common/options.rs
@@ -5,7 +5,7 @@ use std::{
 
 use clap::Parser;
 
-use crate::common::constants::{MAX_HEAP_SIZE, MIN_HEAP_SIZE};
+use crate::common::constants::{GIGABYTE_BYTES, MAX_HEAP_SIZE, MEGABYTE_BYTES, MIN_HEAP_SIZE};
 
 use super::{
     constants::{DEFAULT_MAX_HEAP_SIZE, DEFAULT_MIN_HEAP_SIZE},
@@ -272,10 +272,10 @@ fn validate_max_heap_size_arg(size: usize) -> Result<(), String> {
 fn parse_heap_size_arg(size_arg: &str) -> Result<usize, ()> {
     if size_arg.ends_with("MB") {
         let size = parse_heap_size_number(size_arg)?;
-        Ok(size * 1024 * 1024)
+        Ok(size * MEGABYTE_BYTES)
     } else if size_arg.ends_with("GB") {
         let size = parse_heap_size_number(size_arg)?;
-        Ok(size * 1024 * 1024 * 1024)
+        Ok(size * GIGABYTE_BYTES)
     } else {
         Err(())
     }

--- a/src/js/runtime/bytecode/stack_frame.rs
+++ b/src/js/runtime/bytecode/stack_frame.rs
@@ -1,4 +1,7 @@
-use crate::runtime::{gc::HeapVisitor, scope::Scope, HeapPtr, Value};
+use crate::{
+    common::constants::MEGABYTE_BYTES,
+    runtime::{gc::HeapVisitor, scope::Scope, HeapPtr, Value},
+};
 
 use super::{constant_table::ConstantTable, function::Closure};
 
@@ -299,8 +302,8 @@ impl Iterator for StackFrameIter {
 /// Generic value stored in a stack slot.
 pub type StackSlotValue = usize;
 
-/// Total size of the stack, 4MB.
-const STACK_SIZE: usize = 4 * 1024 * 1024;
+/// Total size of the stack.
+const STACK_SIZE: usize = 4 * MEGABYTE_BYTES;
 
 /// Total number of stack slots that fit in the stack.
 pub const NUM_STACK_SLOTS: usize = STACK_SIZE / std::mem::size_of::<StackSlotValue>();

--- a/src/js/runtime/gc/heap.rs
+++ b/src/js/runtime/gc/heap.rs
@@ -1,7 +1,7 @@
 use std::{alloc::Layout, mem::size_of, ops::Range, ptr::NonNull};
 
 use crate::{
-    common::serialized_heap::SerializedHeap,
+    common::{constants::GIGABYTE_BYTES, serialized_heap::SerializedHeap},
     runtime::{alloc_error::AllocResult, gc::garbage_collector::GarbageCollector, Context},
 };
 
@@ -50,7 +50,7 @@ pub struct Heap {
 
 /// The heap is always aligned to a 1GB boundary. Must be aligned to a power of two alignment
 /// greater than the heap size so that we can mask heap pointers to find start of heap.
-const HEAP_ALIGNMENT: usize = 1024 * 1024 * 1024;
+const HEAP_ALIGNMENT: usize = GIGABYTE_BYTES;
 
 /// All heap items are aligned to 8-byte boundaries
 type HeapItemAlignmentType = u64;

--- a/tests/harness/src/runner.rs
+++ b/tests/harness/src/runner.rs
@@ -21,6 +21,7 @@ use crate::{
 
 use brimstone_core::{
     common::{
+        constants::MEGABYTE_BYTES,
         error::FormatOptions,
         options::{Options, OptionsBuilder},
         wtf_8::Wtf8String,
@@ -48,7 +49,7 @@ pub struct TestRunner {
 const RUNNER_THREAD_STACK_SIZE: usize = 1 << 23;
 
 /// Size of the heap for each test. Use a small value since most tests do not require a large heap.
-const HEAP_SIZE: usize = 1024 * 1024;
+const HEAP_SIZE: usize = MEGABYTE_BYTES;
 
 impl TestRunner {
     pub fn new(


### PR DESCRIPTION
## Summary

Small cleanup for readability, create and use constants for the number of bytes in a megabyte or gigabyte.

## Tests

CI