### PR TITLE
[runtime] Context::alloc_string returns a StringValue instead of a FlatString

### DIFF
--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -43,7 +43,7 @@ macro_rules! builtin_names {
                 $({
                     handle_scope_guard!(*self);
                     self.names.$rust_name = {
-                        let string_value = self.alloc_string($js_name)?.as_string();
+                        let string_value = self.alloc_string($js_name)?;
                         PropertyKey::string_not_array_index(*self, string_value)?
                     };
                 })*
@@ -507,7 +507,7 @@ macro_rules! builtin_symbols {
                 $({
                     handle_scope_guard!(*self);
                     self.well_known_symbols.$rust_name = {
-                        let description = self.alloc_string($description)?.as_string();
+                        let description = self.alloc_string($description)?;
                         *PropertyKey::symbol(SymbolValue::new(*self, Some(description), /* is_private */ false)?)
                     };
                 })*

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -18,7 +18,10 @@ use crate::{
     parser::{
         analyze::analyze, parse_module, parse_script, print_program, source::Source, ParseContext,
     },
-    runtime::{alloc_error::AllocResult, annex_b::init_annex_b_methods, gc::GarbageCollector},
+    runtime::{
+        alloc_error::AllocResult, annex_b::init_annex_b_methods, gc::GarbageCollector,
+        string_value::StringValue,
+    },
 };
 
 use super::{
@@ -464,7 +467,12 @@ impl Context {
     }
 
     #[inline]
-    pub fn alloc_string(&mut self, str: &str) -> AllocResult<Handle<FlatString>> {
+    pub fn alloc_string(&mut self, str: &str) -> AllocResult<Handle<StringValue>> {
+        Ok(self.alloc_string_ptr(str)?.as_string().to_handle())
+    }
+
+    #[inline]
+    pub fn alloc_flat_string(&mut self, str: &str) -> AllocResult<Handle<FlatString>> {
         Ok(self.alloc_string_ptr(str)?.to_handle())
     }
 

--- a/src/js/runtime/eval/expression.rs
+++ b/src/js/runtime/eval/expression.rs
@@ -111,7 +111,7 @@ pub fn eval_typeof(mut cx: Context, value: Handle<Value>) -> AllocResult<Handle<
         }
     };
 
-    Ok(cx.alloc_string(type_string)?.as_string())
+    cx.alloc_string(type_string)
 }
 
 pub fn eval_negate(cx: Context, value: Handle<Value>) -> EvalResult<Handle<Value>> {

--- a/src/js/runtime/function.rs
+++ b/src/js/runtime/function.rs
@@ -33,10 +33,10 @@ pub fn build_function_name(
         let symbol = name.as_symbol();
         if let Some(description) = symbol.description() {
             if symbol.is_private() {
-                StringValue::concat(cx, cx.alloc_string("#")?.as_string(), description.as_string())?
+                StringValue::concat(cx, cx.alloc_string("#")?, description.as_string())?
             } else {
-                let left_paren = cx.alloc_string("[")?.as_string();
-                let right_paren = cx.alloc_string("]")?.as_string();
+                let left_paren = cx.alloc_string("[")?;
+                let right_paren = cx.alloc_string("]")?;
 
                 StringValue::concat_all(cx, &[left_paren, description.as_string(), right_paren])?
             }
@@ -49,7 +49,7 @@ pub fn build_function_name(
 
     // Add prefix to name
     if let Some(prefix) = prefix {
-        let prefix_string = cx.alloc_string(&format!("{prefix} "))?.as_string();
+        let prefix_string = cx.alloc_string(&format!("{prefix} "))?;
         StringValue::concat(cx, prefix_string, name_string)
     } else {
         Ok(name_string)

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -365,7 +365,7 @@ impl DatePrototype {
         mut cx: Context,
         realm: Handle<Realm>,
     ) -> AllocResult<()> {
-        let get_year_name = cx.alloc_string("getYear")?.as_string();
+        let get_year_name = cx.alloc_string("getYear")?;
         let get_year_key = PropertyKey::string_not_array_index_handle(cx, get_year_name)?;
         date_prototype.intrinsic_func(
             cx,
@@ -375,7 +375,7 @@ impl DatePrototype {
             realm,
         )?;
 
-        let set_year_name = cx.alloc_string("setYear")?.as_string();
+        let set_year_name = cx.alloc_string("setYear")?;
         let set_year_key = PropertyKey::string_not_array_index_handle(cx, set_year_name)?;
         date_prototype.intrinsic_func(
             cx,
@@ -386,7 +386,7 @@ impl DatePrototype {
         )?;
 
         // Date.prototype.toGMTString is a direct aliases for Date.prototype.toUTCString
-        let to_gmt_string_name = cx.alloc_string("toGMTString")?.as_string();
+        let to_gmt_string_name = cx.alloc_string("toGMTString")?;
         let to_gmt_string_key = PropertyKey::string_not_array_index_handle(cx, to_gmt_string_name)?;
         let to_gmt_string_method = must_a!(get(cx, date_prototype, cx.names.to_utc_string()));
 
@@ -1874,7 +1874,7 @@ fn time_zone_string(string: &mut String, _time_value: f64) {
 /// ToDateString (https://tc39.es/ecma262/#sec-todatestring)
 pub fn to_date_string(mut cx: Context, time_value: f64) -> AllocResult<Handle<StringValue>> {
     if time_value.is_nan() {
-        return Ok(cx.alloc_string("Invalid Date")?.as_string());
+        return cx.alloc_string("Invalid Date");
     }
 
     let local_time_value = local_time(time_value);
@@ -1886,7 +1886,7 @@ pub fn to_date_string(mut cx: Context, time_value: f64) -> AllocResult<Handle<St
     time_string(&mut string, local_time_value);
     time_zone_string(&mut string, time_value);
 
-    Ok(cx.alloc_string(&string)?.as_string())
+    cx.alloc_string(&string)
 }
 
 #[inline]

--- a/src/js/runtime/intrinsics/error_prototype.rs
+++ b/src/js/runtime/intrinsics/error_prototype.rs
@@ -73,7 +73,7 @@ impl ErrorPrototype {
         } else if message_string.is_empty() {
             Ok(name_string.as_value())
         } else {
-            let separator = cx.alloc_string(": ")?.as_string();
+            let separator = cx.alloc_string(": ")?;
             Ok(StringValue::concat_all(cx, &[name_string, separator, message_string])?.as_value())
         }
     }

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -236,11 +236,11 @@ impl FunctionPrototype {
 
             // Builtin functions have special formatting using the function name
             if function.runtime_function_id().is_some() {
-                let mut string_parts = vec![cx.alloc_string("function ")?.as_string()];
+                let mut string_parts = vec![cx.alloc_string("function ")?];
                 if let Some(name) = function.name() {
                     string_parts.push(name);
                 }
-                string_parts.push(cx.alloc_string("() { [native code] }")?.as_string());
+                string_parts.push(cx.alloc_string("() { [native code] }")?);
 
                 return Ok(StringValue::concat_all(cx, &string_parts)?.as_value());
             }

--- a/src/js/runtime/intrinsics/global_object.rs
+++ b/src/js/runtime/intrinsics/global_object.rs
@@ -599,7 +599,7 @@ fn encode<const INCLUDE_URI_UNESCAPED: bool>(
 pub fn init_global_annex_b_methods(mut cx: Context, realm: Handle<Realm>) -> AllocResult<()> {
     let mut global_object = realm.global_object();
 
-    let escape_name = cx.alloc_string("escape")?.as_string();
+    let escape_name = cx.alloc_string("escape")?;
     let escape_key = PropertyKey::string_not_array_index_handle(cx, escape_name)?;
     global_object.intrinsic_func(
         cx,
@@ -609,7 +609,7 @@ pub fn init_global_annex_b_methods(mut cx: Context, realm: Handle<Realm>) -> All
         realm,
     )?;
 
-    let unescape_name = cx.alloc_string("unescape")?.as_string();
+    let unescape_name = cx.alloc_string("unescape")?;
     let unescape_key = PropertyKey::string_not_array_index_handle(cx, unescape_name)?;
     global_object.intrinsic_func(
         cx,

--- a/src/js/runtime/intrinsics/native_error.rs
+++ b/src/js/runtime/intrinsics/native_error.rs
@@ -27,7 +27,7 @@ macro_rules! create_native_error {
                 message: String,
             ) -> AllocResult<Handle<ErrorObject>> {
                 // Be sure to allocate before creating object
-                let message_value = cx.alloc_string(&message)?.as_string();
+                let message_value = cx.alloc_string(&message)?;
                 Self::new_with_message_value(cx, message_value)
             }
 

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -219,8 +219,8 @@ impl ObjectPrototype {
         let tag = get(cx, object, to_string_tag_key)?;
 
         let tag_string = if tag.is_string() {
-            let string_prefix = cx.alloc_string("[object ")?.as_string();
-            let string_suffix = cx.alloc_string("]")?.as_string();
+            let string_prefix = cx.alloc_string("[object ")?;
+            let string_suffix = cx.alloc_string("]")?;
 
             let full_string =
                 StringValue::concat_all(cx, &[string_prefix, tag.as_string(), string_suffix])?;

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -445,7 +445,7 @@ fn escape_pattern_string(
 ) -> AllocResult<Handle<StringValue>> {
     // Special case the empty pattern string - equivalent to an empty non-capturing group
     if pattern_string.is_empty() {
-        return Ok(cx.alloc_string("(?:)")?.as_string());
+        return cx.alloc_string("(?:)");
     }
 
     // Only need to escape line terminators and forward slash

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -177,7 +177,7 @@ impl RegExpPrototype {
         mut cx: Context,
         realm: Handle<Realm>,
     ) -> AllocResult<()> {
-        let compile_name = cx.alloc_string("compile")?.as_string();
+        let compile_name = cx.alloc_string("compile")?;
         let compile_key = PropertyKey::string_not_array_index_handle(cx, compile_name)?;
         regexp_prototype.intrinsic_func(
             cx,
@@ -272,7 +272,7 @@ impl RegExpPrototype {
         let flags_string = if flags_string.is_empty() {
             cx.names.empty_string().as_string()
         } else {
-            cx.alloc_string(&flags_string)?.as_string()
+            cx.alloc_string(&flags_string)?
         };
 
         Ok(flags_string.as_value())
@@ -703,7 +703,7 @@ impl RegExpPrototype {
 
         // Make sure the sticky flag is included in the flags string
         if !is_sticky {
-            let y_string = cx.alloc_string("y")?.as_string();
+            let y_string = cx.alloc_string("y")?;
             flags_string = StringValue::concat(cx, flags_string, y_string)?;
         }
 

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -305,7 +305,7 @@ impl StringPrototype {
         mut cx: Context,
         realm: Handle<Realm>,
     ) -> AllocResult<()> {
-        let substr_name = cx.alloc_string("substr")?.as_string();
+        let substr_name = cx.alloc_string("substr")?;
         let substr = PropertyKey::string_not_array_index_handle(cx, substr_name)?;
         string_prototype.intrinsic_func(
             cx,
@@ -320,10 +320,10 @@ impl StringPrototype {
         let trim_start = must_a!(get(cx, string_prototype, cx.names.trim_start()));
         let trim_end = must_a!(get(cx, string_prototype, cx.names.trim_end()));
 
-        let trim_left_name = cx.alloc_string("trimLeft")?.as_string();
+        let trim_left_name = cx.alloc_string("trimLeft")?;
         let trim_left = PropertyKey::string_not_array_index_handle(cx, trim_left_name)?;
 
-        let trim_right_name = cx.alloc_string("trimRight")?.as_string();
+        let trim_right_name = cx.alloc_string("trimRight")?;
         let trim_right = PropertyKey::string_not_array_index_handle(cx, trim_right_name)?;
 
         string_prototype.intrinsic_data_prop(cx, trim_left, trim_start)?;
@@ -332,7 +332,7 @@ impl StringPrototype {
         macro_rules! html_methods {
             ($($name:expr, $method:path, $length:expr),*) => {
                 $(
-                    let name = cx.alloc_string($name)?.as_string();
+                    let name = cx.alloc_string($name)?;
                     let key = PropertyKey::string_not_array_index_handle(cx, name)?;
                     string_prototype.intrinsic_func(cx, key, $method, $length, realm)?;
                 )*

--- a/src/js/runtime/intrinsics/symbol_prototype.rs
+++ b/src/js/runtime/intrinsics/symbol_prototype.rs
@@ -119,10 +119,10 @@ pub fn symbol_descriptive_string(
     symbol: Handle<SymbolValue>,
 ) -> AllocResult<Handle<StringValue>> {
     match symbol.description() {
-        None => Ok(cx.alloc_string("Symbol()")?.as_string()),
+        None => Ok(cx.alloc_string("Symbol()")?),
         Some(description) => {
-            let symbol_prefix = cx.alloc_string("Symbol(")?.as_string();
-            let symbol_suffix = cx.alloc_string(")")?.as_string();
+            let symbol_prefix = cx.alloc_string("Symbol(")?;
+            let symbol_suffix = cx.alloc_string(")")?;
 
             StringValue::concat_all(cx, &[symbol_prefix, description.as_string(), symbol_suffix])
         }

--- a/src/js/runtime/property_key.rs
+++ b/src/js/runtime/property_key.rs
@@ -82,7 +82,7 @@ impl PropertyKey {
     #[inline]
     pub fn array_index(mut cx: Context, value: u32) -> AllocResult<PropertyKey> {
         if value == u32::MAX {
-            let string_value = cx.alloc_string(&value.to_string())?.as_string();
+            let string_value = cx.alloc_string(&value.to_string())?;
             return PropertyKey::string_not_array_index(cx, string_value);
         }
 
@@ -102,7 +102,7 @@ impl PropertyKey {
 
     pub fn from_u64(mut cx: Context, value: u64) -> AllocResult<PropertyKey> {
         if value >= u32::MAX as u64 {
-            let string_value = cx.alloc_string(&value.to_string())?.as_string();
+            let string_value = cx.alloc_string(&value.to_string())?;
             return PropertyKey::string_not_array_index(cx, string_value);
         }
 

--- a/src/js/runtime/source_file.rs
+++ b/src/js/runtime/source_file.rs
@@ -31,9 +31,9 @@ type LineOffsetArray = BsArray<u32>;
 impl SourceFile {
     #[inline]
     pub fn new(mut cx: Context, source: &Source) -> AllocResult<Handle<SourceFile>> {
-        let path = cx.alloc_string(source.file_path())?;
+        let path = cx.alloc_flat_string(source.file_path())?;
         let display_name = if source.has_display_name() {
-            Some(cx.alloc_string(source.display_name())?)
+            Some(cx.alloc_flat_string(source.display_name())?)
         } else {
             None
         };

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -28,7 +28,7 @@ impl Test262Object {
         let mut object =
             ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
 
-        let create_realm_string = cx.alloc_string("createRealm")?.as_string();
+        let create_realm_string = cx.alloc_string("createRealm")?;
         let create_realm_key = PropertyKey::string_handle(cx, create_realm_string)?;
         object.intrinsic_func(
             cx,
@@ -38,7 +38,7 @@ impl Test262Object {
             realm,
         )?;
 
-        let eval_script_string = cx.alloc_string("evalScript")?.as_string();
+        let eval_script_string = cx.alloc_string("evalScript")?;
         let eval_script_key = PropertyKey::string_handle(cx, eval_script_string)?;
         object.intrinsic_func(
             cx,
@@ -48,11 +48,11 @@ impl Test262Object {
             realm,
         )?;
 
-        let global_string = cx.alloc_string("global")?.as_string();
+        let global_string = cx.alloc_string("global")?;
         let global_key = PropertyKey::string_handle(cx, global_string)?;
         object.intrinsic_data_prop(cx, global_key, realm.global_object().into())?;
 
-        let detach_array_buffer_string = cx.alloc_string("detachArrayBuffer")?.as_string();
+        let detach_array_buffer_string = cx.alloc_string("detachArrayBuffer")?;
         let detach_array_buffer_key = PropertyKey::string_handle(cx, detach_array_buffer_string)?;
         object.intrinsic_func(
             cx,
@@ -80,7 +80,7 @@ impl Test262Object {
             )?;
 
             // Also install a global print function needed in tests
-            let print_string = cx.alloc_string("print")?.as_string();
+            let print_string = cx.alloc_string("print")?;
             let print_key = PropertyKey::string_handle(cx, print_string)?;
             realm.global_object().intrinsic_func(
                 cx,
@@ -102,7 +102,7 @@ impl Test262Object {
     }
 
     fn print_log_key(mut cx: Context) -> AllocResult<Handle<PropertyKey>> {
-        let print_log_string = cx.alloc_string("$$printLog")?.as_string();
+        let print_log_string = cx.alloc_string("$$printLog")?;
         PropertyKey::string_handle(cx, print_log_string)
     }
 
@@ -233,6 +233,6 @@ impl Test262Object {
 }
 
 fn test_262_key(mut cx: Context) -> AllocResult<Handle<PropertyKey>> {
-    let test_262_string = cx.alloc_string("$262")?.as_string();
+    let test_262_string = cx.alloc_string("$262")?;
     PropertyKey::string_handle(cx, test_262_string)
 }

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -536,7 +536,7 @@ pub fn to_string(mut cx: Context, value_handle: Handle<Value>) -> EvalResult<Han
             match value.as_pointer().descriptor().kind() {
                 HeapItemKind::BigInt => {
                     let bigint_string = value.as_bigint().bigint().to_string();
-                    Ok(cx.alloc_string(&bigint_string)?.as_string())
+                    Ok(cx.alloc_string(&bigint_string)?)
                 }
                 HeapItemKind::Symbol => type_error(cx, "symbol cannot be converted to string"),
                 _ => unreachable!(),
@@ -544,20 +544,20 @@ pub fn to_string(mut cx: Context, value_handle: Handle<Value>) -> EvalResult<Han
         }
     } else {
         match value.get_tag() {
-            NULL_TAG => Ok(cx.alloc_string("null")?.as_string()),
-            UNDEFINED_TAG => Ok(cx.alloc_string("undefined")?.as_string()),
+            NULL_TAG => Ok(cx.alloc_string("null")?),
+            UNDEFINED_TAG => Ok(cx.alloc_string("undefined")?),
             BOOL_TAG => {
                 let str = if value.as_bool() { "true" } else { "false" };
-                Ok(cx.alloc_string(str)?.as_string())
+                Ok(cx.alloc_string(str)?)
             }
             SMI_TAG => {
                 let smi_string = value.as_smi().to_string();
-                Ok(cx.alloc_string(&smi_string)?.as_string())
+                Ok(cx.alloc_string(&smi_string)?)
             }
             // Otherwise must be double
             _ => {
                 let double_string = number_to_string(value.as_double());
-                Ok(cx.alloc_string(&double_string)?.as_string())
+                Ok(cx.alloc_string(&double_string)?)
             }
         }
     }


### PR DESCRIPTION
## Summary

Almost all `cx.alloc_string` calls are immediately converted from `FlatString` to `StringValue` with `as_string`. Let's make `cx.alloc_string` instead return a `StringValue` and create a much rarer `cx.alloc_flat_string` that continues to return `FlatStrings`.

## Tests

CI