### PR TITLE
[tests] Fix fuzzer build broken by alloc_string refactor

### DIFF
--- a/tests/fuzz/src/main.rs
+++ b/tests/fuzz/src/main.rs
@@ -106,7 +106,7 @@ fn install_fuzzilli_function(mut cx: Context) -> AllocResult<()> {
         let fuzzili_id = cx.rust_runtime_functions.register(fuzzilli).unwrap();
 
         let fuzzilli_string = cx.alloc_string("fuzzilli")?;
-        let fuzzilli_key = PropertyKey::string_handle(cx, fuzzilli_string.as_string())?;
+        let fuzzilli_key = PropertyKey::string_handle(cx, fuzzilli_string)?;
         let fuzzilli_function =
             BuiltinFunction::create_custom(cx, fuzzili_id, 2, fuzzilli_key, realm, None)?;
 


### PR DESCRIPTION
## Summary

Accidentally broke the fuzzer build in https://github.com/Hans-Halverson/brimstone/pull/275, need to update one more callsite.

## Tests

CI now passes