### PR TITLE
[common] Format bytes sizes in error messages

### DIFF
--- a/src/js/common/options.rs
+++ b/src/js/common/options.rs
@@ -164,8 +164,9 @@ impl OptionsBuilder {
 
         if self.0.min_heap_size > self.0.max_heap_size {
             return Err(OptionCreationError::new(format!(
-                "Min heap size ({} bytes) cannot be greater than max heap size ({} bytes)",
-                self.0.min_heap_size, self.0.max_heap_size
+                "Min heap size ({}) cannot be greater than max heap size ({})",
+                format_byte_size(self.0.min_heap_size),
+                format_byte_size(self.0.max_heap_size)
             )));
         }
 
@@ -237,7 +238,7 @@ fn parse_min_heap_size_arg(size_arg: &str) -> Result<usize, String> {
 
 fn validate_min_heap_size_arg(size: usize) -> Result<(), String> {
     if size < MIN_HEAP_SIZE {
-        return Err(format!("Min heap size must be at least {} bytes", MIN_HEAP_SIZE));
+        return Err(format!("Min heap size must be at least {}", format_byte_size(MIN_HEAP_SIZE)));
     }
 
     if !size.is_power_of_two() {
@@ -258,7 +259,7 @@ fn parse_max_heap_size_arg(size_arg: &str) -> Result<usize, String> {
 
 fn validate_max_heap_size_arg(size: usize) -> Result<(), String> {
     if size > MAX_HEAP_SIZE {
-        return Err(format!("Max heap size must be at most {} bytes", MAX_HEAP_SIZE));
+        return Err(format!("Max heap size must be at most {}", format_byte_size(MAX_HEAP_SIZE)));
     }
 
     if !size.is_power_of_two() {
@@ -287,6 +288,17 @@ fn parse_heap_size_number(size_arg: &str) -> Result<usize, ()> {
         Ok(size)
     } else {
         Err(())
+    }
+}
+
+/// Format a byte size as "XMB", "XGB", or "XB".
+fn format_byte_size(size: usize) -> String {
+    if size.is_multiple_of(GIGABYTE_BYTES) {
+        format!("{}GB", size / GIGABYTE_BYTES)
+    } else if size.is_multiple_of(MEGABYTE_BYTES) {
+        format!("{}MB", size / MEGABYTE_BYTES)
+    } else {
+        format!("{size}B")
     }
 }
 

--- a/tests/snapshot/cli/heap_size/max_invalid_too_large.exp
+++ b/tests/snapshot/cli/heap_size/max_invalid_too_large.exp
@@ -1,3 +1,3 @@
-error: Invalid value '1024GB' for '--max-heap-size <MAX_HEAP_SIZE>': Max heap size must be at most 4294967296 bytes
+error: Invalid value '1024GB' for '--max-heap-size <MAX_HEAP_SIZE>': Max heap size must be at most 4GB
 
 For more information try '--help'

--- a/tests/snapshot/cli/heap_size/max_less_than_min_default.exp
+++ b/tests/snapshot/cli/heap_size/max_less_than_min_default.exp
@@ -1,1 +1,1 @@
-Min heap size (67108864 bytes) cannot be greater than max heap size (1048576 bytes)
+Min heap size (64MB) cannot be greater than max heap size (1MB)

--- a/tests/snapshot/cli/heap_size/min_greater_than_max.exp
+++ b/tests/snapshot/cli/heap_size/min_greater_than_max.exp
@@ -1,1 +1,1 @@
-Min heap size (67108864 bytes) cannot be greater than max heap size (33554432 bytes)
+Min heap size (64MB) cannot be greater than max heap size (32MB)

--- a/tests/snapshot/cli/heap_size/min_greater_than_max_default.exp
+++ b/tests/snapshot/cli/heap_size/min_greater_than_max_default.exp
@@ -1,1 +1,1 @@
-Min heap size (17179869184 bytes) cannot be greater than max heap size (1073741824 bytes)
+Min heap size (16GB) cannot be greater than max heap size (1GB)

--- a/tests/snapshot/cli/heap_size/min_invalid_too_small.exp
+++ b/tests/snapshot/cli/heap_size/min_invalid_too_small.exp
@@ -1,3 +1,3 @@
-error: Invalid value '0MB' for '--min-heap-size <MIN_HEAP_SIZE>': Min heap size must be at least 1048576 bytes
+error: Invalid value '0MB' for '--min-heap-size <MIN_HEAP_SIZE>': Min heap size must be at least 1MB
 
 For more information try '--help'


### PR DESCRIPTION
## Summary

Error messages now report byte sizes as "XMB" or "XGB" when possible instead of the number of bytes. This greatly improves readability.

## Tests

- Updated error snapshot tests, now much more readable