### PR TITLE
[runtime] Improve error message consistency

### DIFF
--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -218,10 +218,10 @@ impl fmt::Display for ParseError {
                 write!(f, "Rest element may not have a trailing comma")
             }
             ParseError::ThrowArgumentOnNewLine => {
-                write!(f, "No line break is allowed between 'throw' and its expression")
+                write!(f, "No line break is allowed between `throw` and its expression")
             }
             ParseError::ArrowOnNewLine => {
-                write!(f, "No line break is allowed between arrow arguments and '=>'")
+                write!(f, "No line break is allowed between arrow arguments and `=>`")
             }
             ParseError::AmbiguousLetBracket => {
                 write!(f, "Expression cannot start with ambiguous `let [`")
@@ -242,28 +242,28 @@ impl fmt::Display for ParseError {
                 write!(f, "Identifier is a reserved word")
             }
             ParseError::ExpectedNewTarget => {
-                write!(f, "Expected new.target")
+                write!(f, "Expected `new.target`")
             }
             ParseError::ExpectedImportMeta => {
-                write!(f, "Expected import.meta")
+                write!(f, "Expected `import.meta`")
             }
             ParseError::ImportMetaOutsideModule => {
-                write!(f, "import.meta is only allowed in modules")
+                write!(f, "`import.meta` is only allowed in modules")
             }
             ParseError::ExponentLHSUnary => {
                 write!(
                     f,
-                    "Unparenthesized unary expression can't appear on the left hand side of '**'"
+                    "Unparenthesized unary expression cannot appear on the left hand side of `**`"
                 )
             }
             ParseError::TaggedTemplateInChain => {
                 write!(f, "Tagged template cannot be used in optional chain")
             }
             ParseError::NullishCoalesceMixedWithLogical => {
-                write!(f, "Parentheses are required when mixing '??' with '&&' or '||' expressions")
+                write!(f, "Parentheses are required when mixing `??` with `&&` or `||` expressions")
             }
             ParseError::HashNotFollowedByIdentifier => {
-                write!(f, "Expected '#' to be immediately followed by an identifier")
+                write!(f, "Expected `#` to be immediately followed by an identifier")
             }
             ParseError::ForEachInitInvalidVarDecl => {
                 write!(f, "Variable declarations in the left hand side of a for each loop must contain a single declaration with no initializer")
@@ -273,13 +273,13 @@ impl fmt::Display for ParseError {
                 if name == &*ANONYMOUS_DEFAULT_EXPORT_NAME {
                     write!(f, "Default export was already declared in this module")
                 } else {
-                    write!(f, "Redeclaration of {kind} {name}")
+                    write!(f, "Redeclaration of {kind} `{name}`")
                 }
             }
             ParseError::DuplicateLabel => write!(f, "Duplicate label"),
             ParseError::LabelNotFound => write!(f, "Label not found"),
             ParseError::WithInStrictMode => {
-                write!(f, "Strict mode code may not contain 'with' statements")
+                write!(f, "Strict mode code may not contain `with` statements")
             }
             ParseError::DeleteIdentifierInStrictMode => {
                 write!(f, "Cannot delete variables in strict mode")
@@ -288,7 +288,7 @@ impl fmt::Display for ParseError {
                 write!(f, "Cannot delete private properties")
             }
             ParseError::LegacyOctalLiteralInStrictMode => {
-                write!(f, "Cannot use '0'-prefixed octal literals in strict mode")
+                write!(f, "Cannot use `0`-prefixed octal literals in strict mode")
             }
             ParseError::LegacyOctalEscapeSequenceInStrictMode => {
                 write!(f, "Octal escape sequences are not allowed in strict mode")
@@ -297,13 +297,13 @@ impl fmt::Display for ParseError {
                 write!(f, "\\8 and \\9 escape sequences are not allowed in strict mode")
             }
             ParseError::AssignEvalInStrictMode => {
-                write!(f, "Cannot assign to 'eval' in strict mode")
+                write!(f, "Cannot assign to `eval` in strict mode")
             }
             ParseError::AssignArgumentsInStrictMode => {
-                write!(f, "Cannot assign to 'arguments' in strict mode")
+                write!(f, "Cannot assign to `arguments` in strict mode")
             }
             ParseError::UseStrictFunctionNonSimpleParameterList => {
-                write!(f, "'use strict' only allowed in functions with simple parameter lists")
+                write!(f, "`use strict` only allowed in functions with simple parameter lists")
             }
             ParseError::InvalidDuplicateParameters(reason) => {
                 let reason_string = match reason {
@@ -347,22 +347,22 @@ impl fmt::Display for ParseError {
                 write!(f, "Object property initializers do not use `=`")
             }
             ParseError::DuplicatePrivateName(name) => {
-                write!(f, "Redeclaration of private name {name}")
+                write!(f, "Redeclaration of private name `{name}`")
             }
             ParseError::PrivateNameOutsideClass => {
                 write!(f, "Private name outside class")
             }
             ParseError::PrivateNameNotDefined(name) => {
-                write!(f, "Reference to undeclared private name {name}")
+                write!(f, "Reference to undeclared private name `{name}`")
             }
             ParseError::PrivateNameConstructor => {
-                write!(f, "Private name not allowed to be #constructor")
+                write!(f, "Private name not allowed to be `#constructor`")
             }
             ParseError::ArgumentsInClassInitializer => {
-                write!(f, "'arguments' is not allowed in class field initializer or static initialization block")
+                write!(f, "`arguments` is not allowed in class field initializer or static initialization block")
             }
             ParseError::NewTargetOutsideFunction => {
-                write!(f, "new.target only allowed in functions")
+                write!(f, "`new.target` only allowed in functions")
             }
             ParseError::SuperPropertyOutsideMethod => {
                 write!(f, "Super property accesses only allowed in methods")
@@ -377,7 +377,7 @@ impl fmt::Display for ParseError {
                 write!(f, "Const declarations must have an initializer")
             }
             ParseError::LetNameInLexicalDeclaration => {
-                write!(f, "Lexical declarations can't define a 'let' binding")
+                write!(f, "Lexical declarations cannot define a `let` binding")
             }
             ParseError::GetterWrongNumberOfParams => {
                 write!(f, "Getter functions must have no parameters")
@@ -404,7 +404,7 @@ impl fmt::Display for ParseError {
                 write!(f, "Exported name is not defined in module")
             }
             ParseError::DuplicateExport(name) => {
-                write!(f, "Export with name \"{name}\" already exists in module")
+                write!(f, "Export with name `{name}` already exists in module")
             }
             ParseError::ImportAttributeInvalidKey => {
                 write!(f, "Import attribute key must be an identifier or string")

--- a/src/js/runtime/abstract_operations.rs
+++ b/src/js/runtime/abstract_operations.rs
@@ -95,7 +95,7 @@ pub fn create_data_property_or_throw(
 ) -> EvalResult<()> {
     let success = create_data_property(cx, object, key, value)?;
     if !success {
-        return type_error(cx, &format!("Cannot create property {}", key.format()?));
+        return type_error(cx, &format!("cannot create property `{}`", key.format()?));
     }
 
     Ok(())
@@ -123,7 +123,7 @@ pub fn define_property_or_throw(
 ) -> EvalResult<()> {
     let success = object.define_own_property(cx, key, prop_desc)?;
     if !success {
-        return type_error(cx, &format!("cannot define property {}", key.format()?));
+        return type_error(cx, &format!("cannot define property `{}`", key.format()?));
     }
 
     Ok(())
@@ -136,7 +136,7 @@ pub fn delete_property_or_throw(
     key: Handle<PropertyKey>,
 ) -> EvalResult<()> {
     if !object.delete(cx, key)? {
-        return type_error(cx, &format!("cannot delete property {}", key.format()?));
+        return type_error(cx, &format!("cannot delete property `{}`", key.format()?));
     }
 
     Ok(())
@@ -154,7 +154,7 @@ pub fn get_method(
     }
 
     if !is_callable(func) {
-        return type_error(cx, "value is not a function");
+        return type_error(cx, "expected a function");
     }
 
     Ok(Some(func.as_object()))
@@ -308,7 +308,7 @@ pub fn create_list_from_array_like(
     object: Handle<Value>,
 ) -> EvalResult<Vec<Handle<Value>>> {
     if !object.is_object() {
-        return type_error(cx, "value is not an object");
+        return type_error(cx, "expected an object");
     }
 
     let object = object.as_object();
@@ -394,7 +394,7 @@ pub fn species_constructor(
     }
 
     if !constructor.is_object() {
-        return type_error(cx, "constructor must be a function");
+        return type_error(cx, "expected a constructor");
     }
 
     let species_key = cx.well_known_symbols.species();
@@ -538,7 +538,7 @@ pub fn private_get(
     private_name: Handle<SymbolValue>,
 ) -> EvalResult<Handle<Value>> {
     let property = match object.private_element_find(cx, private_name) {
-        None => return type_error(cx, "can't access private field or method"),
+        None => return type_error(cx, "cannot access private field or method"),
         Some(property) => property,
     };
 
@@ -608,7 +608,7 @@ pub fn group_by(
     require_object_coercible(cx, items)?;
 
     if !is_callable(callback) {
-        return type_error(cx, "callback must be a function");
+        return type_error(cx, "expected a function");
     }
 
     let callback = callback.as_object();
@@ -696,7 +696,7 @@ pub fn setter_that_ignores_prototype_properties(
     value: Handle<Value>,
 ) -> EvalResult<()> {
     if !this_value.is_object() {
-        return type_error(cx, "this is not an object");
+        return type_error(cx, "expected an object");
     }
     let this_object = this_value.as_object();
 

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -194,7 +194,7 @@ pub fn array_species_create(
     }
 
     if !is_constructor_value(constructor) {
-        return type_error(cx, "expected array constructor");
+        return type_error(cx, "expected an Array constructor");
     }
 
     let length_value = Value::from(length).to_handle(cx);

--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -321,7 +321,7 @@ pub fn async_generator_validate(
         }
     }
 
-    type_error(cx, "expected async generator")
+    type_error(cx, "expected an async generator")
 }
 
 /// AsyncGeneratorResume (https://tc39.es/ecma262/#sec-asyncgeneratorresume)

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -1954,7 +1954,7 @@ impl VM {
             }
         }
 
-        Ok(CallableObject::Error(type_error_value(self.cx(), "value is not a function")?))
+        Ok(CallableObject::Error(type_error_value(self.cx(), "expected a function")?))
     }
 
     /// Check that a value is a constructor (either a closure or proxy object), returning the
@@ -1978,10 +1978,7 @@ impl VM {
             }
         }
 
-        Ok(CallableObject::Error(type_error_value(
-            self.cx(),
-            "value is not a constructor",
-        )?))
+        Ok(CallableObject::Error(type_error_value(self.cx(), "expected a constructor")?))
     }
 
     /// Track the depth of the stack throwing a stack overflow error when necessary.
@@ -4062,7 +4059,7 @@ impl VM {
             if function.is_nullish() {
                 self.write_register(dest, Value::undefined());
             } else if !is_callable(function) {
-                return type_error(self.cx(), "value is not a function");
+                return type_error(self.cx(), "expected a function");
             } else {
                 self.write_register(dest, *function);
             }
@@ -4352,7 +4349,7 @@ impl VM {
         let name = self.get_constant(instr.name_constant_index()).as_string();
         let name_str = name.to_handle().format()?;
 
-        reference_error(self.cx(), &format!("can't access `{name_str}` before initialization"))
+        reference_error(self.cx(), &format!("cannot access `{name_str}` before initialization"))
     }
 
     #[inline]
@@ -4549,7 +4546,7 @@ impl VM {
     ) -> EvalResult<()> {
         // Iterator's function must return an object, otherwise error
         if !iterator_result.is_object() {
-            return type_error(self.cx(), "iterator's next method must return an object");
+            return type_error(self.cx(), "Iterator `next` method must return an object");
         }
         let iterator_result = iterator_result.as_object();
 
@@ -4585,7 +4582,7 @@ impl VM {
 
                 // Return method must return an object otherwise error
                 if !return_result.is_object() {
-                    return type_error(self.cx(), "iterator's return method must return an object");
+                    return type_error(self.cx(), "Iterator `return` method must return an object");
                 }
             }
 
@@ -4627,7 +4624,7 @@ impl VM {
 
         // Return method must return an object otherwise error.
         if !return_result.is_object() {
-            return type_error(self.cx(), "iterator's return method must return an object");
+            return type_error(self.cx(), "Iterator `return` method must return an object");
         }
 
         Ok(())

--- a/src/js/runtime/error.rs
+++ b/src/js/runtime/error.rs
@@ -124,15 +124,15 @@ pub fn uri_error<T>(cx: Context, message: &str) -> EvalResult<T> {
 }
 
 pub fn err_not_defined<T>(cx: Context, name: Handle<StringValue>) -> EvalResult<T> {
-    reference_error(cx, &format!("{} is not defined", name.format()?))
+    reference_error(cx, &format!("`{}` is not defined", name.format()?))
 }
 
 pub fn err_assign_constant<T>(cx: Context, name: HeapPtr<FlatString>) -> EvalResult<T> {
-    type_error(cx, &format!("can't assign constant `{name}`"))
+    type_error(cx, &format!("cannot assign constant `{name}`"))
 }
 
 pub fn err_cannot_set_property<T>(cx: Context, name: impl std::fmt::Display) -> EvalResult<T> {
-    type_error(cx, &format!("can't set property {name}"))
+    type_error(cx, &format!("cannot set property `{name}`"))
 }
 
 pub fn syntax_parse_error<T>(cx: Context, error: &LocalizedParseError) -> EvalResult<T> {

--- a/src/js/runtime/eval/eval.rs
+++ b/src/js/runtime/eval/eval.rs
@@ -241,13 +241,13 @@ fn eval_declaration_instantiation(mut cx: Context, program: &ast::Program) -> Ev
     if is_global_scope {
         for func_name in &eval_func_names {
             if !can_declare_global_function(cx, scope_object, func_name.cast())? {
-                return type_error(cx, &format!("cannot declare global function {}", *func_name));
+                return type_error(cx, &format!("cannot declare global function `{}`", *func_name));
             }
         }
 
         for var_name in &eval_var_names {
             if !can_declare_global_var(cx, scope_object, var_name.cast())? {
-                return type_error(cx, &format!("cannot declare global var {}", *var_name));
+                return type_error(cx, &format!("cannot declare global variable `{}`", *var_name));
             }
         }
     }
@@ -285,5 +285,5 @@ fn eval_declaration_instantiation(mut cx: Context, program: &ast::Program) -> Ev
 }
 
 fn error_name_already_declared(cx: Context, name: Handle<FlatString>) -> EvalResult<()> {
-    syntax_error(cx, &format!("identifier '{name}' has already been declared"))
+    syntax_error(cx, &format!("identifier `{name}` has already been declared"))
 }

--- a/src/js/runtime/eval/expression.rs
+++ b/src/js/runtime/eval/expression.rs
@@ -559,7 +559,7 @@ pub fn eval_instanceof_expression(
     target: Handle<Value>,
 ) -> EvalResult<bool> {
     if !target.is_object() {
-        return type_error(cx, "invalid instanceof operand");
+        return type_error(cx, "invalid `instanceof` operand");
     }
 
     let has_instance_key = cx.well_known_symbols.has_instance();
@@ -571,7 +571,7 @@ pub fn eval_instanceof_expression(
 
     let target_object = target.as_object();
     if !target_object.is_callable() {
-        return type_error(cx, "invalid 'instanceof' operand");
+        return type_error(cx, "invalid `instanceof` operand");
     }
 
     let has_instance = ordinary_has_instance(cx, target, value)?;
@@ -584,7 +584,7 @@ pub fn eval_in_expression(
     right_value: Handle<Value>,
 ) -> EvalResult<bool> {
     if !right_value.is_object() {
-        return type_error(cx, "right side of 'in' must be an object");
+        return type_error(cx, "right side of `in` must be an object");
     }
 
     let property_key = to_property_key(cx, left_value)?;

--- a/src/js/runtime/generator_object.rs
+++ b/src/js/runtime/generator_object.rs
@@ -218,7 +218,7 @@ fn generator_validate(
         }
     }
 
-    type_error(cx, "expected generator")
+    type_error(cx, "expected a generator")
 }
 
 /// GeneratorResume (https://tc39.es/ecma262/#sec-generatorresume)

--- a/src/js/runtime/global_names.rs
+++ b/src/js/runtime/global_names.rs
@@ -147,11 +147,17 @@ fn global_declaration_instantiation(
 
         if i < global_names.num_functions {
             if !can_declare_global_function(cx, global_object, name_key)? {
-                return type_error(cx, &format!("cannot declare global function {}", *name_handle));
+                return type_error(
+                    cx,
+                    &format!("cannot declare global function `{}`", *name_handle),
+                );
             }
         } else {
             if !can_declare_global_var(cx, global_object, name_key)? {
-                return type_error(cx, &format!("cannot declare global var {}", *name_handle));
+                return type_error(
+                    cx,
+                    &format!("cannot declare global variable `{}`", *name_handle),
+                );
             }
         }
     }

--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -249,7 +249,7 @@ impl ArrayBufferPrototype {
         } else if new_object.is_shared_array_buffer() {
             return type_error(cx, "constructor cannot return SharedArrayBuffer");
         } else {
-            return type_error(cx, "expected array buffer");
+            return type_error(cx, "expected an ArrayBuffer");
         };
 
         throw_if_detached(cx, *new_array_buffer)?;
@@ -317,5 +317,8 @@ fn require_array_buffer(
         }
     }
 
-    type_error(cx, &format!("ArrayBuffer.prototype.{method_name} expected ArrayBuffer"))
+    type_error(
+        cx,
+        &format!("ArrayBuffer.prototype.{method_name} must be called on an ArrayBuffer"),
+    )
 }

--- a/src/js/runtime/intrinsics/array_constructor.rs
+++ b/src/js/runtime/intrinsics/array_constructor.rs
@@ -125,7 +125,7 @@ impl ArrayConstructor {
             None
         } else {
             if !is_callable(map_function_arg) {
-                return type_error(cx, "Array.from map function is not callable");
+                return type_error(cx, "Array.from map function must be a function");
             }
 
             Some(map_function_arg.as_object())

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -553,7 +553,7 @@ impl ArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "Array.prototype.every expected function");
+            return type_error(cx, "Array.prototype.every callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -643,7 +643,7 @@ impl ArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "Array.prototype.filter expected function");
+            return type_error(cx, "Array.prototype.filter callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -693,7 +693,7 @@ impl ArrayPrototype {
 
         let predicate_function = get_argument(cx, arguments, 0);
         if !is_callable(predicate_function) {
-            return type_error(cx, "Array.prototype.find expected function");
+            return type_error(cx, "Array.prototype.find callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
@@ -718,7 +718,7 @@ impl ArrayPrototype {
 
         let predicate_function = get_argument(cx, arguments, 0);
         if !is_callable(predicate_function) {
-            return type_error(cx, "Array.prototype.findIndex expected function");
+            return type_error(cx, "Array.prototype.findIndex callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
@@ -743,7 +743,7 @@ impl ArrayPrototype {
 
         let predicate_function = get_argument(cx, arguments, 0);
         if !is_callable(predicate_function) {
-            return type_error(cx, "Array.prototype.findLast expected function");
+            return type_error(cx, "Array.prototype.findLast callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
@@ -769,7 +769,7 @@ impl ArrayPrototype {
 
         let predicate_function = get_argument(cx, arguments, 0);
         if !is_callable(predicate_function) {
-            return type_error(cx, "Array.prototype.findLastIndex expected function");
+            return type_error(cx, "Array.prototype.findLastIndex callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
@@ -891,7 +891,7 @@ impl ArrayPrototype {
         let this_arg = get_argument(cx, arguments, 1);
 
         if !is_callable(mapper_function) {
-            return type_error(cx, "Array.prototype.flatMap expected function");
+            return type_error(cx, "Array.prototype.flatMap mapper must be a function");
         }
 
         let array = array_species_create(cx, object, 0)?;
@@ -921,7 +921,7 @@ impl ArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "Array.prototype.forEach expected function");
+            return type_error(cx, "Array.prototype.forEach callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -1147,7 +1147,7 @@ impl ArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "Array.prototype.map expected function");
+            return type_error(cx, "Array.prototype.map mapper must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -1241,7 +1241,7 @@ impl ArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "Array.prototype.reduce expected function");
+            return type_error(cx, "Array.prototype.reduce callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -1300,7 +1300,7 @@ impl ArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "Array.prototype.reduceRight expected function");
+            return type_error(cx, "Array.prototype.reduceRight callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -1525,7 +1525,7 @@ impl ArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "Array.prototype.some expected function");
+            return type_error(cx, "Array.prototype.some callback must be a function");
         }
 
         let callback_function = callback_function.as_object();

--- a/src/js/runtime/intrinsics/data_view_prototype.rs
+++ b/src/js/runtime/intrinsics/data_view_prototype.rs
@@ -536,7 +536,7 @@ impl DataViewPrototype {
 #[inline]
 fn require_is_data_view(cx: Context, value: Handle<Value>) -> EvalResult<Handle<DataViewObject>> {
     if !value.is_object() {
-        return type_error(cx, "expected data view");
+        return type_error(cx, "expected a DataView");
     }
 
     let object = value.as_object();
@@ -544,7 +544,7 @@ fn require_is_data_view(cx: Context, value: Handle<Value>) -> EvalResult<Handle<
         return Ok(data_view);
     }
 
-    type_error(cx, "expected data view")
+    type_error(cx, "expected a DataView")
 }
 
 /// GetViewValue (https://tc39.es/ecma262/#sec-getviewvalue)

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -404,7 +404,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.getDate method must be called on Date object");
+            return type_error(cx, "Date.prototype.getDate must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -425,7 +425,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.getDay method must be called on Date object");
+            return type_error(cx, "Date.prototype.getDay must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -446,10 +446,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.getFullYear method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.getFullYear must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -470,7 +467,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.getHours method must be called on Date object");
+            return type_error(cx, "Date.prototype.getHours must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -491,10 +488,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.getMilliseconds method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.getMilliseconds must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -515,10 +509,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.getMinutes method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.getMinutes must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -539,7 +530,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.getMonth method must be called on Date object");
+            return type_error(cx, "Date.prototype.getMonth must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -560,10 +551,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.getSeconds method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.getSeconds must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -584,7 +572,7 @@ impl DatePrototype {
         if let Some(date_value) = this_date_value(this_value) {
             Ok(Value::from(date_value).to_handle(cx))
         } else {
-            type_error(cx, "getTime method must be called on date object")
+            type_error(cx, "Date.prototype.getTime must be called on a Date")
         }
     }
 
@@ -597,7 +585,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "getTimezeonOffset method must be called on date object");
+            return type_error(cx, "Date.prototype.getTimezoneOffset must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -618,7 +606,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.getUTCDate must be called on Date object");
+            return type_error(cx, "Date.prototype.getUTCDate must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -639,7 +627,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.getUTCDay must be called on Date object");
+            return type_error(cx, "Date.prototype.getUTCDay must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -660,7 +648,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.getUTCFullYear must be called on Date object");
+            return type_error(cx, "Date.prototype.getUTCFullYear must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -681,7 +669,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.getUTCHours must be called on Date object");
+            return type_error(cx, "Date.prototype.getUTCHours must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -702,10 +690,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.getUTCMilliseconds method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.getUTCMilliseconds must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -726,10 +711,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.getUTCMinutes method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.getUTCMinutes must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -750,10 +732,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.getUTCMonth method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.getUTCMonth must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -774,10 +753,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.getUTCSeconds method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.getUTCSeconds must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -798,7 +774,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.setDate method must be called on Date object");
+            return type_error(cx, "Date.prototype.setDate must be called on a Date");
         };
 
         let date_arg = get_argument(cx, arguments, 0);
@@ -829,10 +805,7 @@ impl DatePrototype {
         let mut date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.setFullYear method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.setFullYear must be called on a Date");
         };
 
         let year_arg = get_argument(cx, arguments, 0);
@@ -875,7 +848,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.setHours method must be called on Date object");
+            return type_error(cx, "Date.prototype.setHours must be called on a Date");
         };
 
         let hours_arg = get_argument(cx, arguments, 0);
@@ -942,10 +915,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.setMilliseconds method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.setMilliseconds must be called on a Date");
         };
 
         let milliseconds_arg = get_argument(cx, arguments, 0);
@@ -981,10 +951,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.setMinutes method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.setMinutes must be called on a Date");
         };
 
         let minutes_arg = get_argument(cx, arguments, 0);
@@ -1039,7 +1006,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.setMonth method must be called on Date object");
+            return type_error(cx, "Date.prototype.setMonth must be called on a Date");
         };
 
         let month_arg = get_argument(cx, arguments, 0);
@@ -1082,10 +1049,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.setSeconds method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.setSeconds must be called on a Date");
         };
 
         let seconds_arg = get_argument(cx, arguments, 0);
@@ -1131,7 +1095,7 @@ impl DatePrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if this_date_value(this_value).is_none() {
-            return type_error(cx, "Date.prototype.setTime method must be called on Date object");
+            return type_error(cx, "Date.prototype.setTime must be called on a Date");
         };
 
         let time_arg = get_argument(cx, arguments, 0);
@@ -1151,10 +1115,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.setUTCDate method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.setUTCDate must be called on a Date");
         };
 
         let date_arg = get_argument(cx, arguments, 0);
@@ -1183,10 +1144,7 @@ impl DatePrototype {
         let mut date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.setUTCFullYear method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.setUTCFullYear must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -1227,10 +1185,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.setUTCHours method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.setUTCHours must be called on a Date");
         };
 
         let hours_arg = get_argument(cx, arguments, 0);
@@ -1293,10 +1248,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.setUTCMilliseconds method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.setUTCMilliseconds must be called on a Date");
         };
 
         let milliseconds_arg = get_argument(cx, arguments, 0);
@@ -1330,10 +1282,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.setUTCMinutes method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.setUTCMinutes must be called on a Date");
         };
 
         let minutes_arg = get_argument(cx, arguments, 0);
@@ -1386,10 +1335,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.setUTCMonth method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.setUTCMonth must be called on a Date");
         };
 
         let month_arg = get_argument(cx, arguments, 0);
@@ -1430,10 +1376,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.setUTCSeconds method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.setUTCSeconds must be called on a Date");
         };
 
         let seconds_arg = get_argument(cx, arguments, 0);
@@ -1479,10 +1422,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.toDateString method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.toDateString must be called on a Date");
         };
 
         Self::to_date_string_shared(cx, date_value)
@@ -1510,10 +1450,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.toISOString method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.toISOString must be called on a Date");
         };
 
         if !date_value.is_finite() {
@@ -1569,10 +1506,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.toLocaleDateString method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.toLocaleDateString must be called on a Date");
         };
 
         Self::to_date_string_shared(cx, date_value)
@@ -1587,10 +1521,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.toLocaleString method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.toLocaleString must be called on a Date");
         };
 
         Ok(to_date_string(cx, date_value)?.as_value())
@@ -1605,10 +1536,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.toLocaleTimeString method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.toLocaleTimeString must be called on a Date");
         };
 
         Self::to_time_string_shared(cx, date_value)
@@ -1623,7 +1551,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.toString method must be called on Date object");
+            return type_error(cx, "Date.prototype.toString must be called on a Date");
         };
 
         Ok(to_date_string(cx, date_value)?.as_value())
@@ -1638,10 +1566,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.toTimeString method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.toTimeString must be called on a Date");
         };
 
         Self::to_time_string_shared(cx, date_value)
@@ -1671,10 +1596,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(
-                cx,
-                "Date.prototype.toUTCString method must be called on Date object",
-            );
+            return type_error(cx, "Date.prototype.toUTCString must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -1707,7 +1629,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.valueOf method must be called on Date object");
+            return type_error(cx, "Date.prototype.valueOf must be called on a Date");
         };
 
         Ok(Value::from(date_value).to_handle(cx))
@@ -1720,7 +1642,7 @@ impl DatePrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Date.prototype[@@toPrimitive] must be called on object");
+            return type_error(cx, "Date.prototype[@@toPrimitive] must be called on an object");
         }
 
         let hint = get_argument(cx, arguments, 0);
@@ -1743,7 +1665,7 @@ impl DatePrototype {
             }
         }
 
-        type_error(cx, "Invalid hint to Date.prototype[@@toPrimitive]")
+        type_error(cx, "invalid hint to Date.prototype[@@toPrimitive]")
     }
 
     /// Date.prototype.getYear (https://tc39.es/ecma262/#sec-date.prototype.getyear)
@@ -1755,7 +1677,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.getYear method must be called on Date object");
+            return type_error(cx, "Date.prototype.getYear must be called on a Date");
         };
 
         if date_value.is_nan() {
@@ -1776,7 +1698,7 @@ impl DatePrototype {
         let date_value = if let Some(date_value) = this_date_value(this_value) {
             date_value
         } else {
-            return type_error(cx, "Date.prototype.setYear method must be called on Date object");
+            return type_error(cx, "Date.prototype.setYear must be called on a Date");
         };
 
         let year_arg = get_argument(cx, arguments, 0);

--- a/src/js/runtime/intrinsics/error_prototype.rs
+++ b/src/js/runtime/intrinsics/error_prototype.rs
@@ -49,7 +49,7 @@ impl ErrorPrototype {
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "expected object");
+            return type_error(cx, "expected an object");
         }
 
         let this_object = this_value.as_object();

--- a/src/js/runtime/intrinsics/finalization_registry_constructor.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_constructor.rs
@@ -45,7 +45,7 @@ impl FinalizationRegistryConstructor {
 
         let cleanup_callback = get_argument(cx, arguments, 0);
         if !is_callable(cleanup_callback) {
-            return type_error(cx, "FinalizationRegistry cleanup callback is not a function");
+            return type_error(cx, "FinalizationRegistry cleanup callback must be a function");
         }
 
         Ok(FinalizationRegistryObject::new_from_constructor(

--- a/src/js/runtime/intrinsics/finalization_registry_prototype.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_prototype.rs
@@ -53,12 +53,12 @@ impl FinalizationRegistryPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let registry_object =
-            if let Some(registry_object) = this_finalization_registry_value(this_value) {
-                registry_object
-            } else {
-                return type_error(cx, "register method must be called on FinalizationRegistry");
-            };
+        let Some(registry_object) = this_finalization_registry_value(this_value) else {
+            return type_error(
+                cx,
+                "FinalizationRegistry.prototype.register must be called on a FinalizationRegistry",
+            );
+        };
 
         let target = get_argument(cx, arguments, 0);
         let held_value = get_argument(cx, arguments, 1);
@@ -71,7 +71,7 @@ impl FinalizationRegistryPrototype {
         if same_value(target, held_value)? {
             return type_error(
                 cx,
-                "The target and held value arguments to register cannot be the same value",
+                "the target and held value arguments to register cannot be the same value",
             );
         }
 
@@ -102,12 +102,12 @@ impl FinalizationRegistryPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let registry_object =
-            if let Some(registry_object) = this_finalization_registry_value(this_value) {
-                registry_object
-            } else {
-                return type_error(cx, "unregister method must be called on FinalizationRegistry");
-            };
+        let Some(registry_object) = this_finalization_registry_value(this_value) else {
+            return type_error(
+                cx,
+                "FinalizationRegistry.prototype.unregister must be called on a FinalizationRegistry",
+            );
+        };
 
         let unregister_token = get_argument(cx, arguments, 0);
 

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -127,7 +127,7 @@ impl FunctionPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !is_callable(this_value) {
-            return type_error(cx, "value is not a function");
+            return type_error(cx, "expected a function");
         }
 
         let this_arg = get_argument(cx, arguments, 0);
@@ -148,7 +148,7 @@ impl FunctionPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !is_callable(this_value) {
-            return type_error(cx, "value is not a function");
+            return type_error(cx, "expected a function");
         }
 
         let target = this_value.as_object();
@@ -204,7 +204,7 @@ impl FunctionPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !is_callable(this_value) {
-            return type_error(cx, "value is not a function");
+            return type_error(cx, "expected a function");
         }
 
         if arguments.is_empty() {

--- a/src/js/runtime/intrinsics/global_object.rs
+++ b/src/js/runtime/intrinsics/global_object.rs
@@ -399,11 +399,11 @@ fn decode<const INCLUDE_URI_UNESCAPED: bool>(
     macro_rules! parse_hex_byte {
         () => {{
             if i + 2 >= string_length {
-                return uri_error(cx, "Invalid URI escape sequence");
+                return uri_error(cx, "invalid URI escape sequence");
             }
 
             if flat_string.code_unit_at(i) != '%' as u16 {
-                return uri_error(cx, "Invalid URI escape sequence");
+                return uri_error(cx, "invalid URI escape sequence");
             }
 
             let byte = match (
@@ -411,7 +411,7 @@ fn decode<const INCLUDE_URI_UNESCAPED: bool>(
                 get_hex_value(flat_string.code_unit_at(i + 2) as u32),
             ) {
                 (Some(first), Some(second)) => ((first << 4) | second) as u8,
-                _ => return uri_error(cx, "Invalid URI escape sequence"),
+                _ => return uri_error(cx, "invalid URI escape sequence"),
             };
 
             i += 3;
@@ -425,7 +425,7 @@ fn decode<const INCLUDE_URI_UNESCAPED: bool>(
             let code_unit = parse_hex_byte!();
 
             if !is_continuation_byte(code_unit) {
-                return uri_error(cx, "Invalid URI escape sequence");
+                return uri_error(cx, "invalid URI escape sequence");
             }
 
             code_unit
@@ -458,7 +458,7 @@ fn decode<const INCLUDE_URI_UNESCAPED: bool>(
 
                 // Check for overlong encoding
                 if code_point == 0 {
-                    return uri_error(cx, "Invalid URI escape sequence");
+                    return uri_error(cx, "invalid URI escape sequence");
                 }
 
                 code_point |= parse_hex_continuation_byte!() as u32 & 0x3F;
@@ -470,7 +470,7 @@ fn decode<const INCLUDE_URI_UNESCAPED: bool>(
 
                 // Check for overlong encoding
                 if code_point == 0 {
-                    return uri_error(cx, "Invalid URI escape sequence");
+                    return uri_error(cx, "invalid URI escape sequence");
                 }
 
                 code_point |= (parse_hex_continuation_byte!() as u32 & 0x3F) << 6;
@@ -478,7 +478,7 @@ fn decode<const INCLUDE_URI_UNESCAPED: bool>(
 
                 // Check for surrogate code points
                 if char::from_u32(code_point).is_none() {
-                    return uri_error(cx, "Invalid URI escape sequence");
+                    return uri_error(cx, "invalid URI escape sequence");
                 }
 
                 decoded_string.push(code_point);
@@ -488,7 +488,7 @@ fn decode<const INCLUDE_URI_UNESCAPED: bool>(
 
                 // Check for overlong encoding
                 if code_point == 0 {
-                    return uri_error(cx, "Invalid URI escape sequence");
+                    return uri_error(cx, "invalid URI escape sequence");
                 }
 
                 code_point |= (parse_hex_continuation_byte!() as u32 & 0x3F) << 12;
@@ -497,12 +497,12 @@ fn decode<const INCLUDE_URI_UNESCAPED: bool>(
 
                 // Verify code point is in range
                 if char::from_u32(code_point).is_none() {
-                    return uri_error(cx, "Invalid URI escape sequence");
+                    return uri_error(cx, "invalid URI escape sequence");
                 }
 
                 decoded_string.push(code_point);
             } else {
-                return uri_error(cx, "Invalid URI escape sequence");
+                return uri_error(cx, "invalid URI escape sequence");
             }
         } else {
             decoded_string.push(code_unit as u32);
@@ -551,7 +551,7 @@ fn encode<const INCLUDE_URI_UNESCAPED: bool>(
         let char = match char::from_u32(code_point) {
             Some(char) => char,
             None => {
-                return uri_error(cx, "Unpaired surrogate cannot be encoded in URI");
+                return uri_error(cx, "unpaired surrogate cannot be encoded in URI");
             }
         };
 

--- a/src/js/runtime/intrinsics/intrinsics.rs
+++ b/src/js/runtime/intrinsics/intrinsics.rs
@@ -533,7 +533,7 @@ pub fn throw_type_error(
     _: Handle<Value>,
     _: &[Handle<Value>],
 ) -> EvalResult<Handle<Value>> {
-    type_error(cx, "'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them")
+    type_error(cx, "`caller`, `callee`, and `arguments` properties may not be accessed on strict mode functions or the arguments objects for calls to them")
 }
 
 /// %ThrowTypeError% (https://tc39.es/ecma262/#sec-%throwtypeerror%)

--- a/src/js/runtime/intrinsics/iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_prototype.rs
@@ -164,7 +164,7 @@ impl IteratorPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.drop called on non-object");
+            return type_error(cx, "Iterator.prototype.drop must be called on an object");
         }
 
         let iterator_object = this_value.as_object();
@@ -202,14 +202,14 @@ impl IteratorPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.every called on non-object");
+            return type_error(cx, "Iterator.prototype.every must be called on an object");
         }
 
         // Verify the predicate argument is a function, closing the underlying iterator if not
         let predicate_arg = get_argument(cx, arguments, 0);
         if !is_callable(predicate_arg) {
             let error =
-                type_error_value(cx, "Iterator.prototype.every predicate is not a function")?;
+                type_error_value(cx, "Iterator.prototype.every predicate must be a function")?;
             return iterator_close(cx, this_value.as_object(), eval_err!(error));
         }
         let predicate = predicate_arg.as_object();
@@ -247,14 +247,14 @@ impl IteratorPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.filter called on non-object");
+            return type_error(cx, "Iterator.prototype.filter must be called on an object");
         }
 
         // Verify the predicate argument is a function, closing the underlying iterator if not
         let predicate_arg = get_argument(cx, arguments, 0);
         if !is_callable(predicate_arg) {
             let error =
-                type_error_value(cx, "Iterator.prototype.filter predicate is not a function")?;
+                type_error_value(cx, "Iterator.prototype.filter predicate must be a function")?;
             return iterator_close(cx, this_value.as_object(), eval_err!(error));
         }
         let predicate = predicate_arg.as_object();
@@ -271,14 +271,14 @@ impl IteratorPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.find called on non-object");
+            return type_error(cx, "Iterator.prototype.find must be called on an object");
         }
 
         // Verify the predicate argument is a function, closing the underlying iterator if not
         let predicate_arg = get_argument(cx, arguments, 0);
         if !is_callable(predicate_arg) {
             let error =
-                type_error_value(cx, "Iterator.prototype.find predicate is not a function")?;
+                type_error_value(cx, "Iterator.prototype.find predicate must be a function")?;
             return iterator_close(cx, this_value.as_object(), eval_err!(error));
         }
         let predicate = predicate_arg.as_object();
@@ -316,14 +316,14 @@ impl IteratorPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.flatMap called on non-object");
+            return type_error(cx, "Iterator.prototype.flatMap must be called on an object");
         }
 
         // Verify the mapper argument is a function, closing the underlying iterator if not
         let mapper_arg = get_argument(cx, arguments, 0);
         if !is_callable(mapper_arg) {
             let error =
-                type_error_value(cx, "Iterator.prototype.flatMap mapper is not a function")?;
+                type_error_value(cx, "Iterator.prototype.flatMap mapper must be a function")?;
             return iterator_close(cx, this_value.as_object(), eval_err!(error));
         }
         let mapper = mapper_arg.as_object();
@@ -340,14 +340,14 @@ impl IteratorPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.forEach called on non-object");
+            return type_error(cx, "Iterator.prototype.forEach must be called on an object");
         }
 
         // Verify the callback argument is a function, closing the underlying iterator if not
         let callback_arg = get_argument(cx, arguments, 0);
         if !is_callable(callback_arg) {
             let error =
-                type_error_value(cx, "Iterator.prototype.forEach callback is not a function")?;
+                type_error_value(cx, "Iterator.prototype.forEach callback must be a function")?;
             return iterator_close(cx, this_value.as_object(), eval_err!(error));
         }
         let callback = callback_arg.as_object();
@@ -382,13 +382,13 @@ impl IteratorPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.map called on non-object");
+            return type_error(cx, "Iterator.prototype.map must be called on an object");
         }
 
         // Verify the mapper argument is a function, closing the underlying iterator if not
         let mapper_arg = get_argument(cx, arguments, 0);
         if !is_callable(mapper_arg) {
-            let error = type_error_value(cx, "Iterator.prototype.map mapper is not a function")?;
+            let error = type_error_value(cx, "Iterator.prototype.map mapper must be a function")?;
             return iterator_close(cx, this_value.as_object(), eval_err!(error));
         }
         let mapper = mapper_arg.as_object();
@@ -405,14 +405,14 @@ impl IteratorPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.reduce called on non-object");
+            return type_error(cx, "Iterator.prototype.reduce must be called on an object");
         }
 
         // Verify the callback argument is a function, closing the underlying iterator if not
         let callback_arg = get_argument(cx, arguments, 0);
         if !is_callable(callback_arg) {
             let error =
-                type_error_value(cx, "Iterator.prototype.reduce callback is not a function")?;
+                type_error_value(cx, "Iterator.prototype.reduce callback must be a function")?;
             return iterator_close(cx, this_value.as_object(), eval_err!(error));
         }
         let callback = callback_arg.as_object();
@@ -469,14 +469,14 @@ impl IteratorPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.some called on non-object");
+            return type_error(cx, "Iterator.prototype.some must be called on an object");
         }
 
         // Verify the predicate argument is a function, closing the underlying iterator if not
         let predicate_arg = get_argument(cx, arguments, 0);
         if !is_callable(predicate_arg) {
             let error =
-                type_error_value(cx, "Iterator.prototype.some predicate is not a function")?;
+                type_error_value(cx, "Iterator.prototype.some predicate must be a function")?;
             return iterator_close(cx, this_value.as_object(), eval_err!(error));
         }
         let predicate = predicate_arg.as_object();
@@ -514,7 +514,7 @@ impl IteratorPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.take called on non-object");
+            return type_error(cx, "Iterator.prototype.take must be called on an object");
         }
 
         let iterator_object = this_value.as_object();
@@ -552,7 +552,7 @@ impl IteratorPrototype {
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.toArray called on non-object");
+            return type_error(cx, "Iterator.prototype.toArray must be called on an object");
         }
 
         let mut iterated = get_iterator_direct(cx, this_value.as_object())?;

--- a/src/js/runtime/intrinsics/json_object.rs
+++ b/src/js/runtime/intrinsics/json_object.rs
@@ -613,7 +613,7 @@ impl JSONSerializer {
                 self.builder.push_str("null");
             }
         } else if value.is_bigint() {
-            return type_error(cx, "BigInt value can't be serialized to JSON");
+            return type_error(cx, "BigInt value cannot be serialized to JSON");
         } else if value.is_object() && !is_callable(value) {
             if is_array(cx, value)? {
                 self.serialize_json_array(cx, value.as_object())?;
@@ -674,7 +674,7 @@ impl JSONSerializer {
             .any(|ancestor| ancestor.ptr_eq(&value_ptr));
 
         if has_cycle {
-            type_error(cx, "Cyclic object can't be serialized to JSON")
+            type_error(cx, "cyclic object cannot be serialized to JSON")
         } else {
             Ok(())
         }

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -103,7 +103,7 @@ impl MapPrototype {
         let map = if let Some(map) = this_map_value(this_value) {
             map
         } else {
-            return type_error(cx, "clear method must be called on map");
+            return type_error(cx, "Map.prototype.clear must be called on a Map");
         };
 
         map.map_data().clear();
@@ -120,7 +120,7 @@ impl MapPrototype {
         let map = if let Some(map) = this_map_value(this_value) {
             map
         } else {
-            return type_error(cx, "delete method must be called on map");
+            return type_error(cx, "Map.prototype.delete must be called on a Map");
         };
 
         let key = get_argument(cx, arguments, 0);
@@ -142,7 +142,7 @@ impl MapPrototype {
         let map = if let Some(map) = this_map_value(this_value) {
             map
         } else {
-            return type_error(cx, "entries method must be called on map");
+            return type_error(cx, "Map.prototype.entries must be called on a Map");
         };
 
         Ok(MapIterator::new(cx, map, MapIteratorKind::KeyAndValue)?.as_value())
@@ -157,12 +157,12 @@ impl MapPrototype {
         let map = if let Some(map) = this_map_value(this_value) {
             map
         } else {
-            return type_error(cx, "forEach method must be called on map");
+            return type_error(cx, "Map.prototype.forEach must be called on a Map");
         };
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "expected function");
+            return type_error(cx, "Map.prototype.forEach callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -194,7 +194,7 @@ impl MapPrototype {
         let map = if let Some(map) = this_map_value(this_value) {
             map
         } else {
-            return type_error(cx, "get method must be called on map");
+            return type_error(cx, "Map.prototype.get must be called on a Map");
         };
 
         let key = get_argument(cx, arguments, 0);
@@ -217,7 +217,7 @@ impl MapPrototype {
         let map = if let Some(map) = this_map_value(this_value) {
             map
         } else {
-            return type_error(cx, "has method must be called on map");
+            return type_error(cx, "Map.prototype.has must be called on a Map");
         };
 
         let key = get_argument(cx, arguments, 0);
@@ -237,7 +237,7 @@ impl MapPrototype {
         let map = if let Some(map) = this_map_value(this_value) {
             map
         } else {
-            return type_error(cx, "keys method must be called on map");
+            return type_error(cx, "Map.prototype.keys must be called on a Map");
         };
 
         Ok(MapIterator::new(cx, map, MapIteratorKind::Key)?.as_value())
@@ -252,7 +252,7 @@ impl MapPrototype {
         let map = if let Some(map) = this_map_value(this_value) {
             map
         } else {
-            return type_error(cx, "set method must be called on map");
+            return type_error(cx, "Map.prototype.set must be called on a Map");
         };
 
         let mut key = get_argument(cx, arguments, 0);
@@ -277,7 +277,7 @@ impl MapPrototype {
         let map = if let Some(map) = this_map_value(this_value) {
             map
         } else {
-            return type_error(cx, "size accessor must be called on map");
+            return type_error(cx, "Map.prototype.size must be called on a Map");
         };
 
         Ok(Value::from(map.map_data().num_entries_occupied()).to_handle(cx))
@@ -292,7 +292,7 @@ impl MapPrototype {
         let map = if let Some(map) = this_map_value(this_value) {
             map
         } else {
-            return type_error(cx, "values method must be called on map");
+            return type_error(cx, "Map.prototype.values must be called on a Map");
         };
 
         Ok(MapIterator::new(cx, map, MapIteratorKind::Value)?.as_value())

--- a/src/js/runtime/intrinsics/object_constructor.rs
+++ b/src/js/runtime/intrinsics/object_constructor.rs
@@ -310,7 +310,7 @@ impl ObjectConstructor {
     ) -> EvalResult<Handle<Value>> {
         let object = get_argument(cx, arguments, 0);
         if !object.is_object() {
-            return type_error(cx, "value is not an object");
+            return type_error(cx, "expected an object");
         }
 
         let properties_arg = get_argument(cx, arguments, 1);

--- a/src/js/runtime/intrinsics/promise_constructor.rs
+++ b/src/js/runtime/intrinsics/promise_constructor.rs
@@ -738,7 +738,7 @@ impl PromiseConstructor {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Promise.resolve called on non-object");
+            return type_error(cx, "Promise.resolve must be called on an object");
         }
 
         let result = get_argument(cx, arguments, 0);
@@ -752,7 +752,7 @@ impl PromiseConstructor {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Promise.try called on non-object");
+            return type_error(cx, "Promise.try must be called on an object");
         }
 
         let capability = PromiseCapability::new(cx, this_value)?;
@@ -906,7 +906,7 @@ fn get_promise_resolve(
 ) -> EvalResult<Handle<ObjectValue>> {
     let resolve = get(cx, constructor, cx.names.resolve())?;
     if !is_callable(resolve) {
-        return type_error(cx, "resolve property must be a function");
+        return type_error(cx, "`resolve` property must be a function");
     }
 
     Ok(resolve.as_object())

--- a/src/js/runtime/intrinsics/promise_prototype.rs
+++ b/src/js/runtime/intrinsics/promise_prototype.rs
@@ -78,7 +78,7 @@ impl PromisePrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Promise.prototype.finally called on non-object");
+            return type_error(cx, "Promise.prototype.finally must be called on an object");
         }
         let promise = this_value.as_object().cast::<PromiseObject>();
 
@@ -259,7 +259,7 @@ impl PromisePrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !is_promise(*this_value) {
-            return type_error(cx, "Promise.prototype.then called on non-promise");
+            return type_error(cx, "Promise.prototype.then must be called on a Promise");
         }
         let promise = this_value.as_object().cast::<PromiseObject>();
 

--- a/src/js/runtime/intrinsics/reflect_object.rs
+++ b/src/js/runtime/intrinsics/reflect_object.rs
@@ -118,7 +118,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !is_callable(target) {
-            return type_error(cx, "value is not a function");
+            return type_error(cx, "expected a function");
         }
 
         let this_argument = get_argument(cx, arguments, 1);
@@ -136,7 +136,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !is_constructor_value(target) {
-            return type_error(cx, "value is not a constructor");
+            return type_error(cx, "expected a constructor");
         }
 
         let target = target.as_object();
@@ -144,7 +144,7 @@ impl ReflectObject {
         let new_target = if arguments.len() >= 3 {
             let new_target = get_argument(cx, arguments, 2);
             if !is_constructor_value(new_target) {
-                return type_error(cx, "value is not a constructor");
+                return type_error(cx, "expected a constructor");
             }
 
             new_target.as_object()
@@ -166,7 +166,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "value is not an object");
+            return type_error(cx, "expected an object");
         }
 
         let mut target = target.as_object();
@@ -189,7 +189,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "value is not an object");
+            return type_error(cx, "expected an object");
         }
 
         let mut target = target.as_object();
@@ -208,7 +208,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "value is not an object");
+            return type_error(cx, "expected an object");
         }
 
         let key_arg = get_argument(cx, arguments, 1);
@@ -231,7 +231,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "value is not an object");
+            return type_error(cx, "expected an object");
         }
 
         let target = target.as_object();
@@ -255,7 +255,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "value is not an object");
+            return type_error(cx, "expected an object");
         }
 
         let prototype = target.as_object().get_prototype_of(cx)?;
@@ -271,7 +271,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "value is not an object");
+            return type_error(cx, "expected an object");
         }
 
         let target = target.as_object();
@@ -290,7 +290,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "value is not an object");
+            return type_error(cx, "expected an object");
         }
 
         let is_extensible = target.as_object().is_extensible(cx)?;
@@ -305,7 +305,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "value is not an object");
+            return type_error(cx, "expected an object");
         }
 
         let own_keys = target.as_object().own_property_keys(cx)?;
@@ -321,7 +321,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "value is not an object");
+            return type_error(cx, "expected an object");
         }
 
         let result = target.as_object().prevent_extensions(cx)?;
@@ -336,7 +336,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "value is not an object");
+            return type_error(cx, "expected an object");
         }
 
         let key_arg = get_argument(cx, arguments, 1);
@@ -361,7 +361,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "value is not an object");
+            return type_error(cx, "expected an object");
         }
 
         let proto = get_argument(cx, arguments, 1);

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -235,7 +235,7 @@ impl RegExpConstructor {
     ) -> EvalResult<Handle<Value>> {
         let string_arg = get_argument(cx, arguments, 0);
         if !string_arg.is_string() {
-            return type_error(cx, "RegExp.escape called with non-string argument");
+            return type_error(cx, "RegExp.escape argument must be a string");
         }
         let string = string_arg.as_string();
 

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -197,7 +197,7 @@ impl RegExpPrototype {
         let regexp_object = if let Some(regexp_object) = as_regexp_object(this_value) {
             regexp_object
         } else {
-            return type_error(cx, "RegExp.prototype.exec must be called on a regular expression");
+            return type_error(cx, "RegExp.prototype.exec must be called on a RegExp");
         };
 
         let string_arg = get_argument(cx, arguments, 0);
@@ -222,7 +222,7 @@ impl RegExpPrototype {
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Expected a regular expression");
+            return type_error(cx, "expected a RegExp");
         }
 
         let this_object = this_value.as_object();
@@ -312,7 +312,7 @@ impl RegExpPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "RegExp.prototype[@@match] must be called on object");
+            return type_error(cx, "RegExp.prototype[@@match] must be called on an object");
         }
 
         let regexp_object = this_value.as_object();
@@ -383,7 +383,7 @@ impl RegExpPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "RegExp.prototype[@@matchAll] must be called on object");
+            return type_error(cx, "RegExp.prototype[@@matchAll] must be called on an object");
         }
 
         let regexp_object = this_value.as_object();
@@ -428,7 +428,7 @@ impl RegExpPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "RegExp.prototype[@@replace] must be called on object");
+            return type_error(cx, "RegExp.prototype[@@replace] must be called on an object");
         }
 
         let regexp_object = this_value.as_object();
@@ -618,7 +618,7 @@ impl RegExpPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "RegExp.prototype[@@search] must be called on object");
+            return type_error(cx, "RegExp.prototype[@@search] must be called on an object");
         }
 
         let regexp_object = this_value.as_object();
@@ -667,7 +667,7 @@ impl RegExpPrototype {
             }
         }
 
-        type_error(cx, "Expected a regular expression")
+        type_error(cx, "expected a RegExp")
     }
 
     /// RegExp.prototype [ @@split ] (https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.split%)
@@ -847,7 +847,7 @@ impl RegExpPrototype {
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Expected a regular expression");
+            return type_error(cx, "expected a RegExp");
         }
 
         let this_object = this_value.as_object();
@@ -895,10 +895,7 @@ impl RegExpPrototype {
         let regexp_object = if let Some(regexp_object) = as_regexp_object(this_value) {
             regexp_object
         } else {
-            return type_error(
-                cx,
-                "RegExp.prototype.compile must be called on a regular expression",
-            );
+            return type_error(cx, "RegExp.prototype.compile must be called on a RegExp");
         };
 
         let pattern_arg = get_argument(cx, arguments, 0);
@@ -938,7 +935,7 @@ fn regexp_has_flag(
         }
     }
 
-    type_error(cx, "Expected a regular expression")
+    type_error(cx, "expected a RegExp")
 }
 
 pub fn flags_string_contains(
@@ -959,14 +956,14 @@ pub fn regexp_exec(
     if is_callable(exec) {
         let exec_result = call(cx, exec, regexp_object.into(), &[string_value.into()])?;
         if !exec_result.is_null() && !exec_result.is_object() {
-            return type_error(cx, "Regular expression exec must return null or an object");
+            return type_error(cx, "regular expression exec must return null or an object");
         }
 
         return Ok(exec_result);
     }
 
     if !regexp_object.is_regexp_object() {
-        return type_error(cx, "Expected a regular expression");
+        return type_error(cx, "expected a RegExp");
     }
 
     regexp_builtin_exec(cx, regexp_object.cast::<RegExpObject>(), string_value)

--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -161,7 +161,7 @@ impl SetPrototype {
         let set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "add method must be called on set");
+            return type_error(cx, "Set.prototype.add must be called on a Set");
         };
 
         // Convert negative zero to positive zero in set
@@ -182,7 +182,7 @@ impl SetPrototype {
         let set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "clear method must be called on set");
+            return type_error(cx, "Set.prototype.clear must be called on a Set");
         };
 
         set.set_data_ptr().clear();
@@ -199,7 +199,7 @@ impl SetPrototype {
         let set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "delete method must be called on set");
+            return type_error(cx, "Set.prototype.delete must be called on a Set");
         };
 
         let key = get_argument(cx, arguments, 0);
@@ -221,7 +221,7 @@ impl SetPrototype {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "difference method must be called on set");
+            return type_error(cx, "Set.prototype.difference must be called on a Set");
         };
 
         let other = get_argument(cx, arguments, 0);
@@ -290,7 +290,7 @@ impl SetPrototype {
         let set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "entries method must be called on set");
+            return type_error(cx, "Set.prototype.entries must be called on a Set");
         };
 
         Ok(SetIterator::new(cx, set, SetIteratorKind::KeyAndValue)?.as_value())
@@ -305,12 +305,12 @@ impl SetPrototype {
         let set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "forEach method must be called on set");
+            return type_error(cx, "Set.prototype.forEach must be called on a Set");
         };
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "expected function");
+            return type_error(cx, "Set.prototype.forEach callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -340,7 +340,7 @@ impl SetPrototype {
         let set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "has method must be called on set");
+            return type_error(cx, "Set.prototype.has must be called on a Set");
         };
 
         let value = get_argument(cx, arguments, 0);
@@ -360,7 +360,7 @@ impl SetPrototype {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "intersection method must be called on set");
+            return type_error(cx, "Set.prototype.intersection must be called on a Set");
         };
 
         let other = get_argument(cx, arguments, 0);
@@ -432,7 +432,7 @@ impl SetPrototype {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "isDisjointFrom method must be called on set");
+            return type_error(cx, "Set.prototype.isDisjointFrom must be called on a Set");
         };
 
         let other = get_argument(cx, arguments, 0);
@@ -497,7 +497,7 @@ impl SetPrototype {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "isSubsetOf method must be called on set");
+            return type_error(cx, "Set.prototype.isSubsetOf must be called on a Set");
         };
 
         let other = get_argument(cx, arguments, 0);
@@ -541,7 +541,7 @@ impl SetPrototype {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "isSupersetOf method must be called on set");
+            return type_error(cx, "Set.prototype.isSupersetOf must be called on a Set");
         };
 
         let other = get_argument(cx, arguments, 0);
@@ -587,7 +587,7 @@ impl SetPrototype {
         let set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "size accessor must be called on set");
+            return type_error(cx, "Set.prototype.size must be called on a Set");
         };
 
         Ok(Value::from(set.set_data_ptr().num_entries_occupied()).to_handle(cx))
@@ -602,7 +602,7 @@ impl SetPrototype {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "symmetricDifference method must be called on set");
+            return type_error(cx, "Set.prototype.symmetricDifference must be called on a Set");
         };
 
         let other = get_argument(cx, arguments, 0);
@@ -654,7 +654,7 @@ impl SetPrototype {
         let this_set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "union method must be called on set");
+            return type_error(cx, "Set.prototype.union must be called on a Set");
         };
 
         let other = get_argument(cx, arguments, 0);
@@ -692,7 +692,7 @@ impl SetPrototype {
         let set = if let Some(set) = this_set_value(this_value) {
             set
         } else {
-            return type_error(cx, "values method must be called on set");
+            return type_error(cx, "Set.prototype.values must be called on a Set");
         };
 
         Ok(SetIterator::new(cx, set, SetIteratorKind::Value)?.as_value())
@@ -717,7 +717,7 @@ struct SetRecord {
 /// GetSetRecord (https://tc39.es/ecma262/#sec-getsetrecord)
 fn get_set_record(cx: Context, value: Handle<Value>) -> EvalResult<SetRecord> {
     if !value.is_object() {
-        return type_error(cx, "value is not an object");
+        return type_error(cx, "expected an object");
     }
 
     let object = value.as_object();
@@ -725,22 +725,22 @@ fn get_set_record(cx: Context, value: Handle<Value>) -> EvalResult<SetRecord> {
     let raw_size = get(cx, object, cx.names.size())?;
     let num_size = to_number(cx, raw_size)?;
     if num_size.is_nan() {
-        return type_error(cx, "size is not a number");
+        return type_error(cx, "`size` property must be a number");
     }
 
     let int_size = must!(to_integer_or_infinity(cx, num_size));
     if int_size < 0.0 {
-        return type_error(cx, "size is negative");
+        return type_error(cx, "`size` property must not be negative");
     }
 
     let has_method = get(cx, object, cx.names.has())?;
     if !is_callable(has_method) {
-        return type_error(cx, "has method is not callable");
+        return type_error(cx, "`has` method must be a function");
     }
 
     let keys_method = get(cx, object, cx.names.keys())?;
     if !is_callable(keys_method) {
-        return type_error(cx, "keys method is not callable");
+        return type_error(cx, "`keys` method must be a function");
     }
 
     Ok(SetRecord {

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -519,7 +519,7 @@ impl StringPrototype {
 
         let search_string = get_argument(cx, arguments, 0);
         if is_regexp(cx, search_string)? {
-            return type_error(cx, "String.prototype.includes cannot take a regular expression");
+            return type_error(cx, "String.prototype.includes cannot take a RegExp");
         }
 
         let search_string = to_string(cx, search_string)?;

--- a/src/js/runtime/intrinsics/symbol_constructor.rs
+++ b/src/js/runtime/intrinsics/symbol_constructor.rs
@@ -184,7 +184,7 @@ impl SymbolConstructor {
     ) -> EvalResult<Handle<Value>> {
         let symbol_value = get_argument(cx, arguments, 0);
         if !symbol_value.is_symbol() {
-            return type_error(cx, "expected symbol value");
+            return type_error(cx, "expected a Symbol");
         }
         let symbol_value = *symbol_value.as_symbol();
 

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -88,7 +88,7 @@ impl TypedArrayConstructor {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !is_constructor_value(this_value) {
-            return type_error(cx, "TypedArray.from must be called on constructor");
+            return type_error(cx, "TypedArray.from must be called on a constructor");
         }
 
         let this_constructor = this_value.as_object();
@@ -98,7 +98,7 @@ impl TypedArrayConstructor {
             if argument.is_undefined() {
                 None
             } else if !is_callable(argument) {
-                return type_error(cx, "map function must be a function");
+                return type_error(cx, "TypedArray.from map function must be a function");
             } else {
                 Some(argument.as_object())
             }
@@ -182,7 +182,7 @@ impl TypedArrayConstructor {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !is_constructor_value(this_value) {
-            return type_error(cx, "TypedArray.of must be called on constructor");
+            return type_error(cx, "TypedArray.of must be called on a constructor");
         }
 
         let this_constructor = this_value.as_object();

--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -549,7 +549,7 @@ impl TypedArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "expected function");
+            return type_error(cx, "TypedArray.prototype.every callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -654,7 +654,7 @@ impl TypedArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "expected function");
+            return type_error(cx, "TypedArray.prototype.filter callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -711,7 +711,7 @@ impl TypedArrayPrototype {
 
         let predicate_function = get_argument(cx, arguments, 0);
         if !is_callable(predicate_function) {
-            return type_error(cx, "TypedArray.prototype.find expected function");
+            return type_error(cx, "TypedArray.prototype.find callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
@@ -739,7 +739,7 @@ impl TypedArrayPrototype {
 
         let predicate_function = get_argument(cx, arguments, 0);
         if !is_callable(predicate_function) {
-            return type_error(cx, "TypedArray.prototype.findIndex expected function");
+            return type_error(cx, "TypedArray.prototype.findIndex callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
@@ -767,7 +767,7 @@ impl TypedArrayPrototype {
 
         let predicate_function = get_argument(cx, arguments, 0);
         if !is_callable(predicate_function) {
-            return type_error(cx, "TypedArray.prototype.findLast expected function");
+            return type_error(cx, "TypedArray.prototype.findLast callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
@@ -796,7 +796,10 @@ impl TypedArrayPrototype {
 
         let predicate_function = get_argument(cx, arguments, 0);
         if !is_callable(predicate_function) {
-            return type_error(cx, "TypedArray.prototype.findLastIndex expected function");
+            return type_error(
+                cx,
+                "TypedArray.prototype.findLastIndex callback must be a function",
+            );
         }
 
         let predicate_function = predicate_function.as_object();
@@ -825,7 +828,7 @@ impl TypedArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "expected function");
+            return type_error(cx, "TypedArray.prototype.forEach callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -1084,7 +1087,7 @@ impl TypedArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "expected function");
+            return type_error(cx, "TypedArray.prototype.map mapper must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -1125,7 +1128,7 @@ impl TypedArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "expected function");
+            return type_error(cx, "TypedArray.prototype.reduce callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -1172,7 +1175,7 @@ impl TypedArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "expected function");
+            return type_error(cx, "TypedArray.prototype.reduceRight callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -1507,7 +1510,7 @@ impl TypedArrayPrototype {
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "expected function");
+            return type_error(cx, "TypedArray.prototype.some callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -1541,7 +1544,7 @@ impl TypedArrayPrototype {
     ) -> EvalResult<Handle<Value>> {
         let compare_function_arg = get_argument(cx, arguments, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
-            return type_error(cx, "Sort comparator must be a function");
+            return type_error(cx, "TypedArray.prototype.sort comparator must be a function");
         };
 
         let typed_array_record = validate_typed_array(cx, this_value)?;
@@ -1710,7 +1713,7 @@ impl TypedArrayPrototype {
     ) -> EvalResult<Handle<Value>> {
         let compare_function_arg = get_argument(cx, arguments, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
-            return type_error(cx, "Sort comparator must be a function");
+            return type_error(cx, "TypedArray.prototype.toSorted comparator must be a function");
         };
 
         let typed_array_record = validate_typed_array(cx, this_value)?;
@@ -1874,12 +1877,12 @@ macro_rules! create_typed_array_prototype {
 #[inline]
 fn require_typed_array(cx: Context, value: Handle<Value>) -> EvalResult<DynTypedArray> {
     if !value.is_object() {
-        return type_error(cx, "expected typed array");
+        return type_error(cx, "expected a TypedArray");
     }
 
     let object = value.as_object();
     if !object.is_typed_array() {
-        return type_error(cx, "expected typed array");
+        return type_error(cx, "expected a TypedArray");
     }
 
     Ok(object.as_typed_array())

--- a/src/js/runtime/intrinsics/weak_map_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_map_constructor.rs
@@ -61,7 +61,7 @@ impl WeakMapConstructor {
 
         let adder = get(cx, weak_map.into(), cx.names.set_())?;
         if !is_callable(adder) {
-            return type_error(cx, "WeakMap adder is not callable");
+            return type_error(cx, "WeakMap adder must be a function");
         }
 
         add_entries_from_iterable(cx, weak_map.into(), iterable, |cx, key, value| {

--- a/src/js/runtime/intrinsics/weak_map_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_map_prototype.rs
@@ -65,7 +65,7 @@ impl WeakMapPrototype {
         let weak_map_object = if let Some(weak_map_object) = this_weak_map_value(this_value) {
             weak_map_object
         } else {
-            return type_error(cx, "delete method must be called on WeakMap");
+            return type_error(cx, "WeakMap.prototype.delete must be called on a WeakMap");
         };
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value map
@@ -88,7 +88,7 @@ impl WeakMapPrototype {
         let weak_map_object = if let Some(weak_map_object) = this_weak_map_value(this_value) {
             weak_map_object
         } else {
-            return type_error(cx, "get method must be called on WeakMap");
+            return type_error(cx, "WeakMap.prototype.get must be called on a WeakMap");
         };
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value map
@@ -115,7 +115,7 @@ impl WeakMapPrototype {
         let weak_map_object = if let Some(weak_map_object) = this_weak_map_value(this_value) {
             weak_map_object
         } else {
-            return type_error(cx, "has method must be called on WeakMap");
+            return type_error(cx, "WeakMap.prototype.has must be called on a WeakMap");
         };
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value map
@@ -138,7 +138,7 @@ impl WeakMapPrototype {
         let weak_map_object = if let Some(weak_map_object) = this_weak_map_value(this_value) {
             weak_map_object
         } else {
-            return type_error(cx, "set method must be called on WeakMap");
+            return type_error(cx, "WeakMap.prototype.set must be called on a WeakMap");
         };
 
         let key = get_argument(cx, arguments, 0);

--- a/src/js/runtime/intrinsics/weak_ref_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_ref_prototype.rs
@@ -43,7 +43,7 @@ impl WeakRefPrototype {
         if let Some(weak_ref_object) = this_weak_ref_value(this_value) {
             Ok(weak_ref_object.weak_ref_target().to_handle(cx))
         } else {
-            type_error(cx, "deref method must be called on WeakRef")
+            type_error(cx, "WeakRef.prototype.deref must be called on a WeakRef")
         }
     }
 }

--- a/src/js/runtime/intrinsics/weak_set_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_set_constructor.rs
@@ -59,7 +59,7 @@ impl WeakSetConstructor {
 
         let adder = get(cx, weak_set.into(), cx.names.add())?;
         if !is_callable(adder) {
-            return type_error(cx, "WeakSet adder is not callable");
+            return type_error(cx, "WeakSet adder must be a function");
         }
 
         let iterator = get_iterator(cx, iterable, IteratorHint::Sync, None)?;

--- a/src/js/runtime/intrinsics/weak_set_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_set_prototype.rs
@@ -58,7 +58,7 @@ impl WeakSetPrototype {
         let weak_set_object = if let Some(weak_set_object) = this_weak_set_value(this_value) {
             weak_set_object
         } else {
-            return type_error(cx, "add method must be called on WeakSet");
+            return type_error(cx, "WeakSet.prototype.add must be called on a WeakSet");
         };
 
         let value = get_argument(cx, arguments, 0);
@@ -80,7 +80,7 @@ impl WeakSetPrototype {
         let weak_set_object = if let Some(weak_set_object) = this_weak_set_value(this_value) {
             weak_set_object
         } else {
-            return type_error(cx, "delete method must be called on WeakSet");
+            return type_error(cx, "WeakSet.prototype.delete must be called on a WeakSet");
         };
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value set
@@ -103,7 +103,7 @@ impl WeakSetPrototype {
         let weak_set_object = if let Some(weak_set_object) = this_weak_set_value(this_value) {
             weak_set_object
         } else {
-            return type_error(cx, "has method must be called on WeakSet");
+            return type_error(cx, "WeakSet.prototype.has must be called on a WeakSet");
         };
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value set

--- a/src/js/runtime/iterator.rs
+++ b/src/js/runtime/iterator.rs
@@ -62,7 +62,7 @@ pub fn get_iterator(
                 method
             } else {
                 // Inlined from eventual call to IsCallable(undefined) which would fail
-                return type_error(cx, "value is not a function");
+                return type_error(cx, "expected a function");
             }
         }
     };
@@ -125,7 +125,7 @@ pub fn iterator_next(
     };
 
     if !result.is_object() {
-        return type_error(cx, "iterator's next method must return an object");
+        return type_error(cx, "Iterator `next` method must return an object");
     }
 
     Ok(result.as_object())
@@ -172,7 +172,7 @@ pub fn iterator_close(
 
     let inner_value = inner_result?;
     if !inner_value.is_object() {
-        return type_error(cx, "iterator's return method must return an object");
+        return type_error(cx, "Iterator `return` method must return an object");
     }
 
     completion

--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -591,7 +591,7 @@ pub fn dynamic_import(
 
     if !options.is_undefined() {
         if !options.is_object() {
-            let error = type_error_value(cx, "Import options must be an object")?;
+            let error = type_error_value(cx, "import options must be an object")?;
             must!(call_object(cx, capability.reject(), cx.undefined(), &[error]));
             return Ok(capability.promise());
         }
@@ -602,7 +602,7 @@ pub fn dynamic_import(
 
         if !attributes_object.is_undefined() {
             if !attributes_object.is_object() {
-                let error = type_error_value(cx, "Import attributes must be an object")?;
+                let error = type_error_value(cx, "import attributes must be an object")?;
                 must!(call_object(cx, capability.reject(), cx.undefined(), &[error]));
                 return Ok(capability.promise());
             }
@@ -621,7 +621,7 @@ pub fn dynamic_import(
                 let value = must!(get(cx, entry, PropertyKey::from_u8(1).to_handle(cx)));
 
                 if !value.is_string() {
-                    let error = type_error_value(cx, "Import attribute values must be strings")?;
+                    let error = type_error_value(cx, "import attribute values must be strings")?;
                     must!(call_object(cx, capability.reject(), cx.undefined(), &[error]));
                     return Ok(capability.promise());
                 }

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -485,7 +485,7 @@ impl PromiseCapability {
     /// NewPromiseCapability (https://tc39.es/ecma262/#sec-newpromisecapability)
     pub fn new(cx: Context, constructor: Handle<Value>) -> EvalResult<Handle<PromiseCapability>> {
         if !is_constructor_value(constructor) {
-            return type_error(cx, "expected constructor");
+            return type_error(cx, "expected a constructor");
         }
         let constructor = constructor.as_object();
 
@@ -523,9 +523,9 @@ impl PromiseCapability {
         let promise = construct(cx, constructor, &[executor.into()], None)?;
 
         if !is_callable(capability.resolve.to_handle(cx)) {
-            return type_error(cx, "resolve must be callable");
+            return type_error(cx, "`resolve` must be a function");
         } else if !is_callable(capability.reject.to_handle(cx)) {
-            return type_error(cx, "reject must be callable");
+            return type_error(cx, "`reject` must be a function");
         }
 
         // Finally store the promise in the capability record, completing it

--- a/src/js/runtime/property_descriptor.rs
+++ b/src/js/runtime/property_descriptor.rs
@@ -302,7 +302,7 @@ pub fn to_property_descriptor(cx: Context, value: Handle<Value>) -> EvalResult<P
         let get = get(cx, object, cx.names.get())?;
         let is_function = is_callable(get);
         if !is_function && !get.is_undefined() {
-            return type_error(cx, "getter is not callable");
+            return type_error(cx, "getter must be a function");
         }
 
         desc.has_get = true;
@@ -317,7 +317,7 @@ pub fn to_property_descriptor(cx: Context, value: Handle<Value>) -> EvalResult<P
         let set = get(cx, object, cx.names.set_())?;
         let is_function = is_callable(set);
         if !is_function && !set.is_undefined() {
-            return type_error(cx, "setter is not callable");
+            return type_error(cx, "setter must be a function");
         }
 
         desc.has_set = true;
@@ -329,7 +329,7 @@ pub fn to_property_descriptor(cx: Context, value: Handle<Value>) -> EvalResult<P
     }
 
     if (desc.has_get || desc.has_set) && (desc.value.is_some() || desc.is_writable.is_some()) {
-        return type_error(cx, "property desriptor must be data or accesor");
+        return type_error(cx, "property descriptor must be data or accessor");
     }
 
     Ok(desc)

--- a/src/js/runtime/proxy_object.rs
+++ b/src/js/runtime/proxy_object.rs
@@ -118,21 +118,21 @@ impl VirtualObject for Handle<ProxyObject> {
                 return type_error(
                     cx,
                     &format!(
-                        "proxy can't report a non-configurable own property '{}' as non-existent",
+                        "proxy cannot report a non-configurable own property `{}` as non-existent",
                         key.format()?
                     ),
                 );
             }
 
             if !is_extensible_(cx, target)? {
-                return type_error(cx, &format!("proxy can't report an existing own property '{}' as non-existent on a non-extensible object", key.format()?));
+                return type_error(cx, &format!("proxy cannot report an existing own property `{}` as non-existent on a non-extensible object", key.format()?));
             }
 
             return Ok(None);
         } else if !trap_result.is_object() {
             return type_error(
                 cx,
-                "proxy getOwnPropertyDescriptor must return an object or undefined",
+                "proxy `getOwnPropertyDescriptor` must return an object or undefined",
             );
         }
 
@@ -146,7 +146,7 @@ impl VirtualObject for Handle<ProxyObject> {
             return type_error(
                 cx,
                 &format!(
-                    "proxy can't report an incompatible property descriptor for '{}'",
+                    "proxy cannot report an incompatible property descriptor for `{}`",
                     key.format()?
                 ),
             );
@@ -155,10 +155,10 @@ impl VirtualObject for Handle<ProxyObject> {
         if let Some(false) = result_desc.is_configurable {
             if let None | Some(PropertyDescriptor { is_configurable: Some(true), .. }) = target_desc
             {
-                return type_error(cx, &format!("proxy can't report existing configurable property '{}' as non-configurable", key.format()?));
+                return type_error(cx, &format!("proxy cannot report existing configurable property `{}` as non-configurable", key.format()?));
             } else if let Some(false) = result_desc.is_writable {
                 if let Some(true) = target_desc.unwrap().is_writable {
-                    return type_error(cx, &format!("proxy can't report a non-configurable, non-writable property '{}' as writable", key.format()?));
+                    return type_error(cx, &format!("proxy cannot report a non-configurable, non-writable property `{}` as writable", key.format()?));
                 }
             }
         }
@@ -207,7 +207,7 @@ impl VirtualObject for Handle<ProxyObject> {
                 return type_error(
                     cx,
                     &format!(
-                        "proxy can't define a new property '{}' on a non-extensible object",
+                        "proxy cannot define a new property `{}` on a non-extensible object",
                         key.format()?
                     ),
                 );
@@ -215,7 +215,7 @@ impl VirtualObject for Handle<ProxyObject> {
                 return type_error(
                     cx,
                     &format!(
-                        "proxy can't define a non-existent property '{}' as non-configurable",
+                        "proxy cannot define a non-existent property `{}` as non-configurable",
                         key.format()?
                     ),
                 );
@@ -230,7 +230,7 @@ impl VirtualObject for Handle<ProxyObject> {
                 return type_error(
                     cx,
                     &format!(
-                        "proxy can't report an incompatible property descriptor for '{}'",
+                        "proxy cannot report an incompatible property descriptor for `{}`",
                         key.format()?
                     ),
                 );
@@ -238,7 +238,7 @@ impl VirtualObject for Handle<ProxyObject> {
 
             if is_setting_non_configurable {
                 if let Some(true) = target_desc.is_configurable {
-                    return type_error(cx, &format!("proxy can't define an existing configurable property '{}' as non-configurable", key.format()?));
+                    return type_error(cx, &format!("proxy cannot define an existing configurable property `{}` as non-configurable", key.format()?));
                 }
             }
 
@@ -246,7 +246,7 @@ impl VirtualObject for Handle<ProxyObject> {
                 if let Some(false) = target_desc.is_configurable {
                     if let Some(true) = target_desc.is_writable {
                         if let Some(false) = desc.is_writable {
-                            return type_error(cx, &format!("proxy can't define an existing non-configurable writable property '{}' as non-writable", key.format()?));
+                            return type_error(cx, &format!("proxy cannot define an existing non-configurable writable property `{}` as non-writable", key.format()?));
                         }
                     }
                 }
@@ -282,13 +282,13 @@ impl VirtualObject for Handle<ProxyObject> {
                     return type_error(
                         cx,
                         &format!(
-                            "proxy can't report a non-configurable own property '{}' as non-existent", key.format()?
+                            "proxy cannot report a non-configurable own property `{}` as non-existent", key.format()?
                         ),
                     );
                 }
 
                 if !is_extensible_(cx, target)? {
-                    return type_error(cx, &format!("proxy can't report an existing own property '{}' as non-existent on a non-extensible object", key.format()?));
+                    return type_error(cx, &format!("proxy cannot report an existing own property `{}` as non-existent on a non-extensible object", key.format()?));
                 }
             }
         }
@@ -325,14 +325,14 @@ impl VirtualObject for Handle<ProxyObject> {
                 if target_desc.is_data_descriptor() {
                     if let Some(false) = target_desc.is_writable {
                         if !same_value(trap_result, target_desc.value.unwrap())? {
-                            return type_error(cx, &format!("proxy must report the same value for the non-writable, non-configurable property '{}'", key.format()?));
+                            return type_error(cx, &format!("proxy must report the same value for the non-writable, non-configurable property `{}`", key.format()?));
                         }
                     }
                 } else if target_desc.is_accessor_descriptor()
                     && target_desc.get.is_none()
                     && !trap_result.is_undefined()
                 {
-                    return type_error(cx, &format!("proxy must report undefined for a non-configurable accessor property '{}' without a getter", key.format()?));
+                    return type_error(cx, &format!("proxy must report undefined for a non-configurable accessor property `{}` without a getter", key.format()?));
                 }
             }
         }
@@ -374,11 +374,11 @@ impl VirtualObject for Handle<ProxyObject> {
                 if target_desc.is_data_descriptor() {
                     if let Some(false) = target_desc.is_writable {
                         if !same_value(value, target_desc.value.unwrap())? {
-                            return type_error(cx, &format!("proxy can't successfully set a non-writable, non-configurable property '{}'", key.format()?));
+                            return type_error(cx, &format!("proxy cannot successfully set a non-writable, non-configurable property `{}`", key.format()?));
                         }
                     }
                 } else if target_desc.is_accessor_descriptor() && target_desc.set.is_none() {
-                    return type_error(cx, &format!("proxy can't succesfully set an accessor property '{}' without a setter", key.format()?));
+                    return type_error(cx, &format!("proxy cannot successfully set an accessor property `{}` without a setter", key.format()?));
                 }
             }
         }
@@ -414,7 +414,7 @@ impl VirtualObject for Handle<ProxyObject> {
                 return type_error(
                     cx,
                     &format!(
-                        "property '{}' is non-configurable and can't be deleted",
+                        "property `{}` is non-configurable and cannot be deleted",
                         key.format()?
                     ),
                 );
@@ -427,7 +427,7 @@ impl VirtualObject for Handle<ProxyObject> {
             return type_error(
                 cx,
                 &format!(
-                    "proxy can't delete property '{}' on a non-extensible object",
+                    "proxy cannot delete property `{}` on a non-extensible object",
                     key.format()?
                 ),
             );
@@ -455,7 +455,7 @@ impl VirtualObject for Handle<ProxyObject> {
 
         // Inlined CreateListFromArrayLike with type filtering and duplicate detection
         if !trap_result.is_object() {
-            return type_error(cx, "proxy ownKeys must return an array");
+            return type_error(cx, "proxy `ownKeys` must return an array");
         }
 
         let trap_result_object = trap_result.as_object();
@@ -472,7 +472,7 @@ impl VirtualObject for Handle<ProxyObject> {
             if !next.is_string() && !next.is_symbol() {
                 return type_error(
                     cx,
-                    "proxy ownKeys must return an array with only string and symbol objects",
+                    "proxy `ownKeys` must return an array with only string and symbol objects",
                 );
             }
 
@@ -481,7 +481,7 @@ impl VirtualObject for Handle<ProxyObject> {
                 return type_error(
                     cx,
                     &format!(
-                        "proxy ownKeys can't report property '{}' more than once",
+                        "proxy `ownKeys` cannot report property `{}` more than once",
                         key.format()?
                     ),
                 );
@@ -513,7 +513,7 @@ impl VirtualObject for Handle<ProxyObject> {
             if !unchecked_result_keys.remove(&key) {
                 return type_error(
                     cx,
-                    &format!("proxy can't skip a non-configurable property '{}'", key.format()?),
+                    &format!("proxy cannot skip a non-configurable property `{}`", key.format()?),
                 );
             }
         }
@@ -524,7 +524,7 @@ impl VirtualObject for Handle<ProxyObject> {
 
         for key in target_configurable_keys {
             if !unchecked_result_keys.remove(&key) {
-                return type_error(cx, &format!("proxy can't report an existing own property '{}' as non-existent on a non-extensible object", key.format()?));
+                return type_error(cx, &format!("proxy cannot report an existing own property `{}` as non-existent on a non-extensible object", key.format()?));
             }
         }
 
@@ -533,7 +533,7 @@ impl VirtualObject for Handle<ProxyObject> {
             return type_error(
                 cx,
                 &format!(
-                    "proxy can't report a new property '{}' on a non-extensible object",
+                    "proxy cannot report a new property `{}` on a non-extensible object",
                     key.format()?
                 ),
             );
@@ -631,7 +631,7 @@ impl ProxyObject {
         } else if handler_proto.is_null() {
             None
         } else {
-            return type_error(cx, "proxy getPrototypeOf handler must return object or null");
+            return type_error(cx, "proxy `getPrototypeOf` handler must return object or null");
         };
 
         if is_extensible_(cx, target)? {
@@ -643,7 +643,7 @@ impl ProxyObject {
         if !same_opt_object_value_handles(handler_proto, target_proto) {
             return type_error(
                 cx,
-                "proxy getPrototypeOf handler didn't return the target object's prototype",
+                "proxy `getPrototypeOf` handler didn't return the target object's prototype",
             );
         }
 
@@ -690,7 +690,7 @@ impl ProxyObject {
         let target_proto = target.get_prototype_of(cx)?;
 
         if !same_opt_object_value_handles(proto, target_proto) {
-            return type_error(cx, "proxy setPrototypeOf handler returned true, even though the target's prototype is immutable because the target is non-extensible");
+            return type_error(cx, "proxy `setPrototypeOf` handler returned true, even though the target's prototype is immutable because the target is non-extensible");
         }
 
         Ok(true)
@@ -719,7 +719,7 @@ impl ProxyObject {
         let target_result = is_extensible_(cx, target)?;
 
         if trap_result != target_result {
-            return type_error(cx, "proxy must report same extensiblitity as target");
+            return type_error(cx, "proxy must report same extensibility as target");
         }
 
         Ok(trap_result)
@@ -746,7 +746,7 @@ impl ProxyObject {
         let trap_result = to_boolean(*trap_result);
 
         if trap_result && is_extensible_(cx, target)? {
-            return type_error(cx, "proxy can't report an extensible object as non-extensible");
+            return type_error(cx, "proxy cannot report an extensible object as non-extensible");
         }
 
         Ok(trap_result)

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -193,7 +193,7 @@ impl Handle<Realm> {
             let is_global_lex_name = self.get_lexical_name(*name).is_some();
 
             if is_global_var_name || is_global_lex_name {
-                return syntax_error(cx, &format!("redeclaration of {}", *name));
+                return syntax_error(cx, &format!("redeclaration of `{}`", *name));
             }
         }
 
@@ -209,7 +209,7 @@ impl Handle<Realm> {
     ) -> EvalResult<()> {
         for name in names {
             if self.get_lexical_name(*name).is_some() {
-                return syntax_error(cx, &format!("redeclaration of {name}"));
+                return syntax_error(cx, &format!("redeclaration of `{name}`"));
             }
         }
 

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -165,7 +165,7 @@ impl Test262Object {
     ) -> EvalResult<Handle<Value>> {
         let script_text = get_argument(cx, arguments, 0);
         if !script_text.is_string() {
-            return type_error(cx, "expected string");
+            return type_error(cx, "expected a string");
         }
 
         // Use the file path of the active source file

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -689,10 +689,10 @@ pub fn to_index(cx: Context, value_handle: Handle<Value>) -> EvalResult<usize> {
 pub fn require_object_coercible(cx: Context, value: Handle<Value>) -> EvalResult<Handle<Value>> {
     if value.is_nullish() {
         if value.is_null() {
-            return type_error(cx, "can't convert null to object");
+            return type_error(cx, "cannot convert null to object");
         }
 
-        return type_error(cx, "can't convert undefined to object");
+        return type_error(cx, "cannot convert undefined to object");
     }
 
     Ok(value)

--- a/tests/snapshot/error/annex_b/statement/catch_parameter_conflict_leave_hoisted_var.exp
+++ b/tests/snapshot/error/annex_b/statement/catch_parameter_conflict_leave_hoisted_var.exp
@@ -1,4 +1,4 @@
-SyntaxError: Redeclaration of const foo
+SyntaxError: Redeclaration of const `foo`
   ┌ annex_b/statement/catch_parameter_conflict_leave_hoisted_var.js:9:9
   |
 9 |     var foo = 4;

--- a/tests/snapshot/error/error_types/analyze.exp
+++ b/tests/snapshot/error/error_types/analyze.exp
@@ -1,4 +1,4 @@
-SyntaxError: Redeclaration of let x
+SyntaxError: Redeclaration of let `x`
   ┌ error_types/analyze.js:4:7
   |
 4 |   let x = 3;

--- a/tests/snapshot/error/source_locations/expression/binary/in.exp
+++ b/tests/snapshot/error/source_locations/expression/binary/in.exp
@@ -1,4 +1,4 @@
-TypeError: right side of 'in' must be an object
+TypeError: right side of `in` must be an object
   ┌ source_locations/expression/binary/in.js:1:3
   |
 1 | 1 in null

--- a/tests/snapshot/error/source_locations/expression/binary/instanceof.exp
+++ b/tests/snapshot/error/source_locations/expression/binary/instanceof.exp
@@ -1,4 +1,4 @@
-TypeError: invalid instanceof operand
+TypeError: invalid `instanceof` operand
   ┌ source_locations/expression/binary/instanceof.js:1:6
   |
 1 | ({}) instanceof null

--- a/tests/snapshot/error/source_locations/expression/update/error_const.exp
+++ b/tests/snapshot/error/source_locations/expression/update/error_const.exp
@@ -1,4 +1,4 @@
-TypeError: can't assign constant `x`
+TypeError: cannot assign constant `x`
   ┌ source_locations/expression/update/error_const.js:3:3
   |
 3 |   x++;

--- a/tests/snapshot/error/source_locations/expression/yield_star/async_iterator_close_finish_throws_module.exp
+++ b/tests/snapshot/error/source_locations/expression/yield_star/async_iterator_close_finish_throws_module.exp
@@ -1,4 +1,4 @@
-TypeError: iterator's return method must return an object
+TypeError: Iterator `return` method must return an object
    ┌ source_locations/expression/yield_star/async_iterator_close_finish_throws_module.js:15:3
    |
 15 |   yield* iterable;

--- a/tests/snapshot/error/source_locations/loads/check_tdz_global.exp
+++ b/tests/snapshot/error/source_locations/loads/check_tdz_global.exp
@@ -1,4 +1,4 @@
-ReferenceError: can't access `x` before initialization
+ReferenceError: cannot access `x` before initialization
   ┌ source_locations/loads/check_tdz_global.js:1:2
   |
 1 | (x);

--- a/tests/snapshot/error/source_locations/loads/check_tdz_local.exp
+++ b/tests/snapshot/error/source_locations/loads/check_tdz_local.exp
@@ -1,4 +1,4 @@
-ReferenceError: can't access `x` before initialization
+ReferenceError: cannot access `x` before initialization
   ┌ source_locations/loads/check_tdz_local.js:2:3
   |
 2 |   x;

--- a/tests/snapshot/error/source_locations/loads/load_dynamic_unresolved.exp
+++ b/tests/snapshot/error/source_locations/loads/load_dynamic_unresolved.exp
@@ -1,4 +1,4 @@
-ReferenceError: x is not defined
+ReferenceError: `x` is not defined
   ┌ <eval>:1:1
   |
 1 | x

--- a/tests/snapshot/error/source_locations/loads/load_global_unresolved.exp
+++ b/tests/snapshot/error/source_locations/loads/load_global_unresolved.exp
@@ -1,4 +1,4 @@
-ReferenceError: x is not defined
+ReferenceError: `x` is not defined
   ┌ source_locations/loads/load_global_unresolved.js:3:3
   |
 3 |   x;

--- a/tests/snapshot/error/source_locations/statement/for_await/iterator_unpack_result_module.exp
+++ b/tests/snapshot/error/source_locations/statement/for_await/iterator_unpack_result_module.exp
@@ -1,4 +1,4 @@
-TypeError: iterator's next method must return an object
+TypeError: Iterator `next` method must return an object
    ┌ source_locations/statement/for_await/iterator_unpack_result_module.js:12:20
    |
 12 |   for await (var x of iter) {}

--- a/tests/snapshot/error/source_locations/stores/error_const.exp
+++ b/tests/snapshot/error/source_locations/stores/error_const.exp
@@ -1,4 +1,4 @@
-TypeError: can't assign constant `x`
+TypeError: cannot assign constant `x`
   ┌ source_locations/stores/error_const.js:3:3
   |
 3 |   x = 2;

--- a/tests/snapshot/error/source_locations/stores/store_dynamic_unresolved.exp
+++ b/tests/snapshot/error/source_locations/stores/store_dynamic_unresolved.exp
@@ -1,4 +1,4 @@
-ReferenceError: x is not defined
+ReferenceError: `x` is not defined
   ┌ <eval>:1:1
   |
 1 | x = 1

--- a/tests/snapshot/error/source_locations/stores/store_global_unresolved.exp
+++ b/tests/snapshot/error/source_locations/stores/store_global_unresolved.exp
@@ -1,4 +1,4 @@
-ReferenceError: x is not defined
+ReferenceError: `x` is not defined
   ┌ source_locations/stores/store_global_unresolved.js:5:3
   |
 5 |   x = 1;


### PR DESCRIPTION
## Summary

Large LLM-driven set of improvements to error messages.

- Fix outright typos that have been noticed.
- Standardize contractions on "cannot" instead of mix of "can't" and "cannot".
- Standardize quoting of source text including identifiers, operators, language keywords, etc. Previously a mix of backticks and quote types were used and we were inconsistent about when it was used.
- Consistency of references to types. e.g. most builtin types are specified as "RegExp" and "Set" instead of "regular expression" and "set".
- References to "callable" objects replaced with references to "functions".
- Standardize on full method qualification e.g. `WeakMap.prototype.get`.
- Fix many missing articles.
- Prefer "must be" over "is not".
- Capitalization at the start of error messages was changed in some places but is still inconsistent

## Tests

Re-recorded error snapshot tests.