### PR TITLE
[runtime] All runtime method errors are prefixed with method name

### DIFF
--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -151,7 +151,10 @@ impl ArrayBufferPrototype {
         let max_byte_length = if let Some(max_byte_length) = array_buffer.max_byte_length() {
             max_byte_length
         } else {
-            return type_error(cx, "array buffer is not resizable");
+            return type_error(
+                cx,
+                "ArrayBuffer.prototype.resize cannot be used on a fixed-length ArrayBuffer",
+            );
         };
 
         let new_length_arg = get_argument(cx, arguments, 0);
@@ -160,7 +163,10 @@ impl ArrayBufferPrototype {
         throw_if_detached(cx, *array_buffer)?;
 
         if new_byte_length > max_byte_length {
-            return range_error(cx, "new length exceeds max byte length");
+            return range_error(
+                cx,
+                "ArrayBuffer.prototype.resize new length exceeds max byte length",
+            );
         }
 
         // Create new data block with copy of old data at start
@@ -246,18 +252,26 @@ impl ArrayBufferPrototype {
         // Check type of object returned from constructor
         let mut new_array_buffer = if let Some(array_buffer) = new_object.as_array_buffer() {
             array_buffer
-        } else if new_object.is_shared_array_buffer() {
-            return type_error(cx, "constructor cannot return SharedArrayBuffer");
         } else {
-            return type_error(cx, "expected an ArrayBuffer");
+            // Includes case where constructor returns a shared array buffer
+            return type_error(
+                cx,
+                "ArrayBuffer.prototype.slice species constructor must return an ArrayBuffer",
+            );
         };
 
         throw_if_detached(cx, *new_array_buffer)?;
 
         if new_array_buffer.ptr_eq(&array_buffer) {
-            return type_error(cx, "constructor cannot return same array buffer");
+            return type_error(
+                cx,
+                "ArrayBuffer.prototype.slice species constructor cannot return the same ArrayBuffer",
+            );
         } else if (new_array_buffer.byte_length() as u64) < new_length {
-            return type_error(cx, "new array buffer is too small");
+            return type_error(
+                cx,
+                "ArrayBuffer.prototype.slice species constructor returned an ArrayBuffer that is too small",
+            );
         }
 
         // Original array buffer may have become detached during previous calls

--- a/src/js/runtime/intrinsics/array_constructor.rs
+++ b/src/js/runtime/intrinsics/array_constructor.rs
@@ -82,7 +82,7 @@ impl ArrayConstructor {
                 let int_len = must!(to_uint32(cx, length));
 
                 if int_len as f64 != length.as_number() {
-                    return range_error(cx, "invalid array size");
+                    return range_error(cx, "Array constructor length is too large");
                 }
 
                 int_len
@@ -150,7 +150,7 @@ impl ArrayConstructor {
 
             iter_iterator_method_values(cx, items_arg, iterator, &mut |cx, value| {
                 if i >= MAX_SAFE_INTEGER_U64 {
-                    return Some(type_error(cx, "array is too large"));
+                    return Some(type_error(cx, "Array.from array is too large"));
                 }
 
                 let value = if let Some(map_function) = map_function {

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -392,7 +392,7 @@ impl ArrayPrototype {
             let length = length_of_array_like(cx, element)?;
 
             if *n + length > MAX_SAFE_INTEGER_U64 {
-                return type_error(cx, "array is too large");
+                return type_error(cx, "Array.prototype.concat array is too large");
             }
 
             // Property key is shared between iterations
@@ -415,7 +415,7 @@ impl ArrayPrototype {
             }
         } else {
             if *n >= MAX_SAFE_INTEGER_U64 {
-                return type_error(cx, "array is too large");
+                return type_error(cx, "Array.prototype.concat array is too large");
             }
 
             let index_key = PropertyKey::from_u64_handle(cx, *n)?;
@@ -803,7 +803,17 @@ impl ArrayPrototype {
 
         let array = array_species_create(cx, object, 0)?;
 
-        Self::flatten_into_array(cx, array, object, length, 0, depth, None, cx.undefined())?;
+        Self::flatten_into_array(
+            cx,
+            array,
+            object,
+            length,
+            0,
+            depth,
+            None,
+            cx.undefined(),
+            "flat",
+        )?;
 
         Ok(array.as_value())
     }
@@ -818,6 +828,7 @@ impl ArrayPrototype {
         depth: f64,
         mapper_function: Option<Handle<Value>>,
         this_arg: Handle<Value>,
+        method_name: &str,
     ) -> EvalResult<u64> {
         let mut target_index = start;
 
@@ -861,10 +872,14 @@ impl ArrayPrototype {
                         new_depth,
                         None,
                         this_arg,
+                        method_name,
                     )?;
                 } else {
                     if target_index >= MAX_SAFE_INTEGER_U64 {
-                        return type_error(cx, "array is too large");
+                        return type_error(
+                            cx,
+                            &format!("Array.prototype.{method_name} array is too large"),
+                        );
                     }
 
                     target_key.replace(PropertyKey::from_u64(cx, target_index)?);
@@ -905,6 +920,7 @@ impl ArrayPrototype {
             1.0,
             Some(mapper_function),
             this_arg,
+            "flatMap",
         )?;
 
         Ok(array.as_value())
@@ -1213,7 +1229,7 @@ impl ArrayPrototype {
 
         let new_length = length + arguments.len() as u64;
         if new_length > MAX_SAFE_INTEGER_U64 {
-            return type_error(cx, "index is too large");
+            return type_error(cx, "Array.prototype.push array is too large");
         }
 
         // Property key is shared between iterations
@@ -1250,7 +1266,7 @@ impl ArrayPrototype {
         let mut accumulator = if arguments.len() >= 2 {
             get_argument(cx, arguments, 1)
         } else if length == 0 {
-            return type_error(cx, "reduce does not have initial value");
+            return type_error(cx, "Array.prototype.reduce does not have an initial value");
         } else {
             // Property key is shared between iterations
             let mut index_key = PropertyKey::uninit().to_handle(cx);
@@ -1258,7 +1274,10 @@ impl ArrayPrototype {
             // Find the first value in the array if an initial value was not specified
             loop {
                 if initial_index >= length {
-                    return type_error(cx, "reduce of empty array with no initial value");
+                    return type_error(
+                        cx,
+                        "Array.prototype.reduce of empty array with no initial value",
+                    );
                 }
 
                 index_key.replace(PropertyKey::from_u64(cx, initial_index)?);
@@ -1309,14 +1328,17 @@ impl ArrayPrototype {
         let mut accumulator = if arguments.len() >= 2 {
             get_argument(cx, arguments, 1)
         } else if length == 0 {
-            return type_error(cx, "reduceRight does not have initial value");
+            return type_error(cx, "Array.prototype.reduceRight does not have an initial value");
         } else {
             let mut index_key = PropertyKey::uninit().to_handle(cx);
 
             // Find the first value in the array if an initial value was not specified
             loop {
                 if initial_index < 0 {
-                    return type_error(cx, "reduce of empty array with no initial value");
+                    return type_error(
+                        cx,
+                        "Array.prototype.reduceRight of empty array with no initial value",
+                    );
                 }
 
                 index_key.replace(PropertyKey::from_u64(cx, initial_index as u64)?);
@@ -1627,7 +1649,7 @@ impl ArrayPrototype {
 
         let new_length = length + insert_count - actual_delete_count;
         if new_length > MAX_SAFE_INTEGER_U64 {
-            return type_error(cx, "array is too large");
+            return type_error(cx, "Array.prototype.splice array is too large");
         }
 
         // Create array containing deleted elements, which will be return value
@@ -1826,7 +1848,7 @@ impl ArrayPrototype {
         // Determine length of new array and make sure it is in range
         let new_length = length + insert_count - actual_skip_count;
         if new_length > MAX_SAFE_INTEGER_U64 {
-            return type_error(cx, "TypedArray.prototype.toSpliced result array is too large");
+            return type_error(cx, "Array.prototype.toSpliced array is too large");
         }
 
         let array = array_create(cx, new_length, None)?;
@@ -1890,7 +1912,7 @@ impl ArrayPrototype {
         let num_arguments = arguments.len() as u64;
         if num_arguments > 0 {
             if length + num_arguments > MAX_SAFE_INTEGER_U64 {
-                return type_error(cx, "array is too large");
+                return type_error(cx, "Array.prototype.unshift array is too large");
             }
 
             // Shared between iterations

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
@@ -177,7 +177,10 @@ impl AsyncFromSyncIteratorPrototype {
         // Return result must be an object
         let return_result = if_abrupt_reject_promise!(cx, return_result_completion, capability);
         if !return_result.is_object() {
-            let error = type_error_value(cx, "return method must return an object")?;
+            let error = type_error_value(
+                cx,
+                "AsyncFromSyncIterator.prototype.return method must return an object",
+            )?;
             must!(call_object(cx, capability.reject(), cx.undefined(), &[error]));
 
             return Ok(capability.promise().as_value());
@@ -214,7 +217,10 @@ impl AsyncFromSyncIteratorPrototype {
             if_abrupt_reject_promise!(cx, close_result, capability);
 
             // Reject the promise with a new TypeError
-            let error = type_error_value(cx, "throw method is not present")?;
+            let error = type_error_value(
+                cx,
+                "AsyncFromSyncIterator.prototype.throw method is not present",
+            )?;
             must!(call_object(cx, capability.reject(), cx.undefined(), &[error]));
 
             return Ok(capability.promise().as_value());
@@ -232,7 +238,10 @@ impl AsyncFromSyncIteratorPrototype {
         // Throw result must be an object
         let throw_result = if_abrupt_reject_promise!(cx, throw_result_completion, capability);
         if !throw_result.is_object() {
-            let error = type_error_value(cx, "throw method must return an object")?;
+            let error = type_error_value(
+                cx,
+                "AsyncFromSyncIterator.prototype.throw method must return an object",
+            )?;
             must!(call_object(cx, capability.reject(), cx.undefined(), &[error]));
 
             return Ok(capability.promise().as_value());

--- a/src/js/runtime/intrinsics/bigint_constructor.rs
+++ b/src/js/runtime/intrinsics/bigint_constructor.rs
@@ -102,7 +102,7 @@ impl BigIntConstructor {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if cx.current_new_target().is_some() {
-            return type_error(cx, "BigInt is not a constructor");
+            return type_error(cx, "BigInt constructor cannot be used with new");
         }
 
         let value = get_argument(cx, arguments, 0);
@@ -110,7 +110,7 @@ impl BigIntConstructor {
 
         if primitive.is_number() {
             if !is_integral_number(*primitive) {
-                return range_error(cx, "number is not an integer");
+                return range_error(cx, "BigInt constructor argument is not an integer");
             }
 
             if primitive.is_smi() {

--- a/src/js/runtime/intrinsics/bigint_prototype.rs
+++ b/src/js/runtime/intrinsics/bigint_prototype.rs
@@ -55,7 +55,7 @@ impl BigIntPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let bigint_value = this_bigint_value(cx, this_value)?;
+        let bigint_value = this_bigint_value(cx, this_value, "toString")?;
 
         let radix = get_argument(cx, arguments, 0);
         let radix = if radix.is_undefined() {
@@ -63,7 +63,10 @@ impl BigIntPrototype {
         } else {
             let radix_int = to_integer_or_infinity(cx, radix)?;
             if !(2.0..=36.0).contains(&radix_int) {
-                return range_error(cx, "radix must be an integer between 2 and 36");
+                return range_error(
+                    cx,
+                    "BigInt.prototype.toString radix must be an integer between 2 and 36",
+                );
             }
 
             radix_int as u32
@@ -80,11 +83,15 @@ impl BigIntPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        Ok(this_bigint_value(cx, this_value)?.into())
+        Ok(this_bigint_value(cx, this_value, "valueOf")?.into())
     }
 }
 
-fn this_bigint_value(cx: Context, value: Handle<Value>) -> EvalResult<Handle<BigIntValue>> {
+fn this_bigint_value(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<BigIntValue>> {
     if value.is_bigint() {
         return Ok(value.as_bigint());
     }
@@ -96,5 +103,5 @@ fn this_bigint_value(cx: Context, value: Handle<Value>) -> EvalResult<Handle<Big
         }
     }
 
-    type_error(cx, "value cannot be converted to BigInt")
+    type_error(cx, &format!("BigInt.prototype.{method_name} must be called on a BigInt"))
 }

--- a/src/js/runtime/intrinsics/boolean_prototype.rs
+++ b/src/js/runtime/intrinsics/boolean_prototype.rs
@@ -39,7 +39,7 @@ impl BooleanPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let bool_value = this_boolean_value(cx, this_value)?;
+        let bool_value = this_boolean_value(cx, this_value, "toString")?;
         let string_value = if bool_value { "true" } else { "false" };
 
         Ok(cx.alloc_string(string_value)?.as_value())
@@ -51,12 +51,12 @@ impl BooleanPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let bool_value = this_boolean_value(cx, this_value)?;
+        let bool_value = this_boolean_value(cx, this_value, "valueOf")?;
         Ok(cx.bool(bool_value))
     }
 }
 
-fn this_boolean_value(cx: Context, value: Handle<Value>) -> EvalResult<bool> {
+fn this_boolean_value(cx: Context, value: Handle<Value>, method_name: &str) -> EvalResult<bool> {
     if value.is_bool() {
         return Ok(value.as_bool());
     }
@@ -68,5 +68,5 @@ fn this_boolean_value(cx: Context, value: Handle<Value>) -> EvalResult<bool> {
         }
     }
 
-    type_error(cx, "value cannot be converted to boolean")
+    type_error(cx, &format!("Boolean.prototype.{method_name} must be called on a boolean"))
 }

--- a/src/js/runtime/intrinsics/data_view_constructor.rs
+++ b/src/js/runtime/intrinsics/data_view_constructor.rs
@@ -110,12 +110,12 @@ impl DataViewConstructor {
 
         let buffer_argument = get_argument(cx, arguments, 0);
         if !buffer_argument.is_object() {
-            return type_error(cx, "first argument must be an array buffer");
+            return type_error(cx, "DataView constructor first argument must be an array buffer");
         }
 
         let buffer_object = buffer_argument.as_object();
         if !buffer_object.is_array_buffer() {
-            return type_error(cx, "first argument must be an array buffer");
+            return type_error(cx, "DataView constructor first argument must be an array buffer");
         }
 
         let buffer_object = buffer_object.cast::<ArrayBufferObject>();
@@ -130,7 +130,7 @@ impl DataViewConstructor {
             return range_error(
                 cx,
                 &format!(
-                    "offset {offset} is out of bounds for buffer with byte length {buffer_byte_length}"
+                    "DataView constructor offset {offset} is out of bounds for buffer with byte length {buffer_byte_length}"
                 ),
             );
         }
@@ -146,7 +146,10 @@ impl DataViewConstructor {
             let view_byte_length = to_index(cx, byte_length_argument)?;
 
             if offset + view_byte_length > buffer_byte_length {
-                return range_error(cx, "data view byte length is too large for this buffer");
+                return range_error(
+                    cx,
+                    "DataView constructor byte length is too large for this buffer",
+                );
             }
 
             Some(view_byte_length)
@@ -166,12 +169,15 @@ impl DataViewConstructor {
         // Also check if underlying buffer was resized during construction and redo bounds checks
         let buffer_byte_length = buffer_object.byte_length();
         if offset > buffer_byte_length {
-            return range_error(cx, "offset is out of bounds for buffer");
+            return range_error(cx, "DataView constructor offset is out of bounds for buffer");
         }
 
         if !byte_length_argument.is_undefined() {
             if offset + view_byte_length.unwrap() > buffer_byte_length {
-                return range_error(cx, "byte length is too large for this buffer");
+                return range_error(
+                    cx,
+                    "DataView constructor byte length is too large for this buffer",
+                );
             }
         }
 

--- a/src/js/runtime/intrinsics/data_view_prototype.rs
+++ b/src/js/runtime/intrinsics/data_view_prototype.rs
@@ -224,7 +224,7 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let data_view = require_is_data_view(cx, this_value)?;
+        let data_view = this_data_view(cx, this_value, "buffer")?;
         Ok(data_view.viewed_array_buffer().as_value())
     }
 
@@ -234,11 +234,11 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let data_view = require_is_data_view(cx, this_value)?;
+        let data_view = this_data_view(cx, this_value, "byteLength")?;
         let data_view_record = make_data_view_with_buffer_witness_record(data_view);
 
         if is_view_out_of_bounds(&data_view_record) {
-            return type_error(cx, "DataView is out of bounds");
+            return type_error(cx, "DataView.prototype.byteLength DataView is out of bounds");
         }
 
         let byte_length = get_view_byte_length(&data_view_record);
@@ -252,11 +252,11 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let data_view = require_is_data_view(cx, this_value)?;
+        let data_view = this_data_view(cx, this_value, "byteOffset")?;
         let data_view_record = make_data_view_with_buffer_witness_record(data_view);
 
         if is_view_out_of_bounds(&data_view_record) {
-            return type_error(cx, "DataView is out of bounds");
+            return type_error(cx, "DataView.prototype.byteOffset DataView is out of bounds");
         }
 
         Ok(Value::from(data_view.byte_offset()).to_handle(cx))
@@ -268,7 +268,14 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        get_view_value(cx, this_value, arguments, from_big_int64_element, i64::swap_bytes)
+        get_view_value(
+            cx,
+            this_value,
+            arguments,
+            "getBigInt64",
+            from_big_int64_element,
+            i64::swap_bytes,
+        )
     }
 
     /// DataView.prototype.getBigUint64 (https://tc39.es/ecma262/#sec-dataview.prototype.getbiguint64)
@@ -277,7 +284,14 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        get_view_value(cx, this_value, arguments, from_big_uint64_element, u64::swap_bytes)
+        get_view_value(
+            cx,
+            this_value,
+            arguments,
+            "getBigUint64",
+            from_big_uint64_element,
+            u64::swap_bytes,
+        )
     }
 
     /// DataView.prototype.getFloat16 (https://tc39.es/ecma262/#sec-dataview.prototype.getfloat16)
@@ -286,7 +300,14 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        get_view_value(cx, this_value, arguments, from_float16_element, f16_swap_bytes)
+        get_view_value(
+            cx,
+            this_value,
+            arguments,
+            "getFloat16",
+            from_float16_element,
+            f16_swap_bytes,
+        )
     }
 
     /// DataView.prototype.getFloat32 (https://tc39.es/ecma262/#sec-dataview.prototype.getfloat32)
@@ -295,7 +316,14 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        get_view_value(cx, this_value, arguments, from_float32_element, f32_swap_bytes)
+        get_view_value(
+            cx,
+            this_value,
+            arguments,
+            "getFloat32",
+            from_float32_element,
+            f32_swap_bytes,
+        )
     }
 
     /// DataView.prototype.getFloat64 (https://tc39.es/ecma262/#sec-dataview.prototype.getfloat64)
@@ -304,7 +332,14 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        get_view_value(cx, this_value, arguments, from_float64_element, f64_swap_bytes)
+        get_view_value(
+            cx,
+            this_value,
+            arguments,
+            "getFloat64",
+            from_float64_element,
+            f64_swap_bytes,
+        )
     }
 
     /// DataView.prototype.getInt8 (https://tc39.es/ecma262/#sec-dataview.prototype.getint8)
@@ -313,7 +348,7 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        get_view_value(cx, this_value, arguments, from_int8_element, |element| element)
+        get_view_value(cx, this_value, arguments, "getInt8", from_int8_element, |element| element)
     }
 
     /// DataView.prototype.getInt16 (https://tc39.es/ecma262/#sec-dataview.prototype.getint16)
@@ -322,7 +357,7 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        get_view_value(cx, this_value, arguments, from_int16_element, i16::swap_bytes)
+        get_view_value(cx, this_value, arguments, "getInt16", from_int16_element, i16::swap_bytes)
     }
 
     /// DataView.prototype.getInt32 (https://tc39.es/ecma262/#sec-dataview.prototype.getint32)
@@ -331,7 +366,7 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        get_view_value(cx, this_value, arguments, from_int32_element, i32::swap_bytes)
+        get_view_value(cx, this_value, arguments, "getInt32", from_int32_element, i32::swap_bytes)
     }
 
     /// DataView.prototype.getUint8 (https://tc39.es/ecma262/#sec-dataview.prototype.getuint8)
@@ -340,7 +375,7 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        get_view_value(cx, this_value, arguments, from_uint8_element, |element| element)
+        get_view_value(cx, this_value, arguments, "getUint8", from_uint8_element, |element| element)
     }
 
     /// DataView.prototype.getUint16 (https://tc39.es/ecma262/#sec-dataview.prototype.getuint16)
@@ -349,7 +384,7 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        get_view_value(cx, this_value, arguments, from_uint16_element, u16::swap_bytes)
+        get_view_value(cx, this_value, arguments, "getUint16", from_uint16_element, u16::swap_bytes)
     }
 
     /// DataView.prototype.getUint32 (https://tc39.es/ecma262/#sec-dataview.prototype.getuint32)
@@ -358,7 +393,7 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        get_view_value(cx, this_value, arguments, from_uint32_element, u32::swap_bytes)
+        get_view_value(cx, this_value, arguments, "getUint32", from_uint32_element, u32::swap_bytes)
     }
 
     /// DataView.prototype.setBigInt64 (https://tc39.es/ecma262/#sec-dataview.prototype.setbigint64)
@@ -371,6 +406,7 @@ impl DataViewPrototype {
             cx,
             this_value,
             arguments,
+            "setBigInt64",
             ContentType::BigInt,
             to_big_int64_element,
             i64::swap_bytes,
@@ -387,6 +423,7 @@ impl DataViewPrototype {
             cx,
             this_value,
             arguments,
+            "setBigUint64",
             ContentType::BigInt,
             to_big_uint64_element,
             u64::swap_bytes,
@@ -403,6 +440,7 @@ impl DataViewPrototype {
             cx,
             this_value,
             arguments,
+            "setFloat16",
             ContentType::Number,
             to_float16_element,
             f16_swap_bytes,
@@ -419,6 +457,7 @@ impl DataViewPrototype {
             cx,
             this_value,
             arguments,
+            "setFloat32",
             ContentType::Number,
             to_float32_element,
             f32_swap_bytes,
@@ -435,6 +474,7 @@ impl DataViewPrototype {
             cx,
             this_value,
             arguments,
+            "setFloat64",
             ContentType::Number,
             to_float64_element,
             f64_swap_bytes,
@@ -447,9 +487,15 @@ impl DataViewPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        set_view_value(cx, this_value, arguments, ContentType::Number, to_int8_element, |element| {
-            element
-        })
+        set_view_value(
+            cx,
+            this_value,
+            arguments,
+            "setInt8",
+            ContentType::Number,
+            to_int8_element,
+            |element| element,
+        )
     }
 
     /// DataView.prototype.setInt16 (https://tc39.es/ecma262/#sec-dataview.prototype.setint16)
@@ -462,6 +508,7 @@ impl DataViewPrototype {
             cx,
             this_value,
             arguments,
+            "setInt16",
             ContentType::Number,
             to_int16_element,
             i16::swap_bytes,
@@ -478,6 +525,7 @@ impl DataViewPrototype {
             cx,
             this_value,
             arguments,
+            "setInt32",
             ContentType::Number,
             to_int32_element,
             i32::swap_bytes,
@@ -494,6 +542,7 @@ impl DataViewPrototype {
             cx,
             this_value,
             arguments,
+            "setUint8",
             ContentType::Number,
             to_uint8_element,
             |element| element,
@@ -510,6 +559,7 @@ impl DataViewPrototype {
             cx,
             this_value,
             arguments,
+            "setUint16",
             ContentType::Number,
             to_uint16_element,
             u16::swap_bytes,
@@ -526,6 +576,7 @@ impl DataViewPrototype {
             cx,
             this_value,
             arguments,
+            "setUint32",
             ContentType::Number,
             to_uint32_element,
             u32::swap_bytes,
@@ -534,9 +585,16 @@ impl DataViewPrototype {
 }
 
 #[inline]
-fn require_is_data_view(cx: Context, value: Handle<Value>) -> EvalResult<Handle<DataViewObject>> {
+fn this_data_view(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<DataViewObject>> {
     if !value.is_object() {
-        return type_error(cx, "expected a DataView");
+        return type_error(
+            cx,
+            &format!("DataView.prototype.{method_name} must be called on a DataView"),
+        );
     }
 
     let object = value.as_object();
@@ -544,7 +602,7 @@ fn require_is_data_view(cx: Context, value: Handle<Value>) -> EvalResult<Handle<
         return Ok(data_view);
     }
 
-    type_error(cx, "expected a DataView")
+    type_error(cx, &format!("DataView.prototype.{method_name} must be called on a DataView"))
 }
 
 /// GetViewValue (https://tc39.es/ecma262/#sec-getviewvalue)
@@ -553,10 +611,11 @@ fn get_view_value<T>(
     cx: Context,
     this_value: Handle<Value>,
     arguments: &[Handle<Value>],
+    method_name: &str,
     from_element_fn: fn(Context, T) -> AllocResult<Handle<Value>>,
     swap_element_bytes_fn: fn(T) -> T,
 ) -> EvalResult<Handle<Value>> {
-    let data_view = require_is_data_view(cx, this_value)?;
+    let data_view = this_data_view(cx, this_value, method_name)?;
 
     let get_index_arg = get_argument(cx, arguments, 0);
     let get_index = to_index(cx, get_index_arg)?;
@@ -564,7 +623,10 @@ fn get_view_value<T>(
 
     let data_view_record = make_data_view_with_buffer_witness_record(data_view);
     if is_view_out_of_bounds(&data_view_record) {
-        return type_error(cx, "DataView is out of bounds");
+        return type_error(
+            cx,
+            &format!("DataView.prototype.{method_name} DataView is out of bounds"),
+        );
     }
 
     let view_size = get_view_byte_length(&data_view_record);
@@ -573,7 +635,10 @@ fn get_view_value<T>(
     let element_size = std::mem::size_of::<T>();
 
     if get_index + element_size > view_size {
-        return range_error(cx, "byte offset is too large");
+        return range_error(
+            cx,
+            &format!("DataView.prototype.{method_name} byte offset is too large"),
+        );
     }
 
     let buffer_index = get_index + view_offset;
@@ -605,11 +670,12 @@ fn set_view_value<T>(
     cx: Context,
     this_value: Handle<Value>,
     arguments: &[Handle<Value>],
+    method_name: &str,
     content_type: ContentType,
     to_element_fn: fn(Context, Handle<Value>) -> EvalResult<T>,
     swap_element_bytes_fn: fn(T) -> T,
 ) -> EvalResult<Handle<Value>> {
-    let data_view = require_is_data_view(cx, this_value)?;
+    let data_view = this_data_view(cx, this_value, method_name)?;
 
     let get_index_arg = get_argument(cx, arguments, 0);
     let get_index = to_index(cx, get_index_arg)?;
@@ -624,7 +690,10 @@ fn set_view_value<T>(
 
     let data_view_record = make_data_view_with_buffer_witness_record(data_view);
     if is_view_out_of_bounds(&data_view_record) {
-        return type_error(cx, "DataView is out of bounds");
+        return type_error(
+            cx,
+            &format!("DataView.prototype.{method_name} DataView is out of bounds"),
+        );
     }
 
     let view_size = get_view_byte_length(&data_view_record);
@@ -632,7 +701,10 @@ fn set_view_value<T>(
 
     let element_size = std::mem::size_of::<T>();
     if get_index + element_size > view_size {
-        return range_error(cx, "byte offset is too large");
+        return range_error(
+            cx,
+            &format!("DataView.prototype.{method_name} byte offset is too large"),
+        );
     }
 
     // Convert number to bytes with correct endianness

--- a/src/js/runtime/intrinsics/date_constructor.rs
+++ b/src/js/runtime/intrinsics/date_constructor.rs
@@ -10,7 +10,7 @@ use crate::{
             date_object::{
                 make_date, make_day, make_full_year, make_time, time_clip, utc, DateObject,
             },
-            date_prototype::{this_date_value, to_date_string},
+            date_prototype::{to_date_string, validate_date_value},
             rust_runtime::RuntimeFunction,
         },
         object_value::ObjectValue,
@@ -75,7 +75,7 @@ impl DateConstructor {
             get_current_unix_time()
         } else if number_of_args == 1 {
             let date_value =
-                if let Some(date_value_arg) = this_date_value(get_argument(cx, arguments, 0)) {
+                if let Some(date_value_arg) = validate_date_value(get_argument(cx, arguments, 0)) {
                     date_value_arg
                 } else {
                     let arg = get_argument(cx, arguments, 0);

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -7,8 +7,10 @@ use crate::{
         error::{range_error, type_error},
         function::get_argument,
         get,
-        intrinsics::date_object::{day, make_date, make_full_year, make_time, time_clip},
-        intrinsics::rust_runtime::RuntimeFunction,
+        intrinsics::{
+            date_object::{day, make_date, make_full_year, make_time, time_clip},
+            rust_runtime::RuntimeFunction,
+        },
         object_value::ObjectValue,
         property::Property,
         string_value::StringValue,
@@ -401,11 +403,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getDate must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getDate")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -422,11 +420,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getDay must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getDay")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -443,11 +437,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getFullYear must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getFullYear")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -464,11 +454,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getHours must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getHours")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -485,11 +471,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getMilliseconds must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getMilliseconds")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -506,11 +488,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getMinutes must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getMinutes")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -527,11 +505,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getMonth must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getMonth")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -548,11 +522,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getSeconds must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getSeconds")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -569,11 +539,9 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if let Some(date_value) = this_date_value(this_value) {
-            Ok(Value::from(date_value).to_handle(cx))
-        } else {
-            type_error(cx, "Date.prototype.getTime must be called on a Date")
-        }
+        let date_value = this_date_value(cx, this_value, "getTime")?;
+
+        Ok(Value::from(date_value).to_handle(cx))
     }
 
     /// Date.prototype.getTimezoneOffset (https://tc39.es/ecma262/#sec-date.prototype.gettimezoneoffset)
@@ -582,11 +550,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getTimezoneOffset must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getTimezoneOffset")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -603,11 +567,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getUTCDate must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getUTCDate")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -624,11 +584,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getUTCDay must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getUTCDay")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -645,11 +601,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getUTCFullYear must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getUTCFullYear")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -666,11 +618,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getUTCHours must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getUTCHours")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -687,11 +635,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getUTCMilliseconds must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getUTCMilliseconds")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -708,11 +652,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getUTCMinutes must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getUTCMinutes")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -729,11 +669,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getUTCMonth must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getUTCMonth")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -750,11 +686,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getUTCSeconds must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getUTCSeconds")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -771,11 +703,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setDate must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "setDate")?;
 
         let date_arg = get_argument(cx, arguments, 0);
         let date = to_number(cx, date_arg)?.as_number();
@@ -802,11 +730,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let mut date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setFullYear must be called on a Date");
-        };
+        let mut date_value = this_date_value(cx, this_value, "setFullYear")?;
 
         let year_arg = get_argument(cx, arguments, 0);
         let year = to_number(cx, year_arg)?.as_number();
@@ -845,11 +769,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setHours must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "setHours")?;
 
         let hours_arg = get_argument(cx, arguments, 0);
         let hours = to_number(cx, hours_arg)?.as_number();
@@ -912,11 +832,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setMilliseconds must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "setMilliseconds")?;
 
         let milliseconds_arg = get_argument(cx, arguments, 0);
         let milliseconds = to_number(cx, milliseconds_arg)?.as_number();
@@ -948,11 +864,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setMinutes must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "setMinutes")?;
 
         let minutes_arg = get_argument(cx, arguments, 0);
         let minutes = to_number(cx, minutes_arg)?.as_number();
@@ -1003,11 +915,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setMonth must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "setMonth")?;
 
         let month_arg = get_argument(cx, arguments, 0);
         let month = to_number(cx, month_arg)?.as_number();
@@ -1046,11 +954,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setSeconds must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "setSeconds")?;
 
         let seconds_arg = get_argument(cx, arguments, 0);
         let seconds = to_number(cx, seconds_arg)?.as_number();
@@ -1094,9 +998,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if this_date_value(this_value).is_none() {
-            return type_error(cx, "Date.prototype.setTime must be called on a Date");
-        };
+        let _ = this_date_value(cx, this_value, "setTime")?;
 
         let time_arg = get_argument(cx, arguments, 0);
         let time_num = time_clip(to_number(cx, time_arg)?.as_number());
@@ -1112,11 +1014,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setUTCDate must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "setUTCDate")?;
 
         let date_arg = get_argument(cx, arguments, 0);
         let date = to_number(cx, date_arg)?.as_number();
@@ -1141,11 +1039,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let mut date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setUTCFullYear must be called on a Date");
-        };
+        let mut date_value = this_date_value(cx, this_value, "setUTCFullYear")?;
 
         if date_value.is_nan() {
             date_value = 0.0;
@@ -1182,11 +1076,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setUTCHours must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "setUTCHours")?;
 
         let hours_arg = get_argument(cx, arguments, 0);
         let hours = to_number(cx, hours_arg)?.as_number();
@@ -1245,11 +1135,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setUTCMilliseconds must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "setUTCMilliseconds")?;
 
         let milliseconds_arg = get_argument(cx, arguments, 0);
         let milliseconds = to_number(cx, milliseconds_arg)?.as_number();
@@ -1279,11 +1165,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setUTCMinutes must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "setUTCMinutes")?;
 
         let minutes_arg = get_argument(cx, arguments, 0);
         let minutes = to_number(cx, minutes_arg)?.as_number();
@@ -1332,11 +1214,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setUTCMonth must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "setUTCMonth")?;
 
         let month_arg = get_argument(cx, arguments, 0);
         let month = to_number(cx, month_arg)?.as_number();
@@ -1373,11 +1251,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setUTCSeconds must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "setUTCSeconds")?;
 
         let seconds_arg = get_argument(cx, arguments, 0);
         let seconds = to_number(cx, seconds_arg)?.as_number();
@@ -1419,11 +1293,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.toDateString must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "toDateString")?;
 
         Self::to_date_string_shared(cx, date_value)
     }
@@ -1447,14 +1317,10 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.toISOString must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "toISOString")?;
 
         if !date_value.is_finite() {
-            return range_error(cx, "Date value is not finite");
+            return range_error(cx, "Date.prototype.toISOString date value is not finite");
         }
 
         let year = year_from_time(date_value) as i64;
@@ -1503,11 +1369,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.toLocaleDateString must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "toLocaleDateString")?;
 
         Self::to_date_string_shared(cx, date_value)
     }
@@ -1518,11 +1380,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.toLocaleString must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "toLocaleString")?;
 
         Ok(to_date_string(cx, date_value)?.as_value())
     }
@@ -1533,11 +1391,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.toLocaleTimeString must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "toLocaleTimeString")?;
 
         Self::to_time_string_shared(cx, date_value)
     }
@@ -1548,11 +1402,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.toString must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "toString")?;
 
         Ok(to_date_string(cx, date_value)?.as_value())
     }
@@ -1563,11 +1413,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.toTimeString must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "toTimeString")?;
 
         Self::to_time_string_shared(cx, date_value)
     }
@@ -1593,11 +1439,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.toUTCString must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "toUTCString")?;
 
         if date_value.is_nan() {
             return Ok(cx.alloc_static_string("Invalid Date")?.as_value());
@@ -1626,11 +1468,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.valueOf must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "valueOf")?;
 
         Ok(Value::from(date_value).to_handle(cx))
     }
@@ -1665,7 +1503,10 @@ impl DatePrototype {
             }
         }
 
-        type_error(cx, "invalid hint to Date.prototype[@@toPrimitive]")
+        type_error(
+            cx,
+            "Date.prototype[@@toPrimitive] hint argument must be `default`, `string`, or `number`",
+        )
     }
 
     /// Date.prototype.getYear (https://tc39.es/ecma262/#sec-date.prototype.getyear)
@@ -1674,11 +1515,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.getYear must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "getYear")?;
 
         if date_value.is_nan() {
             return Ok(cx.nan());
@@ -1695,11 +1532,7 @@ impl DatePrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let date_value = if let Some(date_value) = this_date_value(this_value) {
-            date_value
-        } else {
-            return type_error(cx, "Date.prototype.setYear must be called on a Date");
-        };
+        let date_value = this_date_value(cx, this_value, "setYear")?;
 
         let year_arg = get_argument(cx, arguments, 0);
         let short_year = to_number(cx, year_arg)?;
@@ -1812,15 +1645,23 @@ pub fn to_date_string(mut cx: Context, time_value: f64) -> EvalResult<Handle<Str
 }
 
 #[inline]
-pub fn this_date_value(value: Handle<Value>) -> Option<f64> {
-    if !value.is_object() {
-        return None;
+pub fn validate_date_value(value: Handle<Value>) -> Option<f64> {
+    if value.is_object() {
+        if let Some(date_object) = value.as_object().as_date_object() {
+            return Some(date_object.date_value());
+        }
     }
 
-    value
-        .as_object()
-        .as_date_object()
-        .map(|date| date.date_value())
+    None
+}
+
+#[inline]
+fn this_date_value(cx: Context, value: Handle<Value>, method_name: &str) -> EvalResult<f64> {
+    if let Some(date_value) = validate_date_value(value) {
+        return Ok(date_value);
+    }
+
+    type_error(cx, &format!("Date.prototype.{} must be called on a Date", method_name))
 }
 
 #[inline]

--- a/src/js/runtime/intrinsics/error_prototype.rs
+++ b/src/js/runtime/intrinsics/error_prototype.rs
@@ -49,7 +49,7 @@ impl ErrorPrototype {
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "expected an object");
+            return type_error(cx, "Error.prototype.toString must be called on an object");
         }
 
         let this_object = this_value.as_object();

--- a/src/js/runtime/intrinsics/finalization_registry_constructor.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_constructor.rs
@@ -45,7 +45,7 @@ impl FinalizationRegistryConstructor {
 
         let cleanup_callback = get_argument(cx, arguments, 0);
         if !is_callable(cleanup_callback) {
-            return type_error(cx, "FinalizationRegistry cleanup callback must be a function");
+            return type_error(cx, "FinalizationRegistry constructor argument must be a function");
         }
 
         Ok(FinalizationRegistryObject::new_from_constructor(

--- a/src/js/runtime/intrinsics/finalization_registry_prototype.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_prototype.rs
@@ -53,25 +53,23 @@ impl FinalizationRegistryPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let Some(registry_object) = this_finalization_registry_value(this_value) else {
-            return type_error(
-                cx,
-                "FinalizationRegistry.prototype.register must be called on a FinalizationRegistry",
-            );
-        };
+        let registry_object = this_finalization_registry_value(cx, this_value, "register")?;
 
         let target = get_argument(cx, arguments, 0);
         let held_value = get_argument(cx, arguments, 1);
         let unregister_token = get_argument(cx, arguments, 2);
 
         if !can_be_held_weakly(cx, *target) {
-            return type_error(cx, "FinalizationRegistry targets must be objects or symbols");
+            return type_error(
+                cx,
+                "FinalizationRegistry.prototype.register target must be an object or symbol",
+            );
         }
 
         if same_value(target, held_value)? {
             return type_error(
                 cx,
-                "the target and held value arguments to register cannot be the same value",
+                "FinalizationRegistry.prototype.register target and held value cannot be the same",
             );
         }
 
@@ -82,7 +80,7 @@ impl FinalizationRegistryPrototype {
         } else {
             return type_error(
                 cx,
-                "FinalizationRegistry unregister tokens must be objects or symbols",
+                "FinalizationRegistry.prototype.register unregister token must be an object or symbol",
             );
         };
 
@@ -102,19 +100,14 @@ impl FinalizationRegistryPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let Some(registry_object) = this_finalization_registry_value(this_value) else {
-            return type_error(
-                cx,
-                "FinalizationRegistry.prototype.unregister must be called on a FinalizationRegistry",
-            );
-        };
+        let registry_object = this_finalization_registry_value(cx, this_value, "unregister")?;
 
         let unregister_token = get_argument(cx, arguments, 0);
 
         if !can_be_held_weakly(cx, *unregister_token) {
             return type_error(
                 cx,
-                "FinalizationRegistry unregister tokens must be objects or symbols",
+                "FinalizationRegistry.prototype.unregister token must be an object or symbol",
             );
         }
 
@@ -125,11 +118,21 @@ impl FinalizationRegistryPrototype {
 }
 
 fn this_finalization_registry_value(
+    cx: Context,
     value: Handle<Value>,
-) -> Option<Handle<FinalizationRegistryObject>> {
-    if !value.is_object() {
-        return None;
+    method_name: &str,
+) -> EvalResult<Handle<FinalizationRegistryObject>> {
+    if value.is_object() {
+        if let Some(registry_object) = value.as_object().as_finalization_registry_object() {
+            return Ok(registry_object);
+        }
     }
 
-    value.as_object().as_finalization_registry_object()
+    type_error(
+        cx,
+        &format!(
+            "FinalizationRegistry.prototype.{} must be called on a FinalizationRegistry",
+            method_name
+        ),
+    )
 }

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -126,18 +126,16 @@ impl FunctionPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !is_callable(this_value) {
-            return type_error(cx, "expected a function");
-        }
+        let this_function = this_function_value(cx, this_value, "apply")?;
 
         let this_arg = get_argument(cx, arguments, 0);
         let arg_array = get_argument(cx, arguments, 1);
 
         if arg_array.is_nullish() {
-            call_object(cx, this_value.as_object(), this_arg, &[])
+            call_object(cx, this_function, this_arg, &[])
         } else {
             let arg_list = create_list_from_array_like(cx, arg_array)?;
-            call_object(cx, this_value.as_object(), this_arg, &arg_list)
+            call_object(cx, this_function, this_arg, &arg_list)
         }
     }
 
@@ -147,11 +145,7 @@ impl FunctionPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !is_callable(this_value) {
-            return type_error(cx, "expected a function");
-        }
-
-        let target = this_value.as_object();
+        let target = this_function_value(cx, this_value, "bind")?;
 
         let this_arg = get_argument(cx, arguments, 0);
         let bound_args = if arguments.is_empty() {
@@ -203,15 +197,13 @@ impl FunctionPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !is_callable(this_value) {
-            return type_error(cx, "expected a function");
-        }
+        let this_function = this_function_value(cx, this_value, "call")?;
 
         if arguments.is_empty() {
-            call_object(cx, this_value.as_object(), cx.undefined(), &[])
+            call_object(cx, this_function, cx.undefined(), &[])
         } else {
             let argument = get_argument(cx, arguments, 0);
-            call_object(cx, this_value.as_object(), argument, &arguments[1..])
+            call_object(cx, this_function, argument, &arguments[1..])
         }
     }
 
@@ -222,7 +214,7 @@ impl FunctionPrototype {
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
-            return type_error(cx, "Function.prototype.toString expected a function");
+            return type_error(cx, "Function.prototype.toString must be called on a function");
         }
 
         let this_object = this_value.as_object();
@@ -269,7 +261,7 @@ impl FunctionPrototype {
                 .as_value());
         }
 
-        type_error(cx, "Function.prototype.toString expected a function")
+        type_error(cx, "Function.prototype.toString must be called on a function")
     }
 
     /// Function.prototype [ @@hasInstance ] (https://tc39.es/ecma262/#sec-function.prototype-%symbol.hasinstance%)
@@ -282,4 +274,19 @@ impl FunctionPrototype {
         let has_instance = ordinary_has_instance(cx, this_value, argument)?;
         Ok(cx.bool(has_instance))
     }
+}
+
+fn this_function_value(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<ObjectValue>> {
+    if !is_callable(value) {
+        return type_error(
+            cx,
+            &format!("Function.prototype.{} must be called on a function", method_name),
+        );
+    }
+
+    Ok(value.as_object())
 }

--- a/src/js/runtime/intrinsics/iterator_constructor.rs
+++ b/src/js/runtime/intrinsics/iterator_constructor.rs
@@ -180,16 +180,11 @@ impl WrapForValidIteratorPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        // Check if called on a WrappedIteratorObject
-        if this_value.is_object() {
-            if let Some(wrapper) = this_value.as_object().as_wrapped_valid_iterator_object() {
-                // Call the wrapped iterator's next method
-                let iterator = wrapper.iterator().as_value();
-                return call(cx, wrapper.next_method(cx), iterator, &[]);
-            }
-        }
+        let wrapper = this_wrapped_valid_iterator_object(cx, this_value, "next")?;
 
-        type_error(cx, "%WrappedValidIterator%.prototype.next called on incompatible object")
+        // Call the wrapped iterator's next method
+        let iterator = wrapper.iterator().as_value();
+        call(cx, wrapper.next_method(cx), iterator, &[])
     }
 
     /// %WrapForValidIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.next)
@@ -198,18 +193,33 @@ impl WrapForValidIteratorPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        // Check if called on a WrappedIteratorObject
-        if this_value.is_object() {
-            if let Some(wrapper) = this_value.as_object().as_wrapped_valid_iterator_object() {
-                // Call the wrapped iterator's return method if one exists
-                let iterator = wrapper.iterator().as_value();
-                return match get_method(cx, iterator, cx.names.return_())? {
-                    None => Ok(create_iter_result_object(cx, cx.undefined(), true)?),
-                    Some(return_) => call_object(cx, return_, iterator, &[]),
-                };
-            }
-        }
+        let wrapper = this_wrapped_valid_iterator_object(cx, this_value, "return")?;
 
-        type_error(cx, "%WrappedValidIterator%.prototype.return called on incompatible object")
+        // Call the wrapped iterator's return method if one exists
+        let iterator = wrapper.iterator().as_value();
+
+        match get_method(cx, iterator, cx.names.return_())? {
+            None => Ok(create_iter_result_object(cx, cx.undefined(), true)?),
+            Some(return_) => call_object(cx, return_, iterator, &[]),
+        }
     }
+}
+
+fn this_wrapped_valid_iterator_object(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<WrappedValidIterator>> {
+    if value.is_object() {
+        if let Some(wrapper) = value.as_object().as_wrapped_valid_iterator_object() {
+            return Ok(wrapper);
+        }
+    }
+
+    type_error(
+        cx,
+        &format!(
+            "%WrappedValidIterator%.prototype.{method_name} must be called on a WrappedValidIterator"
+        ),
+    )
 }

--- a/src/js/runtime/intrinsics/iterator_helper_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_prototype.rs
@@ -53,19 +53,16 @@ impl IteratorHelperPrototype {
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         // GenerateResume adapted for Iterator Helper Objects
-        let mut object = match validate_iterator_helper_object(this_value) {
-            None => {
-                return type_error(
-                    cx,
-                    "%IteratorHelperPrototype%.next called on a non-Iterator Helper object",
-                )
-            }
-            Some(object) => object,
-        };
+        let mut object = this_iterator_helper_object(cx, this_value, "next")?;
 
         let is_start = match object.generator_state() {
             // Error if the "generator" is already executing
-            GeneratorState::Executing => return type_error(cx, "generator is already executing"),
+            GeneratorState::Executing => {
+                return type_error(
+                    cx,
+                    "%IteratorHelperPrototype%.next generator is already executing",
+                );
+            }
             // Error if the "generator" is already completed
             GeneratorState::Completed => {
                 return Ok(create_iter_result_object(cx, cx.undefined(), true)?);
@@ -101,19 +98,16 @@ impl IteratorHelperPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let mut object = match validate_iterator_helper_object(this_value) {
-            None => {
-                return type_error(
-                    cx,
-                    "%IteratorHelperPrototype%.return called on a non-Iterator Helper object",
-                )
-            }
-            Some(object) => object,
-        };
+        let mut object = this_iterator_helper_object(cx, this_value, "return")?;
 
         match object.generator_state() {
             // Error if the "generator" is already executing
-            GeneratorState::Executing => return type_error(cx, "generator is already executing"),
+            GeneratorState::Executing => {
+                return type_error(
+                    cx,
+                    "%IteratorHelperPrototype%.return generator is already executing",
+                );
+            }
             // On completion set the "generator" to completed and return the done result
             GeneratorState::Completed => {
                 return Ok(create_iter_result_object(cx, cx.undefined(), true)?);
@@ -137,10 +131,19 @@ impl IteratorHelperPrototype {
     }
 }
 
-fn validate_iterator_helper_object(value: Handle<Value>) -> Option<Handle<IteratorHelperObject>> {
-    if !value.is_object() {
-        return None;
+fn this_iterator_helper_object(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<IteratorHelperObject>> {
+    if value.is_object() {
+        if let Some(iterator_helper) = value.as_object().as_iterator_helper_object() {
+            return Ok(iterator_helper);
+        }
     }
 
-    value.as_object().as_iterator_helper_object()
+    type_error(
+        cx,
+        &format!("%IteratorHelperPrototype%.{method_name} must be called on an Iterator Helper"),
+    )
 }

--- a/src/js/runtime/intrinsics/iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_prototype.rs
@@ -163,17 +163,13 @@ impl IteratorPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.drop must be called on an object");
-        }
-
-        let iterator_object = this_value.as_object();
+        let this_object = this_object(cx, this_value, "drop")?;
 
         // Verify the limit is a number, closing the underlying iterator if not
         let num_limit_arg = get_argument(cx, arguments, 0);
         let num_limit = match to_number(cx, num_limit_arg) {
             Err(error) => {
-                return iterator_close(cx, iterator_object, Err(error));
+                return iterator_close(cx, this_object, Err(error));
             }
             Ok(num_limit) => num_limit,
         };
@@ -181,17 +177,17 @@ impl IteratorPrototype {
         // Verify that the limit is not NaN or negative, closing the underlying iterator if it is
         if num_limit.is_nan() {
             let error = range_error_value(cx, "Iterator.prototype.drop limit is NaN")?;
-            return iterator_close(cx, iterator_object, eval_err!(error));
+            return iterator_close(cx, this_object, eval_err!(error));
         }
 
         let integer_limit = must!(to_integer_or_infinity(cx, num_limit));
         if integer_limit < 0.0 {
             let error = range_error_value(cx, "Iterator.prototype.drop limit is negative")?;
-            return iterator_close(cx, iterator_object, eval_err!(error));
+            return iterator_close(cx, this_object, eval_err!(error));
         }
 
         // Get the underlying iterator and create a new iterator helper drop object
-        let iterated = get_iterator_direct(cx, iterator_object)?;
+        let iterated = get_iterator_direct(cx, this_object)?;
         Ok(IteratorHelperObject::new_drop(cx, &iterated, integer_limit)?.as_value())
     }
 
@@ -201,20 +197,18 @@ impl IteratorPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.every must be called on an object");
-        }
+        let this_object = this_object(cx, this_value, "every")?;
 
         // Verify the predicate argument is a function, closing the underlying iterator if not
         let predicate_arg = get_argument(cx, arguments, 0);
         if !is_callable(predicate_arg) {
             let error =
                 type_error_value(cx, "Iterator.prototype.every predicate must be a function")?;
-            return iterator_close(cx, this_value.as_object(), eval_err!(error));
+            return iterator_close(cx, this_object, eval_err!(error));
         }
         let predicate = predicate_arg.as_object();
 
-        let mut iterated = get_iterator_direct(cx, this_value.as_object())?;
+        let mut iterated = get_iterator_direct(cx, this_object)?;
         let mut counter: u64 = 0;
         let mut counter_handle: Handle<Value> = Handle::empty(cx);
 
@@ -246,21 +240,19 @@ impl IteratorPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.filter must be called on an object");
-        }
+        let this_object = this_object(cx, this_value, "filter")?;
 
         // Verify the predicate argument is a function, closing the underlying iterator if not
         let predicate_arg = get_argument(cx, arguments, 0);
         if !is_callable(predicate_arg) {
             let error =
                 type_error_value(cx, "Iterator.prototype.filter predicate must be a function")?;
-            return iterator_close(cx, this_value.as_object(), eval_err!(error));
+            return iterator_close(cx, this_object, eval_err!(error));
         }
         let predicate = predicate_arg.as_object();
 
         // Get the underlying iterator and create a new iterator helper map object
-        let iterated = get_iterator_direct(cx, this_value.as_object())?;
+        let iterated = get_iterator_direct(cx, this_object)?;
         Ok(IteratorHelperObject::new_filter(cx, &iterated, predicate)?.as_value())
     }
 
@@ -270,20 +262,18 @@ impl IteratorPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.find must be called on an object");
-        }
+        let this_object = this_object(cx, this_value, "find")?;
 
         // Verify the predicate argument is a function, closing the underlying iterator if not
         let predicate_arg = get_argument(cx, arguments, 0);
         if !is_callable(predicate_arg) {
             let error =
                 type_error_value(cx, "Iterator.prototype.find predicate must be a function")?;
-            return iterator_close(cx, this_value.as_object(), eval_err!(error));
+            return iterator_close(cx, this_object, eval_err!(error));
         }
         let predicate = predicate_arg.as_object();
 
-        let mut iterated = get_iterator_direct(cx, this_value.as_object())?;
+        let mut iterated = get_iterator_direct(cx, this_object)?;
         let mut counter: u64 = 0;
         let mut counter_handle: Handle<Value> = Handle::empty(cx);
 
@@ -315,21 +305,19 @@ impl IteratorPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.flatMap must be called on an object");
-        }
+        let this_object = this_object(cx, this_value, "flatMap")?;
 
         // Verify the mapper argument is a function, closing the underlying iterator if not
         let mapper_arg = get_argument(cx, arguments, 0);
         if !is_callable(mapper_arg) {
             let error =
                 type_error_value(cx, "Iterator.prototype.flatMap mapper must be a function")?;
-            return iterator_close(cx, this_value.as_object(), eval_err!(error));
+            return iterator_close(cx, this_object, eval_err!(error));
         }
         let mapper = mapper_arg.as_object();
 
         // Get the underlying iterator and create a new iterator helper map object
-        let iterated = get_iterator_direct(cx, this_value.as_object())?;
+        let iterated = get_iterator_direct(cx, this_object)?;
         Ok(IteratorHelperObject::new_flat_map(cx, &iterated, mapper)?.as_value())
     }
 
@@ -339,20 +327,18 @@ impl IteratorPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.forEach must be called on an object");
-        }
+        let this_object = this_object(cx, this_value, "forEach")?;
 
         // Verify the callback argument is a function, closing the underlying iterator if not
         let callback_arg = get_argument(cx, arguments, 0);
         if !is_callable(callback_arg) {
             let error =
                 type_error_value(cx, "Iterator.prototype.forEach callback must be a function")?;
-            return iterator_close(cx, this_value.as_object(), eval_err!(error));
+            return iterator_close(cx, this_object, eval_err!(error));
         }
         let callback = callback_arg.as_object();
 
-        let mut iterated = get_iterator_direct(cx, this_value.as_object())?;
+        let mut iterated = get_iterator_direct(cx, this_object)?;
         let mut counter: u64 = 0;
         let mut counter_handle: Handle<Value> = Handle::empty(cx);
 
@@ -381,20 +367,18 @@ impl IteratorPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.map must be called on an object");
-        }
+        let this_object = this_object(cx, this_value, "map")?;
 
         // Verify the mapper argument is a function, closing the underlying iterator if not
         let mapper_arg = get_argument(cx, arguments, 0);
         if !is_callable(mapper_arg) {
             let error = type_error_value(cx, "Iterator.prototype.map mapper must be a function")?;
-            return iterator_close(cx, this_value.as_object(), eval_err!(error));
+            return iterator_close(cx, this_object, eval_err!(error));
         }
         let mapper = mapper_arg.as_object();
 
         // Get the underlying iterator and create a new iterator helper map object
-        let iterated = get_iterator_direct(cx, this_value.as_object())?;
+        let iterated = get_iterator_direct(cx, this_object)?;
         Ok(IteratorHelperObject::new_map(cx, &iterated, mapper)?.as_value())
     }
 
@@ -404,20 +388,18 @@ impl IteratorPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.reduce must be called on an object");
-        }
+        let this_object = this_object(cx, this_value, "reduce")?;
 
         // Verify the callback argument is a function, closing the underlying iterator if not
         let callback_arg = get_argument(cx, arguments, 0);
         if !is_callable(callback_arg) {
             let error =
                 type_error_value(cx, "Iterator.prototype.reduce callback must be a function")?;
-            return iterator_close(cx, this_value.as_object(), eval_err!(error));
+            return iterator_close(cx, this_object, eval_err!(error));
         }
         let callback = callback_arg.as_object();
 
-        let mut iterated = get_iterator_direct(cx, this_value.as_object())?;
+        let mut iterated = get_iterator_direct(cx, this_object)?;
 
         let mut accumulator;
         let mut counter: u64;
@@ -468,20 +450,18 @@ impl IteratorPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.some must be called on an object");
-        }
+        let this_object = this_object(cx, this_value, "some")?;
 
         // Verify the predicate argument is a function, closing the underlying iterator if not
         let predicate_arg = get_argument(cx, arguments, 0);
         if !is_callable(predicate_arg) {
             let error =
                 type_error_value(cx, "Iterator.prototype.some predicate must be a function")?;
-            return iterator_close(cx, this_value.as_object(), eval_err!(error));
+            return iterator_close(cx, this_object, eval_err!(error));
         }
         let predicate = predicate_arg.as_object();
 
-        let mut iterated = get_iterator_direct(cx, this_value.as_object())?;
+        let mut iterated = get_iterator_direct(cx, this_object)?;
         let mut counter: u64 = 0;
         let mut counter_handle: Handle<Value> = Handle::empty(cx);
 
@@ -513,17 +493,13 @@ impl IteratorPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.take must be called on an object");
-        }
-
-        let iterator_object = this_value.as_object();
+        let this_object = this_object(cx, this_value, "take")?;
 
         // Verify the limit is a number, closing the underlying iterator if not
         let num_limit_arg = get_argument(cx, arguments, 0);
         let num_limit = match to_number(cx, num_limit_arg) {
             Err(error) => {
-                return iterator_close(cx, iterator_object, Err(error));
+                return iterator_close(cx, this_object, Err(error));
             }
             Ok(num_limit) => num_limit,
         };
@@ -531,17 +507,17 @@ impl IteratorPrototype {
         // Verify that the limit is not NaN or negative, closing the underlying iterator if it is
         if num_limit.is_nan() {
             let error = range_error_value(cx, "Iterator.prototype.take limit is NaN")?;
-            return iterator_close(cx, iterator_object, eval_err!(error));
+            return iterator_close(cx, this_object, eval_err!(error));
         }
 
         let integer_limit = must!(to_integer_or_infinity(cx, num_limit));
         if integer_limit < 0.0 {
             let error = range_error_value(cx, "Iterator.prototype.take limit is negative")?;
-            return iterator_close(cx, iterator_object, eval_err!(error));
+            return iterator_close(cx, this_object, eval_err!(error));
         }
 
         // Get the underlying iterator and create a new iterator helper take object
-        let iterated = get_iterator_direct(cx, iterator_object)?;
+        let iterated = get_iterator_direct(cx, this_object)?;
         Ok(IteratorHelperObject::new_take(cx, &iterated, integer_limit)?.as_value())
     }
 
@@ -551,11 +527,9 @@ impl IteratorPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "Iterator.prototype.toArray must be called on an object");
-        }
+        let this_object = this_object(cx, this_value, "toArray")?;
 
-        let mut iterated = get_iterator_direct(cx, this_value.as_object())?;
+        let mut iterated = get_iterator_direct(cx, this_object)?;
         let mut items = vec![];
 
         // Collect all all items from the iterator until the iterator is done
@@ -595,4 +569,16 @@ impl IteratorPrototype {
 
         Ok(cx.undefined())
     }
+}
+
+fn this_object(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<ObjectValue>> {
+    if value.is_object() {
+        return Ok(value.as_object());
+    }
+
+    type_error(cx, &format!("Iterator.prototype.{method_name} must be called on an object"))
 }

--- a/src/js/runtime/intrinsics/json_object.rs
+++ b/src/js/runtime/intrinsics/json_object.rs
@@ -73,7 +73,7 @@ impl JSONObject {
         let json_value = if let Some(json_value) = parse_json(&mut lexer) {
             json_value
         } else {
-            return syntax_error(cx, "JSON.parse: Invalid JSON");
+            return syntax_error(cx, "JSON.parse parsed invalid JSON");
         };
 
         // Then convert to a JS value, which may allocate

--- a/src/js/runtime/intrinsics/map_constructor.rs
+++ b/src/js/runtime/intrinsics/map_constructor.rs
@@ -78,7 +78,7 @@ impl MapConstructor {
 
         let adder = get(cx, map_object, cx.names.set_())?;
         if !is_callable(adder) {
-            return type_error(cx, "map must contain a set method");
+            return type_error(cx, "Map constructor result must have a `set` method");
         }
 
         add_entries_from_iterable(cx, map_object.into(), iterable, |cx, key, value| {

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -100,11 +100,7 @@ impl MapPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let map = if let Some(map) = this_map_value(this_value) {
-            map
-        } else {
-            return type_error(cx, "Map.prototype.clear must be called on a Map");
-        };
+        let map = this_map_value(cx, this_value, "clear")?;
 
         map.map_data().clear();
 
@@ -117,11 +113,7 @@ impl MapPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let map = if let Some(map) = this_map_value(this_value) {
-            map
-        } else {
-            return type_error(cx, "Map.prototype.delete must be called on a Map");
-        };
+        let map = this_map_value(cx, this_value, "delete")?;
 
         let key = get_argument(cx, arguments, 0);
 
@@ -139,11 +131,7 @@ impl MapPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let map = if let Some(map) = this_map_value(this_value) {
-            map
-        } else {
-            return type_error(cx, "Map.prototype.entries must be called on a Map");
-        };
+        let map = this_map_value(cx, this_value, "entries")?;
 
         Ok(MapIterator::new(cx, map, MapIteratorKind::KeyAndValue)?.as_value())
     }
@@ -154,15 +142,11 @@ impl MapPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let map = if let Some(map) = this_map_value(this_value) {
-            map
-        } else {
-            return type_error(cx, "Map.prototype.forEach must be called on a Map");
-        };
+        let map = this_map_value(cx, this_value, "forEach")?;
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
-            return type_error(cx, "Map.prototype.forEach callback must be a function");
+            return type_error(cx, "Map.prototype.forEach argument must be a function");
         }
 
         let callback_function = callback_function.as_object();
@@ -191,11 +175,7 @@ impl MapPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let map = if let Some(map) = this_map_value(this_value) {
-            map
-        } else {
-            return type_error(cx, "Map.prototype.get must be called on a Map");
-        };
+        let map = this_map_value(cx, this_value, "get")?;
 
         let key = get_argument(cx, arguments, 0);
 
@@ -214,11 +194,7 @@ impl MapPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let map = if let Some(map) = this_map_value(this_value) {
-            map
-        } else {
-            return type_error(cx, "Map.prototype.has must be called on a Map");
-        };
+        let map = this_map_value(cx, this_value, "has")?;
 
         let key = get_argument(cx, arguments, 0);
 
@@ -234,11 +210,7 @@ impl MapPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let map = if let Some(map) = this_map_value(this_value) {
-            map
-        } else {
-            return type_error(cx, "Map.prototype.keys must be called on a Map");
-        };
+        let map = this_map_value(cx, this_value, "keys")?;
 
         Ok(MapIterator::new(cx, map, MapIteratorKind::Key)?.as_value())
     }
@@ -249,11 +221,7 @@ impl MapPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let map = if let Some(map) = this_map_value(this_value) {
-            map
-        } else {
-            return type_error(cx, "Map.prototype.set must be called on a Map");
-        };
+        let map = this_map_value(cx, this_value, "set")?;
 
         let mut key = get_argument(cx, arguments, 0);
         let value = get_argument(cx, arguments, 1);
@@ -274,11 +242,7 @@ impl MapPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let map = if let Some(map) = this_map_value(this_value) {
-            map
-        } else {
-            return type_error(cx, "Map.prototype.size must be called on a Map");
-        };
+        let map = this_map_value(cx, this_value, "size")?;
 
         Ok(Value::from(map.map_data().num_entries_occupied()).to_handle(cx))
     }
@@ -289,20 +253,22 @@ impl MapPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let map = if let Some(map) = this_map_value(this_value) {
-            map
-        } else {
-            return type_error(cx, "Map.prototype.values must be called on a Map");
-        };
+        let map = this_map_value(cx, this_value, "values")?;
 
         Ok(MapIterator::new(cx, map, MapIteratorKind::Value)?.as_value())
     }
 }
 
-fn this_map_value(value: Handle<Value>) -> Option<Handle<MapObject>> {
-    if !value.is_object() {
-        return None;
+fn this_map_value(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<MapObject>> {
+    if value.is_object() {
+        if let Some(map) = value.as_object().as_map_object() {
+            return Ok(map);
+        }
     }
 
-    value.as_object().as_map_object()
+    type_error(cx, &format!("Map.prototype.{} must be called on a Map", method_name))
 }

--- a/src/js/runtime/intrinsics/number_prototype.rs
+++ b/src/js/runtime/intrinsics/number_prototype.rs
@@ -76,7 +76,7 @@ impl NumberPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let number_value = this_number_value(cx, this_value)?;
+        let number_value = this_number_value(cx, this_value, "toExponential")?;
         let mut number = number_value.as_number();
 
         let fraction_digits_arg = get_argument(cx, arguments, 0);
@@ -87,7 +87,10 @@ impl NumberPrototype {
         }
 
         if !(0.0..=100.0).contains(&num_fraction_digits) {
-            return range_error(cx, "number of fraction digits must between 0 and 100");
+            return range_error(
+                cx,
+                "Number.prototype.toExponential fraction digits must be between 0 and 100",
+            );
         }
 
         // If number of fraction digits is not specified then we need to use the minimum number of
@@ -155,13 +158,16 @@ impl NumberPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let number_value = this_number_value(cx, this_value)?;
+        let number_value = this_number_value(cx, this_value, "toFixed")?;
         let mut number = number_value.as_number();
 
         let fraction_digits_arg = get_argument(cx, arguments, 0);
         let num_fraction_digits = to_integer_or_infinity(cx, fraction_digits_arg)?;
         if !num_fraction_digits.is_finite() || !(0.0..=100.0).contains(&num_fraction_digits) {
-            return range_error(cx, "number of fraction digits must between 0 and 100");
+            return range_error(
+                cx,
+                "Number.prototype.toFixed fraction digits must be between 0 and 100",
+            );
         }
 
         let num_fraction_digits = num_fraction_digits as u8;
@@ -200,7 +206,7 @@ impl NumberPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        Self::to_string(cx, this_value, &[])
+        Self::to_string_impl(cx, this_value, &[], "toLocaleString")
     }
 
     /// Number.prototype.toPrecision (https://tc39.es/ecma262/#sec-number.prototype.toprecision)
@@ -209,7 +215,7 @@ impl NumberPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let number_value = this_number_value(cx, this_value)?;
+        let number_value = this_number_value(cx, this_value, "toPrecision")?;
 
         let precision_arg = get_argument(cx, arguments, 0);
         if precision_arg.is_undefined() {
@@ -225,7 +231,7 @@ impl NumberPrototype {
         if !(1..=100).contains(&precision) {
             return range_error(
                 cx,
-                "Number.prototype.toPrecision requires precision between 1 and 100",
+                "Number.prototype.toPrecision precision must be between 1 and 100",
             );
         }
         let precision = precision as i32;
@@ -289,11 +295,20 @@ impl NumberPrototype {
 
     /// Number.prototype.toString (https://tc39.es/ecma262/#sec-number.prototype.tostring)
     pub fn to_string(
-        mut cx: Context,
+        cx: Context,
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let number_value = this_number_value(cx, this_value)?;
+        Self::to_string_impl(cx, this_value, arguments, "toString")
+    }
+
+    fn to_string_impl(
+        mut cx: Context,
+        this_value: Handle<Value>,
+        arguments: &[Handle<Value>],
+        method_name: &str,
+    ) -> EvalResult<Handle<Value>> {
+        let number_value = this_number_value(cx, this_value, method_name)?;
 
         let radix = get_argument(cx, arguments, 0);
 
@@ -304,7 +319,10 @@ impl NumberPrototype {
                 let radix = radix.as_smi();
 
                 if !(2..=36).contains(&radix) {
-                    return range_error(cx, "radix must be between 2 and 36");
+                    return range_error(
+                        cx,
+                        &format!("Number.prototype.{} radix must be between 2 and 36", method_name),
+                    );
                 }
 
                 radix
@@ -312,7 +330,10 @@ impl NumberPrototype {
                 let radix = to_integer_or_infinity(cx, radix)?;
 
                 if !(2.0..=36.0).contains(&radix) {
-                    return range_error(cx, "radix must be between 2 and 36");
+                    return range_error(
+                        cx,
+                        &format!("Number.prototype.{} radix must be between 2 and 36", method_name),
+                    );
                 }
 
                 radix as i32
@@ -398,7 +419,7 @@ impl NumberPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let number_value = this_number_value(cx, this_value)?;
+        let number_value = this_number_value(cx, this_value, "valueOf")?;
         Ok(number_value.to_handle(cx))
     }
 }
@@ -412,7 +433,11 @@ const RADIX_TO_PRECISION: [u8; 37] = [
     11, 11, 11, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
 ];
 
-fn this_number_value(cx: Context, value_handle: Handle<Value>) -> EvalResult<Value> {
+fn this_number_value(
+    cx: Context,
+    value_handle: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Value> {
     let value = *value_handle;
     if value.is_number() {
         return Ok(value);
@@ -426,7 +451,7 @@ fn this_number_value(cx: Context, value_handle: Handle<Value>) -> EvalResult<Val
         }
     }
 
-    type_error(cx, "value cannot be converted to number")
+    type_error(cx, &format!("Number.prototype.{method_name} must be called on a number"))
 }
 
 /// Decompose an f64 to its exponent and mantissa, where the mantissa is rounded to exactly the

--- a/src/js/runtime/intrinsics/object_constructor.rs
+++ b/src/js/runtime/intrinsics/object_constructor.rs
@@ -284,7 +284,7 @@ impl ObjectConstructor {
         } else if proto.is_null() {
             None
         } else {
-            return type_error(cx, "prototype must be an object or null");
+            return type_error(cx, "Object.create prototype must be an object or null");
         };
 
         let object = object_create_with_optional_proto::<ObjectValue>(
@@ -310,7 +310,7 @@ impl ObjectConstructor {
     ) -> EvalResult<Handle<Value>> {
         let object = get_argument(cx, arguments, 0);
         if !object.is_object() {
-            return type_error(cx, "expected an object");
+            return type_error(cx, "Object.defineProperties target must be an object");
         }
 
         let properties_arg = get_argument(cx, arguments, 1);
@@ -357,7 +357,7 @@ impl ObjectConstructor {
     ) -> EvalResult<Handle<Value>> {
         let object = get_argument(cx, arguments, 0);
         if !object.is_object() {
-            return type_error(cx, "can only define property on an object");
+            return type_error(cx, "Object.defineProperty target must be an object");
         }
 
         let property_arg = get_argument(cx, arguments, 1);
@@ -395,7 +395,7 @@ impl ObjectConstructor {
         }
 
         if !set_integrity_level(cx, object.as_object(), IntegrityLevel::Frozen)? {
-            return type_error(cx, "failed to freeze object");
+            return type_error(cx, "Object.freeze failed to freeze object");
         }
 
         Ok(object)
@@ -648,7 +648,10 @@ impl ObjectConstructor {
         }
 
         if !value.as_object().prevent_extensions(cx)? {
-            return type_error(cx, "failed to prevent extensions on object");
+            return type_error(
+                cx,
+                "Object.preventExtensions failed to prevent extensions on object",
+            );
         }
 
         Ok(value)
@@ -666,7 +669,7 @@ impl ObjectConstructor {
         }
 
         if !set_integrity_level(cx, object.as_object(), IntegrityLevel::Sealed)? {
-            return type_error(cx, "failed to seal object");
+            return type_error(cx, "Object.seal failed to seal object");
         }
 
         Ok(object)
@@ -687,7 +690,7 @@ impl ObjectConstructor {
         } else if proto.is_null() {
             None
         } else {
-            return type_error(cx, "prototype must be an object or null");
+            return type_error(cx, "Object.setPrototypeOf prototype must be an object or null");
         };
 
         if !object.is_object() {
@@ -696,7 +699,7 @@ impl ObjectConstructor {
         let mut object = object.as_object();
 
         if !object.set_prototype_of(cx, proto)? {
-            return type_error(cx, "failed to set object prototype");
+            return type_error(cx, "Object.setPrototypeOf failed to set object prototype");
         }
 
         Ok(object.as_value())

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -297,7 +297,7 @@ impl ObjectPrototype {
         }
 
         if !object.as_object().set_prototype_of(cx, proto)? {
-            return type_error(cx, "failed to set object prototype");
+            return type_error(cx, "Object.prototype.__proto__ failed to set object prototype");
         }
 
         Ok(cx.undefined())
@@ -313,7 +313,7 @@ impl ObjectPrototype {
 
         let getter = get_argument(cx, arguments, 1);
         if !is_callable(getter) {
-            return type_error(cx, "getter must be a function");
+            return type_error(cx, "Object.prototype.__defineGetter__ getter must be a function");
         }
 
         let key_arg = get_argument(cx, arguments, 0);
@@ -335,7 +335,7 @@ impl ObjectPrototype {
 
         let setter = get_argument(cx, arguments, 1);
         if !is_callable(setter) {
-            return type_error(cx, "setter must be a function");
+            return type_error(cx, "Object.prototype.__defineSetter__ setter must be a function");
         }
 
         let key_arg = get_argument(cx, arguments, 0);

--- a/src/js/runtime/intrinsics/promise_constructor.rs
+++ b/src/js/runtime/intrinsics/promise_constructor.rs
@@ -142,6 +142,7 @@ impl PromiseConstructor {
         cx: Context,
         constructor: Handle<Value>,
         iterable: Handle<Value>,
+        method_name: &str,
         mut f: impl FnMut(
             Context,
             &mut Iterator,
@@ -153,7 +154,7 @@ impl PromiseConstructor {
         let capability = PromiseCapability::new(cx, constructor)?;
         let constructor = constructor.as_object();
 
-        let resolve_completion = get_promise_resolve(cx, constructor);
+        let resolve_completion = get_promise_resolve(cx, constructor, method_name);
         let resolve = if_abrupt_reject_promise!(cx, resolve_completion, capability);
 
         let iterator_completion = get_iterator(cx, iterable, IteratorHint::Sync, None);
@@ -274,7 +275,7 @@ impl PromiseConstructor {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         let iterable = get_argument(cx, arguments, 0);
-        Self::collect_iterable_promises(cx, this_value, iterable, Self::perform_promise_all)
+        Self::collect_iterable_promises(cx, this_value, iterable, "all", Self::perform_promise_all)
     }
 
     /// PerformPromiseAll (https://tc39.es/ecma262/#sec-performpromiseall)
@@ -381,7 +382,13 @@ impl PromiseConstructor {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         let iterable = get_argument(cx, arguments, 0);
-        Self::collect_iterable_promises(cx, this_value, iterable, Self::perform_promise_all_settled)
+        Self::collect_iterable_promises(
+            cx,
+            this_value,
+            iterable,
+            "allSettled",
+            Self::perform_promise_all_settled,
+        )
     }
 
     /// Promise.allSettled (https://tc39.es/ecma262/#sec-performpromiseallsettled)
@@ -581,7 +588,7 @@ impl PromiseConstructor {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         let iterable = get_argument(cx, arguments, 0);
-        Self::collect_iterable_promises(cx, this_value, iterable, Self::perform_promise_any)
+        Self::collect_iterable_promises(cx, this_value, iterable, "any", Self::perform_promise_any)
     }
 
     /// PerformPromiseAny (https://tc39.es/ecma262/#sec-performpromiseany)
@@ -691,7 +698,13 @@ impl PromiseConstructor {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         let iterable = get_argument(cx, arguments, 0);
-        Self::collect_iterable_promises(cx, this_value, iterable, Self::perform_promise_race)
+        Self::collect_iterable_promises(
+            cx,
+            this_value,
+            iterable,
+            "race",
+            Self::perform_promise_race,
+        )
     }
 
     /// PerformPromiseRace (https://tc39.es/ecma262/#sec-performpromiserace)
@@ -903,10 +916,14 @@ pub fn reject_builtin_function(
 fn get_promise_resolve(
     cx: Context,
     constructor: Handle<ObjectValue>,
+    method_name: &str,
 ) -> EvalResult<Handle<ObjectValue>> {
     let resolve = get(cx, constructor, cx.names.resolve())?;
     if !is_callable(resolve) {
-        return type_error(cx, "`resolve` property must be a function");
+        return type_error(
+            cx,
+            &format!("Promise.{method_name} must be called on an object with a `resolve` method"),
+        );
     }
 
     Ok(resolve.as_object())

--- a/src/js/runtime/intrinsics/promise_prototype.rs
+++ b/src/js/runtime/intrinsics/promise_prototype.rs
@@ -80,11 +80,11 @@ impl PromisePrototype {
         if !this_value.is_object() {
             return type_error(cx, "Promise.prototype.finally must be called on an object");
         }
-        let promise = this_value.as_object().cast::<PromiseObject>();
+        let promise = this_value.as_object();
 
         let on_finally = get_argument(cx, arguments, 0);
 
-        let constructor = species_constructor(cx, promise.into(), Intrinsic::PromiseConstructor)?;
+        let constructor = species_constructor(cx, promise, Intrinsic::PromiseConstructor)?;
 
         let then_finally;
         let catch_finally;

--- a/src/js/runtime/intrinsics/proxy_constructor.rs
+++ b/src/js/runtime/intrinsics/proxy_constructor.rs
@@ -49,7 +49,7 @@ impl ProxyConstructor {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if cx.current_new_target().is_none() {
-            return type_error(cx, "Proxy is a constructor");
+            return type_error(cx, "Proxy constructor must be called with new");
         }
 
         let target = get_argument(cx, arguments, 0);

--- a/src/js/runtime/intrinsics/reflect_object.rs
+++ b/src/js/runtime/intrinsics/reflect_object.rs
@@ -118,7 +118,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !is_callable(target) {
-            return type_error(cx, "expected a function");
+            return type_error(cx, "Reflect.apply target must be a function");
         }
 
         let this_argument = get_argument(cx, arguments, 1);
@@ -136,7 +136,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !is_constructor_value(target) {
-            return type_error(cx, "expected a constructor");
+            return type_error(cx, "Reflect.construct target must be a constructor");
         }
 
         let target = target.as_object();
@@ -144,7 +144,7 @@ impl ReflectObject {
         let new_target = if arguments.len() >= 3 {
             let new_target = get_argument(cx, arguments, 2);
             if !is_constructor_value(new_target) {
-                return type_error(cx, "expected a constructor");
+                return type_error(cx, "Reflect.construct newTarget must be a constructor");
             }
 
             new_target.as_object()
@@ -166,7 +166,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "expected an object");
+            return type_error(cx, "Reflect.defineProperty target must be an object");
         }
 
         let mut target = target.as_object();
@@ -189,7 +189,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "expected an object");
+            return type_error(cx, "Reflect.deleteProperty target must be an object");
         }
 
         let mut target = target.as_object();
@@ -208,7 +208,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "expected an object");
+            return type_error(cx, "Reflect.get target must be an object");
         }
 
         let key_arg = get_argument(cx, arguments, 1);
@@ -231,7 +231,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "expected an object");
+            return type_error(cx, "Reflect.getOwnPropertyDescriptor target must be an object");
         }
 
         let target = target.as_object();
@@ -255,7 +255,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "expected an object");
+            return type_error(cx, "Reflect.getPrototypeOf target must be an object");
         }
 
         let prototype = target.as_object().get_prototype_of(cx)?;
@@ -271,7 +271,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "expected an object");
+            return type_error(cx, "Reflect.has target must be an object");
         }
 
         let target = target.as_object();
@@ -290,7 +290,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "expected an object");
+            return type_error(cx, "Reflect.isExtensible target must be an object");
         }
 
         let is_extensible = target.as_object().is_extensible(cx)?;
@@ -305,7 +305,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "expected an object");
+            return type_error(cx, "Reflect.ownKeys target must be an object");
         }
 
         let own_keys = target.as_object().own_property_keys(cx)?;
@@ -321,7 +321,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "expected an object");
+            return type_error(cx, "Reflect.preventExtensions target must be an object");
         }
 
         let result = target.as_object().prevent_extensions(cx)?;
@@ -336,7 +336,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "expected an object");
+            return type_error(cx, "Reflect.set target must be an object");
         }
 
         let key_arg = get_argument(cx, arguments, 1);
@@ -361,7 +361,7 @@ impl ReflectObject {
     ) -> EvalResult<Handle<Value>> {
         let target = get_argument(cx, arguments, 0);
         if !target.is_object() {
-            return type_error(cx, "expected an object");
+            return type_error(cx, "Reflect.setPrototypeOf target must be an object");
         }
 
         let proto = get_argument(cx, arguments, 1);
@@ -370,7 +370,7 @@ impl ReflectObject {
         } else if proto.is_null() {
             None
         } else {
-            return type_error(cx, "prototype must be an object or null");
+            return type_error(cx, "Reflect.setPrototypeOf prototype must be an object or null");
         };
 
         let result = target.as_object().set_prototype_of(cx, proto)?;

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -194,11 +194,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let regexp_object = if let Some(regexp_object) = as_regexp_object(this_value) {
-            regexp_object
-        } else {
-            return type_error(cx, "RegExp.prototype.exec must be called on a RegExp");
-        };
+        let regexp_object = this_regexp_object(cx, this_value, "RegExp.prototype.exec")?;
 
         let string_arg = get_argument(cx, arguments, 0);
         let string_value = to_string(cx, string_arg)?;
@@ -212,7 +208,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        regexp_has_flag(cx, this_value, RegExpFlags::DOT_ALL)
+        regexp_has_flag(cx, this_value, RegExpFlags::DOT_ALL, "RegExp.prototype.dotAll")
     }
 
     /// get RegExp.prototype.flags (https://tc39.es/ecma262/#sec-get-regexp.prototype.flags)
@@ -221,11 +217,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "expected a RegExp");
-        }
-
-        let this_object = this_value.as_object();
+        let this_object = this_object(cx, this_value, "RegExp.prototype.flags")?;
 
         let mut flags_string = String::new();
 
@@ -284,7 +276,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        regexp_has_flag(cx, this_value, RegExpFlags::GLOBAL)
+        regexp_has_flag(cx, this_value, RegExpFlags::GLOBAL, "RegExp.prototype.global")
     }
 
     /// get RegExp.prototype.hasIndices (https://tc39.es/ecma262/#sec-get-regexp.prototype.hasIndices)
@@ -293,7 +285,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        regexp_has_flag(cx, this_value, RegExpFlags::HAS_INDICES)
+        regexp_has_flag(cx, this_value, RegExpFlags::HAS_INDICES, "RegExp.prototype.hasIndices")
     }
 
     /// get RegExp.prototype.ignoreCase (https://tc39.es/ecma262/#sec-get-regexp.prototype.ignorecase)
@@ -302,7 +294,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        regexp_has_flag(cx, this_value, RegExpFlags::IGNORE_CASE)
+        regexp_has_flag(cx, this_value, RegExpFlags::IGNORE_CASE, "RegExp.prototype.ignoreCase")
     }
 
     /// RegExp.prototype [ @@match ] (https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.match%)
@@ -311,11 +303,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "RegExp.prototype[@@match] must be called on an object");
-        }
-
-        let regexp_object = this_value.as_object();
+        let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@match]")?;
 
         let string_arg = get_argument(cx, arguments, 0);
         let string_value = to_string(cx, string_arg)?;
@@ -328,7 +316,7 @@ impl RegExpPrototype {
             || flags_string_contains(flags_string, 'v' as u32)?;
 
         if !is_global {
-            return regexp_exec(cx, regexp_object, string_value);
+            return regexp_exec(cx, regexp_object, string_value, "RegExp.prototype[@@match]");
         }
 
         let zero_value = cx.zero();
@@ -338,7 +326,7 @@ impl RegExpPrototype {
         let mut n = 0;
 
         loop {
-            let result = regexp_exec(cx, regexp_object, string_value)?;
+            let result = regexp_exec(cx, regexp_object, string_value, "RegExp.prototype[@@match]")?;
             if result.is_null() {
                 if n == 0 {
                     return Ok(cx.null());
@@ -382,11 +370,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "RegExp.prototype[@@matchAll] must be called on an object");
-        }
-
-        let regexp_object = this_value.as_object();
+        let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@matchAll]")?;
 
         let string_arg = get_argument(cx, arguments, 0);
         let string_value = to_string(cx, string_arg)?;
@@ -418,7 +402,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        regexp_has_flag(cx, this_value, RegExpFlags::MULTILINE)
+        regexp_has_flag(cx, this_value, RegExpFlags::MULTILINE, "RegExp.prototype.multiline")
     }
 
     /// RegExp.prototype [ @@replace ] (https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.replace%)
@@ -427,11 +411,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "RegExp.prototype[@@replace] must be called on an object");
-        }
-
-        let regexp_object = this_value.as_object();
+        let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@replace]")?;
 
         let target_string_arg = get_argument(cx, arguments, 0);
         let target_string = to_string(cx, target_string_arg)?;
@@ -469,7 +449,8 @@ impl RegExpPrototype {
 
         loop {
             // Search target string, finding all matches if global
-            let exec_result = regexp_exec(cx, regexp_object, target_string)?;
+            let exec_result =
+                regexp_exec(cx, regexp_object, target_string, "RegExp.prototype[@@replace]")?;
             if exec_result.is_null() {
                 break;
             }
@@ -617,11 +598,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "RegExp.prototype[@@search] must be called on an object");
-        }
-
-        let regexp_object = this_value.as_object();
+        let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@search]")?;
 
         let string_arg = get_argument(cx, arguments, 0);
         let string_value = to_string(cx, string_arg)?;
@@ -634,7 +611,7 @@ impl RegExpPrototype {
         }
 
         // Perform RegExp search
-        let result = regexp_exec(cx, regexp_object, string_value)?;
+        let result = regexp_exec(cx, regexp_object, string_value, "RegExp.prototype[@@search]")?;
 
         // Restore original last index
         let current_last_index = get(cx, regexp_object, cx.names.last_index())?;
@@ -667,7 +644,7 @@ impl RegExpPrototype {
             }
         }
 
-        type_error(cx, "expected a RegExp")
+        type_error(cx, "RegExp.prototype.source must be called on a RegExp")
     }
 
     /// RegExp.prototype [ @@split ] (https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.split%)
@@ -676,11 +653,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let regexp_object = if this_value.is_object() {
-            this_value.as_object()
-        } else {
-            return type_error(cx, "RegExp.prototype[@@split] must be called on an object");
-        };
+        let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@split]")?;
 
         let string_arg = get_argument(cx, arguments, 0);
         let string_value = to_string(cx, string_arg)?;
@@ -726,7 +699,7 @@ impl RegExpPrototype {
 
         // Handle the empty string case
         if string_value.is_empty() {
-            let exec_result = regexp_exec(cx, splitter, string_value)?;
+            let exec_result = regexp_exec(cx, splitter, string_value, "RegExp.prototype[@@split]")?;
             if !exec_result.is_null() {
                 return Ok(result_array.as_value());
             }
@@ -750,7 +723,7 @@ impl RegExpPrototype {
             set(cx, splitter, cx.names.last_index(), q_value, true)?;
 
             // Execute RegExp at current index, advancing to next index if there is no match
-            let exec_result = regexp_exec(cx, splitter, string_value)?;
+            let exec_result = regexp_exec(cx, splitter, string_value, "RegExp.prototype[@@split]")?;
 
             if exec_result.is_null() {
                 q = advance_string_index(string_value, q, is_unicode)?;
@@ -817,7 +790,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        regexp_has_flag(cx, this_value, RegExpFlags::STICKY)
+        regexp_has_flag(cx, this_value, RegExpFlags::STICKY, "RegExp.prototype.sticky")
     }
 
     /// RegExp.prototype.test (https://tc39.es/ecma262/#sec-regexp.prototype.test)
@@ -826,16 +799,12 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let regexp_object = if this_value.is_object() {
-            this_value.as_object()
-        } else {
-            return type_error(cx, "RegExp.prototype.test must be called on an object");
-        };
+        let regexp_object = this_object(cx, this_value, "test")?;
 
         let string_arg = get_argument(cx, arguments, 0);
         let string_value = to_string(cx, string_arg)?;
 
-        let exec_result = regexp_exec(cx, regexp_object, string_value)?;
+        let exec_result = regexp_exec(cx, regexp_object, string_value, "RegExp.prototype.test")?;
 
         Ok(cx.bool(!exec_result.is_null()))
     }
@@ -846,11 +815,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        if !this_value.is_object() {
-            return type_error(cx, "expected a RegExp");
-        }
-
-        let this_object = this_value.as_object();
+        let this_object = this_object(cx, this_value, "toString")?;
 
         let pattern_value = get(cx, this_object, cx.names.source())?;
         let pattern_string = to_string(cx, pattern_value)?;
@@ -874,7 +839,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        regexp_has_flag(cx, this_value, RegExpFlags::UNICODE_AWARE)
+        regexp_has_flag(cx, this_value, RegExpFlags::UNICODE_AWARE, "RegExp.prototype.unicode")
     }
 
     /// get RegExp.prototype.unicodeSets (https://tc39.es/ecma262/#sec-get-regexp.prototype.unicodesets)
@@ -883,7 +848,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        regexp_has_flag(cx, this_value, RegExpFlags::UNICODE_SETS)
+        regexp_has_flag(cx, this_value, RegExpFlags::UNICODE_SETS, "RegExp.prototype.unicodeSets")
     }
 
     /// RegExp.prototype.compile (https://tc39.es/ecma262/#sec-regexp.prototype.compile)
@@ -892,11 +857,7 @@ impl RegExpPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let regexp_object = if let Some(regexp_object) = as_regexp_object(this_value) {
-            regexp_object
-        } else {
-            return type_error(cx, "RegExp.prototype.compile must be called on a RegExp");
-        };
+        let regexp_object = this_regexp_object(cx, this_value, "RegExp.prototype.compile")?;
 
         let pattern_arg = get_argument(cx, arguments, 0);
         let flags_arg = get_argument(cx, arguments, 1);
@@ -918,11 +879,38 @@ impl RegExpPrototype {
     }
 }
 
+fn this_object(
+    cx: Context,
+    this_value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<ObjectValue>> {
+    if this_value.is_object() {
+        return Ok(this_value.as_object());
+    }
+
+    type_error(cx, &format!("{method_name} must be called on an object"))
+}
+
+fn this_regexp_object(
+    cx: Context,
+    this_value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<RegExpObject>> {
+    if this_value.is_object() {
+        if let Some(regexp_object) = this_value.as_object().as_regexp_object() {
+            return Ok(regexp_object);
+        }
+    }
+
+    type_error(cx, &format!("{method_name} must be called on a RegExp"))
+}
+
 /// RegExpHasFlag (https://tc39.es/ecma262/#sec-regexphasflag)
 fn regexp_has_flag(
     cx: Context,
     this_value: Handle<Value>,
     flag: RegExpFlags,
+    method_name: &str,
 ) -> EvalResult<Handle<Value>> {
     if this_value.is_object() {
         let this_object = this_value.as_object();
@@ -935,7 +923,7 @@ fn regexp_has_flag(
         }
     }
 
-    type_error(cx, "expected a RegExp")
+    type_error(cx, &format!("{method_name} must be called on a RegExp"))
 }
 
 pub fn flags_string_contains(
@@ -950,20 +938,21 @@ pub fn regexp_exec(
     cx: Context,
     regexp_object: Handle<ObjectValue>,
     string_value: Handle<StringValue>,
+    method_name: &str,
 ) -> EvalResult<Handle<Value>> {
     let exec = get(cx, regexp_object, cx.names.exec())?;
 
     if is_callable(exec) {
         let exec_result = call(cx, exec, regexp_object.into(), &[string_value.into()])?;
         if !exec_result.is_null() && !exec_result.is_object() {
-            return type_error(cx, "regular expression exec must return null or an object");
+            return type_error(cx, &format!("{method_name} `exec` must return null or an object"));
         }
 
         return Ok(exec_result);
     }
 
     if !regexp_object.is_regexp_object() {
-        return type_error(cx, "expected a RegExp");
+        return type_error(cx, &format!("{method_name} must be called on a RegExp"));
     }
 
     regexp_builtin_exec(cx, regexp_object.cast::<RegExpObject>(), string_value)

--- a/src/js/runtime/intrinsics/regexp_string_iterator.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator.rs
@@ -119,7 +119,8 @@ impl RegExpStringIteratorPrototype {
         }
 
         // Run the regular expression
-        let match_result = regexp_exec(cx, regexp_object, target_string)?;
+        let match_result =
+            regexp_exec(cx, regexp_object, target_string, "%RegExpStringIteratorPrototype%.next")?;
 
         // No match so return a completed iterator
         if match_result.is_null() {

--- a/src/js/runtime/intrinsics/set_constructor.rs
+++ b/src/js/runtime/intrinsics/set_constructor.rs
@@ -56,7 +56,7 @@ impl SetConstructor {
 
         let adder = get(cx, set_object, cx.names.add())?;
         if !is_callable(adder) {
-            return type_error(cx, "set must contain an add method");
+            return type_error(cx, "Set constructor result must have an `add` method");
         }
 
         let adder = adder.as_object();

--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -158,11 +158,7 @@ impl SetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.add must be called on a Set");
-        };
+        let set = this_set_value(cx, this_value, "add")?;
 
         // Convert negative zero to positive zero in set
         let value = get_argument(cx, arguments, 0);
@@ -179,11 +175,7 @@ impl SetPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.clear must be called on a Set");
-        };
+        let set = this_set_value(cx, this_value, "clear")?;
 
         set.set_data_ptr().clear();
 
@@ -196,11 +188,7 @@ impl SetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.delete must be called on a Set");
-        };
+        let set = this_set_value(cx, this_value, "delete")?;
 
         let key = get_argument(cx, arguments, 0);
 
@@ -218,14 +206,10 @@ impl SetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let this_set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.difference must be called on a Set");
-        };
+        let this_set = this_set_value(cx, this_value, "difference")?;
 
         let other = get_argument(cx, arguments, 0);
-        let other_set_record = get_set_record(cx, other)?;
+        let other_set_record = get_set_record(cx, other, "difference")?;
 
         // Create a copy of this set
         let new_set_data = ValueSet::new_from_set(cx, this_set.set_data())?.to_handle();
@@ -287,11 +271,7 @@ impl SetPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.entries must be called on a Set");
-        };
+        let set = this_set_value(cx, this_value, "entries")?;
 
         Ok(SetIterator::new(cx, set, SetIteratorKind::KeyAndValue)?.as_value())
     }
@@ -302,11 +282,7 @@ impl SetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.forEach must be called on a Set");
-        };
+        let set = this_set_value(cx, this_value, "forEach")?;
 
         let callback_function = get_argument(cx, arguments, 0);
         if !is_callable(callback_function) {
@@ -337,11 +313,7 @@ impl SetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.has must be called on a Set");
-        };
+        let set = this_set_value(cx, this_value, "has")?;
 
         let value = get_argument(cx, arguments, 0);
 
@@ -357,14 +329,10 @@ impl SetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let this_set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.intersection must be called on a Set");
-        };
+        let this_set = this_set_value(cx, this_value, "intersection")?;
 
         let other = get_argument(cx, arguments, 0);
-        let other_set_record = get_set_record(cx, other)?;
+        let other_set_record = get_set_record(cx, other, "intersection")?;
 
         // Create an empty set
         let new_set_data = SetObjectSetField::new(cx, ValueSet::MIN_CAPACITY)?.to_handle();
@@ -429,14 +397,10 @@ impl SetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let this_set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.isDisjointFrom must be called on a Set");
-        };
+        let this_set = this_set_value(cx, this_value, "isDisjointFrom")?;
 
         let other = get_argument(cx, arguments, 0);
-        let other_set_record = get_set_record(cx, other)?;
+        let other_set_record = get_set_record(cx, other, "isDisjointFrom")?;
 
         if this_set.set_data_ptr().num_entries_occupied() as f64 <= other_set_record.size {
             // If this set is smaller or equal to the other set, iterate through this set's keys and
@@ -494,14 +458,10 @@ impl SetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let this_set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.isSubsetOf must be called on a Set");
-        };
+        let this_set = this_set_value(cx, this_value, "isSubsetOf")?;
 
         let other = get_argument(cx, arguments, 0);
-        let other_set_record = get_set_record(cx, other)?;
+        let other_set_record = get_set_record(cx, other, "isSubsetOf")?;
 
         // We can return early if this set is larger than the other set
         if (this_set.set_data_ptr().num_entries_occupied() as f64) > other_set_record.size {
@@ -538,14 +498,10 @@ impl SetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let this_set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.isSupersetOf must be called on a Set");
-        };
+        let this_set = this_set_value(cx, this_value, "isSupersetOf")?;
 
         let other = get_argument(cx, arguments, 0);
-        let other_set_record = get_set_record(cx, other)?;
+        let other_set_record = get_set_record(cx, other, "isSupersetOf")?;
 
         // We can return early if this set is smaller than the other set
         if (this_set.set_data_ptr().num_entries_occupied() as f64) < other_set_record.size {
@@ -584,11 +540,7 @@ impl SetPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.size must be called on a Set");
-        };
+        let set = this_set_value(cx, this_value, "size")?;
 
         Ok(Value::from(set.set_data_ptr().num_entries_occupied()).to_handle(cx))
     }
@@ -599,14 +551,10 @@ impl SetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let this_set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.symmetricDifference must be called on a Set");
-        };
+        let this_set = this_set_value(cx, this_value, "symmetricDifference")?;
 
         let other = get_argument(cx, arguments, 0);
-        let other_set_record = get_set_record(cx, other)?;
+        let other_set_record = get_set_record(cx, other, "symmetricDifference")?;
 
         // Create a copy of this set
         let new_set_data = ValueSet::new_from_set(cx, this_set.set_data())?.to_handle();
@@ -651,14 +599,10 @@ impl SetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let this_set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.union must be called on a Set");
-        };
+        let this_set = this_set_value(cx, this_value, "union")?;
 
         let other = get_argument(cx, arguments, 0);
-        let other_set_record = get_set_record(cx, other)?;
+        let other_set_record = get_set_record(cx, other, "union")?;
 
         // Create a copy of this set
         let new_set_data = ValueSet::new_from_set(cx, this_set.set_data())?.to_handle();
@@ -689,22 +633,24 @@ impl SetPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let set = if let Some(set) = this_set_value(this_value) {
-            set
-        } else {
-            return type_error(cx, "Set.prototype.values must be called on a Set");
-        };
+        let set = this_set_value(cx, this_value, "values")?;
 
         Ok(SetIterator::new(cx, set, SetIteratorKind::Value)?.as_value())
     }
 }
 
-fn this_set_value(value: Handle<Value>) -> Option<Handle<SetObject>> {
-    if !value.is_object() {
-        return None;
+fn this_set_value(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<SetObject>> {
+    if value.is_object() {
+        if let Some(set_object) = value.as_object().as_set_object() {
+            return Ok(set_object);
+        }
     }
 
-    value.as_object().as_set_object()
+    type_error(cx, &format!("Set.prototype.{method_name} must be called on a Set"))
 }
 
 struct SetRecord {
@@ -715,9 +661,9 @@ struct SetRecord {
 }
 
 /// GetSetRecord (https://tc39.es/ecma262/#sec-getsetrecord)
-fn get_set_record(cx: Context, value: Handle<Value>) -> EvalResult<SetRecord> {
+fn get_set_record(cx: Context, value: Handle<Value>, method_name: &str) -> EvalResult<SetRecord> {
     if !value.is_object() {
-        return type_error(cx, "expected an object");
+        return type_error(cx, &format!("Set.prototype.{method_name} argument must be an object"));
     }
 
     let object = value.as_object();
@@ -725,22 +671,34 @@ fn get_set_record(cx: Context, value: Handle<Value>) -> EvalResult<SetRecord> {
     let raw_size = get(cx, object, cx.names.size())?;
     let num_size = to_number(cx, raw_size)?;
     if num_size.is_nan() {
-        return type_error(cx, "`size` property must be a number");
+        return type_error(
+            cx,
+            &format!("Set.prototype.{method_name} `size` property must be a number"),
+        );
     }
 
     let int_size = must!(to_integer_or_infinity(cx, num_size));
     if int_size < 0.0 {
-        return type_error(cx, "`size` property must not be negative");
+        return type_error(
+            cx,
+            &format!("Set.prototype.{method_name} `size` property must not be negative"),
+        );
     }
 
     let has_method = get(cx, object, cx.names.has())?;
     if !is_callable(has_method) {
-        return type_error(cx, "`has` method must be a function");
+        return type_error(
+            cx,
+            &format!("Set.prototype.{method_name} `has` method must be a function"),
+        );
     }
 
     let keys_method = get(cx, object, cx.names.keys())?;
     if !is_callable(keys_method) {
-        return type_error(cx, "`keys` method must be a function");
+        return type_error(
+            cx,
+            &format!("Set.prototype.{method_name} `keys` method must be a function"),
+        );
     }
 
     Ok(SetRecord {

--- a/src/js/runtime/intrinsics/string_constructor.rs
+++ b/src/js/runtime/intrinsics/string_constructor.rs
@@ -124,14 +124,20 @@ impl StringConstructor {
                 if !code_point.is_smi() {
                     return range_error(
                         cx,
-                        &format!("invalid code point {}", code_point.as_number()),
+                        &format!(
+                            "String.fromCodePoint invalid code point {}",
+                            code_point.as_number()
+                        ),
                     );
                 }
 
                 let code_point = code_point.as_smi();
 
                 if !(0..=0x10FFFF).contains(&code_point) {
-                    return range_error(cx, &format!("invalid code point {}", code_point));
+                    return range_error(
+                        cx,
+                        &format!("String.fromCodePoint invalid code point {}", code_point),
+                    );
                 }
 
                 code_point as CodePoint

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -366,7 +366,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "at")?;
         let string = to_string(cx, object)?;
 
         let length = string.len() as i64;
@@ -398,7 +398,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "charAt")?;
         let string = to_string(cx, object)?;
 
         let position_arg = get_argument(cx, arguments, 0);
@@ -419,7 +419,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "charCodeAt")?;
         let string = to_string(cx, object)?;
 
         let position_arg = get_argument(cx, arguments, 0);
@@ -439,7 +439,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "codePointAt")?;
         let string = to_string(cx, object)?;
 
         let position_arg = get_argument(cx, arguments, 0);
@@ -459,7 +459,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "concat")?;
         let mut concat_string = to_string(cx, object)?;
 
         for argument in arguments {
@@ -476,13 +476,13 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "endsWith")?;
         let string = to_string(cx, object)?;
         let length = string.len();
 
         let search_value = get_argument(cx, arguments, 0);
         if is_regexp(cx, search_value)? {
-            return type_error(cx, "first argument to endsWith cannot be a RegExp");
+            return type_error(cx, "String.prototype.endsWith first argument cannot be a RegExp");
         }
 
         let search_string = to_string(cx, search_value)?;
@@ -516,7 +516,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "includes")?;
         let string = to_string(cx, object)?;
 
         let search_string = get_argument(cx, arguments, 0);
@@ -544,7 +544,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "indexOf")?;
         let string = to_string(cx, object)?;
 
         let search_arg = get_argument(cx, arguments, 0);
@@ -570,7 +570,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "isWellFormed")?;
         let string = to_string(cx, object)?;
 
         Ok(cx.bool(string.is_well_formed()?))
@@ -582,7 +582,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "lastIndexOf")?;
         let string = to_string(cx, object)?;
 
         let search_arg = get_argument(cx, arguments, 0);
@@ -611,7 +611,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "localeCompare")?;
         let string = to_string(cx, object)?;
 
         let other_arg = get_argument(cx, arguments, 0);
@@ -639,7 +639,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let this_object = require_object_coercible(cx, this_value)?;
+        let this_object = this_object_coercible_value(cx, this_value, "match")?;
 
         let regexp_arg = get_argument(cx, arguments, 0);
         if regexp_arg.is_object() {
@@ -667,7 +667,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let this_object = require_object_coercible(cx, this_value)?;
+        let this_object = this_object_coercible_value(cx, this_value, "matchAll")?;
 
         let regexp_arg = get_argument(cx, arguments, 0);
         if regexp_arg.is_object() {
@@ -718,7 +718,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "normalize")?;
         let string = to_string(cx, object)?;
 
         let form_arg = get_argument(cx, arguments, 0);
@@ -769,7 +769,7 @@ impl StringPrototype {
         let max_length_arg = get_argument(cx, arguments, 0);
         let fill_string_arg = get_argument(cx, arguments, 1);
 
-        Self::pad_string(cx, this_value, max_length_arg, fill_string_arg, false)
+        Self::pad_string(cx, this_value, max_length_arg, fill_string_arg, false, "padEnd")
     }
 
     /// String.prototype.padStart (https://tc39.es/ecma262/#sec-string.prototype.padstart)
@@ -781,7 +781,7 @@ impl StringPrototype {
         let max_length_arg = get_argument(cx, arguments, 0);
         let fill_string_arg = get_argument(cx, arguments, 1);
 
-        Self::pad_string(cx, this_value, max_length_arg, fill_string_arg, true)
+        Self::pad_string(cx, this_value, max_length_arg, fill_string_arg, true, "padStart")
     }
 
     pub fn pad_string(
@@ -790,8 +790,9 @@ impl StringPrototype {
         max_length_arg: Handle<Value>,
         fill_string_arg: Handle<Value>,
         is_start: bool,
+        method_name: &str,
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, method_name)?;
         let string = to_string(cx, object)?;
 
         let int_max_length = to_length(cx, max_length_arg)?;
@@ -801,7 +802,13 @@ impl StringPrototype {
         if int_max_length <= string_length as u64 {
             return Ok(string.as_value());
         } else if int_max_length > u32::MAX as u64 {
-            return range_error(cx, "target string length exceeds maximum string size");
+            return range_error(
+                cx,
+                &format!(
+                    "String.prototype.{} target string length exceeds maximum string size",
+                    method_name
+                ),
+            );
         }
 
         let int_max_length = int_max_length as u32;
@@ -844,13 +851,16 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "repeat")?;
         let string = to_string(cx, object)?;
 
         let n_arg = get_argument(cx, arguments, 0);
         let n = to_integer_or_infinity(cx, n_arg)?;
         if n.is_sign_negative() || n.is_infinite() {
-            return range_error(cx, "count must be a finite, non-negative number");
+            return range_error(
+                cx,
+                "String.prototype.repeat count must be a finite, non-negative number",
+            );
         } else if n > MAX_U32_AS_F64 {
             return string_exceeds_max_length_error(cx);
         } else if n == 0.0 {
@@ -866,7 +876,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "replace")?;
 
         let search_arg = get_argument(cx, arguments, 0);
         let replace_arg = get_argument(cx, arguments, 1);
@@ -948,7 +958,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "replaceAll")?;
 
         let search_arg = get_argument(cx, arguments, 0);
         let replace_arg = get_argument(cx, arguments, 1);
@@ -1062,7 +1072,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "search")?;
 
         // Use the @@search method of the argument if one exists
         let regexp_arg = get_argument(cx, arguments, 0);
@@ -1092,7 +1102,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "slice")?;
         let string = to_string(cx, object)?;
         let length = string.len();
 
@@ -1138,7 +1148,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "split")?;
 
         let separator_argument = get_argument(cx, arguments, 0);
         let limit_argument = get_argument(cx, arguments, 1);
@@ -1232,13 +1242,13 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "startsWith")?;
         let string = to_string(cx, object)?;
         let length = string.len();
 
         let search_value = get_argument(cx, arguments, 0);
         if is_regexp(cx, search_value)? {
-            return type_error(cx, "first argument to startsWith cannot be a RegExp");
+            return type_error(cx, "String.prototype.startsWith first argument cannot be a RegExp");
         }
 
         let search_string = to_string(cx, search_value)?;
@@ -1279,7 +1289,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "substring")?;
         let string = to_string(cx, object)?;
         let length = string.len();
 
@@ -1308,7 +1318,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "toLowerCase")?;
         let string = to_string(cx, object)?;
 
         Ok(string.to_lower_case(cx)?.as_value())
@@ -1320,7 +1330,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        this_string_value(cx, this_value)
+        this_string_value(cx, this_value, "toString")
     }
 
     /// String.prototype.toUpperCase (https://tc39.es/ecma262/#sec-string.prototype.touppercase)
@@ -1329,7 +1339,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "toUpperCase")?;
         let string = to_string(cx, object)?;
 
         Ok(string.to_upper_case(cx)?.as_value())
@@ -1341,7 +1351,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "toWellFormed")?;
         let string = to_string(cx, object)?;
 
         Ok(string.to_well_formed(cx)?.to_handle().as_value())
@@ -1353,7 +1363,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "trim")?;
         let string = to_string(cx, object)?;
 
         Ok(string.trim(cx, true, true)?.as_value())
@@ -1365,7 +1375,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "trimEnd")?;
         let string = to_string(cx, object)?;
 
         Ok(string.trim(cx, false, true)?.as_value())
@@ -1377,7 +1387,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "trimStart")?;
         let string = to_string(cx, object)?;
 
         Ok(string.trim(cx, true, false)?.as_value())
@@ -1389,7 +1399,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "iterator")?;
         let string = to_string(cx, object)?;
 
         let flat_string = string.flatten()?;
@@ -1403,7 +1413,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let object = require_object_coercible(cx, this_value)?;
+        let object = this_object_coercible_value(cx, this_value, "substr")?;
         let string = to_string(cx, object)?;
 
         let string_length = string.len() as u32;
@@ -1446,9 +1456,10 @@ impl StringPrototype {
         mut cx: Context,
         value: Handle<Value>,
         tag: &str,
+        method_name: &str,
         attribute_and_value: Option<(&str, Handle<Value>)>,
     ) -> EvalResult<Handle<StringValue>> {
-        let object = require_object_coercible(cx, value)?;
+        let object = this_object_coercible_value(cx, value, method_name)?;
         let string = to_string(cx, object)?.to_wtf8_string()?;
 
         let mut html = Wtf8String::new();
@@ -1491,7 +1502,8 @@ impl StringPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         let name_arg = get_argument(cx, arguments, 0);
-        let html_string = Self::create_html(cx, this_value, "a", Some(("name", name_arg)))?;
+        let html_string =
+            Self::create_html(cx, this_value, "a", "anchor", Some(("name", name_arg)))?;
         Ok(html_string.as_value())
     }
 
@@ -1501,7 +1513,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let html_string = Self::create_html(cx, this_value, "big", None)?;
+        let html_string = Self::create_html(cx, this_value, "big", "big", None)?;
         Ok(html_string.as_value())
     }
 
@@ -1511,7 +1523,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let html_string = Self::create_html(cx, this_value, "blink", None)?;
+        let html_string = Self::create_html(cx, this_value, "blink", "blink", None)?;
         Ok(html_string.as_value())
     }
 
@@ -1521,7 +1533,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let html_string = Self::create_html(cx, this_value, "b", None)?;
+        let html_string = Self::create_html(cx, this_value, "b", "bold", None)?;
         Ok(html_string.as_value())
     }
 
@@ -1531,7 +1543,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let html_string = Self::create_html(cx, this_value, "tt", None)?;
+        let html_string = Self::create_html(cx, this_value, "tt", "fixed", None)?;
         Ok(html_string.as_value())
     }
 
@@ -1542,7 +1554,8 @@ impl StringPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         let color_arg = get_argument(cx, arguments, 0);
-        let html_string = Self::create_html(cx, this_value, "font", Some(("color", color_arg)))?;
+        let html_string =
+            Self::create_html(cx, this_value, "font", "fontcolor", Some(("color", color_arg)))?;
         Ok(html_string.as_value())
     }
 
@@ -1553,7 +1566,8 @@ impl StringPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         let size_arg = get_argument(cx, arguments, 0);
-        let html_string = Self::create_html(cx, this_value, "font", Some(("size", size_arg)))?;
+        let html_string =
+            Self::create_html(cx, this_value, "font", "fontsize", Some(("size", size_arg)))?;
         Ok(html_string.as_value())
     }
 
@@ -1563,7 +1577,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let html_string = Self::create_html(cx, this_value, "i", None)?;
+        let html_string = Self::create_html(cx, this_value, "i", "italics", None)?;
         Ok(html_string.as_value())
     }
 
@@ -1574,7 +1588,7 @@ impl StringPrototype {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         let url_arg = get_argument(cx, arguments, 0);
-        let html_string = Self::create_html(cx, this_value, "a", Some(("href", url_arg)))?;
+        let html_string = Self::create_html(cx, this_value, "a", "link", Some(("href", url_arg)))?;
         Ok(html_string.as_value())
     }
 
@@ -1584,7 +1598,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let html_string = Self::create_html(cx, this_value, "small", None)?;
+        let html_string = Self::create_html(cx, this_value, "small", "small", None)?;
         Ok(html_string.as_value())
     }
 
@@ -1594,7 +1608,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let html_string = Self::create_html(cx, this_value, "strike", None)?;
+        let html_string = Self::create_html(cx, this_value, "strike", "strike", None)?;
         Ok(html_string.as_value())
     }
 
@@ -1604,7 +1618,7 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let html_string = Self::create_html(cx, this_value, "sub", None)?;
+        let html_string = Self::create_html(cx, this_value, "sub", "sub", None)?;
         Ok(html_string.as_value())
     }
 
@@ -1614,12 +1628,31 @@ impl StringPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let html_string = Self::create_html(cx, this_value, "sup", None)?;
+        let html_string = Self::create_html(cx, this_value, "sup", "sup", None)?;
         Ok(html_string.as_value())
     }
 }
 
-fn this_string_value(cx: Context, value: Handle<Value>) -> EvalResult<Handle<Value>> {
+fn this_object_coercible_value(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<Value>> {
+    if value.is_nullish() {
+        return type_error(
+            cx,
+            &format!("String.prototype.{} called on null or undefined", method_name),
+        );
+    }
+
+    Ok(value)
+}
+
+fn this_string_value(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<Value>> {
     if value.is_string() {
         return Ok(value);
     }
@@ -1631,7 +1664,7 @@ fn this_string_value(cx: Context, value: Handle<Value>) -> EvalResult<Handle<Val
         }
     }
 
-    type_error(cx, "value cannot be converted to string")
+    type_error(cx, &format!("String.prototype.{} must be called on a string", method_name))
 }
 
 #[allow(clippy::upper_case_acronyms)]

--- a/src/js/runtime/intrinsics/symbol_constructor.rs
+++ b/src/js/runtime/intrinsics/symbol_constructor.rs
@@ -142,7 +142,7 @@ impl SymbolConstructor {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         if cx.current_new_target().is_some() {
-            return type_error(cx, "Symbol is not a constructor");
+            return type_error(cx, "Symbol constructor must be called with new");
         }
 
         let description_arg = get_argument(cx, arguments, 0);
@@ -184,7 +184,7 @@ impl SymbolConstructor {
     ) -> EvalResult<Handle<Value>> {
         let symbol_value = get_argument(cx, arguments, 0);
         if !symbol_value.is_symbol() {
-            return type_error(cx, "expected a Symbol");
+            return type_error(cx, "Symbol.keyFor argument must be a symbol");
         }
         let symbol_value = *symbol_value.as_symbol();
 

--- a/src/js/runtime/intrinsics/symbol_prototype.rs
+++ b/src/js/runtime/intrinsics/symbol_prototype.rs
@@ -71,7 +71,7 @@ impl SymbolPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let symbol_value = this_symbol_value(cx, this_value)?;
+        let symbol_value = this_symbol_value(cx, this_value, "description")?;
         match symbol_value.as_symbol().description() {
             None => Ok(cx.undefined()),
             Some(desc) => Ok(desc.as_value()),
@@ -84,7 +84,7 @@ impl SymbolPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let symbol_value = this_symbol_value(cx, this_value)?;
+        let symbol_value = this_symbol_value(cx, this_value, "toString")?;
         Ok(symbol_descriptive_string(cx, symbol_value.as_symbol())?.as_value())
     }
 
@@ -94,11 +94,15 @@ impl SymbolPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        this_symbol_value(cx, this_value)
+        this_symbol_value(cx, this_value, "valueOf")
     }
 }
 
-fn this_symbol_value(cx: Context, value: Handle<Value>) -> EvalResult<Handle<Value>> {
+fn this_symbol_value(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<Value>> {
     if value.is_symbol() {
         return Ok(value);
     }
@@ -110,7 +114,7 @@ fn this_symbol_value(cx: Context, value: Handle<Value>) -> EvalResult<Handle<Val
         }
     }
 
-    type_error(cx, "value cannot be converted to symbol")
+    type_error(cx, &format!("Symbol.prototype.{} must be called on a symbol", method_name))
 }
 
 /// SymbolDescriptiveString (https://tc39.es/ecma262/#sec-symboldescriptivestring)

--- a/src/js/runtime/intrinsics/typed_array.rs
+++ b/src/js/runtime/intrinsics/typed_array.rs
@@ -55,6 +55,15 @@ pub enum ContentType {
     BigInt,
 }
 
+impl ContentType {
+    pub fn format(&self) -> &'static str {
+        match self {
+            ContentType::Number => "numbers",
+            ContentType::BigInt => "BigInts",
+        }
+    }
+}
+
 /// Abstraction over typed arrays, allowing for generic access of properties.
 pub trait TypedArray {
     /// Length of the array. None represents a value of AUTO.

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -122,8 +122,12 @@ impl TypedArrayConstructor {
             let length = values.len();
 
             let length_value = Value::from(length).to_handle(cx);
-            let target_object =
-                typed_array_create_from_constructor_object(cx, this_constructor, &[length_value])?;
+            let target_object = typed_array_create_from_constructor_object(
+                cx,
+                this_constructor,
+                &[length_value],
+                "TypedArray.from",
+            )?;
 
             // Shared between iterations
             let mut index_key = PropertyKey::uninit().to_handle(cx);
@@ -150,8 +154,12 @@ impl TypedArrayConstructor {
         let length = length_of_array_like(cx, array_like)? as usize;
 
         let length_value = Value::from(length).to_handle(cx);
-        let target_object =
-            typed_array_create_from_constructor_object(cx, this_constructor, &[length_value])?;
+        let target_object = typed_array_create_from_constructor_object(
+            cx,
+            this_constructor,
+            &[length_value],
+            "TypedArray.from",
+        )?;
 
         // Shared between iterations
         let mut index_key = PropertyKey::uninit().to_handle(cx);
@@ -189,8 +197,12 @@ impl TypedArrayConstructor {
         let length = arguments.len();
         let length_value = Value::from(length).to_handle(cx);
 
-        let typed_array =
-            typed_array_create_from_constructor(cx, this_constructor, &[length_value])?;
+        let typed_array = typed_array_create_from_constructor(
+            cx,
+            this_constructor,
+            &[length_value],
+            "TypedArray.of",
+        )?;
         let object = typed_array.into_object_value();
 
         // Shared between iterations
@@ -739,7 +751,13 @@ macro_rules! create_typed_array_constructor {
 
                 let source_record = make_typed_array_with_buffer_witness_record(source_typed_array);
                 if is_typed_array_out_of_bounds(&source_record) {
-                    return type_error(cx, "typed array is out of bounds");
+                    return type_error(
+                        cx,
+                        &format!(
+                            "{} constructor source array is out of bounds",
+                            cx.names.$rust_name().format()?
+                        ),
+                    );
                 }
 
                 let source_array_length = typed_array_length(&source_record);
@@ -775,7 +793,11 @@ macro_rules! create_typed_array_constructor {
                     if source_typed_array.content_type() != $content_type {
                         return type_error(
                             cx,
-                            "typed arrays must both contain either numbers or BigInts",
+                            &format!(
+                                "{} constructor source array must contain {}",
+                                cx.names.$rust_name().format()?,
+                                $content_type.format()
+                            ),
                         );
                     }
 
@@ -826,7 +848,8 @@ macro_rules! create_typed_array_constructor {
                     return range_error(
                         cx,
                         &format!(
-                            "byte offset must be a multiple of {} but found {}",
+                            "{} constructor byte offset must be a multiple of {} but found {}",
+                            cx.names.$rust_name().format()?,
                             element_size!(),
                             offset
                         ),
@@ -841,7 +864,13 @@ macro_rules! create_typed_array_constructor {
                 }
 
                 if array_buffer.is_detached() {
-                    return type_error(cx, "cannot create typed array from detached array buffer");
+                    return type_error(
+                        cx,
+                        &format!(
+                            "{} constructor source cannot be a detached array buffer",
+                            cx.names.$rust_name().format()?,
+                        ),
+                    );
                 }
 
                 let byte_length = array_buffer.byte_length();
@@ -850,7 +879,13 @@ macro_rules! create_typed_array_constructor {
 
                 if length.is_undefined() && !buffer_is_fixed_length {
                     if offset > byte_length {
-                        return range_error(cx, "byte offset larger than array buffer length");
+                        return range_error(
+                            cx,
+                            &format!(
+                                "{} constructor byte offset must not be larger than array buffer length",
+                                cx.names.$rust_name().format()?
+                            ),
+                        );
                     }
 
                     result_new_byte_length = None;
@@ -860,7 +895,8 @@ macro_rules! create_typed_array_constructor {
                         return range_error(
                             cx,
                             &format!(
-                                "array buffer length must be a multiple of {} but found {}",
+                                "{} constructor source length must be a multiple of {} but found {}",
+                                cx.names.$rust_name().format()?,
                                 element_size!(),
                                 byte_length
                             ),
@@ -870,7 +906,13 @@ macro_rules! create_typed_array_constructor {
                     let maybe_negative_new_byte_length = byte_length as i64 - offset as i64;
 
                     if maybe_negative_new_byte_length < 0 {
-                        return range_error(cx, "byte offset larger than array buffer length");
+                        return range_error(
+                            cx,
+                            &format!(
+                                "{} constructor byte offset must not be larger than array buffer length",
+                                cx.names.$rust_name().format()?
+                            ),
+                        );
                     }
 
                     let new_byte_length = maybe_negative_new_byte_length as usize;
@@ -881,7 +923,13 @@ macro_rules! create_typed_array_constructor {
                     let new_byte_length = new_length * element_size!();
 
                     if offset + new_byte_length as usize > byte_length {
-                        return range_error(cx, "byte offset larger than array buffer length");
+                        return range_error(
+                            cx,
+                            &format!(
+                                "{} constructor byte offset must not be larger than array buffer length",
+                                cx.names.$rust_name().format()?
+                            ),
+                        );
                     }
 
                     result_new_byte_length = Some(new_byte_length);

--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -321,7 +321,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "at")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -353,7 +353,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array = require_typed_array(cx, this_value)?;
+        let typed_array = this_typed_array(cx, this_value, "buffer")?;
         Ok(typed_array.viewed_array_buffer().as_value())
     }
 
@@ -363,7 +363,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array = require_typed_array(cx, this_value)?;
+        let typed_array = this_typed_array(cx, this_value, "byteLength")?;
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
         if is_typed_array_out_of_bounds(&typed_array_record) {
@@ -381,7 +381,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array = require_typed_array(cx, this_value)?;
+        let typed_array = this_typed_array(cx, this_value, "byteOffset")?;
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
         if is_typed_array_out_of_bounds(&typed_array_record) {
@@ -397,7 +397,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "copyWithin")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -529,7 +529,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "entries")?;
         let typed_array_object = typed_array_record.typed_array.into_object_value();
 
         Ok(ArrayIterator::new(cx, typed_array_object, ArrayIteratorKind::KeyAndValue)?.as_value())
@@ -541,7 +541,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "every")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -581,7 +581,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "fill")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -624,7 +624,7 @@ impl TypedArrayPrototype {
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
         if is_typed_array_out_of_bounds(&typed_array_record) {
-            return type_error(cx, "typed array is out of bounds");
+            return type_error(cx, "TypedArray.prototype.fill typed array is out of bounds");
         }
 
         let end_index = u64::min(end_index, typed_array_length(&typed_array_record) as u64);
@@ -646,7 +646,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "filter")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -684,7 +684,8 @@ impl TypedArrayPrototype {
         // Then create a new array that contains the kept values
         let num_kept_values = kept_values.len();
         let num_kept_values_value = Value::from(num_kept_values).to_handle(cx);
-        let array = typed_array_species_create_object(cx, typed_array, &[num_kept_values_value])?;
+        let array =
+            typed_array_species_create_object(cx, typed_array, &[num_kept_values_value], "filter")?;
 
         // Shared between iterations
         let mut index_key = PropertyKey::uninit().to_handle(cx);
@@ -703,7 +704,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "find")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -731,7 +732,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "findIndex")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -759,7 +760,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "findLast")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -788,7 +789,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "findLastIndex")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -820,7 +821,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "forEach")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -857,7 +858,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "includes")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -904,7 +905,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "indexOf")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -952,7 +953,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "join")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -993,7 +994,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "keys")?;
         let typed_array_object = typed_array_record.typed_array.into_object_value();
 
         Ok(ArrayIterator::new(cx, typed_array_object, ArrayIteratorKind::Key)?.as_value())
@@ -1005,7 +1006,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "lastIndexOf")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -1061,7 +1062,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array = require_typed_array(cx, this_value)?;
+        let typed_array = this_typed_array(cx, this_value, "length")?;
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
         if is_typed_array_out_of_bounds(&typed_array_record) {
@@ -1079,7 +1080,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "map")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -1094,7 +1095,7 @@ impl TypedArrayPrototype {
         let this_arg = get_argument(cx, arguments, 1);
 
         let length_value = Value::from(length).to_handle(cx);
-        let array = typed_array_species_create_object(cx, typed_array, &[length_value])?;
+        let array = typed_array_species_create_object(cx, typed_array, &[length_value], "map")?;
 
         // Shared between iterations
         let mut index_key = PropertyKey::uninit().to_handle(cx);
@@ -1120,7 +1121,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "reduce")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -1137,7 +1138,7 @@ impl TypedArrayPrototype {
         let mut accumulator = if arguments.len() >= 2 {
             get_argument(cx, arguments, 1)
         } else if length == 0 {
-            return type_error(cx, "reduce does not have initial value");
+            return type_error(cx, "TypedArray.prototype.reduce does not have an initial value");
         } else {
             initial_index = 1;
             let first_index_key = PropertyKey::array_index_handle(cx, 0)?;
@@ -1167,7 +1168,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "reduceRight")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -1184,7 +1185,10 @@ impl TypedArrayPrototype {
         let mut accumulator = if arguments.len() >= 2 {
             get_argument(cx, arguments, 1)
         } else if length == 0 {
-            return type_error(cx, "reduceRight does not have initial value");
+            return type_error(
+                cx,
+                "TypedArray.prototype.reduceRight does not have an initial value",
+            );
         } else {
             let last_index_key = PropertyKey::from_u64_handle(cx, initial_index as u64)?;
             initial_index -= 1;
@@ -1214,7 +1218,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "reverse")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -1252,7 +1256,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "set")?;
         let typed_array = typed_array_record.typed_array;
 
         let offset_arg = get_argument(cx, arguments, 1);
@@ -1287,7 +1291,7 @@ impl TypedArrayPrototype {
 
         let target_record = make_typed_array_with_buffer_witness_record(target);
         if is_typed_array_out_of_bounds(&target_record) {
-            return type_error(cx, "typed array is out of bounds");
+            return type_error(cx, "TypedArray.prototype.set target typed array is out of bounds");
         }
         let target_length = typed_array_length(&target_record) as u64;
 
@@ -1295,7 +1299,7 @@ impl TypedArrayPrototype {
 
         let source_record = make_typed_array_with_buffer_witness_record(source);
         if is_typed_array_out_of_bounds(&source_record) {
-            return type_error(cx, "typed array is out of bounds");
+            return type_error(cx, "TypedArray.prototype.set source typed array is out of bounds");
         }
         let source_length = typed_array_length(&source_record);
 
@@ -1367,7 +1371,7 @@ impl TypedArrayPrototype {
     ) -> EvalResult<()> {
         let target_record = make_typed_array_with_buffer_witness_record(target);
         if is_typed_array_out_of_bounds(&target_record) {
-            return type_error(cx, "typed array is out of bounds");
+            return type_error(cx, "TypedArray.prototype.set target typed array is out of bounds");
         }
 
         let target_length = typed_array_length(&target_record) as u64;
@@ -1401,7 +1405,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "slice")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -1438,7 +1442,7 @@ impl TypedArrayPrototype {
 
         let count = end_index.saturating_sub(start_index);
         let count_value = Value::from(count).to_handle(cx);
-        let new_typed_array = typed_array_species_create(cx, typed_array, &[count_value])?;
+        let new_typed_array = typed_array_species_create(cx, typed_array, &[count_value], "slice")?;
         let array = new_typed_array.into_object_value();
 
         if count == 0 {
@@ -1447,7 +1451,7 @@ impl TypedArrayPrototype {
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
         if is_typed_array_out_of_bounds(&typed_array_record) {
-            return type_error(cx, "typed array is out of bounds");
+            return type_error(cx, "TypedArray.prototype.slice typed array is out of bounds");
         }
 
         let end_index = u64::min(end_index, typed_array_length(&typed_array_record) as u64);
@@ -1502,7 +1506,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "some")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -1547,7 +1551,7 @@ impl TypedArrayPrototype {
             return type_error(cx, "TypedArray.prototype.sort comparator must be a function");
         };
 
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "sort")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -1578,7 +1582,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array = require_typed_array(cx, this_value)?;
+        let typed_array = this_typed_array(cx, this_value, "subarray")?;
         let buffer = typed_array.viewed_array_buffer();
 
         let source_record = make_typed_array_with_buffer_witness_record(typed_array);
@@ -1629,6 +1633,7 @@ impl TypedArrayPrototype {
                 cx,
                 typed_array,
                 &[buffer.into(), begin_byte_offset_value],
+                "subarray",
             )?
         } else {
             let new_length_value = Value::from(new_length).to_handle(cx);
@@ -1636,6 +1641,7 @@ impl TypedArrayPrototype {
                 cx,
                 typed_array,
                 &[buffer.into(), begin_byte_offset_value, new_length_value],
+                "subarray",
             )?
         };
 
@@ -1648,7 +1654,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "toLocaleString")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -1682,13 +1688,13 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "toReversed")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let array = typed_array_create_same_type(cx, typed_array, length)?;
+        let array = typed_array_create_same_type(cx, typed_array, length, "toReversed")?;
 
         // Keys are shared between iterations
         let mut from_key = PropertyKey::uninit().to_handle(cx);
@@ -1716,13 +1722,13 @@ impl TypedArrayPrototype {
             return type_error(cx, "TypedArray.prototype.toSorted comparator must be a function");
         };
 
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "toSorted")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let sorted_array = typed_array_create_same_type(cx, typed_array, length)?;
+        let sorted_array = typed_array_create_same_type(cx, typed_array, length, "toSorted")?;
 
         let sorted_values = sort_indexed_properties::<INCLUDE_HOLES, TYPED_ARRAY>(
             cx,
@@ -1749,7 +1755,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "values")?;
         let typed_array_object = typed_array_record.typed_array.into_object_value();
 
         Ok(ArrayIterator::new(cx, typed_array_object, ArrayIteratorKind::Value)?.as_value())
@@ -1761,7 +1767,7 @@ impl TypedArrayPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let typed_array_record = validate_typed_array(cx, this_value)?;
+        let typed_array_record = this_typed_array_record(cx, this_value, "with")?;
         let typed_array = typed_array_record.typed_array;
 
         let object = typed_array.into_object_value();
@@ -1806,7 +1812,7 @@ impl TypedArrayPrototype {
         }
         let actual_index = actual_index as u64;
 
-        let array = typed_array_create_same_type(cx, typed_array, length as u64)?;
+        let array = typed_array_create_same_type(cx, typed_array, length as u64, "with")?;
 
         // Key is shared between iterations
         let mut key = PropertyKey::uninit().to_handle(cx);
@@ -1875,17 +1881,22 @@ macro_rules! create_typed_array_prototype {
 }
 
 #[inline]
-fn require_typed_array(cx: Context, value: Handle<Value>) -> EvalResult<DynTypedArray> {
-    if !value.is_object() {
-        return type_error(cx, "expected a TypedArray");
+fn this_typed_array(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<DynTypedArray> {
+    if value.is_object() {
+        let object = value.as_object();
+        if object.is_typed_array() {
+            return Ok(object.as_typed_array());
+        }
     }
 
-    let object = value.as_object();
-    if !object.is_typed_array() {
-        return type_error(cx, "expected a TypedArray");
-    }
-
-    Ok(object.as_typed_array())
+    type_error(
+        cx,
+        &format!("TypedArray.prototype.{method_name} must be called on a TypedArray"),
+    )
 }
 
 /// TypedArraySpeciesCreate (https://tc39.es/ecma262/#typedarray-species-create)
@@ -1893,8 +1904,9 @@ fn typed_array_species_create_object(
     cx: Context,
     exemplar: DynTypedArray,
     arguments: &[Handle<Value>],
+    method_name: &str,
 ) -> EvalResult<Handle<ObjectValue>> {
-    let result = typed_array_species_create(cx, exemplar, arguments)?;
+    let result = typed_array_species_create(cx, exemplar, arguments, method_name)?;
     Ok(result.into_object_value())
 }
 
@@ -1902,6 +1914,7 @@ fn typed_array_species_create(
     cx: Context,
     exemplar: DynTypedArray,
     arguments: &[Handle<Value>],
+    method_name: &str,
 ) -> EvalResult<DynTypedArray> {
     let intrinsic = match exemplar.kind() {
         TypedArrayKind::Int8Array => Intrinsic::Int8ArrayConstructor,
@@ -1920,10 +1933,18 @@ fn typed_array_species_create(
 
     let constructor = species_constructor(cx, exemplar.into_object_value(), intrinsic)?;
 
-    let result = typed_array_create_from_constructor(cx, constructor, arguments)?;
+    let result = typed_array_create_from_constructor(
+        cx,
+        constructor,
+        arguments,
+        &format!("TypedArray.prototype.{method_name}"),
+    )?;
 
     if result.content_type() != exemplar.content_type() {
-        return type_error(cx, "typed arrays must both contain either numbers or BigInts");
+        return type_error(
+            cx,
+            &format!("TypedArray.prototype.{method_name} species constructor must return a typed array that contains {}", exemplar.content_type().format()),
+        );
     }
 
     Ok(result)
@@ -1934,8 +1955,9 @@ pub fn typed_array_create_from_constructor_object(
     cx: Context,
     constructor: Handle<ObjectValue>,
     arguments: &[Handle<Value>],
+    full_method_name: &str,
 ) -> EvalResult<Handle<ObjectValue>> {
-    let result = typed_array_create_from_constructor(cx, constructor, arguments)?;
+    let result = typed_array_create_from_constructor(cx, constructor, arguments, full_method_name)?;
     Ok(result.into_object_value())
 }
 
@@ -1943,20 +1965,28 @@ pub fn typed_array_create_from_constructor(
     cx: Context,
     constructor: Handle<ObjectValue>,
     arguments: &[Handle<Value>],
+    full_method_name: &str,
 ) -> EvalResult<DynTypedArray> {
     let new_typed_array = construct(cx, constructor, arguments, None)?;
 
-    let new_typed_array_record = validate_typed_array(cx, new_typed_array.into())?;
+    let new_typed_array_record = species_constructor_result_typed_array_record(
+        cx,
+        new_typed_array.into(),
+        full_method_name,
+    )?;
 
     if arguments.len() == 1 && arguments[0].is_number() {
         if is_typed_array_out_of_bounds(&new_typed_array_record) {
-            return type_error(cx, "typed array is out of bounds");
+            return type_error(cx, &format!("{full_method_name} species constructor returned a typed array that is out of bounds"));
         }
 
         let new_typed_array_length = typed_array_length(&new_typed_array_record);
 
         if (new_typed_array_length as f64) < arguments[0].as_number() {
-            return type_error(cx, "typed array does not have expected length");
+            return type_error(
+                cx,
+                &format!("{full_method_name} species constructor returned a typed array that does not have the expected length"),
+            );
         }
     }
 
@@ -1968,6 +1998,7 @@ fn typed_array_create_same_type(
     cx: Context,
     exemplar: DynTypedArray,
     length: u64,
+    method_name: &str,
 ) -> EvalResult<Handle<ObjectValue>> {
     let constructor_instrinsic = match exemplar.kind() {
         TypedArrayKind::Int8Array => Intrinsic::Int8ArrayConstructor,
@@ -1987,20 +2018,56 @@ fn typed_array_create_same_type(
     let constructor = cx.get_intrinsic(constructor_instrinsic);
     let length_value = Value::from(length).to_handle(cx);
 
-    typed_array_create_from_constructor_object(cx, constructor, &[length_value])
+    typed_array_create_from_constructor_object(
+        cx,
+        constructor,
+        &[length_value],
+        &format!("TypedArray.prototype.{method_name}"),
+    )
 }
 
 /// ValidateTypedArray (https://tc39.es/ecma262/#sec-validatetypedarray)
 #[inline]
-fn validate_typed_array(
+fn this_typed_array_record(
     cx: Context,
     value: Handle<Value>,
+    method_name: &str,
 ) -> EvalResult<TypedArrayWithBufferWitnessRecord> {
-    let typed_array = require_typed_array(cx, value)?;
+    let typed_array = this_typed_array(cx, value, method_name)?;
     let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
 
     if is_typed_array_out_of_bounds(&typed_array_record) {
-        return type_error(cx, "typed array is out of bounds");
+        return type_error(
+            cx,
+            &format!("TypedArray.prototype.{method_name} typed array is out of bounds"),
+        );
+    }
+
+    Ok(typed_array_record)
+}
+
+fn species_constructor_result_typed_array_record(
+    cx: Context,
+    value: Handle<Value>,
+    full_method_name: &str,
+) -> EvalResult<TypedArrayWithBufferWitnessRecord> {
+    if !value.is_object() || !value.as_object().is_typed_array() {
+        return type_error(
+            cx,
+            &format!("{full_method_name} species constructor must return a typed array"),
+        );
+    }
+
+    let typed_array = value.as_object().as_typed_array();
+    let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
+
+    if is_typed_array_out_of_bounds(&typed_array_record) {
+        return type_error(
+            cx,
+            &format!(
+                "{full_method_name} species constructor returned a typed array that is out of bounds"
+            ),
+        );
     }
 
     Ok(typed_array_record)

--- a/src/js/runtime/intrinsics/weak_map_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_map_constructor.rs
@@ -61,7 +61,7 @@ impl WeakMapConstructor {
 
         let adder = get(cx, weak_map.into(), cx.names.set_())?;
         if !is_callable(adder) {
-            return type_error(cx, "WeakMap adder must be a function");
+            return type_error(cx, "WeakMap constructor result must have a `set` method");
         }
 
         add_entries_from_iterable(cx, weak_map.into(), iterable, |cx, key, value| {

--- a/src/js/runtime/intrinsics/weak_map_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_map_prototype.rs
@@ -62,11 +62,7 @@ impl WeakMapPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let weak_map_object = if let Some(weak_map_object) = this_weak_map_value(this_value) {
-            weak_map_object
-        } else {
-            return type_error(cx, "WeakMap.prototype.delete must be called on a WeakMap");
-        };
+        let weak_map_object = this_weak_map_object(cx, this_value, "delete")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value map
         let value = get_argument(cx, arguments, 0);
@@ -85,11 +81,7 @@ impl WeakMapPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let weak_map_object = if let Some(weak_map_object) = this_weak_map_value(this_value) {
-            weak_map_object
-        } else {
-            return type_error(cx, "WeakMap.prototype.get must be called on a WeakMap");
-        };
+        let weak_map_object = this_weak_map_object(cx, this_value, "get")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value map
         let key = get_argument(cx, arguments, 0);
@@ -112,11 +104,7 @@ impl WeakMapPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let weak_map_object = if let Some(weak_map_object) = this_weak_map_value(this_value) {
-            weak_map_object
-        } else {
-            return type_error(cx, "WeakMap.prototype.has must be called on a WeakMap");
-        };
+        let weak_map_object = this_weak_map_object(cx, this_value, "has")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value map
         let key = get_argument(cx, arguments, 0);
@@ -135,17 +123,13 @@ impl WeakMapPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let weak_map_object = if let Some(weak_map_object) = this_weak_map_value(this_value) {
-            weak_map_object
-        } else {
-            return type_error(cx, "WeakMap.prototype.set must be called on a WeakMap");
-        };
+        let weak_map_object = this_weak_map_object(cx, this_value, "set")?;
 
         let key = get_argument(cx, arguments, 0);
         let value = get_argument(cx, arguments, 1);
 
         if !can_be_held_weakly(cx, *key) {
-            return type_error(cx, "WeakMap keys must be objects or symbols");
+            return type_error(cx, "WeakMap.prototype.set key must be an object or symbol");
         }
 
         weak_map_object.insert(cx, key, value)?;
@@ -154,10 +138,16 @@ impl WeakMapPrototype {
     }
 }
 
-fn this_weak_map_value(value: Handle<Value>) -> Option<Handle<WeakMapObject>> {
-    if !value.is_object() {
-        return None;
+fn this_weak_map_object(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<WeakMapObject>> {
+    if value.is_object() {
+        if let Some(weak_map_object) = value.as_object().as_weak_map_object() {
+            return Ok(weak_map_object);
+        }
     }
 
-    value.as_object().as_weak_map_object()
+    type_error(cx, &format!("WeakMap.prototype.{method_name} must be called on a WeakMap"))
 }

--- a/src/js/runtime/intrinsics/weak_ref_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_ref_constructor.rs
@@ -104,7 +104,10 @@ impl WeakRefConstructor {
 
         let target_value = get_argument(cx, arguments, 0);
         if !can_be_held_weakly(cx, *target_value) {
-            return type_error(cx, "WeakRef only holds objects and symbols");
+            return type_error(
+                cx,
+                "WeakRef constructor argument must be an object or an unregistered symbol",
+            );
         }
 
         Ok(WeakRefObject::new_from_constructor(cx, new_target, target_value)?.as_value())

--- a/src/js/runtime/intrinsics/weak_set_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_set_constructor.rs
@@ -59,7 +59,7 @@ impl WeakSetConstructor {
 
         let adder = get(cx, weak_set.into(), cx.names.add())?;
         if !is_callable(adder) {
-            return type_error(cx, "WeakSet adder must be a function");
+            return type_error(cx, "WeakSet constructor result must have an `add` method");
         }
 
         let iterator = get_iterator(cx, iterable, IteratorHint::Sync, None)?;

--- a/src/js/runtime/intrinsics/weak_set_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_set_prototype.rs
@@ -55,15 +55,14 @@ impl WeakSetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let weak_set_object = if let Some(weak_set_object) = this_weak_set_value(this_value) {
-            weak_set_object
-        } else {
-            return type_error(cx, "WeakSet.prototype.add must be called on a WeakSet");
-        };
+        let weak_set_object = this_weak_set_value(cx, this_value, "add")?;
 
         let value = get_argument(cx, arguments, 0);
         if !can_be_held_weakly(cx, *value) {
-            return type_error(cx, "WeakSet only holds objects and symbols");
+            return type_error(
+                cx,
+                "WeakSet.prototype.add argument must be an object or an unregistered symbol",
+            );
         }
 
         weak_set_object.insert(cx, value)?;
@@ -77,11 +76,7 @@ impl WeakSetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let weak_set_object = if let Some(weak_set_object) = this_weak_set_value(this_value) {
-            weak_set_object
-        } else {
-            return type_error(cx, "WeakSet.prototype.delete must be called on a WeakSet");
-        };
+        let weak_set_object = this_weak_set_value(cx, this_value, "delete")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value set
         let value = get_argument(cx, arguments, 0);
@@ -100,11 +95,7 @@ impl WeakSetPrototype {
         this_value: Handle<Value>,
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let weak_set_object = if let Some(weak_set_object) = this_weak_set_value(this_value) {
-            weak_set_object
-        } else {
-            return type_error(cx, "WeakSet.prototype.has must be called on a WeakSet");
-        };
+        let weak_set_object = this_weak_set_value(cx, this_value, "has")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value set
         let value = get_argument(cx, arguments, 0);
@@ -118,10 +109,16 @@ impl WeakSetPrototype {
     }
 }
 
-fn this_weak_set_value(value: Handle<Value>) -> Option<Handle<WeakSetObject>> {
-    if !value.is_object() {
-        return None;
+fn this_weak_set_value(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Handle<WeakSetObject>> {
+    if value.is_object() {
+        if let Some(weak_set_object) = value.as_object().as_weak_set_object() {
+            return Ok(weak_set_object);
+        }
     }
 
-    value.as_object().as_weak_set_object()
+    type_error(cx, &format!("WeakSet.prototype.{} must be called on a WeakSet", method_name))
 }

--- a/tests/snapshot/error/source_locations/statement/for_await/async_iterator_close_finish_module.exp
+++ b/tests/snapshot/error/source_locations/statement/for_await/async_iterator_close_finish_module.exp
@@ -1,4 +1,4 @@
-TypeError: return method must return an object
+TypeError: AsyncFromSyncIterator.prototype.return method must return an object
    ┌ source_locations/statement/for_await/async_iterator_close_finish_module.js:15:20
    |
 15 |   for await (var x of iterable) {

--- a/tests/snapshot/error/stack_trace/use_nearest_location.exp
+++ b/tests/snapshot/error/stack_trace/use_nearest_location.exp
@@ -1,4 +1,4 @@
-TypeError: generator is already executing
+TypeError: %IteratorHelperPrototype%.next generator is already executing
   ┌ stack_trace/use_nearest_location.js:3:20
   |
 3 | var i = { next() { ii.next() } };


### PR DESCRIPTION
## Summary

All methods in the runtime now prefix their own errors with the full method name.

- When helper methods are used pass the method name into the helper method.
- Standardize this refinement helpers into `this_<type>` methods shared between methods

## Tests

- CI