### PR TITLE
[runtime] Avoid unbounded Vec::with_capacity calls

### DIFF
--- a/src/js/runtime/abstract_operations.rs
+++ b/src/js/runtime/abstract_operations.rs
@@ -4,6 +4,7 @@ use crate::{
     must, must_a,
     runtime::{
         alloc_error::AllocResult,
+        error::range_error,
         iterator::iter_iterator_values,
         numeric_constants::MAX_SAFE_INTEGER_U64,
         type_utilities::{same_value_zero, to_property_key},
@@ -302,10 +303,15 @@ pub fn length_of_array_like(cx: Context, object: Handle<ObjectValue>) -> EvalRes
     to_length(cx, length_value)
 }
 
+/// Cap number of elements that can be created from an array-like object so that we don't allocate
+/// too large of a rust vec.
+const MAX_ARRAY_LIKE_LENGTH: usize = 2 << 16;
+
 /// CreateListFromArrayLike (https://tc39.es/ecma262/#sec-createlistfromarraylike)
-pub fn create_list_from_array_like(
+pub fn create_list_from_array_like_arguments(
     cx: Context,
     object: Handle<Value>,
+    method_name: &str,
 ) -> EvalResult<Vec<Handle<Value>>> {
     if !object.is_object() {
         return type_error(cx, "expected an object");
@@ -313,6 +319,10 @@ pub fn create_list_from_array_like(
 
     let object = object.as_object();
     let length = length_of_array_like(cx, object)?;
+
+    if length > MAX_ARRAY_LIKE_LENGTH as u64 {
+        return range_error(cx, &format!("{} arguments list is too large", method_name));
+    }
 
     let mut vec = Vec::with_capacity(length as usize);
 

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -2,7 +2,8 @@ use crate::{
     must,
     runtime::{
         abstract_operations::{
-            call_object, create_list_from_array_like, has_own_property, ordinary_has_instance,
+            call_object, create_list_from_array_like_arguments, has_own_property,
+            ordinary_has_instance,
         },
         alloc_error::AllocResult,
         bound_function_object::BoundFunctionObject,
@@ -134,7 +135,8 @@ impl FunctionPrototype {
         if arg_array.is_nullish() {
             call_object(cx, this_function, this_arg, &[])
         } else {
-            let arg_list = create_list_from_array_like(cx, arg_array)?;
+            let arg_list =
+                create_list_from_array_like_arguments(cx, arg_array, "Function.prototype.apply")?;
             call_object(cx, this_function, this_arg, &arg_list)
         }
     }

--- a/src/js/runtime/intrinsics/reflect_object.rs
+++ b/src/js/runtime/intrinsics/reflect_object.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    abstract_operations::{call_object, construct, create_list_from_array_like},
+    abstract_operations::{call_object, construct, create_list_from_array_like_arguments},
     alloc_error::AllocResult,
     array_object::create_array_from_list,
     error::type_error,
@@ -123,7 +123,8 @@ impl ReflectObject {
 
         let this_argument = get_argument(cx, arguments, 1);
         let arguments_arg = get_argument(cx, arguments, 2);
-        let arguments_list = create_list_from_array_like(cx, arguments_arg)?;
+        let arguments_list =
+            create_list_from_array_like_arguments(cx, arguments_arg, "Reflect.apply")?;
 
         call_object(cx, target.as_object(), this_argument, &arguments_list)
     }
@@ -153,7 +154,8 @@ impl ReflectObject {
         };
 
         let arguments_arg = get_argument(cx, arguments, 1);
-        let arguments_list = create_list_from_array_like(cx, arguments_arg)?;
+        let arguments_list =
+            create_list_from_array_like_arguments(cx, arguments_arg, "Reflect.construct")?;
 
         Ok(construct(cx, target, &arguments_list, Some(new_target))?.as_value())
     }

--- a/src/js/runtime/proxy_object.rs
+++ b/src/js/runtime/proxy_object.rs
@@ -1,6 +1,10 @@
 use std::{collections::HashSet, mem::size_of};
 
-use crate::{extend_object, must, runtime::alloc_error::AllocResult, set_uninit};
+use crate::{
+    extend_object, must,
+    runtime::{alloc_error::AllocResult, error::range_error},
+    set_uninit,
+};
 
 use super::{
     abstract_operations::{
@@ -460,6 +464,13 @@ impl VirtualObject for Handle<ProxyObject> {
 
         let trap_result_object = trap_result.as_object();
         let length = length_of_array_like(cx, trap_result_object)?;
+
+        // Cap own keys length so that we don't allocate too large of a rust vec
+        const MAX_OWN_KEYS: usize = 1 << 20;
+
+        if length as usize >= MAX_OWN_KEYS {
+            return range_error(cx, "proxy `ownKeys` result exceeds maximum allowed length");
+        }
 
         let mut trap_result_keys = Vec::with_capacity(length as usize);
         let mut unchecked_result_keys = HashSet::new();

--- a/tests/integration/regression/000017.js
+++ b/tests/integration/regression/000017.js
@@ -1,0 +1,10 @@
+/*---
+description: Array-like objects could cause native allocations to OOM, now throw RangeErrors.
+---*/
+
+const arrayLike = { length: 1e100 };
+
+assert.throws(RangeError, () => Function.prototype.apply(() => {}, arrayLike));
+assert.throws(RangeError, () => Reflect.apply(() => {}, undefined, arrayLike));
+assert.throws(RangeError, () => Reflect.construct(Object, arrayLike));
+assert.throws(RangeError, () => Reflect.ownKeys(new Proxy({}, { ownKeys: () => arrayLike })));


### PR DESCRIPTION
## Summary

There are two places where user-provided values can be used directly in `Vec::with_capacity` leading to native OOMs. Cap the vectors capacity in both of these places (array-like arguments lists and proxy own keys lists) throwing a `RangeError` if the cap is exceeded.

Caught by the fuzzer.

## Tests

- Added regression test for all runtime method calls that previously crashes due to this issue