### PR TITLE
[parser] Fix crashes caused by missing EOF checks in literals and private identifiers

### DIFF
--- a/src/js/parser/lexer.rs
+++ b/src/js/parser/lexer.rs
@@ -1067,6 +1067,11 @@ impl<'a> Lexer<'a> {
 
                         self.eat('\n');
                     }
+                    // EOF directly after backslash
+                    EOF_CHAR => {
+                        let loc = self.mark_loc(self.pos);
+                        return self.error(loc, ParseError::UnterminatedStringLiteral);
+                    }
                     // Non-escape character, use character directly
                     other => {
                         if is_ascii(other) {
@@ -1383,6 +1388,11 @@ impl<'a> Lexer<'a> {
 
                         self.eat('\n');
                     }
+                    // EOF directly after backslash
+                    EOF_CHAR => {
+                        let loc = self.mark_loc(self.pos);
+                        return self.error(loc, ParseError::UnterminatedTemplateLiteral);
+                    }
                     // Non-escape character, use character directly
                     other => {
                         if is_ascii(other) {
@@ -1432,6 +1442,10 @@ impl<'a> Lexer<'a> {
                     value.push_char('\n');
 
                     self.eat('\n');
+                }
+                EOF_CHAR => {
+                    let loc = self.mark_loc(self.pos);
+                    return self.error(loc, ParseError::UnterminatedTemplateLiteral);
                 }
                 _ => value.push(self.lex_ascii_or_unicode_character()?),
             })
@@ -1684,7 +1698,7 @@ impl<'a> Lexer<'a> {
         // Must start with an identifier start code point. Fast path for ASCII-only identifiers.
         let (token, loc) = if is_id_start_ascii(self.current) {
             self.lex_identifier_ascii(start_pos)?
-        } else {
+        } else if self.current != EOF_CHAR {
             // Otherwise starts with either a unicode code point or an escape sequence
             let start_code_point = if self.current == '\\' as u32 {
                 self.lex_identifier_unicode_escape_sequence()?
@@ -1702,6 +1716,10 @@ impl<'a> Lexer<'a> {
                 let loc = self.mark_loc(start_pos);
                 return self.error(loc, ParseError::HashNotFollowedByIdentifier);
             }
+        } else {
+            // Hash followed by EOF
+            let loc = self.mark_loc(start_pos);
+            return self.error(loc, ParseError::HashNotFollowedByIdentifier);
         };
 
         let Token::Identifier(id) = token else {

--- a/tests/integration/language/expression/private_identifier.js/syntax_errors.js
+++ b/tests/integration/language/expression/private_identifier.js/syntax_errors.js
@@ -1,0 +1,5 @@
+/*---
+description: Syntax error for private identifiers.
+---*/
+
+assert.throws(SyntaxError, () => eval('#'));

--- a/tests/integration/language/expression/string/unterminated_string_literal.js
+++ b/tests/integration/language/expression/string/unterminated_string_literal.js
@@ -1,0 +1,18 @@
+/*---
+description: Syntax error for unterminated string literals.
+---*/
+
+// Fast paths
+assert.throws(SyntaxError, () => eval('"'));
+assert.throws(SyntaxError, () => eval("'"));
+assert.throws(SyntaxError, () => eval('"a'));
+assert.throws(SyntaxError, () => eval('"a\n"'));
+
+// Backslash followed directly by EOF
+assert.throws(SyntaxError, () => eval('"\\'));
+
+// Slow paths
+assert.throws(SyntaxError, () => eval('"a\\a'));
+assert.throws(SyntaxError, () => eval('"a\\a\n"'));
+assert.throws(SyntaxError, () => eval('"a\\a\\'));
+

--- a/tests/integration/language/expression/template/unterminated_template_literal.js
+++ b/tests/integration/language/expression/template/unterminated_template_literal.js
@@ -7,3 +7,9 @@ assert.throws(SyntaxError, () => eval('`$'));
 assert.throws(SyntaxError, () => eval('`${'));
 assert.throws(SyntaxError, () => eval('`${1'));
 assert.throws(SyntaxError, () => eval('`${1}'));
+
+// Backslash followed directly by EOF
+assert.throws(SyntaxError, () => eval('`a\\'));
+
+// Slow path
+assert.throws(SyntaxError, () => eval('`a\\a'));


### PR DESCRIPTION
## Summary

Fix places in the lexer where we were failing to check for EOF leading to downstream crashes. This was occurring in string and template literal escape sequences, the template literal slow path, and after the hash code point in a private identifier.

Initial case found by fuzzer, others found by audit.

## Tests

- Added integration tests for all the new syntax errors, including some similar missing ones for unterminated literals