### PR TITLE
[runtime] Handle resized ArrayBuffer during ArrayBuffer.prototype.slice

### DIFF
--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -277,12 +277,19 @@ impl ArrayBufferPrototype {
         // Original array buffer may have become detached during previous calls
         throw_if_detached(cx, *array_buffer)?;
 
-        // Copy data from original array buffer to new array buffer
-        unsafe {
-            let source = array_buffer.data().as_ptr().add(start_index as usize);
-            let target = new_array_buffer.data().as_mut_ptr();
+        // Original array buffer may have become resized during previous calls. Make sure to adjust
+        // copied length accordingly.
+        let current_length = array_buffer.byte_length() as u64;
+        if start_index < current_length {
+            let copied_length = u64::min(new_length, current_length - start_index);
 
-            std::ptr::copy_nonoverlapping(source, target, new_length as usize)
+            // Copy data from original array buffer to new array buffer
+            unsafe {
+                let source = array_buffer.data().as_ptr().add(start_index as usize);
+                let target = new_array_buffer.data().as_mut_ptr();
+
+                std::ptr::copy_nonoverlapping(source, target, copied_length as usize);
+            }
         }
 
         Ok(new_array_buffer.as_value())

--- a/tests/integration/regression/000018.js
+++ b/tests/integration/regression/000018.js
@@ -1,0 +1,26 @@
+/*---
+description: ArrayBuffer.prototype.slice clamps copying after resizeable buffer shrinks.
+---*/
+
+const buffer = new ArrayBuffer(8, { maxByteLength: 8 });
+const bytes = new Uint8Array(buffer);
+
+for (let i = 0; i < bytes.length; i++) {
+  bytes[i] = i + 1;
+}
+
+const start = {
+  valueOf() {
+    buffer.resize(2);
+    return 4;
+  },
+};
+
+const sliced = buffer.slice(start);
+const slicedBytes = new Uint8Array(sliced);
+
+assert.sameValue(sliced.byteLength, 4);
+assert.sameValue(slicedBytes[0], 0);
+assert.sameValue(slicedBytes[1], 0);
+assert.sameValue(slicedBytes[2], 0);
+assert.sameValue(slicedBytes[3], 0);


### PR DESCRIPTION
## Summary

Handle missing spec behavior for resized `ArrayBuffer` during `ArrayBuffer.prototype.slice`. We must check the new length and cap the copied bytes.

## Tests

- Added regression test for this case - previously failed at `assert.sameValue(slicedBytes[0], 0)`