### PR TITLE
[bytecode] Fix decoding of extra wide exception handler entries

### DIFF
--- a/src/js/runtime/bytecode/exception_handlers.rs
+++ b/src/js/runtime/bytecode/exception_handlers.rs
@@ -207,7 +207,7 @@ impl Iterator for ExceptionHandlersIterator {
             let entry_size = match self.width {
                 WidthEnum::Narrow => 1,
                 WidthEnum::Wide => 2,
-                WidthEnum::ExtraWide => 4,
+                WidthEnum::ExtraWide => 8,
             };
             self.current = unsafe { self.current.add(entry_size * 4) };
 

--- a/tests/integration/regression/000019.js
+++ b/tests/integration/regression/000019.js
@@ -1,0 +1,13 @@
+/*---
+description: >
+  Extra wide exception handler entries (bytecode size > 2^16). Previously were decoded incorrectly
+  and could cause crashes.
+---*/
+
+let program = 'let result = 0;\n';
+for (let i = 0; i < (2 << 11); i++) {
+  program += `try { const x${i} = ${i}; } catch (e) {}\n`;
+}
+program += 'throw new Test262Error();';
+
+assert.throws(Test262Error, () => eval(program));


### PR DESCRIPTION
## Summary

Extra-wide exception handler entries are used once the bytecode size exceeds 2^16 bytes. These are meant to be 8 bytes wide but during decoding were treated as 4 bytes, leading to downstream crashes.

## Tests

- Added regression test that previously crashed due to this bug. Generates a large enough program that uses exception handlers to trigger the bug.