### PR TITLE
[regexp] Fix overflow in lookbehind at start of two byte string

### DIFF
--- a/src/js/parser/lexer_stream.rs
+++ b/src/js/parser/lexer_stream.rs
@@ -709,19 +709,6 @@ impl LexerStream for HeapTwoByteCodePointLexerStream<'_> {
         } else {
             self.advance_backwards_n(1);
         }
-
-        let prev_code_unit = self.buf[self.pos - 1];
-        if is_low_surrogate_code_unit(prev_code_unit) && self.pos >= 2 {
-            let prev_prev_code_unit = self.buf[self.pos - 2];
-            if is_high_surrogate_code_unit(prev_prev_code_unit) {
-                self.pos -= 2;
-                self.current = code_point_from_surrogate_pair(prev_prev_code_unit, prev_code_unit);
-                return;
-            }
-        }
-
-        self.pos -= 1;
-        self.current = prev_code_unit as u32;
     }
 
     #[inline]

--- a/tests/integration/regression/000020.js
+++ b/tests/integration/regression/000020.js
@@ -1,0 +1,5 @@
+/*---
+description: Lookbehind at the start of a two-byte string does not overflow.
+---*/
+
+assert(/(?<=a)b/u.test("abc😀"));


### PR DESCRIPTION
## Summary

Lookbehind at the very start of a two byte string was causing integer overflow. The code this was coming from was actually unncessary - the previous calls to `advance_backwards_n` safely handle string bounds while setting the current code point and position.

## Tests

- Added regression test for this case, previously crashed in debug mode