### PR TITLE
[bytecode] Support loads/stores of this in derived constructors using dynamic lookups

### DIFF
--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -93,6 +93,8 @@ struct FunctionStackEntry {
     is_derived_constructor: bool,
     is_static_initializer: bool,
     is_class_field_initializer: bool,
+    /// Whether this function represents the top level of an eval script.
+    is_eval_toplevel: bool,
 }
 
 enum AllowSuperStackEntry {
@@ -1051,6 +1053,7 @@ impl<'a> Analyzer<'a> {
             is_derived_constructor,
             is_static_initializer,
             is_class_field_initializer: false,
+            is_eval_toplevel: false,
         });
 
         // Return is not allowed in static initializers, but is allowed in all other functions
@@ -1445,6 +1448,7 @@ impl<'a> Analyzer<'a> {
             is_derived_constructor: false,
             is_static_initializer: false,
             is_class_field_initializer: true,
+            is_eval_toplevel: false,
         });
 
         visit_opt!(self, prop.value, visit_outer_expression);
@@ -1659,11 +1663,26 @@ impl<'a> Analyzer<'a> {
         let (def_scope, is_capture) = self.scope_tree.resolve_use(current_scope, &THIS_NAME, loc);
 
         // Only set scope if this is a capture of a `this` binding or if `this` is for a derived
-        // constructor.
+        // constructor. Otherwise `this` does not need to resolve to a materialized binding.
+        let enclosing_non_arrow_function = self.enclosing_non_arrow_function();
         let is_derived_constructor_this = matches!(
-            self.enclosing_non_arrow_function(),
+            enclosing_non_arrow_function,
             Some(FunctionStackEntry { is_derived_constructor: true, .. })
         );
+
+        if is_derived_constructor_this {
+            let scope = def_scope.unwrap_resolved();
+            let binding = scope.get_binding(&THIS_NAME);
+            let implicit_this = binding.kind().as_implicit_this().unwrap();
+
+            implicit_this.set_in_derived_constructor(true);
+
+            let is_eval_toplevel = matches!(
+                enclosing_non_arrow_function,
+                Some(FunctionStackEntry { is_eval_toplevel: true, .. })
+            );
+            implicit_this.set_in_derived_constructor_eval_toplevel(is_eval_toplevel);
+        }
 
         if is_capture || is_derived_constructor_this {
             set_scope(AstPtr::from_ref(def_scope.unwrap_resolved()));
@@ -1725,6 +1744,7 @@ pub fn analyze_for_eval<'a>(
     // If in function add a synthetic function entry
     if in_function {
         analyzer.function_stack.push(FunctionStackEntry {
+            is_eval_toplevel: true,
             is_arrow_function: false,
             is_method: in_method,
             is_static: in_static,

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -868,7 +868,6 @@ impl<'a> Parser<'a> {
         // Function scope node must contain the params and body, but not function name.
         let scope = self.enter_function_scope(
             start_pos, /* is_arrow */ false, /* is_expression */ !is_decl,
-            /* is_derived_constructor */ false,
         )?;
 
         // Named function expressions bind name within function scope
@@ -914,7 +913,6 @@ impl<'a> Parser<'a> {
         start_pos: Pos,
         is_arrow: bool,
         is_expression: bool,
-        is_derived_constructor: bool,
     ) -> ParseResult<AstPtr<AstScopeNode<'a>>> {
         let scope = self.scope_builder.enter_scope(ScopeNodeKind::Function {
             id: start_pos,
@@ -925,7 +923,7 @@ impl<'a> Parser<'a> {
         // All non-arrow functions have a `this`, which should be treated as a var-scoped binding
         // when determining if it is captured by an arrow function.
         if !is_arrow {
-            let kind = BindingKind::ImplicitThis { in_derived_constructor: is_derived_constructor };
+            let kind = BindingKind::new_implicit_this();
             self.scope_builder.add_binding(&THIS_NAME, kind).unwrap();
         }
 
@@ -1739,7 +1737,6 @@ impl<'a> Parser<'a> {
         // Function scope node must contain params and body
         let scope = self.enter_function_scope(
             start_pos, /* is_arrow */ true, /* is_expression */ false,
-            /* is_derived_constructor */ false,
         )?;
 
         let is_async = self.token == Token::Async;
@@ -3475,14 +3472,10 @@ impl<'a> Parser<'a> {
 
         match self.token {
             Token::LeftParen => {
-                let is_derived_constructor = if in_class_with_super
+                let is_derived_constructor = in_class_with_super
                     && !property_name.is_computed
                     && !property_name.is_private
-                {
-                    Self::is_constructor_key(&property_name.key)
-                } else {
-                    false
-                };
+                    && Self::is_constructor_key(&property_name.key);
 
                 self.parse_method_property(
                     property_name.key,
@@ -3686,10 +3679,7 @@ impl<'a> Parser<'a> {
 
         // Function scope node must contain params and body
         let scope = self.enter_function_scope(
-            start_pos,
-            /* is_arrow */ false,
-            /* is_expression */ false,
-            is_derived_constructor,
+            start_pos, /* is_arrow */ false, /* is_expression */ false,
         )?;
 
         // Derived constructors add self as a fake binding, since they will need to be looked up
@@ -4030,7 +4020,6 @@ impl<'a> Parser<'a> {
 
         let init_scope = self.enter_function_scope(
             start_pos, /* is_arrow */ false, /* is_expression */ false,
-            /* is_derived_constructor */ false,
         )?;
         *scope = Some(init_scope);
 

--- a/src/js/parser/scope_tree.rs
+++ b/src/js/parser/scope_tree.rs
@@ -50,7 +50,7 @@ impl<'a> ScopeTree<'a> {
 
         // All root scopes start with an implicit `this` binding
         scope_tree
-            .add_binding(&THIS_NAME, BindingKind::ImplicitThis { in_derived_constructor: false })
+            .add_binding(&THIS_NAME, BindingKind::new_implicit_this())
             .unwrap();
 
         scope_tree
@@ -1037,10 +1037,7 @@ pub enum BindingKind<'a> {
         is_namespace: bool,
     },
     /// An implicit `this` binding introduced in a function or root scope.
-    ImplicitThis {
-        /// Whether this is the `this` value for a derived constructor.
-        in_derived_constructor: bool,
-    },
+    ImplicitThis(ImplicitThisBinding),
     /// An implicit `arguments` binding introduced in a function. Note that any var or var function
     /// is treated as an "explicit" `arguments` binding and will require an arguments object.
     ImplicitArguments,
@@ -1060,6 +1057,10 @@ pub enum BindingKind<'a> {
 impl<'a> BindingKind<'a> {
     pub fn new_function_parameter(index: u32) -> BindingKind<'a> {
         BindingKind::FunctionParameter { init_pos: Cell::new(0), index }
+    }
+
+    pub fn new_implicit_this() -> BindingKind<'a> {
+        BindingKind::ImplicitThis(ImplicitThisBinding::new())
     }
 
     /// Whether this is a LexicallyScopedDeclaration from the spec.
@@ -1124,6 +1125,14 @@ impl<'a> BindingKind<'a> {
         matches!(self, BindingKind::Import { is_namespace: true })
     }
 
+    pub fn as_implicit_this(&self) -> Option<&ImplicitThisBinding> {
+        if let BindingKind::ImplicitThis(binding) = self {
+            Some(binding)
+        } else {
+            None
+        }
+    }
+
     fn has_tdz(&self) -> bool {
         matches!(
             self,
@@ -1148,6 +1157,44 @@ impl<'a> BindingKind<'a> {
                 | BindingKind::Function { is_lexical: false, .. }
                 | BindingKind::ImplicitArguments
         )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ImplicitThisBinding {
+    /// Whether this is the `this` value for a derived constructor.
+    ///
+    /// Note that this is set during analysis not parsing.
+    in_derived_constructor: Cell<bool>,
+    /// Whether this is the `this` value for a derived constructor at the root scope of an eval.
+    ///
+    /// Note that this is set during analysis not parsing.
+    in_derived_constructor_eval_toplevel: Cell<bool>,
+}
+
+impl ImplicitThisBinding {
+    fn new() -> Self {
+        // Flags are set later during analysis
+        Self {
+            in_derived_constructor: Cell::new(false),
+            in_derived_constructor_eval_toplevel: Cell::new(false),
+        }
+    }
+
+    pub fn in_derived_constructor(&self) -> bool {
+        self.in_derived_constructor.get()
+    }
+
+    pub fn in_derived_constructor_eval_toplevel(&self) -> bool {
+        self.in_derived_constructor_eval_toplevel.get()
+    }
+
+    pub fn set_in_derived_constructor(&self, value: bool) {
+        self.in_derived_constructor.set(value);
+    }
+
+    pub fn set_in_derived_constructor_eval_toplevel(&self, value: bool) {
+        self.in_derived_constructor_eval_toplevel.set(value);
     }
 }
 

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -2992,7 +2992,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         expr: &ast::ThisExpression,
         dest: ExprDest,
     ) -> EmitResult<GenRegister> {
-        self.gen_load_this(expr.scope, expr.loc.start, dest)
+        self.gen_load_this(expr.scope, expr.loc.start, dest, /* skip_init_check */ false)
     }
 
     fn gen_load_this(
@@ -3000,6 +3000,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         scope: Option<AstPtr<AstScopeNode>>,
         pos: Pos,
         dest: ExprDest,
+        skip_init_check: bool,
     ) -> EmitResult<GenRegister> {
         let mut needs_init_check = false;
 
@@ -3007,37 +3008,69 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         // the dest.
         let this_value = if let Some(scope) = scope.as_ref() {
             let binding = scope.as_ref().get_binding(&THIS_NAME);
+            let implicit_this = binding.kind().as_implicit_this().unwrap();
 
-            if let BindingKind::ImplicitThis { in_derived_constructor: true } = binding.kind() {
+            if implicit_this.in_derived_constructor()
+                || implicit_this.in_derived_constructor_eval_toplevel()
+            {
                 needs_init_check = true;
             }
 
             match binding.vm_location() {
+                // Captured `this`
                 Some(VMLocation::Scope { scope_id, index }) => {
                     self.gen_load_scope_binding(scope_id, index, dest)?
                 }
-                _ => {
-                    // A scope may be resolved but `this` is not captured in some cases, e.g. for
-                    // `this` in a derived constructor.
-                    self.gen_mov_reg_to_dest(Register::this(), dest)?
+                // In derived constructor eval `this` is stored in a captured scope outside the
+                // eval. Must be loaded/stored dynamically to support `this` initialization.
+                _ if implicit_this.in_derived_constructor_eval_toplevel() => {
+                    self.gen_load_dynamic_identifier(&THIS_NAME, pos, dest)?
                 }
+                _ => self.gen_mov_reg_to_dest(Register::this(), dest)?,
             }
         } else {
             // Otherwise `this` is for the current function
-            if self.is_derived_constructor() {
-                needs_init_check = true;
-            }
-
             self.gen_mov_reg_to_dest(Register::this(), dest)?
         };
 
         // Check if this was initialized
-        if needs_init_check {
+        if needs_init_check && !skip_init_check {
             self.writer
                 .check_this_initialized_instruction(this_value, pos);
         }
 
         Ok(this_value)
+    }
+
+    fn gen_store_this(
+        &mut self,
+        scope: AstPtr<AstScopeNode>,
+        pos: Pos,
+        value: GenRegister,
+    ) -> EmitResult<()> {
+        let binding = scope.as_ref().get_binding(&THIS_NAME);
+
+        let in_derived_constructor_eval_toplevel = binding
+            .kind()
+            .as_implicit_this()
+            .unwrap()
+            .in_derived_constructor_eval_toplevel();
+
+        match binding.vm_location() {
+            // Captured `this`
+            Some(VMLocation::Scope { scope_id, index }) => {
+                self.gen_store_scope_binding(scope_id, index, value)
+            }
+            // In derived constructor eval `this` is stored in a captured scope outside the
+            // eval. Must be loaded/stored dynamically to support `this` initialization.
+            _ if in_derived_constructor_eval_toplevel => {
+                self.gen_store_dynamic_identifier(&THIS_NAME, value, pos)
+            }
+            _ => {
+                self.write_mov_instruction(Register::this(), value);
+                Ok(())
+            }
+        }
     }
 
     fn gen_unary_minus_expression(
@@ -4570,8 +4603,12 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 // Emit the property itself, which may be a computed expression or literal name
                 let property = if let ast::Pattern::SuperMember(member) = member {
                     let super_pos = member.loc.start;
-                    let this_value =
-                        self.gen_load_this(member.this_scope, super_pos, ExprDest::Any)?;
+                    let this_value = self.gen_load_this(
+                        member.this_scope,
+                        super_pos,
+                        ExprDest::Any,
+                        /* skip_init_check */ false,
+                    )?;
 
                     if member.is_computed {
                         let key = self.gen_expression(&member.property)?;
@@ -4854,7 +4891,12 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
             let property = if let ast::Expression::SuperMember(member) = member {
                 let super_pos = member.loc.start;
-                let this_value = self.gen_load_this(member.this_scope, super_pos, ExprDest::Any)?;
+                let this_value = self.gen_load_this(
+                    member.this_scope,
+                    super_pos,
+                    ExprDest::Any,
+                    /* skip_init_check */ false,
+                )?;
 
                 if member.is_computed {
                     let key = self.gen_expression(&member.property)?;
@@ -5639,7 +5681,12 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         let super_pos = expr.loc.start;
 
         // Load `this` value and home object
-        let this_value = self.gen_load_this(expr.this_scope, super_pos, ExprDest::Any)?;
+        let this_value = self.gen_load_this(
+            expr.this_scope,
+            super_pos,
+            ExprDest::Any,
+            /* skip_init_check */ false,
+        )?;
         let home_object = self.gen_load_home_object(expr, ExprDest::Any)?;
 
         // Store `this` value in the CallReceiver if one is provided
@@ -5778,19 +5825,14 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             }
         }
 
-        // Load `this` value to a register if `this` was captured
-        let mut captured_this = None;
-        let this_value = if let Some(VMLocation::Scope { scope_id, index }) = super_call
-            .this_scope
-            .as_ref()
-            .get_binding(&THIS_NAME)
-            .vm_location()
-        {
-            captured_this = Some((scope_id, index));
-            self.gen_load_scope_binding(scope_id, index, ExprDest::Any)?
-        } else {
-            Register::this()
-        };
+        // Load `this` value without init check, since initialization is checked by the following
+        // CheckSuperAlreadyCalled instruction.
+        let this_value = self.gen_load_this(
+            Some(super_call.this_scope),
+            super_pos,
+            ExprDest::Any,
+            /* skip_init_check */ true,
+        )?;
 
         // Check if super was already called and initialized `this` value, erroring if so
         self.writer
@@ -5799,11 +5841,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         self.register_allocator.release(this_value);
 
         // Always store the result of the super call as the value of `this`
-        if let Some((scope_id, index)) = captured_this {
-            self.gen_store_scope_binding(scope_id, index, call_result)?;
-        } else {
-            self.write_mov_instruction(Register::this(), call_result);
-        }
+        self.gen_store_this(super_call.this_scope, super_pos, call_result)?;
 
         // Derived constructors initialize fields after the super call
         if self.is_derived_constructor() {
@@ -6183,7 +6221,12 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         let super_pos = member.loc.start;
 
         let home_object = self.gen_load_home_object(member, ExprDest::Any)?;
-        let this_value = self.gen_load_this(member.this_scope, super_pos, ExprDest::Any)?;
+        let this_value = self.gen_load_this(
+            member.this_scope,
+            super_pos,
+            ExprDest::Any,
+            /* skip_init_check */ false,
+        )?;
 
         let property = if member.is_computed {
             self.gen_expression(&member.property)?

--- a/tests/integration/language/class/derived_constructor_this_in_eval.js
+++ b/tests/integration/language/class/derived_constructor_this_in_eval.js
@@ -1,0 +1,77 @@
+
+/*---
+description: Accessing `this` from direct eval in a derived constructor.
+---*/
+
+class Base {
+  overridden() {
+    return 5;
+  }
+
+  method() {
+    return 7;
+  }
+}
+
+// Accessing `this` from direct eval without initialization errors
+class C1 extends Base {
+    constructor() {
+      eval('this');
+    }
+}
+
+assert.throws(ReferenceError, () => new C());
+
+// Successful access to `this` from direct eval after initialization
+class C2 extends Base {
+    constructor() {
+      super();
+      eval('this.fromEval = this.method();');
+    }
+}
+
+const c2 = new C2();
+assert.sameValue(c2.fromEval, 7);
+
+// Super called in eval should work correctly and successfully initialize `this`
+class C3 extends Base {
+  constructor() {
+    eval('super()');
+  }
+}
+
+assert.sameValue(new C3().method(), 7);
+
+// Super called twice within eval errors
+class C4 extends Base {
+  constructor() {
+    super();
+    eval('super()');
+  }
+}
+
+assert.throws(ReferenceError, () => new C4());
+
+// Super method calls should throw if `this` is uninitialized, even in eval
+class C5 extends Base {
+  constructor() {
+    eval('super.method()');
+  }
+}
+
+assert.throws(ReferenceError, () => new C5());
+
+// Super method calls should work if `this` is initialized, even in eval
+class C6 extends Base {
+  overridden() {
+    return 6;
+  }
+
+  constructor() {
+    super();
+    eval('this.fromEval = super.overridden();');
+  }
+}
+
+const c6 = new C6();
+assert.sameValue(c6.fromEval, 5);

--- a/tests/snapshot/bytecode/eval/derived_constructor_this.exp
+++ b/tests/snapshot/bytecode/eval/derived_constructor_this.exp
@@ -1,0 +1,242 @@
+[BytecodeFunction: <global>] {
+  Parameters: 0, Registers: 2
+      0: LoadEmpty r1
+      2: NewClass r0, c1, c0, r1, r0
+      8: StoreToScope r0, 1, 0
+     12: PushLexicalScope c2
+     14: LoadEmpty r1
+     16: StoreToScope r1, 0, 0
+     20: LoadFromScope r1, 1, 1
+     24: CheckTdz r1, c3
+     27: NewClass r0, c5, c4, r1, r0
+     33: StoreToScope r0, 0, 0
+     37: PopScope 
+     38: StoreToScope r0, 2, 0
+     42: PushLexicalScope c6
+     44: LoadEmpty r1
+     46: StoreToScope r1, 0, 0
+     50: LoadFromScope r1, 1, 1
+     54: CheckTdz r1, c3
+     57: NewClass r0, c8, c7, r1, r0
+     63: StoreToScope r0, 0, 0
+     67: PopScope 
+     68: StoreToScope r0, 3, 0
+     72: PushLexicalScope c9
+     74: LoadEmpty r1
+     76: StoreToScope r1, 0, 0
+     80: LoadFromScope r1, 1, 1
+     84: CheckTdz r1, c3
+     87: NewClass r0, c11, c10, r1, r0
+     93: StoreToScope r0, 0, 0
+     97: PopScope 
+     98: StoreToScope r0, 4, 0
+    102: PushLexicalScope c12
+    104: LoadEmpty r1
+    106: StoreToScope r1, 0, 0
+    110: LoadFromScope r1, 1, 1
+    114: CheckTdz r1, c3
+    117: NewClass r0, c14, c13, r1, r0
+    123: StoreToScope r0, 0, 0
+    127: PopScope 
+    128: StoreToScope r0, 5, 0
+    132: Mov r0, <scope>
+    135: LoadFromScope r1, 2, 0
+    139: CheckTdz r1, c15
+    142: Construct r1, r1, r1, r1, 0
+    148: Jump 5 (.L0)
+    150: Mov <scope>, r0
+  .L0:
+    153: Mov r0, <scope>
+    156: LoadFromScope r1, 3, 0
+    160: CheckTdz r1, c16
+    163: Construct r1, r1, r1, r1, 0
+    169: Jump 5 (.L1)
+    171: Mov <scope>, r0
+  .L1:
+    174: Mov r0, <scope>
+    177: LoadFromScope r1, 4, 0
+    181: CheckTdz r1, c17
+    184: Construct r1, r1, r1, r1, 0
+    190: Jump 5 (.L2)
+    192: Mov <scope>, r0
+  .L2:
+    195: Mov r0, <scope>
+    198: LoadFromScope r1, 5, 0
+    202: CheckTdz r1, c18
+    205: Construct r1, r1, r1, r1, 0
+    211: Jump 5 (.L3)
+    213: Mov <scope>, r0
+  .L3:
+    216: LoadUndefined r0
+    218: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: Base]
+    1: [ClassNames]
+    2: [ScopeNames]
+    3: [String: Base]
+    4: [BytecodeFunction: C1]
+    5: [ClassNames]
+    6: [ScopeNames]
+    7: [BytecodeFunction: C2]
+    8: [ClassNames]
+    9: [ScopeNames]
+    10: [BytecodeFunction: C3]
+    11: [ClassNames]
+    12: [ScopeNames]
+    13: [BytecodeFunction: C4]
+    14: [ClassNames]
+    15: [String: C1]
+    16: [String: C2]
+    17: [String: C3]
+    18: [String: C4]
+  Exception Handlers:
+    135-148 -> 150
+    156-169 -> 171
+    177-190 -> 192
+    198-211 -> 213
+}
+
+[BytecodeFunction: Base] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: C1] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: LoadEmpty <this>
+     4: StoreToScope <this>, 0, 0
+     8: StoreToScope r0, 3, 0
+    12: StoreToScope <closure>, 1, 0
+    16: NewUnmappedArguments r0
+    18: StoreToScope r0, 2, 0
+    22: LoadGlobal r0, c1
+    25: LoadConstant r1, c2
+    28: CallMaybeEval r0, r0, r1, 1, 11
+    34: LoadFromScope r0, 0, 0
+    38: CheckThisInitialized r0
+    40: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: this]
+}
+
+[BytecodeFunction: C2] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: LoadEmpty <this>
+     4: StoreToScope <this>, 0, 0
+     8: StoreToScope r0, 3, 0
+    12: StoreToScope <closure>, 1, 0
+    16: NewUnmappedArguments r0
+    18: StoreToScope r0, 2, 0
+    22: LoadGlobal r0, c1
+    25: LoadConstant r1, c2
+    28: CallMaybeEval r0, r0, r1, 1, 11
+    34: LoadFromScope r0, 0, 0
+    38: CheckThisInitialized r0
+    40: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: this.fromEval = this.method();]
+}
+
+[BytecodeFunction: C3] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: LoadEmpty <this>
+     4: StoreToScope <this>, 0, 0
+     8: StoreToScope r0, 3, 0
+    12: StoreToScope <closure>, 1, 0
+    16: NewUnmappedArguments r0
+    18: StoreToScope r0, 2, 0
+    22: LoadGlobal r0, c1
+    25: LoadConstant r1, c2
+    28: CallMaybeEval r0, r0, r1, 1, 11
+    34: LoadFromScope r0, 0, 0
+    38: CheckThisInitialized r0
+    40: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: super()]
+}
+
+[BytecodeFunction: C4] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: LoadEmpty <this>
+     4: StoreToScope <this>, 0, 0
+     8: StoreToScope r0, 3, 0
+    12: StoreToScope <closure>, 1, 0
+    16: NewUnmappedArguments r0
+    18: StoreToScope r0, 2, 0
+    22: LoadGlobal r0, c1
+    25: LoadConstant r1, c2
+    28: CallMaybeEval r0, r0, r1, 1, 11
+    34: LoadFromScope r0, 0, 0
+    38: CheckThisInitialized r0
+    40: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: super.method()]
+}
+
+[BytecodeFunction: <eval>] {
+  Parameters: 0, Registers: 1
+    0: LoadDynamic r0, c0
+    3: CheckThisInitialized r0
+    5: Ret r0
+  Constant Table:
+    0: [String: this]
+}
+
+[BytecodeFunction: <eval>] {
+  Parameters: 0, Registers: 4
+     0: LoadDynamic r1, c0
+     3: CheckThisInitialized r1
+     5: LoadDynamic r2, c0
+     8: CheckThisInitialized r2
+    10: GetNamedProperty r3, r2, c2
+    14: CallWithReceiver r0, r3, r2, r3, 0
+    20: SetNamedProperty r1, c1, r0
+    24: Ret r0
+  Constant Table:
+    0: [String: this]
+    1: [String: fromEval]
+    2: [String: method]
+}
+
+[BytecodeFunction: <eval>] {
+  Parameters: 0, Registers: 3
+     0: LoadDynamic r1, c0
+     3: GetSuperConstructor r1, r1
+     6: LoadDynamic r2, c1
+     9: Construct r0, r1, r2, r2, 0
+    15: LoadDynamic r1, c2
+    18: CheckSuperAlreadyCalled r1
+    20: StoreDynamic r0, c2
+    23: Ret r0
+  Constant Table:
+    0: [String: %constructor]
+    1: [String: %new.target]
+    2: [String: this]
+}
+
+[BytecodeFunction: <eval>] {
+  Parameters: 0, Registers: 3
+     0: LoadDynamic r1, c0
+     3: CheckThisInitialized r1
+     5: LoadDynamic r2, c1
+     8: GetNamedSuperProperty r2, r2, r1, c2
+    13: CallWithReceiver r0, r2, r1, r2, 0
+    19: Ret r0
+  Constant Table:
+    0: [String: this]
+    1: [String: %homeObject]
+    2: [String: method]
+}

--- a/tests/snapshot/bytecode/eval/derived_constructor_this.js
+++ b/tests/snapshot/bytecode/eval/derived_constructor_this.js
@@ -1,0 +1,32 @@
+// OPTIONS: --run
+
+class Base {}
+
+class C1 extends Base {
+    constructor() {
+      eval('this');
+    }
+}
+
+class C2 extends Base {
+    constructor() {
+      eval('this.fromEval = this.method();');
+    }
+}
+
+class C3 extends Base {
+  constructor() {
+    eval('super()');
+  }
+}
+
+class C4 extends Base {
+  constructor() {
+    eval('super.method()');
+  }
+}
+
+try { new C1(); } catch {}
+try { new C2(); } catch {}
+try { new C3(); } catch {}
+try { new C4(); } catch {}


### PR DESCRIPTION
## Summary

Add proper support for `this` in eval in derived constructors. Derived constructors are the only place where `this` needs to be mutable, as it must be explicitly initialized. This means direct eval must read/write from a mutable, captured `this` stored in a VM scope.

We did not have proper support for this before, instead assuming that access in eval used the standard `this` register in each stack frame. Now we add a special case - `this` access in eval within derived constructors uses dynamic load/stores to the captured `this` binding (we don't calculate scope depth across the eval boundary).

- We add this to the existing `gen_load_this` and new `gen_store_this` utility
- Also need to add analysis to track whether `this` is in eval within a derived constructor. Set this later in analysis along with whether the `this` is in a derived constructor in general.

Initial bug found by the fuzzer.

## Tests

- Added integration test for `this` access, `super()`, calls, and super member accesses in eval within derived constructors
- Added bytecode snapshot tests for the above cases