### PR TITLE
[runtime] Rename BaseDescriptors to DescriptorRegistry, move to own file

### DIFF
--- a/src/js/runtime/accessor.rs
+++ b/src/js/runtime/accessor.rs
@@ -26,7 +26,7 @@ impl Accessor {
     ) -> AllocResult<Handle<Accessor>> {
         let mut accessor = cx.alloc_uninit::<Accessor>()?;
 
-        set_uninit!(accessor.descriptor, cx.base_descriptors.get(HeapItemKind::Accessor));
+        set_uninit!(accessor.descriptor, cx.descriptors.get(HeapItemKind::Accessor));
         set_uninit!(accessor.get, get.map(|v| *v));
         set_uninit!(accessor.set, set.map(|v| *v));
 

--- a/src/js/runtime/array_properties.rs
+++ b/src/js/runtime/array_properties.rs
@@ -357,7 +357,7 @@ impl DenseArrayProperties {
         let size = Self::calculate_size_in_bytes(capacity as usize);
         let mut object = cx.alloc_uninit_with_size::<DenseArrayProperties>(size)?;
 
-        set_uninit!(object.descriptor, cx.base_descriptors.get(HeapItemKind::DenseArrayProperties));
+        set_uninit!(object.descriptor, cx.descriptors.get(HeapItemKind::DenseArrayProperties));
         set_uninit!(object.len, 0);
         object.array.init_with_uninit(capacity as usize);
 

--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -116,7 +116,7 @@ impl AsyncGeneratorObject {
         let size = Self::calculate_size_in_bytes(stack_frame.len());
         let mut generator = cx.alloc_uninit_with_size::<AsyncGeneratorObject>(size)?;
 
-        let descriptor = cx.base_descriptors.get(HeapItemKind::AsyncGenerator);
+        let descriptor = cx.descriptors.get(HeapItemKind::AsyncGenerator);
         object_ordinary_init(cx, generator.into(), descriptor, Some(*prototype));
 
         set_uninit!(generator.state, AsyncGeneratorState::SuspendedStart);
@@ -264,10 +264,7 @@ impl AsyncGeneratorRequest {
     ) -> AllocResult<HeapPtr<AsyncGeneratorRequest>> {
         let mut request = cx.alloc_uninit::<AsyncGeneratorRequest>()?;
 
-        set_uninit!(
-            request.descriptor,
-            cx.base_descriptors.get(HeapItemKind::AsyncGeneratorRequest)
-        );
+        set_uninit!(request.descriptor, cx.descriptors.get(HeapItemKind::AsyncGeneratorRequest));
         set_uninit!(request.capability, *capability);
         set_uninit!(request.completion_value, *completion_value);
         set_uninit!(request.completion_type, completion_type);

--- a/src/js/runtime/boxed_value.rs
+++ b/src/js/runtime/boxed_value.rs
@@ -20,7 +20,7 @@ impl BoxedValue {
     pub fn new(cx: Context, value: Handle<Value>) -> AllocResult<HeapPtr<BoxedValue>> {
         let mut scope = cx.alloc_uninit::<BoxedValue>()?;
 
-        set_uninit!(scope.descriptor, cx.base_descriptors.get(HeapItemKind::BoxedValue));
+        set_uninit!(scope.descriptor, cx.descriptors.get(HeapItemKind::BoxedValue));
         set_uninit!(scope.value, *value);
 
         Ok(scope)

--- a/src/js/runtime/bytecode/constant_table.rs
+++ b/src/js/runtime/bytecode/constant_table.rs
@@ -30,7 +30,7 @@ impl ConstantTable {
         let size = Self::calculate_size_in_bytes(constants.len());
         let mut object = cx.alloc_uninit_with_size::<ConstantTable>(size)?;
 
-        set_uninit!(object.descriptor, cx.base_descriptors.get(HeapItemKind::ConstantTable));
+        set_uninit!(object.descriptor, cx.descriptors.get(HeapItemKind::ConstantTable));
 
         // Copy constants into inline constants array
         object.constants.init_with_uninit(constants.len());

--- a/src/js/runtime/bytecode/exception_handlers.rs
+++ b/src/js/runtime/bytecode/exception_handlers.rs
@@ -117,7 +117,7 @@ impl ExceptionHandlers {
         let size = Self::calculate_size_in_bytes(handlers.len());
         let mut object = cx.alloc_uninit_with_size::<ExceptionHandlers>(size)?;
 
-        set_uninit!(object.descriptor, cx.base_descriptors.get(HeapItemKind::ExceptionHandlers));
+        set_uninit!(object.descriptor, cx.descriptors.get(HeapItemKind::ExceptionHandlers));
         set_uninit!(object.width, width);
         object.handlers.init_from_slice(&handlers);
 

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -280,7 +280,7 @@ impl BytecodeFunction {
         let size = Self::calculate_size_in_bytes(bytecode.len());
         let mut object = cx.alloc_uninit_with_size::<BytecodeFunction>(size)?;
 
-        set_uninit!(object.descriptor, cx.base_descriptors.get(HeapItemKind::BytecodeFunction));
+        set_uninit!(object.descriptor, cx.descriptors.get(HeapItemKind::BytecodeFunction));
         set_uninit!(object.constant_table, constant_table.map(|c| *c));
         set_uninit!(object.exception_handlers, exception_handlers.map(|h| *h));
         set_uninit!(object.realm, *realm);
@@ -322,7 +322,7 @@ impl BytecodeFunction {
             new_target_index = Some(0);
         }
 
-        set_uninit!(object.descriptor, cx.base_descriptors.get(HeapItemKind::BytecodeFunction));
+        set_uninit!(object.descriptor, cx.descriptors.get(HeapItemKind::BytecodeFunction));
         set_uninit!(object.constant_table, None);
         set_uninit!(object.exception_handlers, None);
         set_uninit!(object.realm, *realm);

--- a/src/js/runtime/class_names.rs
+++ b/src/js/runtime/class_names.rs
@@ -78,7 +78,7 @@ impl ClassNames {
         let size = Self::calculate_size_in_bytes(num_methods);
         let mut class_names = cx.alloc_uninit_with_size::<ClassNames>(size)?;
 
-        set_uninit!(class_names.descriptor, cx.base_descriptors.get(HeapItemKind::ClassNames));
+        set_uninit!(class_names.descriptor, cx.descriptors.get(HeapItemKind::ClassNames));
         set_uninit!(class_names.home_object, home_object);
         set_uninit!(class_names.static_home_object, static_home_object);
 

--- a/src/js/runtime/collections/array.rs
+++ b/src/js/runtime/collections/array.rs
@@ -30,7 +30,7 @@ impl<T: Clone> BsArray<T> {
         let size = Self::calculate_size_in_bytes(length);
         let mut array = cx.alloc_uninit_with_size::<BsArray<T>>(size)?;
 
-        set_uninit!(array.descriptor, cx.base_descriptors.get(kind));
+        set_uninit!(array.descriptor, cx.descriptors.get(kind));
         array.array.init_with(length, initial);
 
         Ok(array)
@@ -44,7 +44,7 @@ impl<T: Clone> BsArray<T> {
         let size = Self::calculate_size_in_bytes(slice.len());
         let mut array = cx.alloc_uninit_with_size::<BsArray<T>>(size)?;
 
-        set_uninit!(array.descriptor, cx.base_descriptors.get(kind));
+        set_uninit!(array.descriptor, cx.descriptors.get(kind));
         array.array.init_from_slice(slice);
 
         Ok(array)
@@ -60,7 +60,7 @@ impl<T> BsArray<T> {
         let size = Self::calculate_size_in_bytes(length);
         let mut array = cx.alloc_uninit_with_size::<BsArray<T>>(size)?;
 
-        set_uninit!(array.descriptor, cx.base_descriptors.get(kind));
+        set_uninit!(array.descriptor, cx.descriptors.get(kind));
         array.array.init_with_uninit(length);
 
         Ok(array)

--- a/src/js/runtime/collections/hash_map.rs
+++ b/src/js/runtime/collections/hash_map.rs
@@ -60,7 +60,7 @@ impl<K: Eq + Hash + Clone, V: Clone> BsHashMap<K, V> {
     }
 
     pub fn init(&mut self, cx: Context, kind: HeapItemKind, capacity: usize) {
-        set_uninit!(self.descriptor, cx.base_descriptors.get(kind));
+        set_uninit!(self.descriptor, cx.descriptors.get(kind));
         set_uninit!(self.len, 0);
 
         // Initialize entries array to empty

--- a/src/js/runtime/collections/index_map.rs
+++ b/src/js/runtime/collections/index_map.rs
@@ -72,7 +72,7 @@ impl<K: Eq + Hash + Clone, V: Clone> BsIndexMap<K, V> {
         let size = Self::calculate_size_in_bytes(capacity);
         let mut hash_map = cx.alloc_uninit_with_size::<BsIndexMap<K, V>>(size)?;
 
-        set_uninit!(hash_map.descriptor, cx.base_descriptors.get(kind));
+        set_uninit!(hash_map.descriptor, cx.descriptors.get(kind));
         set_uninit!(hash_map.is_tombstone, false);
         set_uninit!(hash_map.num_occupied, 0);
         set_uninit!(hash_map.num_deleted, 0);

--- a/src/js/runtime/collections/vec.rs
+++ b/src/js/runtime/collections/vec.rs
@@ -27,7 +27,7 @@ impl<T: Clone + Copy> BsVec<T> {
         let size = Self::calculate_size_in_bytes(capacity);
         let mut vec = cx.alloc_uninit_with_size::<BsVec<T>>(size)?;
 
-        set_uninit!(vec.descriptor, cx.base_descriptors.get(kind));
+        set_uninit!(vec.descriptor, cx.descriptors.get(kind));
         set_uninit!(vec.length, 0);
         vec.array.init_with_uninit(capacity);
 

--- a/src/js/runtime/collections/weak_vec.rs
+++ b/src/js/runtime/collections/weak_vec.rs
@@ -34,7 +34,7 @@ impl BsWeakVec {
         let size = Self::calculate_size_in_bytes(capacity);
         let mut vec = cx.alloc_uninit_with_size::<BsWeakVec>(size)?;
 
-        set_uninit!(vec.descriptor, cx.base_descriptors.get(HeapItemKind::WeakVec));
+        set_uninit!(vec.descriptor, cx.descriptors.get(HeapItemKind::WeakVec));
         set_uninit!(vec.length, 0);
         set_uninit!(vec.next_weak_vec, None);
         vec.array.init_with_uninit(capacity);

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -19,8 +19,8 @@ use crate::{
         analyze::analyze, parse_module, parse_script, print_program, source::Source, ParseContext,
     },
     runtime::{
-        alloc_error::AllocResult, annex_b::init_annex_b_methods, gc::GarbageCollector,
-        string_value::StringValue,
+        alloc_error::AllocResult, annex_b::init_annex_b_methods,
+        descriptor_registry::DescriptorRegistry, gc::GarbageCollector, string_value::StringValue,
     },
 };
 
@@ -34,7 +34,7 @@ use super::{
     collections::{BsHashMap, BsHashMapField},
     error::BsResult,
     gc::{Heap, HeapRootsDeserializer, HeapVisitor},
-    heap_item_descriptor::{BaseDescriptors, HeapItemKind},
+    heap_item_descriptor::HeapItemKind,
     interned_strings::InternedStrings,
     intrinsics::{intrinsics::Intrinsic, rust_runtime::RustRuntimeFunctionRegistry},
     module::{
@@ -74,7 +74,7 @@ pub struct ContextCell {
     global_symbol_registry: HeapPtr<GlobalSymbolRegistry>,
     pub names: BuiltinNames,
     pub well_known_symbols: BuiltinSymbols,
-    pub base_descriptors: BaseDescriptors,
+    pub descriptors: DescriptorRegistry,
     pub rust_runtime_functions: RustRuntimeFunctionRegistry,
 
     /// The virtual machine used to execute bytecode.
@@ -132,7 +132,7 @@ impl Context {
             global_symbol_registry: HeapPtr::uninit(),
             names: BuiltinNames::uninit(),
             well_known_symbols: BuiltinSymbols::uninit(),
-            base_descriptors: BaseDescriptors::uninit_empty(),
+            descriptors: DescriptorRegistry::uninit_empty(),
             rust_runtime_functions: RustRuntimeFunctionRegistry::new(),
             vm: None,
             initial_realm: HeapPtr::uninit(),
@@ -186,7 +186,7 @@ impl Context {
 
         handle_scope!(cx, {
             // Initialize all uninitialized fields
-            cx.base_descriptors = BaseDescriptors::new(cx)?;
+            cx.descriptors = DescriptorRegistry::new(cx)?;
             InternedStrings::init(cx)?;
 
             cx.init_builtin_names()?;
@@ -219,7 +219,7 @@ impl Context {
         let mut cx = *self;
 
         // Initialize all uninitialized fields
-        cx.base_descriptors = BaseDescriptors::uninit();
+        cx.descriptors = DescriptorRegistry::uninit();
 
         // Deserialize the heap roots
         HeapRootsDeserializer::deserialize(cx, serialized);
@@ -596,7 +596,7 @@ impl Context {
     fn visit_permanent_roots(&mut self, visitor: &mut impl HeapVisitor) {
         self.names.visit_roots(visitor);
         self.well_known_symbols.visit_roots(visitor);
-        self.base_descriptors.visit_roots(visitor);
+        self.descriptors.visit_roots(visitor);
         visitor.visit_pointer(&mut self.initial_realm);
 
         visitor.visit_pointer(&mut self.default_named_properties);

--- a/src/js/runtime/descriptor_registry.rs
+++ b/src/js/runtime/descriptor_registry.rs
@@ -1,0 +1,203 @@
+use crate::runtime::{
+    alloc_error::AllocResult,
+    arguments_object::MappedArgumentsObject,
+    heap_item_descriptor::{DescFlags, HeapItemDescriptor, HeapItemKind},
+    module::module_namespace_object::ModuleNamespaceObject,
+    ordinary_object::OrdinaryObject,
+};
+
+use super::{
+    array_object::ArrayObject,
+    gc::{HeapPtr, HeapVisitor},
+    intrinsics::typed_array::{
+        BigInt64Array, BigUInt64Array, Float16Array, Float32Array, Float64Array, Int16Array,
+        Int32Array, Int8Array, UInt16Array, UInt32Array, UInt8Array, UInt8ClampedArray,
+    },
+    proxy_object::ProxyObject,
+    string_object::StringObject,
+    Context,
+};
+
+/// Central registry for all descriptors in a context.
+pub struct DescriptorRegistry {
+    descriptors: Vec<HeapPtr<HeapItemDescriptor>>,
+}
+
+impl DescriptorRegistry {
+    pub fn uninit_empty() -> Self {
+        DescriptorRegistry { descriptors: vec![] }
+    }
+
+    pub fn uninit() -> Self {
+        let mut descriptors = vec![];
+
+        descriptors.reserve_exact(HeapItemKind::count());
+        unsafe { descriptors.set_len(HeapItemKind::count()) };
+
+        DescriptorRegistry { descriptors }
+    }
+
+    pub fn new(cx: Context) -> AllocResult<DescriptorRegistry> {
+        let mut base_descriptors = Self::uninit();
+        let descriptors = &mut base_descriptors.descriptors;
+
+        // First set up the descriptor descriptor since it is needed for all others
+        let descriptor = HeapItemDescriptor::new_descriptor_descriptor(cx)?.to_handle();
+        descriptors[HeapItemKind::Descriptor as usize] = *descriptor;
+
+        macro_rules! register_descriptor {
+            ($object_kind:expr, $object_ty:ty, $flags:expr) => {
+                let desc =
+                    HeapItemDescriptor::new::<$object_ty>(cx, descriptor, $object_kind, $flags)?;
+                descriptors[$object_kind as usize] = desc;
+            };
+        }
+
+        macro_rules! ordinary_object_descriptor {
+            ($object_kind:expr) => {
+                register_descriptor!($object_kind, OrdinaryObject, DescFlags::IS_OBJECT);
+            };
+        }
+
+        macro_rules! other_heap_item_descriptor {
+            ($object_kind:expr) => {
+                register_descriptor!($object_kind, OrdinaryObject, DescFlags::empty());
+            };
+        }
+
+        ordinary_object_descriptor!(HeapItemKind::OrdinaryObject);
+        register_descriptor!(HeapItemKind::Proxy, ProxyObject, DescFlags::IS_OBJECT);
+
+        ordinary_object_descriptor!(HeapItemKind::BooleanObject);
+        ordinary_object_descriptor!(HeapItemKind::NumberObject);
+        register_descriptor!(HeapItemKind::StringObject, StringObject, DescFlags::IS_OBJECT);
+        ordinary_object_descriptor!(HeapItemKind::SymbolObject);
+        ordinary_object_descriptor!(HeapItemKind::BigIntObject);
+        register_descriptor!(HeapItemKind::ArrayObject, ArrayObject, DescFlags::IS_OBJECT);
+        ordinary_object_descriptor!(HeapItemKind::RegExpObject);
+        ordinary_object_descriptor!(HeapItemKind::ErrorObject);
+        ordinary_object_descriptor!(HeapItemKind::DateObject);
+        ordinary_object_descriptor!(HeapItemKind::SetObject);
+        ordinary_object_descriptor!(HeapItemKind::MapObject);
+        ordinary_object_descriptor!(HeapItemKind::WeakRefObject);
+        ordinary_object_descriptor!(HeapItemKind::WeakSetObject);
+        ordinary_object_descriptor!(HeapItemKind::WeakMapObject);
+        ordinary_object_descriptor!(HeapItemKind::FinalizationRegistryObject);
+
+        register_descriptor!(
+            HeapItemKind::MappedArgumentsObject,
+            MappedArgumentsObject,
+            DescFlags::IS_OBJECT
+        );
+        ordinary_object_descriptor!(HeapItemKind::UnmappedArgumentsObject);
+
+        register_descriptor!(HeapItemKind::Int8Array, Int8Array, DescFlags::IS_OBJECT);
+        register_descriptor!(HeapItemKind::UInt8Array, UInt8Array, DescFlags::IS_OBJECT);
+        register_descriptor!(
+            HeapItemKind::UInt8ClampedArray,
+            UInt8ClampedArray,
+            DescFlags::IS_OBJECT
+        );
+        register_descriptor!(HeapItemKind::Int16Array, Int16Array, DescFlags::IS_OBJECT);
+        register_descriptor!(HeapItemKind::UInt16Array, UInt16Array, DescFlags::IS_OBJECT);
+        register_descriptor!(HeapItemKind::Int32Array, Int32Array, DescFlags::IS_OBJECT);
+        register_descriptor!(HeapItemKind::UInt32Array, UInt32Array, DescFlags::IS_OBJECT);
+        register_descriptor!(HeapItemKind::BigInt64Array, BigInt64Array, DescFlags::IS_OBJECT);
+        register_descriptor!(HeapItemKind::BigUInt64Array, BigUInt64Array, DescFlags::IS_OBJECT);
+        register_descriptor!(HeapItemKind::Float16Array, Float16Array, DescFlags::IS_OBJECT);
+        register_descriptor!(HeapItemKind::Float32Array, Float32Array, DescFlags::IS_OBJECT);
+        register_descriptor!(HeapItemKind::Float64Array, Float64Array, DescFlags::IS_OBJECT);
+
+        ordinary_object_descriptor!(HeapItemKind::ArrayBufferObject);
+        ordinary_object_descriptor!(HeapItemKind::DataViewObject);
+
+        ordinary_object_descriptor!(HeapItemKind::ArrayIterator);
+        ordinary_object_descriptor!(HeapItemKind::StringIterator);
+        ordinary_object_descriptor!(HeapItemKind::SetIterator);
+        ordinary_object_descriptor!(HeapItemKind::MapIterator);
+        ordinary_object_descriptor!(HeapItemKind::RegExpStringIterator);
+        other_heap_item_descriptor!(HeapItemKind::ForInIterator);
+        ordinary_object_descriptor!(HeapItemKind::AsyncFromSyncIterator);
+        ordinary_object_descriptor!(HeapItemKind::WrappedValidIterator);
+        ordinary_object_descriptor!(HeapItemKind::IteratorHelperObject);
+
+        ordinary_object_descriptor!(HeapItemKind::ObjectPrototype);
+
+        other_heap_item_descriptor!(HeapItemKind::String);
+        other_heap_item_descriptor!(HeapItemKind::Symbol);
+        other_heap_item_descriptor!(HeapItemKind::BigInt);
+        other_heap_item_descriptor!(HeapItemKind::Accessor);
+
+        ordinary_object_descriptor!(HeapItemKind::Promise);
+        other_heap_item_descriptor!(HeapItemKind::PromiseReaction);
+        other_heap_item_descriptor!(HeapItemKind::PromiseCapability);
+
+        other_heap_item_descriptor!(HeapItemKind::Realm);
+
+        ordinary_object_descriptor!(HeapItemKind::Closure);
+        other_heap_item_descriptor!(HeapItemKind::BytecodeFunction);
+        other_heap_item_descriptor!(HeapItemKind::ConstantTable);
+        other_heap_item_descriptor!(HeapItemKind::ExceptionHandlers);
+        other_heap_item_descriptor!(HeapItemKind::SourceFile);
+
+        other_heap_item_descriptor!(HeapItemKind::Scope);
+        other_heap_item_descriptor!(HeapItemKind::ScopeNames);
+        other_heap_item_descriptor!(HeapItemKind::GlobalNames);
+        other_heap_item_descriptor!(HeapItemKind::ClassNames);
+
+        other_heap_item_descriptor!(HeapItemKind::SourceTextModule);
+        other_heap_item_descriptor!(HeapItemKind::SyntheticModule);
+        register_descriptor!(
+            HeapItemKind::ModuleNamespaceObject,
+            ModuleNamespaceObject,
+            DescFlags::IS_OBJECT
+        );
+        other_heap_item_descriptor!(HeapItemKind::ImportAttributes);
+
+        ordinary_object_descriptor!(HeapItemKind::Generator);
+        ordinary_object_descriptor!(HeapItemKind::AsyncGenerator);
+        other_heap_item_descriptor!(HeapItemKind::AsyncGeneratorRequest);
+
+        other_heap_item_descriptor!(HeapItemKind::DenseArrayProperties);
+        other_heap_item_descriptor!(HeapItemKind::SparseArrayProperties);
+
+        other_heap_item_descriptor!(HeapItemKind::CompiledRegExpObject);
+
+        other_heap_item_descriptor!(HeapItemKind::BoxedValue);
+
+        other_heap_item_descriptor!(HeapItemKind::ObjectNamedPropertiesMap);
+        other_heap_item_descriptor!(HeapItemKind::MapObjectValueMap);
+        other_heap_item_descriptor!(HeapItemKind::SetObjectValueSet);
+        other_heap_item_descriptor!(HeapItemKind::ExportMap);
+        other_heap_item_descriptor!(HeapItemKind::WeakMapObjectWeakValueMap);
+        other_heap_item_descriptor!(HeapItemKind::WeakSetObjectWeakValueSet);
+        other_heap_item_descriptor!(HeapItemKind::GlobalSymbolRegistryMap);
+        other_heap_item_descriptor!(HeapItemKind::InternedStringsSet);
+        other_heap_item_descriptor!(HeapItemKind::LexicalNamesMap);
+        other_heap_item_descriptor!(HeapItemKind::ModuleCacheMap);
+
+        other_heap_item_descriptor!(HeapItemKind::ValueArray);
+        other_heap_item_descriptor!(HeapItemKind::ByteArray);
+        other_heap_item_descriptor!(HeapItemKind::U32Array);
+        other_heap_item_descriptor!(HeapItemKind::ModuleRequestArray);
+        other_heap_item_descriptor!(HeapItemKind::ModuleOptionArray);
+        other_heap_item_descriptor!(HeapItemKind::StackFrameInfoArray);
+        other_heap_item_descriptor!(HeapItemKind::FinalizationRegistryCells);
+        other_heap_item_descriptor!(HeapItemKind::GlobalScopes);
+
+        other_heap_item_descriptor!(HeapItemKind::ValueVec);
+        other_heap_item_descriptor!(HeapItemKind::WeakVec);
+
+        Ok(base_descriptors)
+    }
+
+    pub fn get(&self, kind: HeapItemKind) -> HeapPtr<HeapItemDescriptor> {
+        self.descriptors[kind as usize]
+    }
+
+    pub fn visit_roots(&mut self, visitor: &mut impl HeapVisitor) {
+        for descriptor in &mut self.descriptors {
+            visitor.visit_pointer(descriptor);
+        }
+    }
+}

--- a/src/js/runtime/for_in_iterator.rs
+++ b/src/js/runtime/for_in_iterator.rs
@@ -45,7 +45,7 @@ impl ForInIterator {
         let size = Self::calculate_size_in_bytes(keys.len());
         let mut iterator = cx.alloc_uninit_with_size::<ForInIterator>(size)?;
 
-        set_uninit!(iterator.descriptor, cx.base_descriptors.get(HeapItemKind::ForInIterator));
+        set_uninit!(iterator.descriptor, cx.descriptors.get(HeapItemKind::ForInIterator));
         set_uninit!(iterator.object, *object);
         set_uninit!(iterator.index, 0);
 

--- a/src/js/runtime/generator_object.rs
+++ b/src/js/runtime/generator_object.rs
@@ -118,7 +118,7 @@ impl GeneratorObject {
         let size = Self::calculate_size_in_bytes(stack_frame.len());
         let mut generator = cx.alloc_uninit_with_size::<GeneratorObject>(size)?;
 
-        let descriptor = cx.base_descriptors.get(HeapItemKind::Generator);
+        let descriptor = cx.descriptors.get(HeapItemKind::Generator);
         object_ordinary_init(cx, generator.into(), descriptor, prototype.map(|p| *p));
 
         set_uninit!(generator.state, GeneratorState::SuspendedStart);

--- a/src/js/runtime/global_names.rs
+++ b/src/js/runtime/global_names.rs
@@ -46,7 +46,7 @@ impl GlobalNames {
         let size = Self::calculate_size_in_bytes(num_names);
         let mut global_names = cx.alloc_uninit_with_size::<GlobalNames>(size)?;
 
-        set_uninit!(global_names.descriptor, cx.base_descriptors.get(HeapItemKind::GlobalNames));
+        set_uninit!(global_names.descriptor, cx.descriptors.get(HeapItemKind::GlobalNames));
         set_uninit!(global_names.scope_names, *scope_names);
         global_names.num_functions = funcs.len();
 

--- a/src/js/runtime/heap_item_descriptor.rs
+++ b/src/js/runtime/heap_item_descriptor.rs
@@ -4,23 +4,15 @@ use bitflags::bitflags;
 
 use crate::{
     runtime::{
-        alloc_error::AllocResult, arguments_object::MappedArgumentsObject,
-        module::module_namespace_object::ModuleNamespaceObject, ordinary_object::OrdinaryObject,
+        alloc_error::AllocResult, ordinary_object::OrdinaryObject,
         rust_vtables::extract_virtual_object_vtable, Value,
     },
     set_uninit,
 };
 
 use super::{
-    array_object::ArrayObject,
     gc::{Handle, HeapItem, HeapPtr, HeapVisitor},
-    intrinsics::typed_array::{
-        BigInt64Array, BigUInt64Array, Float16Array, Float32Array, Float64Array, Int16Array,
-        Int32Array, Int8Array, UInt16Array, UInt32Array, UInt8Array, UInt8ClampedArray,
-    },
     object_value::{VirtualObject, VirtualObjectVtable},
-    proxy_object::ProxyObject,
-    string_object::StringObject,
     Context,
 };
 
@@ -165,7 +157,7 @@ pub enum HeapItemKind {
 }
 
 impl HeapItemKind {
-    const fn count() -> usize {
+    pub const fn count() -> usize {
         HeapItemKind::Last as usize
     }
 }
@@ -198,6 +190,28 @@ impl HeapItemDescriptor {
         Ok(desc)
     }
 
+    /// Create the singleton descriptor descriptor, which all descriptors have in their
+    /// `descriptor` field.
+    pub fn new_descriptor_descriptor(cx: Context) -> AllocResult<HeapPtr<HeapItemDescriptor>> {
+        // Create fake handle which will be read from, in order to initialize descriptor descriptor
+        let value = Value::empty();
+        let fake_descriptor_handle = Handle::<Value>::from_fixed_non_heap_ptr(&value).cast();
+
+        // First set up the singleton descriptor descriptor, using an arbitrary vtable
+        // (e.g. OrdinaryObject). Can only set self pointer after object initially created.
+        let mut descriptor = HeapItemDescriptor::new::<OrdinaryObject>(
+            cx,
+            fake_descriptor_handle,
+            HeapItemKind::Descriptor,
+            DescFlags::empty(),
+        )?;
+
+        // Descriptor descriptor points to itself, like all other descriptors
+        descriptor.descriptor = descriptor;
+
+        Ok(descriptor)
+    }
+
     #[inline]
     pub const fn kind(&self) -> HeapItemKind {
         self.kind
@@ -212,200 +226,9 @@ impl HeapItemDescriptor {
     pub fn is_object(&self) -> bool {
         self.flags.contains(DescFlags::IS_OBJECT)
     }
-}
 
-pub struct BaseDescriptors {
-    descriptors: Vec<HeapPtr<HeapItemDescriptor>>,
-}
-
-impl BaseDescriptors {
-    pub fn uninit_empty() -> Self {
-        BaseDescriptors { descriptors: vec![] }
-    }
-
-    pub fn uninit() -> Self {
-        let mut descriptors = vec![];
-
-        descriptors.reserve_exact(HeapItemKind::count());
-        unsafe { descriptors.set_len(HeapItemKind::count()) };
-
-        BaseDescriptors { descriptors }
-    }
-
-    pub fn new(cx: Context) -> AllocResult<BaseDescriptors> {
-        let mut base_descriptors = Self::uninit();
-        let descriptors = &mut base_descriptors.descriptors;
-
-        // Create fake handle which will be read from, in order to initialize descriptor descriptor
-        let value = Value::empty();
-        let fake_descriptor_handle = Handle::<Value>::from_fixed_non_heap_ptr(&value).cast();
-
-        // First set up the singleton descriptor descriptor, using an arbitrary vtable
-        // (e.g. OrdinaryObject). Can only set self pointer after object initially created.
-        let mut descriptor = HeapItemDescriptor::new::<OrdinaryObject>(
-            cx,
-            fake_descriptor_handle,
-            HeapItemKind::Descriptor,
-            DescFlags::empty(),
-        )?
-        .to_handle();
-        descriptor.descriptor = *descriptor;
-        descriptors[HeapItemKind::Descriptor as usize] = *descriptor;
-
-        macro_rules! register_descriptor {
-            ($object_kind:expr, $object_ty:ty, $flags:expr) => {
-                let desc =
-                    HeapItemDescriptor::new::<$object_ty>(cx, descriptor, $object_kind, $flags)?;
-                descriptors[$object_kind as usize] = desc;
-            };
-        }
-
-        macro_rules! ordinary_object_descriptor {
-            ($object_kind:expr) => {
-                register_descriptor!($object_kind, OrdinaryObject, DescFlags::IS_OBJECT);
-            };
-        }
-
-        macro_rules! other_heap_item_descriptor {
-            ($object_kind:expr) => {
-                register_descriptor!($object_kind, OrdinaryObject, DescFlags::empty());
-            };
-        }
-
-        ordinary_object_descriptor!(HeapItemKind::OrdinaryObject);
-        register_descriptor!(HeapItemKind::Proxy, ProxyObject, DescFlags::IS_OBJECT);
-
-        ordinary_object_descriptor!(HeapItemKind::BooleanObject);
-        ordinary_object_descriptor!(HeapItemKind::NumberObject);
-        register_descriptor!(HeapItemKind::StringObject, StringObject, DescFlags::IS_OBJECT);
-        ordinary_object_descriptor!(HeapItemKind::SymbolObject);
-        ordinary_object_descriptor!(HeapItemKind::BigIntObject);
-        register_descriptor!(HeapItemKind::ArrayObject, ArrayObject, DescFlags::IS_OBJECT);
-        ordinary_object_descriptor!(HeapItemKind::RegExpObject);
-        ordinary_object_descriptor!(HeapItemKind::ErrorObject);
-        ordinary_object_descriptor!(HeapItemKind::DateObject);
-        ordinary_object_descriptor!(HeapItemKind::SetObject);
-        ordinary_object_descriptor!(HeapItemKind::MapObject);
-        ordinary_object_descriptor!(HeapItemKind::WeakRefObject);
-        ordinary_object_descriptor!(HeapItemKind::WeakSetObject);
-        ordinary_object_descriptor!(HeapItemKind::WeakMapObject);
-        ordinary_object_descriptor!(HeapItemKind::FinalizationRegistryObject);
-
-        register_descriptor!(
-            HeapItemKind::MappedArgumentsObject,
-            MappedArgumentsObject,
-            DescFlags::IS_OBJECT
-        );
-        ordinary_object_descriptor!(HeapItemKind::UnmappedArgumentsObject);
-
-        register_descriptor!(HeapItemKind::Int8Array, Int8Array, DescFlags::IS_OBJECT);
-        register_descriptor!(HeapItemKind::UInt8Array, UInt8Array, DescFlags::IS_OBJECT);
-        register_descriptor!(
-            HeapItemKind::UInt8ClampedArray,
-            UInt8ClampedArray,
-            DescFlags::IS_OBJECT
-        );
-        register_descriptor!(HeapItemKind::Int16Array, Int16Array, DescFlags::IS_OBJECT);
-        register_descriptor!(HeapItemKind::UInt16Array, UInt16Array, DescFlags::IS_OBJECT);
-        register_descriptor!(HeapItemKind::Int32Array, Int32Array, DescFlags::IS_OBJECT);
-        register_descriptor!(HeapItemKind::UInt32Array, UInt32Array, DescFlags::IS_OBJECT);
-        register_descriptor!(HeapItemKind::BigInt64Array, BigInt64Array, DescFlags::IS_OBJECT);
-        register_descriptor!(HeapItemKind::BigUInt64Array, BigUInt64Array, DescFlags::IS_OBJECT);
-        register_descriptor!(HeapItemKind::Float16Array, Float16Array, DescFlags::IS_OBJECT);
-        register_descriptor!(HeapItemKind::Float32Array, Float32Array, DescFlags::IS_OBJECT);
-        register_descriptor!(HeapItemKind::Float64Array, Float64Array, DescFlags::IS_OBJECT);
-
-        ordinary_object_descriptor!(HeapItemKind::ArrayBufferObject);
-        ordinary_object_descriptor!(HeapItemKind::DataViewObject);
-
-        ordinary_object_descriptor!(HeapItemKind::ArrayIterator);
-        ordinary_object_descriptor!(HeapItemKind::StringIterator);
-        ordinary_object_descriptor!(HeapItemKind::SetIterator);
-        ordinary_object_descriptor!(HeapItemKind::MapIterator);
-        ordinary_object_descriptor!(HeapItemKind::RegExpStringIterator);
-        other_heap_item_descriptor!(HeapItemKind::ForInIterator);
-        ordinary_object_descriptor!(HeapItemKind::AsyncFromSyncIterator);
-        ordinary_object_descriptor!(HeapItemKind::WrappedValidIterator);
-        ordinary_object_descriptor!(HeapItemKind::IteratorHelperObject);
-
-        ordinary_object_descriptor!(HeapItemKind::ObjectPrototype);
-
-        other_heap_item_descriptor!(HeapItemKind::String);
-        other_heap_item_descriptor!(HeapItemKind::Symbol);
-        other_heap_item_descriptor!(HeapItemKind::BigInt);
-        other_heap_item_descriptor!(HeapItemKind::Accessor);
-
-        ordinary_object_descriptor!(HeapItemKind::Promise);
-        other_heap_item_descriptor!(HeapItemKind::PromiseReaction);
-        other_heap_item_descriptor!(HeapItemKind::PromiseCapability);
-
-        other_heap_item_descriptor!(HeapItemKind::Realm);
-
-        ordinary_object_descriptor!(HeapItemKind::Closure);
-        other_heap_item_descriptor!(HeapItemKind::BytecodeFunction);
-        other_heap_item_descriptor!(HeapItemKind::ConstantTable);
-        other_heap_item_descriptor!(HeapItemKind::ExceptionHandlers);
-        other_heap_item_descriptor!(HeapItemKind::SourceFile);
-
-        other_heap_item_descriptor!(HeapItemKind::Scope);
-        other_heap_item_descriptor!(HeapItemKind::ScopeNames);
-        other_heap_item_descriptor!(HeapItemKind::GlobalNames);
-        other_heap_item_descriptor!(HeapItemKind::ClassNames);
-
-        other_heap_item_descriptor!(HeapItemKind::SourceTextModule);
-        other_heap_item_descriptor!(HeapItemKind::SyntheticModule);
-        register_descriptor!(
-            HeapItemKind::ModuleNamespaceObject,
-            ModuleNamespaceObject,
-            DescFlags::IS_OBJECT
-        );
-        other_heap_item_descriptor!(HeapItemKind::ImportAttributes);
-
-        ordinary_object_descriptor!(HeapItemKind::Generator);
-        ordinary_object_descriptor!(HeapItemKind::AsyncGenerator);
-        other_heap_item_descriptor!(HeapItemKind::AsyncGeneratorRequest);
-
-        other_heap_item_descriptor!(HeapItemKind::DenseArrayProperties);
-        other_heap_item_descriptor!(HeapItemKind::SparseArrayProperties);
-
-        other_heap_item_descriptor!(HeapItemKind::CompiledRegExpObject);
-
-        other_heap_item_descriptor!(HeapItemKind::BoxedValue);
-
-        other_heap_item_descriptor!(HeapItemKind::ObjectNamedPropertiesMap);
-        other_heap_item_descriptor!(HeapItemKind::MapObjectValueMap);
-        other_heap_item_descriptor!(HeapItemKind::SetObjectValueSet);
-        other_heap_item_descriptor!(HeapItemKind::ExportMap);
-        other_heap_item_descriptor!(HeapItemKind::WeakMapObjectWeakValueMap);
-        other_heap_item_descriptor!(HeapItemKind::WeakSetObjectWeakValueSet);
-        other_heap_item_descriptor!(HeapItemKind::GlobalSymbolRegistryMap);
-        other_heap_item_descriptor!(HeapItemKind::InternedStringsSet);
-        other_heap_item_descriptor!(HeapItemKind::LexicalNamesMap);
-        other_heap_item_descriptor!(HeapItemKind::ModuleCacheMap);
-
-        other_heap_item_descriptor!(HeapItemKind::ValueArray);
-        other_heap_item_descriptor!(HeapItemKind::ByteArray);
-        other_heap_item_descriptor!(HeapItemKind::U32Array);
-        other_heap_item_descriptor!(HeapItemKind::ModuleRequestArray);
-        other_heap_item_descriptor!(HeapItemKind::ModuleOptionArray);
-        other_heap_item_descriptor!(HeapItemKind::StackFrameInfoArray);
-        other_heap_item_descriptor!(HeapItemKind::FinalizationRegistryCells);
-        other_heap_item_descriptor!(HeapItemKind::GlobalScopes);
-
-        other_heap_item_descriptor!(HeapItemKind::ValueVec);
-        other_heap_item_descriptor!(HeapItemKind::WeakVec);
-
-        Ok(base_descriptors)
-    }
-
-    pub fn get(&self, kind: HeapItemKind) -> HeapPtr<HeapItemDescriptor> {
-        self.descriptors[kind as usize]
-    }
-
-    pub fn visit_roots(&mut self, visitor: &mut impl HeapVisitor) {
-        for descriptor in &mut self.descriptors {
-            visitor.visit_pointer(descriptor);
-        }
+    pub fn set_descriptor(&mut self, descriptor: HeapPtr<HeapItemDescriptor>) {
+        self.descriptor = descriptor;
     }
 }
 

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
@@ -42,10 +42,7 @@ impl AsyncFromSyncIterator {
             Intrinsic::AsyncFromSyncIteratorPrototype,
         )?;
 
-        set_uninit!(
-            object.descriptor,
-            cx.base_descriptors.get(HeapItemKind::AsyncFromSyncIterator)
-        );
+        set_uninit!(object.descriptor, cx.descriptors.get(HeapItemKind::AsyncFromSyncIterator));
         set_uninit!(object.iterator, *iterator.iterator);
         set_uninit!(object.next_method, *iterator.next_method);
 

--- a/src/js/runtime/intrinsics/finalization_registry_object.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_object.rs
@@ -100,11 +100,7 @@ impl FinalizationRegistryCells {
         let size = Self::calculate_size_in_bytes(capacity);
         let mut cells = cx.alloc_uninit_with_size::<FinalizationRegistryCells>(size)?;
 
-        set_uninit!(
-            cells.descriptor,
-            cx.base_descriptors
-                .get(HeapItemKind::FinalizationRegistryCells)
-        );
+        set_uninit!(cells.descriptor, cx.descriptors.get(HeapItemKind::FinalizationRegistryCells));
         set_uninit!(cells.num_occupied, 0);
         set_uninit!(cells.num_deleted, 0);
 

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -52,7 +52,7 @@ impl FunctionPrototype {
         let mut object = function_prototype.as_object();
 
         // Initialize all fields of the prototype objec
-        let descriptor_ptr = cx.base_descriptors.get(HeapItemKind::Closure);
+        let descriptor_ptr = cx.descriptors.get(HeapItemKind::Closure);
         object_ordinary_init(cx, *object, descriptor_ptr, Some(object_proto_ptr));
 
         // The prototype object is a function which accepts any arguments and returns undefined

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -44,7 +44,7 @@ impl ObjectPrototype {
     ) -> AllocResult<()> {
         let mut object = object.as_object();
 
-        let descriptor = cx.base_descriptors.get(HeapItemKind::ObjectPrototype);
+        let descriptor = cx.descriptors.get(HeapItemKind::ObjectPrototype);
         object_ordinary_init(cx, *object, descriptor, None);
 
         // Constructor property is added once ObjectConstructor has been created

--- a/src/js/runtime/mod.rs
+++ b/src/js/runtime/mod.rs
@@ -16,6 +16,7 @@ mod collections;
 pub mod console;
 mod context;
 pub mod debug_print;
+mod descriptor_registry;
 pub mod error;
 pub mod eval;
 pub mod eval_result;

--- a/src/js/runtime/module/import_attributes.rs
+++ b/src/js/runtime/module/import_attributes.rs
@@ -32,7 +32,7 @@ impl ImportAttributes {
         let size = Self::calculate_size_in_bytes(num_entries);
         let mut object = cx.alloc_uninit_with_size::<ImportAttributes>(size)?;
 
-        set_uninit!(object.descriptor, cx.base_descriptors.get(HeapItemKind::ImportAttributes));
+        set_uninit!(object.descriptor, cx.descriptors.get(HeapItemKind::ImportAttributes));
 
         object.attribute_pairs.init_with_uninit(num_entries);
         for (i, (key, value)) in attribute_pairs.iter().enumerate() {

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -144,7 +144,7 @@ impl SourceTextModule {
         let size = Self::calculate_size_in_bytes(num_entries);
         let mut object = cx.alloc_uninit_with_size::<SourceTextModule>(size)?;
 
-        set_uninit!(object.descriptor, cx.base_descriptors.get(HeapItemKind::SourceTextModule));
+        set_uninit!(object.descriptor, cx.descriptors.get(HeapItemKind::SourceTextModule));
         set_uninit!(object.id, next_module_id());
         set_uninit!(object.state, ModuleState::New);
         set_uninit!(object.has_top_level_await, has_top_level_await);

--- a/src/js/runtime/module/synthetic_module.rs
+++ b/src/js/runtime/module/synthetic_module.rs
@@ -72,7 +72,7 @@ impl SyntheticModule {
         let mut module = cx.alloc_uninit::<SyntheticModule>()?;
 
         // Note that kind is not initialized here, as it is initialized by the caller
-        set_uninit!(module.descriptor, cx.base_descriptors.get(HeapItemKind::SyntheticModule));
+        set_uninit!(module.descriptor, cx.descriptors.get(HeapItemKind::SyntheticModule));
         set_uninit!(module.id, next_module_id());
         set_uninit!(module.module_scope, *module_scope);
         set_uninit!(module.namespace_object, None);

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -181,7 +181,7 @@ impl ObjectValue {
     ) -> AllocResult<Handle<ObjectValue>> {
         let mut object = cx.alloc_uninit::<ObjectValue>()?;
 
-        set_uninit!(object.descriptor, cx.base_descriptors.get(HeapItemKind::OrdinaryObject));
+        set_uninit!(object.descriptor, cx.descriptors.get(HeapItemKind::OrdinaryObject));
         set_uninit!(object.prototype, prototype.map(|p| *p));
         set_uninit!(object.named_properties, cx.default_named_properties);
         set_uninit!(object.array_properties, cx.default_array_properties);

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -578,7 +578,7 @@ pub fn ordinary_own_string_symbol_property_keys(
 pub fn ordinary_object_create(cx: Context) -> AllocResult<Handle<ObjectValue>> {
     let object = cx.alloc_uninit::<ObjectValue>()?;
 
-    let descriptor = cx.base_descriptors.get(HeapItemKind::OrdinaryObject);
+    let descriptor = cx.descriptors.get(HeapItemKind::OrdinaryObject);
     let proto = cx.get_intrinsic_ptr(Intrinsic::ObjectPrototype);
     object_ordinary_init(cx, object, descriptor, Some(proto));
 
@@ -595,7 +595,7 @@ where
 {
     let object = cx.alloc_uninit::<T>()?;
 
-    let descriptor = cx.base_descriptors.get(descriptor_kind);
+    let descriptor = cx.descriptors.get(descriptor_kind);
     let proto = cx.get_intrinsic_ptr(intrinsic_proto);
     object_ordinary_init(cx, object.into(), descriptor, Some(proto));
 
@@ -613,7 +613,7 @@ where
 {
     let object = cx.alloc_uninit_with_size::<T>(size)?;
 
-    let descriptor = cx.base_descriptors.get(descriptor_kind);
+    let descriptor = cx.descriptors.get(descriptor_kind);
     let proto = cx.get_intrinsic_ptr(intrinsic_proto);
     object_ordinary_init(cx, object.into(), descriptor, Some(proto));
 
@@ -630,7 +630,7 @@ where
 {
     let object = cx.alloc_uninit::<T>()?;
 
-    let descriptor = cx.base_descriptors.get(descriptor_kind);
+    let descriptor = cx.descriptors.get(descriptor_kind);
     object_ordinary_init(cx, object.into(), descriptor, Some(*proto));
 
     Ok(object)
@@ -646,7 +646,7 @@ where
 {
     let object = cx.alloc_uninit::<T>()?;
 
-    let descriptor = cx.base_descriptors.get(descriptor_kind);
+    let descriptor = cx.descriptors.get(descriptor_kind);
     let proto = proto.map(|p| *p);
     object_ordinary_init(cx, object.into(), descriptor, proto);
 
@@ -683,7 +683,7 @@ where
 
     let object = cx.alloc_uninit::<T>()?;
 
-    let descriptor = cx.base_descriptors.get(descriptor_kind);
+    let descriptor = cx.descriptors.get(descriptor_kind);
     object_ordinary_init(cx, object.into(), descriptor, Some(*proto));
 
     Ok(object)

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -435,7 +435,7 @@ impl PromiseReaction {
     ) -> AllocResult<HeapPtr<PromiseReaction>> {
         let mut reaction = cx.alloc_uninit::<PromiseReaction>()?;
 
-        set_uninit!(reaction.descriptor, cx.base_descriptors.get(HeapItemKind::PromiseReaction));
+        set_uninit!(reaction.descriptor, cx.descriptors.get(HeapItemKind::PromiseReaction));
         set_uninit!(
             reaction.handler,
             ReactionHandler::AwaitResume { suspended_generator: *suspended_generator }
@@ -454,7 +454,7 @@ impl PromiseReaction {
     ) -> AllocResult<HeapPtr<PromiseReaction>> {
         let mut reaction = cx.alloc_uninit::<PromiseReaction>()?;
 
-        set_uninit!(reaction.descriptor, cx.base_descriptors.get(HeapItemKind::PromiseReaction));
+        set_uninit!(reaction.descriptor, cx.descriptors.get(HeapItemKind::PromiseReaction));
         set_uninit!(
             reaction.handler,
             ReactionHandler::Then {
@@ -492,10 +492,7 @@ impl PromiseCapability {
         // Create an empty capability object whose fields will be set later
         let mut capability = cx.alloc_uninit::<PromiseCapability>()?;
 
-        set_uninit!(
-            capability.descriptor,
-            cx.base_descriptors.get(HeapItemKind::PromiseCapability)
-        );
+        set_uninit!(capability.descriptor, cx.descriptors.get(HeapItemKind::PromiseCapability));
         set_uninit!(capability.promise, None);
         set_uninit!(capability.resolve, Value::undefined());
         set_uninit!(capability.reject, Value::undefined());

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -63,7 +63,7 @@ impl Realm {
             let size = Self::calculate_size_in_bytes();
             let mut realm = cx.alloc_uninit_with_size::<Realm>(size)?;
 
-            set_uninit!(realm.descriptor, cx.base_descriptors.get(HeapItemKind::Realm));
+            set_uninit!(realm.descriptor, cx.descriptors.get(HeapItemKind::Realm));
             set_uninit!(realm.global_object, HeapPtr::uninit());
             set_uninit!(realm.global_scopes, HeapPtr::uninit());
             set_uninit!(realm.lexical_names, HeapPtr::uninit());
@@ -322,7 +322,7 @@ impl GlobalScopes {
         let size = Self::calculate_size_in_bytes(capacity);
         let mut global_scopes = cx.alloc_uninit_with_size::<GlobalScopes>(size)?;
 
-        set_uninit!(global_scopes.descriptor, cx.base_descriptors.get(HeapItemKind::GlobalScopes));
+        set_uninit!(global_scopes.descriptor, cx.descriptors.get(HeapItemKind::GlobalScopes));
         set_uninit!(global_scopes.len, 0);
 
         // Leave scopes array uninitialized

--- a/src/js/runtime/regexp/compiled_regexp.rs
+++ b/src/js/runtime/regexp/compiled_regexp.rs
@@ -70,7 +70,7 @@ impl CompiledRegExpObject {
         let size = Self::calculate_size_in_bytes(instructions.len(), num_capture_groups);
         let mut object = cx.alloc_uninit_with_size::<CompiledRegExpObject>(size)?;
 
-        set_uninit!(object.descriptor, cx.base_descriptors.get(HeapItemKind::CompiledRegExpObject));
+        set_uninit!(object.descriptor, cx.descriptors.get(HeapItemKind::CompiledRegExpObject));
         set_uninit!(object.escaped_pattern_source, *escaped_pattern_source);
         set_uninit!(object.flags, regexp.flags);
         set_uninit!(object.has_named_capture_groups, has_named_capture_groups);

--- a/src/js/runtime/scope.rs
+++ b/src/js/runtime/scope.rs
@@ -59,7 +59,7 @@ impl Scope {
         let size = Self::calculate_size_in_bytes(num_slots);
         let mut scope = cx.alloc_uninit_with_size::<Scope>(size)?;
 
-        set_uninit!(scope.descriptor, cx.base_descriptors.get(HeapItemKind::Scope));
+        set_uninit!(scope.descriptor, cx.descriptors.get(HeapItemKind::Scope));
         set_uninit!(scope.kind, kind);
         set_uninit!(scope.parent, parent.map(|p| *p));
         set_uninit!(scope.scope_names, *scope_names);

--- a/src/js/runtime/scope_names.rs
+++ b/src/js/runtime/scope_names.rs
@@ -66,7 +66,7 @@ impl ScopeNames {
         let size = Self::calculate_size_in_bytes(names.len());
         let mut scope_names = cx.alloc_uninit_with_size::<ScopeNames>(size)?;
 
-        set_uninit!(scope_names.descriptor, cx.base_descriptors.get(HeapItemKind::ScopeNames));
+        set_uninit!(scope_names.descriptor, cx.descriptors.get(HeapItemKind::ScopeNames));
         set_uninit!(scope_names.flags, flags);
 
         // Copy names into inline names array

--- a/src/js/runtime/source_file.rs
+++ b/src/js/runtime/source_file.rs
@@ -43,7 +43,7 @@ impl SourceFile {
         let size = Self::calculate_size_in_bytes(source.contents.len());
         let mut scope = cx.alloc_uninit_with_size::<SourceFile>(size)?;
 
-        set_uninit!(scope.descriptor, cx.base_descriptors.get(HeapItemKind::SourceFile));
+        set_uninit!(scope.descriptor, cx.descriptors.get(HeapItemKind::SourceFile));
         set_uninit!(scope.line_offsets, None);
         set_uninit!(scope.path, *path);
         set_uninit!(scope.display_name, display_name.map(|n| *n));

--- a/src/js/runtime/string_value.rs
+++ b/src/js/runtime/string_value.rs
@@ -759,7 +759,7 @@ impl FlatString {
         let size = Self::calculate_size_in_bytes(len, StringWidth::OneByte);
         let mut string = cx.alloc_uninit_with_size::<FlatString>(size)?;
 
-        set_uninit!(string.descriptor, cx.base_descriptors.get(HeapItemKind::String));
+        set_uninit!(string.descriptor, cx.descriptors.get(HeapItemKind::String));
         set_uninit!(string.len, len);
         set_uninit!(string.kind, StringKind::OneByte);
         set_uninit!(string.is_interned, false);
@@ -782,7 +782,7 @@ impl FlatString {
         let size = Self::calculate_size_in_bytes(len, StringWidth::TwoByte);
         let mut string = cx.alloc_uninit_with_size::<FlatString>(size)?;
 
-        set_uninit!(string.descriptor, cx.base_descriptors.get(HeapItemKind::String));
+        set_uninit!(string.descriptor, cx.descriptors.get(HeapItemKind::String));
         set_uninit!(string.len, len);
         set_uninit!(string.kind, StringKind::TwoByte);
         set_uninit!(string.is_interned, false);
@@ -1298,7 +1298,7 @@ impl ConcatString {
     ) -> EvalResult<Handle<StringValue>> {
         let mut string = cx.alloc_uninit::<ConcatString>()?;
 
-        set_uninit!(string.descriptor, cx.base_descriptors.get(HeapItemKind::String));
+        set_uninit!(string.descriptor, cx.descriptors.get(HeapItemKind::String));
         set_uninit!(string.len, len);
         set_uninit!(string.kind, StringKind::Concat);
         set_uninit!(string.width, width);

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -574,7 +574,7 @@ impl SymbolValue {
         let description = description.map(|d| d.flatten()).transpose()?;
         let mut symbol = cx.alloc_uninit::<SymbolValue>()?;
 
-        set_uninit!(symbol.descriptor, cx.base_descriptors.get(HeapItemKind::Symbol));
+        set_uninit!(symbol.descriptor, cx.descriptors.get(HeapItemKind::Symbol));
         set_uninit!(symbol.description, description.map(|desc| *desc));
         set_uninit!(symbol.hash_code, cx.rand.gen::<u32>());
         set_uninit!(symbol.is_private, is_private);
@@ -689,7 +689,7 @@ impl BigIntValue {
         let mut bigint = cx.alloc_uninit_with_size::<BigIntValue>(size)?;
 
         // Copy raw parts of BigInt into BigIntValue
-        set_uninit!(bigint.descriptor, cx.base_descriptors.get(HeapItemKind::BigInt));
+        set_uninit!(bigint.descriptor, cx.descriptors.get(HeapItemKind::BigInt));
         set_uninit!(bigint.len, digits.len());
         set_uninit!(bigint.sign, sign);
 


### PR DESCRIPTION
## Summary

Small cleanup as per title. Focuses `heap_item_descriptor.rs` which will soon be modified substantially.

## Tests

Just a refactor, CI