### PR TITLE
[tests] Bump test262 and promote stage 4 proposals in test definitions

### DIFF
--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -7,6 +7,11 @@
       // Bugs (We intend to fix these)
       //
       ////////////////////////////////////////
+
+      // Incorrectly treating as ambiguous binding when resolving
+      "language/module-code/ambiguous-export-bindings/namespace-unambiguous-if-import-star-as-and-export.js",
+      "language/module-code/ambiguous-export-bindings/namespace-unambiguous-if-export-star-as-from-and-import-star-as-and-export.js",
+
       // Different rejection order for promises when evaluating modules with top-level await
       "language/module-code/top-level-await/rejection-order.js",
 
@@ -162,9 +167,16 @@
   "unimplemented": {
     "features": [
       // Stage 4 proposals which need to be implemented
+      "explicit-resource-management",
       "iterator-sequencing",
+      "joint-iteration",
+      "json-parse-with-source",
       "uint8array-base64",
+      "upsert",
+      "Array.fromAsync",
+      "Atomics.pause",
       "Math.sumPrecise",
+      "Temporal",
 
       // Other unimplemented features
       "SharedArrayBuffer",
@@ -192,23 +204,19 @@
       "caller",
 
       // Stage < 4 proposals
+      "await-dictionary",
       "decorators",
-      "explicit-resource-management",
-      "import-assertions",
+      "error-stack-accessor",
       "import-defer",
+      "import-text",
       "immutable-arraybuffer",
-      "json-parse-with-source",
       "legacy-regexp",
       "nonextensible-applies-to-private",
       "source-phase-imports",
-      "upsert",
-      "Array.fromAsync",
-      "Atomics.pause",
       "FinalizationRegistry.prototype.cleanupSome",
       "Intl.DurationFormat",
       "Intl.Locale-info",
       "Intl.NumberFormat-v3",
-      "Temporal",
       "ShadowRealm"
     ]
   },

--- a/tests/test262/install_test262.sh
+++ b/tests/test262/install_test262.sh
@@ -6,8 +6,8 @@ CURRENT_DIR=$(cd "$(dirname "$0")" && pwd)
 TEST262_REPO_DIR="$CURRENT_DIR/test262"
 
 # Pinned commit hash of test262 repo that we test off of. Be sure to also update README.md.
-# Last updated on 2025-11-18
-TEST262_COMMIT_SHA="cff568602848f8d083074c45a72b1503c1e00bad"
+# Last updated on 2026-05-30
+TEST262_COMMIT_SHA="227d905513f790dec90858d04ddf8cf81326706f"
 
 # Clone the test262 repo if it is not already present
 if [ ! -d "$TEST262_REPO_DIR" ]; then


### PR DESCRIPTION
## Summary

Upgrade to a recent version of test262.

- Suppress newly failing tests.
- In the test ignores file promote all stage 4 proposals out of non-standard and into the unimplemented section for tracking. This is a large number of tests, mostly due to Temporal.

## Tests

- CI
- `cargo run brimstone-test -- --ignore-unimplemented` has no failing tests still