### PR TITLE
[runtime] Implement Map and WeakMap upsert proposal

### DIFF
--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -246,6 +246,8 @@ builtin_names!(
     (get_milliseconds, "getMilliseconds"),
     (get_minutes, "getMinutes"),
     (get_month, "getMonth"),
+    (get_or_insert, "getOrInsert"),
+    (get_or_insert_computed, "getOrInsertComputed"),
     (get_own_property_descriptor, "getOwnPropertyDescriptor"),
     (get_own_property_descriptors, "getOwnPropertyDescriptors"),
     (get_own_property_names, "getOwnPropertyNames"),

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    abstract_operations::call_object,
+    abstract_operations::{call, call_object},
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
@@ -63,6 +63,20 @@ impl MapPrototype {
             realm,
         )?;
         object.intrinsic_func(cx, cx.names.get(), RuntimeFunction::MapPrototype_get, 1, realm)?;
+        object.intrinsic_func(
+            cx,
+            cx.names.get_or_insert(),
+            RuntimeFunction::MapPrototype_get_or_insert,
+            2,
+            realm,
+        )?;
+        object.intrinsic_func(
+            cx,
+            cx.names.get_or_insert_computed(),
+            RuntimeFunction::MapPrototype_get_or_insert_computed,
+            2,
+            realm,
+        )?;
         object.intrinsic_func(cx, cx.names.has(), RuntimeFunction::MapPrototype_has, 1, realm)?;
         object.intrinsic_func(cx, cx.names.keys(), RuntimeFunction::MapPrototype_keys, 0, realm)?;
         object.intrinsic_func(cx, cx.names.set_(), RuntimeFunction::MapPrototype_set, 2, realm)?;
@@ -188,6 +202,65 @@ impl MapPrototype {
         }
     }
 
+    /// Map.prototype.getOrInsert (https://tc39.es/ecma262/#sec-map.prototype.getorinsert)
+    pub fn get_or_insert(
+        cx: Context,
+        this_value: Handle<Value>,
+        arguments: &[Handle<Value>],
+    ) -> EvalResult<Handle<Value>> {
+        let map = this_map_value(cx, this_value, "getOrInsert")?;
+
+        let key = get_argument(cx, arguments, 0);
+        let value = get_argument(cx, arguments, 1);
+
+        // May allocate
+        let map_key = ValueCollectionKey::from(key)?;
+
+        if let Some(existing_value) = map.map_data().get(&map_key) {
+            Ok(existing_value.to_handle(cx))
+        } else {
+            map.insert(cx, key, value)?;
+            Ok(value)
+        }
+    }
+
+    /// Map.prototype.getOrInsertComputed (https://tc39.es/ecma262/#sec-map.prototype.getorinsertcomputed)
+    pub fn get_or_insert_computed(
+        cx: Context,
+        this_value: Handle<Value>,
+        arguments: &[Handle<Value>],
+    ) -> EvalResult<Handle<Value>> {
+        let map = this_map_value(cx, this_value, "getOrInsertComputed")?;
+
+        let key = get_argument(cx, arguments, 0);
+        let callback = get_argument(cx, arguments, 1);
+
+        if !is_callable(callback) {
+            return type_error(
+                cx,
+                "Map.prototype.getOrInsertComputed second argument must be a function",
+            );
+        }
+
+        // May allocate
+        let map_key = ValueCollectionKey::from(key)?;
+
+        if let Some(existing_value) = map.map_data().get(&map_key) {
+            return Ok(existing_value.to_handle(cx));
+        }
+
+        // We don't actually perform key canonicalization when inserting into the map. The only
+        // place where canonicalization is observable is the key passed to the callback.
+        let canonicalized_key = canonicalize_map_key(cx, key);
+
+        let value = call(cx, callback, cx.undefined(), &[canonicalized_key])?;
+
+        // Write the (key, value) pair, even if the callback already inserted a value for the key
+        map.insert(cx, key, value)?;
+
+        Ok(value.to_handle(cx))
+    }
+
     /// Map.prototype.has (https://tc39.es/ecma262/#sec-map.prototype.has)
     pub fn has(
         cx: Context,
@@ -271,4 +344,14 @@ fn this_map_value(
     }
 
     type_error(cx, &format!("Map.prototype.{} must be called on a Map", method_name))
+}
+
+/// Canonicalized form of each map key. Not actually stored in the map but still observable in
+/// some cases.
+fn canonicalize_map_key(cx: Context, key: Handle<Value>) -> Handle<Value> {
+    if key.is_negative_zero() {
+        cx.zero()
+    } else {
+        key
+    }
 }

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -405,6 +405,8 @@ rust_runtime_functions!(
     (MapPrototype_entries, MapPrototype::entries),
     (MapPrototype_for_each, MapPrototype::for_each),
     (MapPrototype_get, MapPrototype::get),
+    (MapPrototype_get_or_insert, MapPrototype::get_or_insert),
+    (MapPrototype_get_or_insert_computed, MapPrototype::get_or_insert_computed),
     (MapPrototype_has, MapPrototype::has),
     (MapPrototype_keys, MapPrototype::keys),
     (MapPrototype_set, MapPrototype::set),
@@ -732,6 +734,11 @@ rust_runtime_functions!(
     (WeakMapConstructor_construct, WeakMapConstructor::construct),
     (WeakMapPrototype_delete, WeakMapPrototype::delete),
     (WeakMapPrototype_get, WeakMapPrototype::get),
+    (WeakMapPrototype_get_or_insert, WeakMapPrototype::get_or_insert),
+    (
+        WeakMapPrototype_get_or_insert_computed,
+        WeakMapPrototype::get_or_insert_computed
+    ),
     (WeakMapPrototype_has, WeakMapPrototype::has),
     (WeakMapPrototype_set, WeakMapPrototype::set),
     (WeakRefConstructor_construct, WeakRefConstructor::construct),

--- a/src/js/runtime/intrinsics/weak_map_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_map_prototype.rs
@@ -1,8 +1,16 @@
 use crate::runtime::{
-    alloc_error::AllocResult, error::type_error, eval_result::EvalResult, function::get_argument,
-    intrinsics::rust_runtime::RuntimeFunction,
-    intrinsics::weak_ref_constructor::can_be_held_weakly, object_value::ObjectValue,
-    property::Property, realm::Realm, value::ValueCollectionKey, Context, Handle, Value,
+    abstract_operations::call,
+    alloc_error::AllocResult,
+    error::type_error,
+    eval_result::EvalResult,
+    function::get_argument,
+    intrinsics::{rust_runtime::RuntimeFunction, weak_ref_constructor::can_be_held_weakly},
+    object_value::ObjectValue,
+    property::Property,
+    realm::Realm,
+    type_utilities::is_callable,
+    value::ValueCollectionKey,
+    Context, Handle, Value,
 };
 
 use super::{intrinsics::Intrinsic, weak_map_object::WeakMapObject};
@@ -28,6 +36,20 @@ impl WeakMapPrototype {
             cx.names.get(),
             RuntimeFunction::WeakMapPrototype_get,
             1,
+            realm,
+        )?;
+        object.intrinsic_func(
+            cx,
+            cx.names.get_or_insert(),
+            RuntimeFunction::WeakMapPrototype_get_or_insert,
+            2,
+            realm,
+        )?;
+        object.intrinsic_func(
+            cx,
+            cx.names.get_or_insert_computed(),
+            RuntimeFunction::WeakMapPrototype_get_or_insert_computed,
+            2,
             realm,
         )?;
         object.intrinsic_func(
@@ -98,6 +120,65 @@ impl WeakMapPrototype {
         }
     }
 
+    /// WeakMap.prototype.getOrInsert (https://tc39.es/ecma262/#sec-weakmap.prototype.getorinsert)
+    pub fn get_or_insert(
+        cx: Context,
+        this_value: Handle<Value>,
+        arguments: &[Handle<Value>],
+    ) -> EvalResult<Handle<Value>> {
+        let weak_map_object = this_weak_map_object(cx, this_value, "getOrInsert")?;
+
+        let key = get_argument(cx, arguments, 0);
+        let value = get_argument(cx, arguments, 1);
+
+        validate_can_be_held_weakly(cx, key, "getOrInsert")?;
+
+        // May allocate
+        let map_key = ValueCollectionKey::from(key)?;
+
+        if let Some(existing_value) = weak_map_object.weak_map_data().get(&map_key) {
+            Ok(existing_value.to_handle(cx))
+        } else {
+            weak_map_object.insert(cx, key, value)?;
+            Ok(value)
+        }
+    }
+
+    /// WeakMap.prototype.getOrInsertComputed (https://tc39.es/ecma262/#sec-weakmap.prototype.getorinsertcomputed)
+    pub fn get_or_insert_computed(
+        cx: Context,
+        this_value: Handle<Value>,
+        arguments: &[Handle<Value>],
+    ) -> EvalResult<Handle<Value>> {
+        let weak_map_object = this_weak_map_object(cx, this_value, "getOrInsertComputed")?;
+
+        let key = get_argument(cx, arguments, 0);
+        let callback = get_argument(cx, arguments, 1);
+
+        validate_can_be_held_weakly(cx, key, "getOrInsertComputed")?;
+
+        if !is_callable(callback) {
+            return type_error(
+                cx,
+                "WeakMap.prototype.getOrInsertComputed second argument must be a function",
+            );
+        }
+
+        // May allocate
+        let map_key = ValueCollectionKey::from(key)?;
+
+        if let Some(existing_value) = weak_map_object.weak_map_data().get(&map_key) {
+            return Ok(existing_value.to_handle(cx));
+        }
+
+        let value = call(cx, callback, cx.undefined(), &[key])?;
+
+        // Write the (key, value) pair, even if the callback already inserted a value for the key
+        weak_map_object.insert(cx, key, value)?;
+
+        Ok(value.to_handle(cx))
+    }
+
     /// WeakMap.prototype.has (https://tc39.es/ecma262/#sec-weakmap.prototype.has)
     pub fn has(
         cx: Context,
@@ -128,9 +209,7 @@ impl WeakMapPrototype {
         let key = get_argument(cx, arguments, 0);
         let value = get_argument(cx, arguments, 1);
 
-        if !can_be_held_weakly(cx, *key) {
-            return type_error(cx, "WeakMap.prototype.set key must be an object or symbol");
-        }
+        validate_can_be_held_weakly(cx, key, "set")?;
 
         weak_map_object.insert(cx, key, value)?;
 
@@ -150,4 +229,20 @@ fn this_weak_map_object(
     }
 
     type_error(cx, &format!("WeakMap.prototype.{method_name} must be called on a WeakMap"))
+}
+
+/// Throw a TypeError if the given key cannot be held weakly.
+fn validate_can_be_held_weakly(
+    cx: Context,
+    key: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<()> {
+    if !can_be_held_weakly(cx, *key) {
+        return type_error(
+            cx,
+            &format!("WeakMap.prototype.{method_name} key must be an object or symbol"),
+        );
+    }
+
+    Ok(())
 }

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -172,7 +172,6 @@
       "joint-iteration",
       "json-parse-with-source",
       "uint8array-base64",
-      "upsert",
       "Array.fromAsync",
       "Atomics.pause",
       "Math.sumPrecise",


### PR DESCRIPTION
## Summary

Implement the upsert proposal (https://github.com/tc39/proposal-upsert). This adds the methods `{Map, WeakMap}.prototype.{getOrInsert, getOrInsertComputed}`.

## Tests

- Remove `upsert` from test262 unimplemented list, all test262 upsert tests now pass