### PR TITLE
[module] Named export of imported namespace object to be treated as a re-export

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -469,12 +469,8 @@ impl<'a> BytecodeProgramGenerator<'a> {
                         // Local name is guaranteed to be an id since there is no `from` clause
                         let local_id = specifier.local.to_id();
 
-                        if matches!(
-                            local_id.get_binding().kind(),
-                            BindingKind::Import { is_namespace: false }
-                        ) {
-                            // If we are exporting a non-namespace import then this is actually a
-                            // named re-export. Find the corresponding import entry.
+                        if matches!(local_id.get_binding().kind(), BindingKind::Import { .. }) {
+                            // An export of an imported binding is treated as a named re-export
                             let import_entry = imports
                                 .iter()
                                 .find(|entry| entry.local_name == local_name)

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -8,10 +8,6 @@
       //
       ////////////////////////////////////////
 
-      // Incorrectly treating as ambiguous binding when resolving
-      "language/module-code/ambiguous-export-bindings/namespace-unambiguous-if-import-star-as-and-export.js",
-      "language/module-code/ambiguous-export-bindings/namespace-unambiguous-if-export-star-as-from-and-import-star-as-and-export.js",
-
       // Different rejection order for promises when evaluating modules with top-level await
       "language/module-code/top-level-await/rejection-order.js",
 
@@ -173,13 +169,13 @@
       "json-parse-with-source",
       "uint8array-base64",
       "Array.fromAsync",
-      "Atomics.pause",
       "Math.sumPrecise",
       "Temporal",
 
       // Other unimplemented features
       "SharedArrayBuffer",
-      "Atomics"
+      "Atomics",
+      "Atomics.pause"
     ]
   },
   // Tests for features that are not part of the standard. These tests are always ignored, and do


### PR DESCRIPTION
## Summary

Fix a bug in import/export resolution that differed from the spec. A named export of an imported namespace object should be treated directly as a re-export.

This was exposed by new test262 tests that hit this case.

## Tests

- All `language/module-code/ambiguous-export-bindings/*` tests now pass