### PR TITLE
[runtime] Shared utility for resolving and clamping relative indices in runtime methods

### DIFF
--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -10,7 +10,7 @@ use crate::runtime::{
     object_value::ObjectValue,
     property::Property,
     realm::Realm,
-    type_utilities::{to_index, to_integer_or_infinity},
+    type_utilities::{resolve_relative_index_argument, to_index},
     Context, EvalResult, Handle, Value,
 };
 
@@ -212,31 +212,12 @@ impl ArrayBufferPrototype {
 
         // Calculate the start index of the slice
         let start_arg = get_argument(cx, arguments, 0);
-        let relative_start = to_integer_or_infinity(cx, start_arg)?;
-        let start_index = if relative_start < 0.0 {
-            if relative_start == f64::NEG_INFINITY {
-                0
-            } else {
-                i64::max(length as i64 + relative_start as i64, 0) as u64
-            }
-        } else {
-            u64::min(relative_start as u64, length)
-        };
+        let start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
         // Calculate the end index of the slice
         let end_argument = get_argument(cx, arguments, 1);
         let end_index = if !end_argument.is_undefined() {
-            let relative_end = to_integer_or_infinity(cx, end_argument)?;
-
-            if relative_end < 0.0 {
-                if relative_end == f64::NEG_INFINITY {
-                    0
-                } else {
-                    i64::max(length as i64 + relative_end as i64, 0) as u64
-                }
-            } else {
-                u64::min(relative_end as u64, length)
-            }
+            resolve_relative_index_argument(cx, end_argument, length)?
         } else {
             length
         };

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -24,8 +24,9 @@ use crate::{
         string_value::StringValue,
         to_string,
         type_utilities::{
-            is_array, is_callable, is_less_than, is_strictly_equal, same_value_zero, to_boolean,
-            to_integer_or_infinity, to_number, to_object,
+            is_array, is_callable, is_less_than, is_strictly_equal,
+            resolve_relative_index_argument, same_value_zero, to_boolean, to_integer_or_infinity,
+            to_number, to_object,
         },
         Context, EvalResult, Handle, Value,
     },
@@ -437,42 +438,14 @@ impl ArrayPrototype {
         let length = length_of_array_like(cx, object)?;
 
         let target_arg = get_argument(cx, arguments, 0);
-        let relative_target = to_integer_or_infinity(cx, target_arg)?;
-        let mut to_index = if relative_target < 0.0 {
-            if relative_target == f64::NEG_INFINITY {
-                0
-            } else {
-                i64::max(length as i64 + relative_target as i64, 0) as u64
-            }
-        } else {
-            u64::min(relative_target as u64, length)
-        };
+        let mut to_index = resolve_relative_index_argument(cx, target_arg, length)?;
 
         let start_arg = get_argument(cx, arguments, 1);
-        let relative_start = to_integer_or_infinity(cx, start_arg)?;
-        let mut from_index = if relative_start < 0.0 {
-            if relative_start == f64::NEG_INFINITY {
-                0
-            } else {
-                i64::max(length as i64 + relative_start as i64, 0) as u64
-            }
-        } else {
-            u64::min(relative_start as u64, length)
-        };
+        let mut from_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
         let end_argument = get_argument(cx, arguments, 2);
         let from_end_index = if !end_argument.is_undefined() {
-            let relative_end = to_integer_or_infinity(cx, end_argument)?;
-
-            if relative_end < 0.0 {
-                if relative_end == f64::NEG_INFINITY {
-                    0
-                } else {
-                    i64::max(length as i64 + relative_end as i64, 0) as u64
-                }
-            } else {
-                u64::min(relative_end as u64, length)
-            }
+            resolve_relative_index_argument(cx, end_argument, length)?
         } else {
             length
         };
@@ -593,30 +566,11 @@ impl ArrayPrototype {
         let value = get_argument(cx, arguments, 0);
 
         let start_arg = get_argument(cx, arguments, 1);
-        let relative_start = to_integer_or_infinity(cx, start_arg)?;
-        let start_index = if relative_start < 0.0 {
-            if relative_start == f64::NEG_INFINITY {
-                0
-            } else {
-                i64::max(length as i64 + relative_start as i64, 0) as u64
-            }
-        } else {
-            u64::min(relative_start as u64, length)
-        };
+        let start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
         let end_argument = get_argument(cx, arguments, 2);
         let end_index = if !end_argument.is_undefined() {
-            let relative_end = to_integer_or_infinity(cx, end_argument)?;
-
-            if relative_end < 0.0 {
-                if relative_end == f64::NEG_INFINITY {
-                    0
-                } else {
-                    i64::max(length as i64 + relative_end as i64, 0) as u64
-                }
-            } else {
-                u64::min(relative_end as u64, length)
-            }
+            resolve_relative_index_argument(cx, end_argument, length)?
         } else {
             length
         };
@@ -978,18 +932,7 @@ impl ArrayPrototype {
         let search_element = get_argument(cx, arguments, 0);
 
         let n_arg = get_argument(cx, arguments, 1);
-        let mut n = to_integer_or_infinity(cx, n_arg)?;
-        if n == f64::INFINITY {
-            return Ok(cx.bool(false));
-        } else if n == f64::NEG_INFINITY {
-            n = 0.0;
-        }
-
-        let start_index = if n >= 0.0 {
-            n as u64
-        } else {
-            i64::max(length as i64 + n as i64, 0) as u64
-        };
+        let start_index = resolve_relative_index_argument(cx, n_arg, length)?;
 
         // Property key is shared between iterations
         let mut key = PropertyKey::uninit().to_handle(cx);
@@ -1022,18 +965,7 @@ impl ArrayPrototype {
         let search_element = get_argument(cx, arguments, 0);
 
         let n_arg = get_argument(cx, arguments, 1);
-        let mut n = to_integer_or_infinity(cx, n_arg)?;
-        if n == f64::INFINITY {
-            return Ok(cx.negative_one());
-        } else if n == f64::NEG_INFINITY {
-            n = 0.0;
-        }
-
-        let start_index = if n >= 0.0 {
-            n as u64
-        } else {
-            i64::max(length as i64 + n as i64, 0) as u64
-        };
+        let start_index = resolve_relative_index_argument(cx, n_arg, length)?;
 
         // Property key is shared between iterations
         let mut key = PropertyKey::uninit().to_handle(cx);
@@ -1479,30 +1411,11 @@ impl ArrayPrototype {
         let length = length_of_array_like(cx, object)?;
 
         let start_arg = get_argument(cx, arguments, 0);
-        let relative_start = to_integer_or_infinity(cx, start_arg)?;
-        let start_index = if relative_start < 0.0 {
-            if relative_start == f64::NEG_INFINITY {
-                0
-            } else {
-                i64::max(length as i64 + relative_start as i64, 0) as u64
-            }
-        } else {
-            u64::min(relative_start as u64, length)
-        };
+        let start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
         let end_argument = get_argument(cx, arguments, 1);
         let end_index = if !end_argument.is_undefined() {
-            let relative_end = to_integer_or_infinity(cx, end_argument)?;
-
-            if relative_end < 0.0 {
-                if relative_end == f64::NEG_INFINITY {
-                    0
-                } else {
-                    i64::max(length as i64 + relative_end as i64, 0) as u64
-                }
-            } else {
-                u64::min(relative_end as u64, length)
-            }
+            resolve_relative_index_argument(cx, end_argument, length)?
         } else {
             length
         };
@@ -1624,16 +1537,7 @@ impl ArrayPrototype {
         let length = length_of_array_like(cx, object)?;
 
         let start_arg = get_argument(cx, arguments, 0);
-        let relative_start = to_integer_or_infinity(cx, start_arg)?;
-        let start_index = if relative_start < 0.0 {
-            if relative_start == f64::NEG_INFINITY {
-                0
-            } else {
-                i64::max(length as i64 + relative_start as i64, 0) as u64
-            }
-        } else {
-            u64::min(relative_start as u64, length)
-        };
+        let start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
         let insert_count = (arguments.len() as u64).saturating_sub(2);
 
@@ -1821,16 +1725,7 @@ impl ArrayPrototype {
 
         // Determine absolute start index from the relative index argument
         let start_arg = get_argument(cx, arguments, 0);
-        let relative_start = to_integer_or_infinity(cx, start_arg)?;
-        let actual_start_index = if relative_start < 0.0 {
-            if relative_start == f64::NEG_INFINITY {
-                0
-            } else {
-                i64::max(length as i64 + relative_start as i64, 0) as u64
-            }
-        } else {
-            u64::min(relative_start as u64, length)
-        };
+        let actual_start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
         let insert_count = (arguments.len() as u64).saturating_sub(2);
 

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -35,8 +35,8 @@ use crate::{
         },
         to_string,
         type_utilities::{
-            is_callable, is_regexp, require_object_coercible, to_integer_or_infinity, to_length,
-            to_number, to_uint32,
+            is_callable, is_regexp, require_object_coercible, resolve_relative_index_argument,
+            to_integer_or_infinity, to_length, to_number, to_uint32,
         },
         value::Value,
         Context, Handle, HeapPtr, PropertyKey,
@@ -1107,30 +1107,11 @@ impl StringPrototype {
         let length = string.len();
 
         let start_arg = get_argument(cx, arguments, 0);
-        let relative_start = to_integer_or_infinity(cx, start_arg)?;
-        let start_index = if relative_start < 0.0 {
-            if relative_start == f64::NEG_INFINITY {
-                0
-            } else {
-                i64::max(length as i64 + relative_start as i64, 0) as u32
-            }
-        } else {
-            u32::min(relative_start as u32, length)
-        };
+        let start_index = resolve_relative_index_argument(cx, start_arg, length as u64)? as u32;
 
         let end_argument = get_argument(cx, arguments, 1);
         let end_index = if !end_argument.is_undefined() {
-            let relative_end = to_integer_or_infinity(cx, end_argument)?;
-
-            if relative_end < 0.0 {
-                if relative_end == f64::NEG_INFINITY {
-                    0
-                } else {
-                    i64::max(length as i64 + relative_end as i64, 0) as u32
-                }
-            } else {
-                u32::min(relative_end as u32, length)
-            }
+            resolve_relative_index_argument(cx, end_argument, length as u64)? as u32
         } else {
             length
         };
@@ -1420,21 +1401,8 @@ impl StringPrototype {
 
         // Convert the start argument to an integer
         let start_arg = get_argument(cx, arguments, 0);
-        let start = to_integer_or_infinity(cx, start_arg)?;
-
-        // Find the starting index, treating negative numbers as ofsets from the end of the string
-        // and handling infinities.
-        let start_index = if start.is_infinite() {
-            if start == f64::INFINITY {
-                string_length
-            } else {
-                0
-            }
-        } else if start < 0.0 {
-            i32::max(string_length as i32 + (start as i32), 0) as u32
-        } else {
-            u32::min(start as u32, string_length)
-        };
+        let start_index =
+            resolve_relative_index_argument(cx, start_arg, string_length as u64)? as u32;
 
         // Second argument is the length
         let length_arg = get_argument(cx, arguments, 1);

--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -24,8 +24,8 @@ use crate::{
         string_value::StringValue,
         to_string,
         type_utilities::{
-            is_callable, is_strictly_equal, same_object_value, same_value_zero, to_bigint,
-            to_boolean, to_integer_or_infinity, to_number, to_object,
+            is_callable, is_strictly_equal, resolve_relative_index_argument, same_object_value,
+            same_value_zero, to_bigint, to_boolean, to_integer_or_infinity, to_number, to_object,
         },
         Context, EvalResult, Handle, PropertyKey, Realm, Value,
     },
@@ -404,42 +404,14 @@ impl TypedArrayPrototype {
         let length = typed_array_length(&typed_array_record) as u64;
 
         let target_arg = get_argument(cx, arguments, 0);
-        let relative_target = to_integer_or_infinity(cx, target_arg)?;
-        let to_index = if relative_target < 0.0 {
-            if relative_target == f64::NEG_INFINITY {
-                0
-            } else {
-                i64::max(length as i64 + relative_target as i64, 0) as u64
-            }
-        } else {
-            u64::min(relative_target as u64, length)
-        };
+        let to_index = resolve_relative_index_argument(cx, target_arg, length)?;
 
         let start_arg = get_argument(cx, arguments, 1);
-        let relative_start = to_integer_or_infinity(cx, start_arg)?;
-        let from_start_index = if relative_start < 0.0 {
-            if relative_start == f64::NEG_INFINITY {
-                0
-            } else {
-                i64::max(length as i64 + relative_start as i64, 0) as u64
-            }
-        } else {
-            u64::min(relative_start as u64, length)
-        };
+        let from_start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
         let end_argument = get_argument(cx, arguments, 2);
         let from_end_index = if !end_argument.is_undefined() {
-            let relative_end = to_integer_or_infinity(cx, end_argument)?;
-
-            if relative_end < 0.0 {
-                if relative_end == f64::NEG_INFINITY {
-                    0
-                } else {
-                    i64::max(length as i64 + relative_end as i64, 0) as u64
-                }
-            } else {
-                u64::min(relative_end as u64, length)
-            }
+            resolve_relative_index_argument(cx, end_argument, length)?
         } else {
             length
         };
@@ -594,30 +566,11 @@ impl TypedArrayPrototype {
         };
 
         let start_arg = get_argument(cx, arguments, 1);
-        let relative_start = to_integer_or_infinity(cx, start_arg)?;
-        let start_index = if relative_start < 0.0 {
-            if relative_start == f64::NEG_INFINITY {
-                0
-            } else {
-                i64::max(length as i64 + relative_start as i64, 0) as u64
-            }
-        } else {
-            u64::min(relative_start as u64, length)
-        };
+        let start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
         let end_argument = get_argument(cx, arguments, 2);
         let end_index = if !end_argument.is_undefined() {
-            let relative_end = to_integer_or_infinity(cx, end_argument)?;
-
-            if relative_end < 0.0 {
-                if relative_end == f64::NEG_INFINITY {
-                    0
-                } else {
-                    i64::max(length as i64 + relative_end as i64, 0) as u64
-                }
-            } else {
-                u64::min(relative_end as u64, length)
-            }
+            resolve_relative_index_argument(cx, end_argument, length)?
         } else {
             length
         };
@@ -871,18 +824,7 @@ impl TypedArrayPrototype {
         let search_element = get_argument(cx, arguments, 0);
 
         let n_arg = get_argument(cx, arguments, 1);
-        let mut n = to_integer_or_infinity(cx, n_arg)?;
-        if n == f64::INFINITY {
-            return Ok(cx.bool(false));
-        } else if n == f64::NEG_INFINITY {
-            n = 0.0;
-        }
-
-        let start_index = if n >= 0.0 {
-            n as u64
-        } else {
-            i64::max(length as i64 + n as i64, 0) as u64
-        };
+        let start_index = resolve_relative_index_argument(cx, n_arg, length)?;
 
         // Shared between iterations
         let mut key = PropertyKey::uninit().to_handle(cx);
@@ -918,18 +860,7 @@ impl TypedArrayPrototype {
         let search_element = get_argument(cx, arguments, 0);
 
         let n_arg = get_argument(cx, arguments, 1);
-        let mut n = to_integer_or_infinity(cx, n_arg)?;
-        if n == f64::INFINITY {
-            return Ok(cx.negative_one());
-        } else if n == f64::NEG_INFINITY {
-            n = 0.0;
-        }
-
-        let start_index = if n >= 0.0 {
-            n as u64
-        } else {
-            i64::max(length as i64 + n as i64, 0) as u64
-        };
+        let start_index = resolve_relative_index_argument(cx, n_arg, length)?;
 
         // Shared between iterations
         let mut key = PropertyKey::uninit().to_handle(cx);
@@ -1412,30 +1343,11 @@ impl TypedArrayPrototype {
         let length = typed_array_length(&typed_array_record) as u64;
 
         let start_arg = get_argument(cx, arguments, 0);
-        let relative_start = to_integer_or_infinity(cx, start_arg)?;
-        let start_index = if relative_start < 0.0 {
-            if relative_start == f64::NEG_INFINITY {
-                0
-            } else {
-                i64::max(length as i64 + relative_start as i64, 0) as u64
-            }
-        } else {
-            u64::min(relative_start as u64, length)
-        };
+        let start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
         let end_argument = get_argument(cx, arguments, 1);
         let end_index = if !end_argument.is_undefined() {
-            let relative_end = to_integer_or_infinity(cx, end_argument)?;
-
-            if relative_end < 0.0 {
-                if relative_end == f64::NEG_INFINITY {
-                    0
-                } else {
-                    i64::max(length as i64 + relative_end as i64, 0) as u64
-                }
-            } else {
-                u64::min(relative_end as u64, length)
-            }
+            resolve_relative_index_argument(cx, end_argument, length)?
         } else {
             length
         };
@@ -1593,30 +1505,11 @@ impl TypedArrayPrototype {
         };
 
         let start_arg = get_argument(cx, arguments, 0);
-        let relative_start = to_integer_or_infinity(cx, start_arg)?;
-        let start_index = if relative_start < 0.0 {
-            if relative_start == f64::NEG_INFINITY {
-                0
-            } else {
-                i64::max(source_length as i64 + relative_start as i64, 0) as u64
-            }
-        } else {
-            u64::min(relative_start as u64, source_length)
-        };
+        let start_index = resolve_relative_index_argument(cx, start_arg, source_length)?;
 
         let end_argument = get_argument(cx, arguments, 1);
         let end_index = if !end_argument.is_undefined() {
-            let relative_end = to_integer_or_infinity(cx, end_argument)?;
-
-            if relative_end < 0.0 {
-                if relative_end == f64::NEG_INFINITY {
-                    0
-                } else {
-                    i64::max(source_length as i64 + relative_end as i64, 0) as u64
-                }
-            } else {
-                u64::min(relative_end as u64, source_length)
-            }
+            resolve_relative_index_argument(cx, end_argument, source_length)?
         } else {
             source_length
         };

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -219,6 +219,29 @@ pub fn to_integer_or_infinity_f64(number_f64: f64) -> f64 {
     integer_f64
 }
 
+/// Resolve a relative index argument to an absolute index, clamping to the range [0, length].
+/// Negative indices are offsets from the end of the collection.
+///
+/// Expects to be run on a runtime method's argument value and performs its own ToIntegerOrInfinity
+/// conversion.
+pub fn resolve_relative_index_argument(
+    cx: Context,
+    argument: Handle<Value>,
+    length: u64,
+) -> EvalResult<u64> {
+    let relative_index = to_integer_or_infinity(cx, argument)?;
+
+    if relative_index < 0.0 {
+        if relative_index == f64::NEG_INFINITY {
+            Ok(0)
+        } else {
+            Ok(i64::max(length as i64 + relative_index as i64, 0) as u64)
+        }
+    } else {
+        Ok(u64::min(relative_index as u64, length))
+    }
+}
+
 /// ToInt32 (https://tc39.es/ecma262/#sec-toint32)
 pub fn to_int32(cx: Context, value_handle: Handle<Value>) -> EvalResult<i32> {
     // Fast pass if the value is a smi


### PR DESCRIPTION
## Summary

We reused the same pattern for resolving and clamping relative indices across various `String`, `Array`, `TypedArray`, and `ArrayBuffer` runtime methods.

Extract this logic into a shared `resolve_relative_index_argument` utility.

## Tests

CI