### PR TITLE
[regexp] Support WSpace alias for White_Space binary unicode property

### DIFF
--- a/src/js/common/unicode_property.rs
+++ b/src/js/common/unicode_property.rs
@@ -145,7 +145,7 @@ impl BinaryUnicodeProperty {
             "Unified_Ideograph" | "UIdeo" => BinaryUnicodeProperty::UnifiedIdeograph,
             "Uppercase" | "Upper" => BinaryUnicodeProperty::Uppercase,
             "Variation_Selector" | "VS" => BinaryUnicodeProperty::VariationSelector,
-            "White_Space" | "space" => BinaryUnicodeProperty::WhiteSpace,
+            "White_Space" | "WSpace" | "space" => BinaryUnicodeProperty::WhiteSpace,
             "XID_Continue" | "XIDC" => BinaryUnicodeProperty::XIDContinue,
             "XID_Start" | "XIDS" => BinaryUnicodeProperty::XIDStart,
             _ => return None,

--- a/tests/integration/built-ins/RegExp/wspace_alias.js
+++ b/tests/integration/built-ins/RegExp/wspace_alias.js
@@ -1,0 +1,7 @@
+/*---
+description: >
+  Parse the "WSpace" alias for the White_Space unicode binary property. Non-standard but this
+  appears to be an oversight and the browser engines support this alias. 
+---*/
+
+assert(/\p{WSpace}/u.test(' ')) 


### PR DESCRIPTION
## Summary

The ECMAScript spec is missing the "WSpace" alias for the White_Space binary unicode property. This is the only property alias missing that is specified by unicode, and the browser engines all support this alias.

This appears to be an oversight in the spec (https://github.com/tc39/ecma262/issues/3286). Let's match browser engine behavior here and hope this is eventually standardized.

## Tests

- Added new integration test verifying that `\p{WSpace}` can be successfully used