### PR TITLE
[regexp] Fix Annex B regexp character class control letter escape sequences

### DIFF
--- a/src/js/parser/regexp_parser.rs
+++ b/src/js/parser/regexp_parser.rs
@@ -1127,23 +1127,16 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
                     Ok(ClassRange::Single('-' as u32))
                 }
                 // Annex B supports `\cX` escapes in character classes
-                'c' if self.in_annex_b_mode => {
-                    match_u32!(match self.peek2() {
-                        // For valid control characters the value is the lower 5 bits
-                        '0'..='9' | '_' if !self.is_unicode_aware() => {
-                            self.advance2();
-                            let escaped_value = self.current() % 32;
-                            self.advance();
+                'c' if self.in_annex_b_mode
+                    && !self.is_unicode_aware()
+                    && Self::is_numeric_or_underscore(self.peek2()) =>
+                {
+                    // For valid control characters the value is the lower 5 bits
+                    self.advance2();
+                    let escaped_value = self.current() % 32;
+                    self.advance();
 
-                            Ok(ClassRange::Single(escaped_value))
-                        }
-                        // If `\c` is not followed by a valid control character then it instead is
-                        // parsed as a literal `\` character followed by a `c` character.
-                        _ => {
-                            self.advance();
-                            Ok(ClassRange::Single('\\' as u32))
-                        }
-                    })
+                    Ok(ClassRange::Single(escaped_value))
                 }
                 // Unicode properties
                 'p' if self.is_unicode_aware() => {
@@ -1181,6 +1174,13 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
         let code_point = self.parse_unicode_codepoint()?;
 
         Ok(ClassRange::Single(code_point))
+    }
+
+    fn is_numeric_or_underscore(code_point: u32) -> bool {
+        match_u32!(match code_point {
+            '0'..='9' | '_' => true,
+            _ => false,
+        })
     }
 
     /// Parse a character class when in `v` mode.

--- a/tests/integration/annexB/built-ins/RegExp/class_control_letter.js
+++ b/tests/integration/annexB/built-ins/RegExp/class_control_letter.js
@@ -1,0 +1,45 @@
+/*---
+description: Class control letter escapes in Annex B.
+---*/
+
+// Extra control letter escapes parsed in non-unicode mode
+assert(new RegExp("[\\c0]").test("\x10"));
+assert(new RegExp("[\\c1]").test("\x11"));
+assert(new RegExp("[\\c2]").test("\x12"));
+assert(new RegExp("[\\c3]").test("\x13"));
+assert(new RegExp("[\\c4]").test("\x14"));
+assert(new RegExp("[\\c5]").test("\x15"));
+assert(new RegExp("[\\c6]").test("\x16"));
+assert(new RegExp("[\\c7]").test("\x17"));
+assert(new RegExp("[\\c8]").test("\x18"));
+assert(new RegExp("[\\c9]").test("\x19"));
+assert(new RegExp("[\\c_]").test("\x1F"));
+
+// Extra control letter escapes not parsed in unicode mode
+assert.throws(SyntaxError, () => new RegExp("[\\c0]", "u"));
+assert.throws(SyntaxError, () => new RegExp("[\\c1]", "u"));
+assert.throws(SyntaxError, () => new RegExp("[\\c2]", "u"));
+assert.throws(SyntaxError, () => new RegExp("[\\c3]", "u"));
+assert.throws(SyntaxError, () => new RegExp("[\\c4]", "u"));
+assert.throws(SyntaxError, () => new RegExp("[\\c5]", "u"));
+assert.throws(SyntaxError, () => new RegExp("[\\c6]", "u"));
+assert.throws(SyntaxError, () => new RegExp("[\\c7]", "u"));
+assert.throws(SyntaxError, () => new RegExp("[\\c8]", "u"));
+assert.throws(SyntaxError, () => new RegExp("[\\c9]", "u"));
+assert.throws(SyntaxError, () => new RegExp("[\\c_]", "u"));
+
+// Malformed control letter escape in unicode mode
+assert.throws(SyntaxError, () => new RegExp("[\\c]", "u"));
+
+// Malformed control letter escape doesn't throw in non-unicode mode
+assert(new RegExp("^[\\c]*$").test("c\\\\"));
+
+// Valid control letter escape in any mode
+assert(new RegExp("[\\cA]").test("\x01"));
+assert(new RegExp("[\\cZ]").test("\x1A"));
+assert(new RegExp("[\\ca]").test("\x01"));
+assert(new RegExp("[\\cz]").test("\x1A"));
+assert(new RegExp("[\\cA]", "u").test("\x01"));
+assert(new RegExp("[\\cZ]", "u").test("\x1A"));
+assert(new RegExp("[\\ca]", "u").test("\x01"));
+assert(new RegExp("[\\cz]", "u").test("\x1A"));


### PR DESCRIPTION
## Summary

In Annex B mode we had a RegExp parser bug where we incorrectly parsed invalid `\c` and `\cX` escape sequences.

Fix by refining the case to only match when a `\cX` escape sequence appears in non-unicode mode and `X` is `0-9` or `_` as per Annex B. This allows all other cases to continue to existing logic which is correct instead of buggy fallbacks in the Annex B `\cX` case.

## Tests

- Added tests for Annex B character class control letter escape sequences in both unicode and non-unicode mode