### PR TITLE
[runtime] Fix promise rejection order for top level await

### DIFF
--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -535,6 +535,12 @@ fn async_module_execution_rejected(
     module.set_state(ModuleState::Evaluated);
     module.set_async_evaluation(cx, false);
 
+    // If entire cycle has been completed, reject the top-level capability for the cycle
+    if let Some(capability) = module.top_level_capability_ptr() {
+        debug_assert!(module.cycle_root_ptr().unwrap().ptr_eq(&module));
+        must_a!(call_object(cx, capability.reject(), cx.undefined(), &[error]));
+    }
+
     // Reject execution of all async parent modules as well
     if let Some(async_parent_modules) = module.async_parent_modules() {
         // Reuse handle between iterations
@@ -544,12 +550,6 @@ fn async_module_execution_rejected(
             parent_module_handle.replace(async_parent_modules.as_slice()[i]);
             async_module_execution_rejected(cx, parent_module_handle, error)?;
         }
-    }
-
-    // If entire cycle has been completed, reject the top-level capability for the cycle
-    if let Some(capability) = module.top_level_capability_ptr() {
-        debug_assert!(module.cycle_root_ptr().unwrap().ptr_eq(&module));
-        must_a!(call_object(cx, capability.reject(), cx.undefined(), &[error]));
     }
 
     Ok(())

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -8,9 +8,6 @@
       //
       ////////////////////////////////////////
 
-      // Different rejection order for promises when evaluating modules with top-level await
-      "language/module-code/top-level-await/rejection-order.js",
-
       // A variety of failures in introduced SpiderMonkey tests
       "staging/sm/*",
 


### PR DESCRIPTION
## Summary

Fixes a failing test262 tests for promise rejection order in top level await. Exposed a bug where we differed from the spec by rejecting a module's capability after its ancestor module, not before.

## Tests

- test262 `language/module-code/top-level-await/rejection-order.js` now passes