### PR TITLE
[regexp] Fix clearing of captures when no progress is made by introducing new instruction

### DIFF
--- a/src/js/runtime/regexp/compiler.rs
+++ b/src/js/runtime/regexp/compiler.rs
@@ -33,12 +33,12 @@ use crate::{
                 AcceptInstruction, AssertEndInstruction, AssertEndOrNewlineInstruction,
                 AssertNotWordBoundaryInstruction, AssertStartInstruction,
                 AssertStartOrNewlineInstruction, AssertWordBoundaryInstruction,
-                BackreferenceInstruction, BranchInstruction, ClearCaptureInstruction,
-                CompareBetweenInstruction, CompareEqualsInstruction, ConsumeIfFalseInstruction,
-                ConsumeIfTrueInstruction, FailInstruction, Instruction, InstructionIterator,
-                InstructionIteratorMut, JumpInstruction, LiteralInstruction, LookaroundInstruction,
-                LoopInstruction, MarkCapturePointInstruction, OpCode, ProgressInstruction,
-                WildcardInstruction, WildcardNoNewlineInstruction,
+                BackreferenceInstruction, BranchInstruction, ClearCaptureIfNoProgressInstruction,
+                ClearCaptureInstruction, CompareBetweenInstruction, CompareEqualsInstruction,
+                ConsumeIfFalseInstruction, ConsumeIfTrueInstruction, FailInstruction, Instruction,
+                InstructionIterator, InstructionIteratorMut, JumpInstruction, LiteralInstruction,
+                LookaroundInstruction, LoopInstruction, MarkCapturePointInstruction, OpCode,
+                ProgressInstruction, WildcardInstruction, WildcardNoNewlineInstruction,
                 WordBoundaryMoveToPreviousInstruction,
             },
         },
@@ -204,6 +204,18 @@ impl CompiledRegExpBuilder {
 
     fn emit_progress_instruction(&mut self, progress_index: u32) {
         ProgressInstruction::write(self.current_block_buf(), progress_index);
+    }
+
+    fn emit_clear_capture_if_no_progress_instruction(
+        &mut self,
+        capture_group_index: u32,
+        progress_index: u32,
+    ) {
+        ClearCaptureIfNoProgressInstruction::write(
+            self.current_block_buf(),
+            capture_group_index,
+            progress_index,
+        )
     }
 
     fn emit_loop_instruction(
@@ -876,9 +888,8 @@ impl CompiledRegExpBuilder {
         }
 
         // If we are in a quantifier with a minimum of 0 repetitions, then 0-length matches of that
-        // quantifier should not set captures. This is implemented by detecting this case with a
-        // progress instruction to make sure the quantifier consumed, and if not clearing all
-        // captures in the subexpression.
+        // quantifier should not set captures. This is implemented with an instruction that clears
+        // each capture if no progress is detected.
         //
         // Note that the progress instruction must be patched before the start of the quantifier.
         if quantifier.min == 0
@@ -891,29 +902,9 @@ impl CompiledRegExpBuilder {
                 this.emit_progress_instruction(progress_index);
             });
 
-            // Then after the quantifier completes
-            let check_progress_and_continue_block = self.new_block();
-            let clear_captures_block = self.new_block();
-            let join_block = self.new_block();
-            self.emit_branch_instruction(check_progress_and_continue_block, clear_captures_block);
-
-            // Start by checking progress, and if we pass then proceed to the join block with
-            // captures intact.
-            self.in_block(check_progress_and_continue_block, |this| {
-                this.emit_progress_instruction(progress_index);
-                this.emit_jump_instruction(join_block);
-            });
-
-            // If checking progress failed then we will end up in this path and should clear all
-            // captures before proceeding.
-            self.in_block(clear_captures_block, |this| {
-                for capture_index in &quantifier_info.captures {
-                    this.emit_clear_capture_instruction(*capture_index);
-                }
-                this.emit_jump_instruction(join_block);
-            });
-
-            self.set_current_block(join_block);
+            for capture_index in &quantifier_info.captures {
+                self.emit_clear_capture_if_no_progress_instruction(*capture_index, progress_index);
+            }
         }
 
         quantifier_info

--- a/src/js/runtime/regexp/instruction.rs
+++ b/src/js/runtime/regexp/instruction.rs
@@ -68,6 +68,12 @@ pub enum OpCode {
     /// Layout: [[opcode: u8] [padding: u24] [progress_index: u32]]
     Progress,
 
+    /// A conditional ClearCapture which only clears the capture if there has been no progress at
+    /// the given progress index.
+    ///
+    /// Layout: [[opcode: u8] [padding: u24] [capture_group_index: u32] [progress_index: u32]]
+    ClearCaptureIfNoProgress,
+
     /// Check if the loop register is less than the provided max value. Proceed if so, otherwise
     /// jump to the end branch instruction. Always increment the loop register by 1.
     ///
@@ -174,6 +180,7 @@ impl OpCode {
             OpCode::MarkCapturePoint => MarkCapturePointInstruction::SIZE,
             OpCode::ClearCapture => ClearCaptureInstruction::SIZE,
             OpCode::Progress => ProgressInstruction::SIZE,
+            OpCode::ClearCaptureIfNoProgress => ClearCaptureIfNoProgressInstruction::SIZE,
             OpCode::Loop => LoopInstruction::SIZE,
             OpCode::AssertStart => AssertStartInstruction::SIZE,
             OpCode::AssertEnd => AssertEndInstruction::SIZE,
@@ -230,6 +237,9 @@ impl Instruction {
             OpCode::MarkCapturePoint => self.cast::<MarkCapturePointInstruction>().debug_print(),
             OpCode::ClearCapture => self.cast::<ClearCaptureInstruction>().debug_print(),
             OpCode::Progress => self.cast::<ProgressInstruction>().debug_print(),
+            OpCode::ClearCaptureIfNoProgress => self
+                .cast::<ClearCaptureIfNoProgressInstruction>()
+                .debug_print(),
             OpCode::Loop => self.cast::<LoopInstruction>().debug_print(),
             OpCode::AssertStart => self.cast::<AssertStartInstruction>().debug_print(),
             OpCode::AssertEnd => self.cast::<AssertEndInstruction>().debug_print(),
@@ -459,14 +469,15 @@ impl MarkCapturePointInstruction {
 }
 
 regexp_bytecode_instruction!(
-ClearCaptureInstruction,
-OpCode::ClearCapture,
-2,
-impl TInstruction {
-    fn debug_print(&self) -> String {
-        format!("{:?}({})", Self::OPCODE, self.capture_group_index())
+    ClearCaptureInstruction,
+    OpCode::ClearCapture,
+    2,
+    impl TInstruction {
+        fn debug_print(&self) -> String {
+            format!("{:?}({})", Self::OPCODE, self.capture_group_index())
+        }
     }
-});
+);
 
 impl ClearCaptureInstruction {
     #[inline]
@@ -499,6 +510,35 @@ impl ProgressInstruction {
 
     pub fn write(buf: &mut Vec<u32>, progress_index: u32) {
         write_u32!(buf, Self::OPCODE);
+        write_u32!(buf, progress_index);
+    }
+}
+
+regexp_bytecode_instruction!(
+    ClearCaptureIfNoProgressInstruction,
+    OpCode::ClearCaptureIfNoProgress,
+    3,
+    impl TInstruction {
+        fn debug_print(&self) -> String {
+            format!("{:?}({}, {})", Self::OPCODE, self.capture_group_index(), self.progress_index())
+        }
+    }
+);
+
+impl ClearCaptureIfNoProgressInstruction {
+    #[inline]
+    pub fn capture_group_index(&self) -> u32 {
+        self.0[1]
+    }
+
+    #[inline]
+    pub fn progress_index(&self) -> u32 {
+        self.0[2]
+    }
+
+    pub fn write(buf: &mut Vec<u32>, capture_group_index: u32, progress_index: u32) {
+        write_u32!(buf, Self::OPCODE);
+        write_u32!(buf, capture_group_index);
         write_u32!(buf, progress_index);
     }
 }

--- a/src/js/runtime/regexp/matcher.rs
+++ b/src/js/runtime/regexp/matcher.rs
@@ -16,12 +16,13 @@ use crate::{
                 AssertEndInstruction, AssertEndOrNewlineInstruction,
                 AssertNotWordBoundaryInstruction, AssertStartInstruction,
                 AssertStartOrNewlineInstruction, AssertWordBoundaryInstruction,
-                BackreferenceInstruction, BranchInstruction, ClearCaptureInstruction,
-                CompareBetweenInstruction, CompareEqualsInstruction, ConsumeIfFalseInstruction,
-                ConsumeIfTrueInstruction, Instruction, JumpInstruction, LiteralInstruction,
-                LookaroundInstruction, LoopInstruction, MarkCapturePointInstruction, OpCode,
-                ProgressInstruction, TInstruction, WildcardInstruction,
-                WildcardNoNewlineInstruction, WordBoundaryMoveToPreviousInstruction,
+                BackreferenceInstruction, BranchInstruction, ClearCaptureIfNoProgressInstruction,
+                ClearCaptureInstruction, CompareBetweenInstruction, CompareEqualsInstruction,
+                ConsumeIfFalseInstruction, ConsumeIfTrueInstruction, Instruction, JumpInstruction,
+                LiteralInstruction, LookaroundInstruction, LoopInstruction,
+                MarkCapturePointInstruction, OpCode, ProgressInstruction, TInstruction,
+                WildcardInstruction, WildcardNoNewlineInstruction,
+                WordBoundaryMoveToPreviousInstruction,
             },
         },
         string_value::StringValue,
@@ -298,23 +299,29 @@ impl<T: LexerStream> MatchEngine<T> {
                 }
                 OpCode::ClearCapture => {
                     let instr = instr.cast::<ClearCaptureInstruction>();
+                    self.clear_capture_at_index(instr.capture_group_index());
 
-                    // Clearing just the ending capture point for the group is enough
-                    let capture_point_index = instr.capture_group_index() * 2 + 1;
-                    self.push_capture_point(capture_point_index, EMPTY_STRING_INDEX);
                     self.advance_instruction::<ClearCaptureInstruction>();
                 }
                 OpCode::Progress => {
                     let instr = instr.cast::<ProgressInstruction>();
                     let progress_index = instr.progress_index();
 
-                    let string_index = self.string_lexer.pos() as u32;
-                    if self.get_progress_point(progress_index) != string_index {
-                        self.push_progress_point(progress_index, string_index);
+                    if self.has_made_progress(progress_index) {
+                        self.mark_progress_point(progress_index);
                         self.advance_instruction::<ProgressInstruction>();
                     } else {
                         self.backtrack()?;
                     }
+                }
+                OpCode::ClearCaptureIfNoProgress => {
+                    let instr = instr.cast::<ClearCaptureIfNoProgressInstruction>();
+
+                    if !self.has_made_progress(instr.progress_index()) {
+                        self.clear_capture_at_index(instr.capture_group_index());
+                    }
+
+                    self.advance_instruction::<ClearCaptureIfNoProgressInstruction>();
                 }
                 OpCode::Loop => {
                     let instr = instr.cast::<LoopInstruction>();
@@ -561,13 +568,22 @@ impl<T: LexerStream> MatchEngine<T> {
         self.set_capture_point(capture_point_index, string_index);
     }
 
-    fn push_progress_point(&mut self, progress_point_index: u32, string_index: u32) {
+    /// Whether the engine is further in the source since the last time a given progress point was
+    /// marked.
+    fn has_made_progress(&self, progress_index: u32) -> bool {
+        let string_index = self.string_lexer.pos() as u32;
+        self.get_progress_point(progress_index) != string_index
+    }
+
+    /// Mark the current position in the source at the given progress point.
+    fn mark_progress_point(&mut self, progress_point_index: u32) {
         // Save old progress point on backtrack stack
+        let current_string_index = self.string_lexer.pos() as u32;
         let old_string_index = self.get_progress_point(progress_point_index);
         self.backtrack_stack
             .push(BacktrackEntry::ProgressPoint(progress_point_index, old_string_index));
 
-        self.set_progress_point(progress_point_index, string_index);
+        self.set_progress_point(progress_point_index, current_string_index);
     }
 
     fn push_loop_register(&mut self, loop_register_index: u32, value: usize) {
@@ -577,6 +593,14 @@ impl<T: LexerStream> MatchEngine<T> {
             .push(BacktrackEntry::LoopRegister(loop_register_index, old_value));
 
         self.set_loop_register(loop_register_index, value);
+    }
+
+    /// Clear the capture group with the given index.
+    ///
+    /// Clearing just the ending capture point for the group is enough.
+    fn clear_capture_at_index(&mut self, capture_group_index: u32) {
+        let capture_point_index = capture_group_index * 2 + 1;
+        self.push_capture_point(capture_point_index, EMPTY_STRING_INDEX);
     }
 
     fn execute_backreference<const DIRECTION: bool>(

--- a/tests/integration/regression/000021.js
+++ b/tests/integration/regression/000021.js
@@ -1,0 +1,6 @@
+/*---
+description: Quantifier matches should only be cleared if the match was empty.
+---*/
+
+assert.sameValue(/^(x)?\1y$/.exec("xy"), null);
+assert.compareArray(/^(x)?\1y$/.exec("y"), ["y", undefined]);

--- a/tests/snapshot/regexp_bytecode/quantifiers/clear_captures_if_no_progress.exp
+++ b/tests/snapshot/regexp_bytecode/quantifiers/clear_captures_if_no_progress.exp
@@ -1,0 +1,54 @@
+[CompiledRegExpObject: /(x)?/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Progress(0)
+    11: Branch(20, 14)
+    14: ClearCaptureIfNoProgress(1, 0)
+    17: MarkCapturePoint(1)
+    19: Accept
+    20: MarkCapturePoint(2)
+    22: Literal(x)
+    23: MarkCapturePoint(3)
+    25: Jump(14)
+}
+
+[CompiledRegExpObject: /((x)(y)(z))?/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Progress(0)
+    11: Branch(29, 14)
+    14: ClearCaptureIfNoProgress(2, 0)
+    17: ClearCaptureIfNoProgress(3, 0)
+    20: ClearCaptureIfNoProgress(4, 0)
+    23: ClearCaptureIfNoProgress(1, 0)
+    26: MarkCapturePoint(1)
+    28: Accept
+    29: MarkCapturePoint(2)
+    31: MarkCapturePoint(4)
+    33: Literal(x)
+    34: MarkCapturePoint(5)
+    36: MarkCapturePoint(6)
+    38: Literal(y)
+    39: MarkCapturePoint(7)
+    41: MarkCapturePoint(8)
+    43: Literal(z)
+    44: MarkCapturePoint(9)
+    46: MarkCapturePoint(3)
+    48: Jump(14)
+}
+
+[CompiledRegExpObject: /x?/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Branch(15, 12)
+    12: MarkCapturePoint(1)
+    14: Accept
+    15: Literal(x)
+    16: Jump(12)
+}

--- a/tests/snapshot/regexp_bytecode/quantifiers/clear_captures_if_no_progress.js
+++ b/tests/snapshot/regexp_bytecode/quantifiers/clear_captures_if_no_progress.js
@@ -1,0 +1,5 @@
+/(x)?/;
+/((x)(y)(z))?/;
+
+// No progress point needed if there were no captures
+/x?/;


### PR DESCRIPTION
## Summary

We have a bug in RegExp quantifier matching around empty matches and how capture groups are cleared. Quantifiers that allow zero repetitions and contain capture groups will clear those capture groups if the quantifier matches the empty string, even if the matches are empty and would otherwise be allowed.

The gadget used for implementing this in bytecode unfortunately was buggy. We were first generating a branch that first visited a progress in one branch and in the other cleared all capture groups, with the intention that if no progress was made we would backtrack to the fallback branch and clear all captures. The problem is that we could also pass the progress instruction then later hit a backtrack point for other reasons, which would put us down the clear capture groups and proceed path.

Instead let's introduce a new `ClearCaptureGroupIfNoProgress` instruction which has the semantics we want. Then this gadget just becomes a sequence of these new instructions for all capture groups in the quantifier.

## Tests

- Added regression test fixed by this change
- Added regexp bytecode snapshot tests for generating the new instruction