### PR TITLE
[parser] Parse valid unicode escape sequences of any length

### DIFF
--- a/src/js/parser/lexer.rs
+++ b/src/js/parser/lexer.rs
@@ -1105,7 +1105,7 @@ impl<'a> Lexer<'a> {
                     let loc = self.mark_loc(self.pos);
                     return self.error(loc, ParseError::UnterminatedStringLiteral);
                 }
-                // Otherwise add
+                // Otherwise add single literal code point
                 _ => value.push(self.lex_ascii_or_unicode_code_point()?),
             })
         }
@@ -1534,7 +1534,7 @@ impl<'a> Lexer<'a> {
             }
 
             let mut value = 0;
-            for _ in 0..6 {
+            while is_in_unicode_range(value) {
                 if let Some(hex_value) = get_hex_value(self.current) {
                     self.advance();
                     value <<= 4;

--- a/tests/integration/language/syntax/long_unicode_escape_sequences.js
+++ b/tests/integration/language/syntax/long_unicode_escape_sequences.js
@@ -1,0 +1,39 @@
+/*---
+description: ^
+  Unicode code point escape sequences `\u{...}` of any length are parsed correctly, including with
+  any number of leading zeros.
+---*/
+
+// In string literals
+assert.sameValue("\u{0000000000000061}", "a");
+assert.sameValue("\u{0000000000}".charCodeAt(0), 0);
+assert.sameValue("\u{00000010FFFF}", "\u{10FFFF}");
+
+// In template literals
+assert.sameValue(`\u{0000000000000061}`, "a");
+assert.sameValue(`\u{0000000000}`, "\0");
+assert.sameValue(`\u{00000010FFFF}`, "\u{10FFFF}");
+
+// In identifiers
+const \u{0000000061} = 1;
+assert.sameValue(a, 1);
+var b\u{0000000063} = 2;
+assert.sameValue(bc, 2);
+
+// In private identifiers
+class C {
+  #\u{0000000064} = 5;
+
+  get() {
+    return this.#d;
+  }
+}
+assert.sameValue(new C().get(), 5);
+
+// Throws a SyntaxError if out of range
+assert.throws(SyntaxError, function () {
+  eval('"\\u{00000110000}"');
+});
+assert.throws(SyntaxError, function () {
+  eval('"\\u{0000000FFFFFFFF}"');
+});


### PR DESCRIPTION
## Summary

We were failing to parse valid unicode escape sequences with any number of leading zeros. Instead keep processing numbers until code point is out of range, ignoring leading zeros.

## Tests

- Added integration test for all places where affected unicode escape sequences can appear: string literals, template literals, identifiers, and private identifiers