### PR TITLE
[common][regexp] Generate Graphviz DOT files for RegExp bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .agents
 .claude
 
+dotfiles
 target
 node_modules
 tests/test262/test262

--- a/src/js/common/filesystem.rs
+++ b/src/js/common/filesystem.rs
@@ -1,0 +1,62 @@
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
+
+/// Utility for reserving unique file paths.
+pub struct FileNameReserver {
+    used_paths: Mutex<HashSet<PathBuf>>,
+}
+
+impl FileNameReserver {
+    pub fn new() -> Self {
+        Self { used_paths: Mutex::new(HashSet::new()) }
+    }
+
+    /// Reserve a unique file path given the directory, file name, and extension.
+    ///
+    /// Aggressively sanitizes the file name. Attempts to use the provided name but may need to
+    /// append suffixes for uniqueness.
+    pub fn reserve_unique_path(
+        &self,
+        directory: &Path,
+        file_name: &str,
+        extension: &str,
+    ) -> PathBuf {
+        let sanitized = sanitize_file_name(file_name);
+
+        let mut used_paths = self.used_paths.lock().unwrap();
+
+        let mut path = directory.join(&sanitized).with_extension(extension);
+        let mut suffix = 2;
+        while used_paths.contains(&path) {
+            path = directory
+                .join(format!("{sanitized}_{suffix}"))
+                .with_extension(extension);
+            suffix += 1;
+        }
+
+        used_paths.insert(path.clone());
+
+        path
+    }
+}
+
+/// Sanitize a name into a filesystem-safe name by replacing non-alphanumeric characters and
+/// truncating to a reasonable length.
+fn sanitize_file_name(name: &str) -> String {
+    const MAX_LEN: usize = 128;
+
+    let sanitized: String = name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .take(MAX_LEN)
+        .collect();
+
+    if sanitized.is_empty() {
+        "EMPTY".to_owned()
+    } else {
+        sanitized
+    }
+}

--- a/src/js/common/graphviz.rs
+++ b/src/js/common/graphviz.rs
@@ -39,8 +39,13 @@ impl DotGraphBuilder {
 
     /// Add and return a node with the given id.
     pub fn add_node(&mut self, id: &str) -> &mut DotNode {
-        self.nodes
-            .insert(id.to_owned(), DotNode { id: id.to_owned(), attributes: vec![] });
+        let had_entry = self
+            .nodes
+            .insert(id.to_owned(), DotNode { id: id.to_owned(), attributes: vec![] })
+            .is_some();
+
+        assert!(!had_entry, "Duplicate graphviz node id");
+
         self.nodes.get_mut(id).unwrap()
     }
 
@@ -114,7 +119,11 @@ impl fmt::Display for DotGraphBuilder {
             writeln!(f, ";")?;
         }
 
-        for node in self.nodes.values() {
+        // Iterate over nodes sorted by their keys for deterministic ordering
+        let mut node_entries = self.nodes.iter().collect::<Vec<_>>();
+        node_entries.sort_by_key(|(key, _)| *key);
+
+        for (_, node) in node_entries {
             write!(f, "  {}", quote(&node.id))?;
             write_attributes(f, &node.attributes)?;
             writeln!(f, ";")?;

--- a/src/js/common/graphviz.rs
+++ b/src/js/common/graphviz.rs
@@ -1,0 +1,166 @@
+use std::fmt;
+
+use hashbrown::HashMap;
+
+/// A small, general-purpose Graphviz DOT file builder.
+pub struct DotGraphBuilder {
+    name: String,
+    nodes: HashMap<String, DotNode>,
+    edges: Vec<DotEdge>,
+    graph_attributes: Vec<(String, String)>,
+    node_default_attributes: Vec<(String, String)>,
+    edge_default_attributes: Vec<(String, String)>,
+}
+
+/// A node in a DotGraphBuilder. Nodes are identified by their `id` field.
+pub struct DotNode {
+    id: String,
+    attributes: Vec<(String, String)>,
+}
+
+/// A directed edge in a DotGraphBuilder.
+pub struct DotEdge {
+    from: String,
+    to: String,
+    attributes: Vec<(String, String)>,
+}
+
+impl DotGraphBuilder {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            nodes: HashMap::new(),
+            edges: vec![],
+            graph_attributes: vec![],
+            node_default_attributes: vec![],
+            edge_default_attributes: vec![],
+        }
+    }
+
+    /// Add and return a node with the given id.
+    pub fn add_node(&mut self, id: &str) -> &mut DotNode {
+        self.nodes
+            .insert(id.to_owned(), DotNode { id: id.to_owned(), attributes: vec![] });
+        self.nodes.get_mut(id).unwrap()
+    }
+
+    /// Add and return an edge between two node ids.
+    pub fn add_edge(&mut self, from: &str, to: &str) -> &mut DotEdge {
+        self.edges
+            .push(DotEdge { from: from.to_owned(), to: to.to_owned(), attributes: vec![] });
+        self.edges.last_mut().unwrap()
+    }
+
+    /// Get a mutable reference to a node by id.
+    pub fn get_node(&mut self, id: &str) -> &mut DotNode {
+        self.nodes.get_mut(id).unwrap()
+    }
+
+    /// Set a graph-level attribute.
+    pub fn set_graph_attribute(&mut self, key: &str, value: &str) -> &mut Self {
+        self.graph_attributes
+            .push((key.to_owned(), value.to_owned()));
+        self
+    }
+
+    /// Set a default attribute applied to every node.
+    pub fn set_node_default_attribute(&mut self, key: &str, value: &str) -> &mut Self {
+        self.node_default_attributes
+            .push((key.to_owned(), value.to_owned()));
+        self
+    }
+
+    /// Set a default attribute applied to every edge.
+    pub fn set_edge_default_attribute(&mut self, key: &str, value: &str) -> &mut Self {
+        self.edge_default_attributes
+            .push((key.to_owned(), value.to_owned()));
+        self
+    }
+}
+
+impl DotNode {
+    /// Attach an attribute to this node.
+    pub fn attribute(&mut self, key: &str, value: &str) -> &mut Self {
+        self.attributes.push((key.to_owned(), value.to_owned()));
+        self
+    }
+}
+
+impl DotEdge {
+    /// Attach an attribute to this edge.
+    pub fn attribute(&mut self, key: &str, value: &str) -> &mut Self {
+        self.attributes.push((key.to_owned(), value.to_owned()));
+        self
+    }
+}
+
+impl fmt::Display for DotGraphBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "digraph {} {{", quote(&self.name))?;
+
+        for (key, value) in &self.graph_attributes {
+            writeln!(f, "  {key}={};", quote(value))?;
+        }
+
+        if !self.node_default_attributes.is_empty() {
+            write!(f, "  node")?;
+            write_attributes(f, &self.node_default_attributes)?;
+            writeln!(f, ";")?;
+        }
+
+        if !self.edge_default_attributes.is_empty() {
+            write!(f, "  edge")?;
+            write_attributes(f, &self.edge_default_attributes)?;
+            writeln!(f, ";")?;
+        }
+
+        for node in self.nodes.values() {
+            write!(f, "  {}", quote(&node.id))?;
+            write_attributes(f, &node.attributes)?;
+            writeln!(f, ";")?;
+        }
+
+        for edge in &self.edges {
+            write!(f, "  {} -> {}", quote(&edge.from), quote(&edge.to))?;
+            write_attributes(f, &edge.attributes)?;
+            writeln!(f, ";")?;
+        }
+
+        write!(f, "}}")
+    }
+}
+
+fn write_attributes(f: &mut fmt::Formatter<'_>, attributes: &[(String, String)]) -> fmt::Result {
+    if attributes.is_empty() {
+        return Ok(());
+    }
+
+    write!(f, " [")?;
+    for (i, (key, value)) in attributes.iter().enumerate() {
+        if i > 0 {
+            write!(f, ", ")?;
+        }
+        write!(f, "{key}={}", quote(value))?;
+    }
+    write!(f, "]")
+}
+
+/// Wrap a string in double quotes and escape the necessary characters for the DOT language.
+fn quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            _ => out.push(c),
+        }
+    }
+
+    out.push('"');
+    out
+}
+
+pub const DOTFILE_EXTENSION: &str = "dot";

--- a/src/js/common/mod.rs
+++ b/src/js/common/mod.rs
@@ -1,6 +1,8 @@
 pub mod alloc;
 pub mod constants;
 pub mod error;
+pub mod filesystem;
+pub mod graphviz;
 pub mod icu;
 mod icu_data;
 pub mod macros;

--- a/src/js/common/options.rs
+++ b/src/js/common/options.rs
@@ -1,5 +1,6 @@
 use std::{
     fmt,
+    path::PathBuf,
     sync::{Mutex, MutexGuard},
 };
 
@@ -28,6 +29,11 @@ pub struct Args {
     /// Print the bytecode for all RegExps to the console
     #[arg(long, default_value_t = false)]
     pub print_regexp_bytecode: bool,
+
+    /// Save a Graphviz DOT file of the bytecode for all RegExps into the given directory. Defaults
+    /// to the "dotfiles" directory.
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = DEFAULT_REGEXP_DOTFILE_DIRECTORY)]
+    pub save_regexp_bytecode_dotfiles: Option<String>,
 
     /// Parse as module instead of script
     #[arg(short, long, default_value_t = false)]
@@ -81,6 +87,9 @@ pub struct Options {
     /// Print the bytecode for all RegExps to the console
     pub print_regexp_bytecode: bool,
 
+    /// Output directory for Graphviz RegExp bytecode dotfiles, if any.
+    pub regexp_dotfile_directory: Option<PathBuf>,
+
     /// Buffer to write all dumped output into instead of stdout
     pub dump_buffer: Option<Mutex<String>>,
 
@@ -130,6 +139,7 @@ impl OptionsBuilder {
             print_ast: false,
             print_bytecode: false,
             print_regexp_bytecode: false,
+            regexp_dotfile_directory: None,
             dump_buffer: None,
             min_heap_size: DEFAULT_MIN_HEAP_SIZE,
             max_heap_size: DEFAULT_MAX_HEAP_SIZE,
@@ -141,11 +151,17 @@ impl OptionsBuilder {
 
     /// Create new options from command line arguments.
     pub fn new_from_args(args: &Args) -> Self {
+        let regexp_dotfile_directory = args
+            .save_regexp_bytecode_dotfiles
+            .as_ref()
+            .map(|dir| PathBuf::from(dir));
+
         OptionsBuilder::new()
             .annex_b(args.annex_b)
             .print_ast(args.print_ast)
             .print_bytecode(args.print_bytecode)
             .print_regexp_bytecode(args.print_regexp_bytecode)
+            .regexp_dotfile_directory(regexp_dotfile_directory)
             .min_heap_size(args.min_heap_size.unwrap_or(DEFAULT_MIN_HEAP_SIZE))
             .max_heap_size(args.max_heap_size.unwrap_or(DEFAULT_MAX_HEAP_SIZE))
             .no_color(args.no_color)
@@ -194,6 +210,11 @@ impl OptionsBuilder {
         self
     }
 
+    pub fn regexp_dotfile_directory(mut self, directory: Option<PathBuf>) -> Self {
+        self.0.regexp_dotfile_directory = directory;
+        self
+    }
+
     pub fn min_heap_size(mut self, min_heap_size: usize) -> Self {
         self.0.min_heap_size = min_heap_size;
         self
@@ -227,6 +248,8 @@ impl OptionsBuilder {
         self
     }
 }
+
+const DEFAULT_REGEXP_DOTFILE_DIRECTORY: &str = "dotfiles";
 
 fn parse_min_heap_size_arg(size_arg: &str) -> Result<usize, String> {
     let size = parse_heap_size_arg(size_arg)

--- a/src/js/common/options.rs
+++ b/src/js/common/options.rs
@@ -154,7 +154,7 @@ impl OptionsBuilder {
         let regexp_dotfile_directory = args
             .save_regexp_bytecode_dotfiles
             .as_ref()
-            .map(|dir| PathBuf::from(dir));
+            .map(PathBuf::from);
 
         OptionsBuilder::new()
             .annex_b(args.annex_b)

--- a/src/js/parser/regexp.rs
+++ b/src/js/parser/regexp.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use bitflags::bitflags;
 
 use crate::{
@@ -82,6 +84,44 @@ impl RegExpFlags {
     /// The `y` flag is set
     pub fn is_sticky(&self) -> bool {
         self.contains(Self::STICKY)
+    }
+}
+
+impl fmt::Display for RegExpFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.has_indices() {
+            f.write_str("d")?;
+        }
+
+        if self.is_global() {
+            f.write_str("g")?;
+        }
+
+        if self.is_case_insensitive() {
+            f.write_str("i")?;
+        }
+
+        if self.is_multiline() {
+            f.write_str("m")?;
+        }
+
+        if self.is_dot_all() {
+            f.write_str("s")?;
+        }
+
+        if self.has_simple_unicode_flag() {
+            f.write_str("u")?;
+        }
+
+        if self.has_unicode_sets_flag() {
+            f.write_str("v")?;
+        }
+
+        if self.is_sticky() {
+            f.write_str("y")?;
+        }
+
+        Ok(())
     }
 }
 

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -10,6 +10,7 @@ use rand::{rngs::StdRng, SeedableRng};
 
 use crate::{
     common::{
+        filesystem::FileNameReserver,
         options::Options,
         serialized_heap::SerializedHeap,
         wtf_8::{Wtf8Str, Wtf8String},
@@ -111,6 +112,9 @@ pub struct ContextCell {
     /// Options passed to this program.
     pub options: Rc<Options>,
 
+    /// Reserves unique file paths for any debug files written during this session.
+    pub debug_file_name_reserver: FileNameReserver,
+
     /// Set once module resolution has been completed.
     pub has_finished_module_resolution: bool,
 
@@ -149,6 +153,7 @@ impl Context {
             default_named_properties: HeapPtr::uninit(),
             default_array_properties: HeapPtr::uninit(),
             options: options.clone(),
+            debug_file_name_reserver: FileNameReserver::new(),
             has_finished_module_resolution: false,
             async_evaluation_counter: NonZeroUsize::MIN,
             // We want the initial heap generation to be deterministic so use seeded PRNG. After

--- a/src/js/runtime/regexp/compiled_regexp.rs
+++ b/src/js/runtime/regexp/compiled_regexp.rs
@@ -1,7 +1,7 @@
 use std::mem::size_of;
 
 use crate::{
-    common::math::round_to_power_of_two,
+    common::{graphviz::DotGraphBuilder, math::round_to_power_of_two},
     field_offset,
     parser::regexp::{RegExp, RegExpFlags},
     runtime::{
@@ -11,7 +11,7 @@ use crate::{
         debug_print::{DebugPrint, DebugPrinter},
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
-        regexp::instruction::InstructionIterator,
+        regexp::{graphviz::compiled_regexp_to_dot_graph, instruction::InstructionIterator},
         string_value::{FlatString, StringValue},
         Context, Handle, HeapPtr,
     },
@@ -146,6 +146,12 @@ impl CompiledRegExpObject {
                 self.num_capture_groups as usize,
             )
         }
+    }
+}
+
+impl HeapPtr<CompiledRegExpObject> {
+    pub fn to_dot_graph(&self) -> DotGraphBuilder {
+        compiled_regexp_to_dot_graph(*self)
     }
 }
 

--- a/src/js/runtime/regexp/compiler.rs
+++ b/src/js/runtime/regexp/compiler.rs
@@ -29,6 +29,7 @@ use crate::{
         debug_print::{DebugPrint, DebugPrintMode},
         regexp::{
             compiled_regexp::CompiledRegExpObject,
+            graphviz::save_regexp_dotfile_if_needed,
             instruction::{
                 AcceptInstruction, AssertEndInstruction, AssertEndOrNewlineInstruction,
                 AssertNotWordBoundaryInstruction, AssertStartInstruction,
@@ -1564,6 +1565,8 @@ pub fn compile_regexp(
         let bytecode_string = compiled_regexp.debug_print(DebugPrintMode::Verbose);
         cx.print_or_add_to_dump_buffer(&bytecode_string);
     }
+
+    save_regexp_dotfile_if_needed(cx, *compiled_regexp);
 
     Ok(compiled_regexp)
 }

--- a/src/js/runtime/regexp/graphviz.rs
+++ b/src/js/runtime/regexp/graphviz.rs
@@ -1,0 +1,227 @@
+use std::{fs, ops::Range};
+
+use crate::{
+    common::graphviz::{DotGraphBuilder, DOTFILE_EXTENSION},
+    runtime::{
+        regexp::{
+            compiled_regexp::CompiledRegExpObject,
+            instruction::{
+                BranchInstruction, Instruction, InstructionIterator, JumpInstruction,
+                LookaroundInstruction, LoopInstruction, OpCode,
+            },
+        },
+        Context, HeapPtr,
+    },
+};
+
+/// If the option is set, generate a Graphviz DOT file for the a compiled RegExp and write to disk.
+pub fn save_regexp_dotfile_if_needed(
+    context: Context,
+    compiled_regexp: HeapPtr<CompiledRegExpObject>,
+) {
+    let output_directory = match context.options.regexp_dotfile_directory.clone() {
+        Some(dir) => dir,
+        None => return,
+    };
+
+    let pattern = compiled_regexp
+        .escaped_pattern_source()
+        .format()
+        .unwrap_or_default();
+
+    let output_path = context.debug_file_name_reserver.reserve_unique_path(
+        &output_directory,
+        &pattern,
+        DOTFILE_EXTENSION,
+    );
+
+    let dot_graph = compiled_regexp.to_dot_graph();
+    let dot_file = dot_graph.to_string();
+
+    if let Err(error) =
+        fs::create_dir_all(&output_directory).and_then(|()| fs::write(&output_path, dot_file))
+    {
+        eprintln!("Failed to write RegExp dotfile {}: {error}", output_path.display());
+    }
+}
+
+/// Render a Graphviz DOT representation of the compiled RegExp bytecode.
+pub fn compiled_regexp_to_dot_graph(regexp: HeapPtr<CompiledRegExpObject>) -> DotGraphBuilder {
+    let mut graph = DotGraphBuilder::new("regexp");
+
+    add_graph_title(&mut graph, regexp);
+    add_default_attributes(&mut graph);
+    add_start_node(&mut graph);
+    add_nodes_and_edges(&mut graph, regexp);
+
+    graph
+}
+
+/// Each basic block's starting offset can be used as its unique id.
+fn block_to_node_id(block_start_offset: usize) -> String {
+    block_start_offset.to_string()
+}
+
+fn add_graph_title(graph: &mut DotGraphBuilder, regexp: HeapPtr<CompiledRegExpObject>) {
+    let pattern = regexp.escaped_pattern_source().format().unwrap_or_default();
+    let graph_title = format!("/{pattern}/{}", regexp.flags);
+
+    graph.set_graph_attribute("label", &graph_title);
+}
+
+fn add_start_node(graph: &mut DotGraphBuilder) {
+    // Start node points to the first block
+    graph.add_node("start").attribute("label", "start");
+    graph.add_edge("start", &block_to_node_id(0));
+}
+
+fn add_default_attributes(graph: &mut DotGraphBuilder) {
+    graph.set_graph_attribute("labelloc", "t");
+    graph.set_node_default_attribute("shape", "box");
+    graph.set_node_default_attribute("fontname", "monospace");
+    graph.set_edge_default_attribute("fontname", "monospace");
+}
+
+fn is_basic_block_end(instr: &Instruction) -> bool {
+    matches!(
+        instr.opcode(),
+        OpCode::Jump
+            | OpCode::Branch
+            | OpCode::Loop
+            | OpCode::Lookaround
+            | OpCode::Accept
+            | OpCode::Fail
+    )
+}
+
+/// Iterate over all basic blocks in the compiled instructions.
+///
+/// Call `f` for each basic block, passing the block's offset range and an iterator over the
+/// instructions in the block.
+fn iter_basic_blocks(instructions: &[u32], mut f: impl FnMut(Range<usize>, InstructionIterator)) {
+    // Determine boundaries of all basic blocks in the program
+    let mut block_bounds = vec![];
+    block_bounds.push(0);
+
+    let mut offset = 0;
+    for instruction in InstructionIterator::new(instructions) {
+        offset += instruction.size();
+
+        if is_basic_block_end(instruction) {
+            block_bounds.push(offset);
+        }
+    }
+
+    for bounds in block_bounds.windows(2) {
+        let bounds = bounds[0]..bounds[1];
+        let basic_block = &instructions[bounds.clone()];
+        let iter = InstructionIterator::new(basic_block);
+
+        f(bounds, iter);
+    }
+}
+
+fn add_nodes_and_edges(graph: &mut DotGraphBuilder, regexp: HeapPtr<CompiledRegExpObject>) {
+    let mut offset = 0;
+
+    iter_basic_blocks(regexp.instructions(), |block_bounds, mut instructions| {
+        let mut node_label = String::new();
+
+        let node_id = block_to_node_id(block_bounds.start);
+        graph.add_node(&node_id);
+
+        while let Some(instruction) = instructions.next() {
+            let next_offset = offset + instruction.size();
+
+            // Accumulate text for all instructions in the block for the node label
+            node_label.push_str(&format!("{offset}: {}\n", instruction.debug_print()));
+
+            // Last instruction determines all control flow edges out of the block
+            if instructions.is_end() {
+                let next_node_id = block_to_node_id(next_offset);
+
+                add_node_color(graph, instruction, &node_id);
+                add_node_edges(graph, instruction, &node_id, &next_node_id);
+            }
+
+            offset = next_offset;
+        }
+
+        graph.get_node(&node_id).attribute("label", &node_label);
+    });
+}
+
+fn add_node_color(graph: &mut DotGraphBuilder, block_last_instr: &Instruction, node_id: &str) {
+    const ACCEPT_COLOR: &str = "#d6f5d6";
+    const FAIL_COLOR: &str = "#f5d6d6";
+
+    let node = graph.get_node(node_id);
+
+    match block_last_instr.opcode() {
+        OpCode::Accept => {
+            node.attribute("style", "filled")
+                .attribute("fillcolor", ACCEPT_COLOR);
+        }
+        OpCode::Fail => {
+            node.attribute("style", "filled")
+                .attribute("fillcolor", FAIL_COLOR);
+        }
+        _ => {}
+    }
+}
+
+fn add_node_edges(
+    graph: &mut DotGraphBuilder,
+    terminator_instr: &Instruction,
+    node_id: &str,
+    fallthrough_node_id: &str,
+) {
+    match terminator_instr.opcode() {
+        OpCode::Jump => {
+            let instr = terminator_instr.cast::<JumpInstruction>();
+            let target_node_id = block_to_node_id(instr.target() as usize);
+
+            graph.add_edge(node_id, &target_node_id);
+        }
+        OpCode::Branch => {
+            let instr = terminator_instr.cast::<BranchInstruction>();
+            let first_node_id = block_to_node_id(instr.first_branch() as usize);
+            let second_node_id = block_to_node_id(instr.second_branch() as usize);
+
+            graph.add_edge(node_id, &first_node_id);
+            graph
+                .add_edge(node_id, &second_node_id)
+                .attribute("color", "gray50")
+                .attribute("style", "dashed");
+        }
+        // Loop has implicit continue edge which falls through to the next block
+        OpCode::Loop => {
+            let instr = terminator_instr.cast::<LoopInstruction>();
+            let end_node_id = block_to_node_id(instr.end_branch() as usize);
+
+            graph
+                .add_edge(node_id, &end_node_id)
+                .attribute("label", "end");
+            graph
+                .add_edge(node_id, fallthrough_node_id)
+                .attribute("label", "continue");
+        }
+        // Lookaround has implicit success edge which falls through to the next block
+        OpCode::Lookaround => {
+            let instr = terminator_instr.cast::<LookaroundInstruction>();
+            let body_node_id = block_to_node_id(instr.body_branch() as usize);
+
+            graph
+                .add_edge(node_id, &body_node_id)
+                .attribute("color", "blue")
+                .attribute("style", "dotted")
+                .attribute("label", "lookaround");
+            graph.add_edge(node_id, fallthrough_node_id);
+        }
+        OpCode::Accept | OpCode::Fail => {}
+        // No explicit control flow instruction means fall through to the next block.
+        _ => {
+            graph.add_edge(node_id, fallthrough_node_id);
+        }
+    }
+}

--- a/src/js/runtime/regexp/graphviz.rs
+++ b/src/js/runtime/regexp/graphviz.rs
@@ -1,4 +1,4 @@
-use std::{fs, ops::Range};
+use std::{collections::HashSet, fs, ops::Range};
 
 use crate::{
     common::graphviz::{DotGraphBuilder, DOTFILE_EXTENSION},
@@ -20,7 +20,7 @@ pub fn save_regexp_dotfile_if_needed(
     compiled_regexp: HeapPtr<CompiledRegExpObject>,
 ) {
     let output_directory = match context.options.regexp_dotfile_directory.clone() {
-        Some(dir) => dir,
+        Some(directory) => directory,
         None => return,
     };
 
@@ -82,66 +82,90 @@ fn add_default_attributes(graph: &mut DotGraphBuilder) {
     graph.set_edge_default_attribute("fontname", "monospace");
 }
 
-fn is_basic_block_end(instr: &Instruction) -> bool {
-    matches!(
-        instr.opcode(),
-        OpCode::Jump
-            | OpCode::Branch
-            | OpCode::Loop
-            | OpCode::Lookaround
-            | OpCode::Accept
-            | OpCode::Fail
-    )
+/// Determine boundaries of all basic blocks in the bytecode.
+///
+/// Must reconstruct these boundaries by detecting terminator instructions and their branches.
+/// Return a vec containing the offsets of the [start, end) of every basic block in the bytecode.
+fn build_basic_block_bounds(bytecode: &[u32]) -> Vec<usize> {
+    let mut block_bounds = HashSet::new();
+    block_bounds.insert(0);
+
+    let mut offset = 0;
+    for instr in InstructionIterator::new(bytecode) {
+        offset += instr.size();
+
+        let is_basic_block_end = match instr.opcode() {
+            OpCode::Fail | OpCode::Accept => true,
+            OpCode::Jump => {
+                block_bounds.insert(instr.cast::<JumpInstruction>().target() as usize);
+                true
+            }
+            OpCode::Branch => {
+                let instr = instr.cast::<BranchInstruction>();
+                block_bounds.insert(instr.first_branch() as usize);
+                block_bounds.insert(instr.second_branch() as usize);
+                true
+            }
+            OpCode::Loop => {
+                block_bounds.insert(instr.cast::<LoopInstruction>().end_branch() as usize);
+                true
+            }
+            OpCode::Lookaround => {
+                block_bounds.insert(instr.cast::<LookaroundInstruction>().body_branch() as usize);
+                true
+            }
+            _ => false,
+        };
+
+        if is_basic_block_end {
+            block_bounds.insert(offset);
+        }
+    }
+
+    // Sort deduped block boundaries to construct the final list
+    let mut sorted_block_bounds = block_bounds.into_iter().collect::<Vec<_>>();
+    sorted_block_bounds.sort();
+
+    sorted_block_bounds
 }
 
 /// Iterate over all basic blocks in the compiled instructions.
 ///
 /// Call `f` for each basic block, passing the block's offset range and an iterator over the
 /// instructions in the block.
-fn iter_basic_blocks(instructions: &[u32], mut f: impl FnMut(Range<usize>, InstructionIterator)) {
-    // Determine boundaries of all basic blocks in the program
-    let mut block_bounds = vec![];
-    block_bounds.push(0);
-
-    let mut offset = 0;
-    for instruction in InstructionIterator::new(instructions) {
-        offset += instruction.size();
-
-        if is_basic_block_end(instruction) {
-            block_bounds.push(offset);
-        }
-    }
+fn iter_basic_blocks(bytecode: &[u32], mut f: impl FnMut(Range<usize>, InstructionIterator)) {
+    let block_bounds = build_basic_block_bounds(bytecode);
 
     for bounds in block_bounds.windows(2) {
         let bounds = bounds[0]..bounds[1];
-        let basic_block = &instructions[bounds.clone()];
-        let iter = InstructionIterator::new(basic_block);
+        let basic_block_bytecode = &bytecode[bounds.clone()];
+        let iter = InstructionIterator::new(basic_block_bytecode);
 
         f(bounds, iter);
     }
 }
 
 fn add_nodes_and_edges(graph: &mut DotGraphBuilder, regexp: HeapPtr<CompiledRegExpObject>) {
-    let mut offset = 0;
-
     iter_basic_blocks(regexp.instructions(), |block_bounds, mut instructions| {
         let mut node_label = String::new();
 
         let node_id = block_to_node_id(block_bounds.start);
         graph.add_node(&node_id);
 
-        while let Some(instruction) = instructions.next() {
-            let next_offset = offset + instruction.size();
+        let mut offset = block_bounds.start;
+
+        while let Some(instr) = instructions.next() {
+            let next_offset = offset + instr.size();
 
             // Accumulate text for all instructions in the block for the node label
-            node_label.push_str(&format!("{offset}: {}\n", instruction.debug_print()));
+            node_label.push_str(&format!("{offset}: {}\n", instr.debug_print()));
 
             // Last instruction determines all control flow edges out of the block
             if instructions.is_end() {
                 let next_node_id = block_to_node_id(next_offset);
 
-                add_node_color(graph, instruction, &node_id);
-                add_node_edges(graph, instruction, &node_id, &next_node_id);
+                add_node_color(graph, instr, &node_id);
+                add_node_edges(graph, instr, &node_id, &next_node_id);
             }
 
             offset = next_offset;

--- a/src/js/runtime/regexp/instruction.rs
+++ b/src/js/runtime/regexp/instruction.rs
@@ -749,13 +749,17 @@ impl<'a> InstructionIterator<'a> {
 
         Self { ptr, end, _marker: PhantomData }
     }
+
+    pub fn is_end(&self) -> bool {
+        self.ptr >= self.end
+    }
 }
 
 impl<'a> Iterator for InstructionIterator<'a> {
     type Item = &'a Instruction;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.ptr >= self.end {
+        if self.is_end() {
             return None;
         }
 

--- a/src/js/runtime/regexp/mod.rs
+++ b/src/js/runtime/regexp/mod.rs
@@ -1,4 +1,5 @@
 pub mod compiled_regexp;
 pub mod compiler;
+pub mod graphviz;
 pub mod instruction;
 pub mod matcher;


### PR DESCRIPTION
## Summary

Create a simple Graphviz DOT file generator for RegExp bytecode. This visualizes the control flow graph, with basic blocks as nodes and directed edges between them.

The core Graphviz graph builder and serialization logic is kept common, as it will be reused for DOT file generation of JS bytecode in the future.

- Creates a shared global file name reserver which guarantees sanitized, unique file names
- DOT file generator must parse the bytecode into basic blocks and discover all edges

## Tests

- CI
- Verified by generating some example graphviz diagrams from bytecode