### PR TITLE
[bytecode] Fix jump constant instruction bytecode printing

### DIFF
--- a/src/js/runtime/bytecode/constant_table.rs
+++ b/src/js/runtime/bytecode/constant_table.rs
@@ -68,6 +68,11 @@ impl ConstantTable {
         self.constants.as_mut_slice()[index] = value;
     }
 
+    /// Get a raw signed offset stored in the constant table.
+    pub fn get_constant_offset(&self, index: usize) -> isize {
+        self.get_constant(index).as_raw_bits() as isize
+    }
+
     fn get_metadata_ptr(&self) -> *const u8 {
         let ptr = self as *const ConstantTable as *const u8;
         unsafe { ptr.add(Self::metadata_offset(self.constants.len())) }

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -476,7 +476,7 @@ impl DebugPrint for HeapPtr<BytecodeFunction> {
 
         // Followed by instructions which are further indented
         printer.inc_indent();
-        debug_format_instructions(self.bytecode(), printer);
+        debug_format_instructions(*self, printer);
         printer.dec_indent();
 
         // Followed by the constant table if present

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -9,6 +9,7 @@ use crate::{
     count, replace_expr,
     runtime::{
         bytecode::{
+            function::BytecodeFunction,
             operand::{ConstantIndex, Operand, OperandType, Register, SInt, UInt},
             width::{
                 ExtraWide, Narrow, SignedWidthRepr, UnsignedWidthRepr, Wide, Width, WidthEnum,
@@ -16,6 +17,7 @@ use crate::{
             writer::BytecodeWriter,
         },
         debug_print::DebugPrinter,
+        HeapPtr,
     },
 };
 
@@ -27,8 +29,10 @@ pub trait Instruction: fmt::Display {
     fn operand_types(&self) -> &[OperandType];
     fn width(&self) -> WidthEnum;
 
-    /// Return a raw operand at the given index. The operand is extended to a usize, though may
-    /// actually represent a smaller or unsigned integer.
+    /// Return a raw operand at the given index, interpreted as unsigned and extended to a usize.
+    fn get_raw_operand_unsigned(&self, index: usize) -> usize;
+
+    /// Return a raw operand at the given index, interpreted as signed and extended to an isize.
     fn get_raw_operand_signed(&self, index: usize) -> isize;
 
     /// Total length in bytes of this instruction's operands. Does not include the opcode or width
@@ -150,6 +154,11 @@ macro_rules! define_instructions {
                 #[inline]
                 fn width(&self) -> WidthEnum {
                     W::ENUM
+                }
+
+                #[inline]
+                fn get_raw_operand_unsigned(&self, index: usize) -> usize {
+                    self.0[index].to_usize()
                 }
 
                 #[inline]
@@ -2076,7 +2085,9 @@ impl<'a> Iterator for InstructionIterator<'a> {
     }
 }
 
-pub fn debug_format_instructions(bytecode: &[u8], printer: &mut DebugPrinter) {
+pub fn debug_format_instructions(function: HeapPtr<BytecodeFunction>, printer: &mut DebugPrinter) {
+    let bytecode = function.bytecode();
+
     // Initial pass to find the max instruction length and max offset in the bytecode to calculate
     // padding. Also determine the jump targets so that they can be labeled.
     let mut prev_offset = 0;
@@ -2089,7 +2100,7 @@ pub fn debug_format_instructions(bytecode: &[u8], printer: &mut DebugPrinter) {
         prev_offset = offset;
         offsets.push(offset);
 
-        if let Some(jump_offset) = get_jump_offset(instr) {
+        if let Some(jump_offset) = get_jump_offset(function, instr) {
             jump_targets.insert((offset as isize + jump_offset) as usize);
         }
     }
@@ -2143,7 +2154,7 @@ pub fn debug_format_instructions(bytecode: &[u8], printer: &mut DebugPrinter) {
         printer.write(&instr.to_string());
 
         // If this is a jump instruction, print the target label following the jump offset
-        if let Some(jump_offset) = get_jump_offset(instr) {
+        if let Some(jump_offset) = get_jump_offset(function, instr) {
             let target_offset = (offset as isize + jump_offset) as usize;
             let target_label = jump_targets[&target_offset];
 
@@ -2154,14 +2165,22 @@ pub fn debug_format_instructions(bytecode: &[u8], printer: &mut DebugPrinter) {
     }
 }
 
-fn get_jump_offset(instr: &dyn Instruction) -> Option<isize> {
+fn get_jump_offset(function: HeapPtr<BytecodeFunction>, instr: &dyn Instruction) -> Option<isize> {
     let opcode = instr.opcode();
 
-    if opcode == OpCode::Jump || opcode == OpCode::JumpConstant {
-        Some(instr.get_raw_operand_signed(0))
+    let offset_operand_index = if opcode == OpCode::Jump || opcode == OpCode::JumpConstant {
+        0
     } else if opcode >= OpCode::JumpTrue && opcode <= OpCode::JumpNotNullishConstant {
-        Some(instr.get_raw_operand_signed(1))
+        1
     } else {
-        None
+        return None;
+    };
+
+    if instr.operand_types()[offset_operand_index] == OperandType::ConstantIndex {
+        let constant_index = instr.get_raw_operand_unsigned(offset_operand_index);
+        let constant_table = function.constant_table_ptr();
+        constant_table.map(|constant_table| constant_table.get_constant_offset(constant_index))
+    } else {
+        Some(instr.get_raw_operand_signed(offset_operand_index))
     }
 }

--- a/src/js/runtime/bytecode/operand.rs
+++ b/src/js/runtime/bytecode/operand.rs
@@ -123,6 +123,7 @@ operand_type!(SInt, SIGNED);
 // An index into the constant table
 operand_type!(ConstantIndex, UNSIGNED);
 
+#[derive(PartialEq)]
 pub enum OperandType {
     Register,
     UInt,

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -1425,8 +1425,8 @@ impl VM {
 
     #[inline]
     fn get_constant_offset<W: Width>(&self, constant_index: ConstantIndex<W>) -> isize {
-        // Constant offsets are encoded as a raw isize, not a value
-        self.get_constant(constant_index).as_raw_bits() as isize
+        self.constant_table()
+            .get_constant_offset(constant_index.value().to_usize())
     }
 
     /// Set the PC to the jump target, specified as a relative offset immediate.

--- a/tests/snapshot/bytecode/bytecode/jump_patching.exp
+++ b/tests/snapshot/bytecode/bytecode/jump_patching.exp
@@ -130,6 +130,7 @@
     264: Call r0, r0, r1, 10
     269: LoadImmediate r0, 1
     272: Ret r0
+  .L0:
     274: LoadImmediate r0, 2
     277: Ret r0
   Constant Table:
@@ -151,10 +152,10 @@
 
 [BytecodeFunction: testShortPatchJump2] {
   Parameters: 1, Registers: 11
-      0: JumpToBooleanFalse a0, 8 (.L1)
+      0: JumpToBooleanFalse a0, 8 (.L0)
       3: LoadImmediate r0, 1
-      6: JumpConstant c1 (.L0)
-  .L1:
+      6: JumpConstant c1 (.L1)
+  .L0:
       8: LoadGlobal r0, c0
      11: LoadImmediate r1, 1
      14: LoadImmediate r2, 2
@@ -239,6 +240,7 @@
     263: LoadImmediate r9, 9
     266: LoadImmediate r10, 10
     269: Call r0, r0, r1, 10
+  .L1:
     274: LoadImmediate r0, 2
     277: Ret r0
   Constant Table:

--- a/tests/snapshot/bytecode/expression/yield_star.exp
+++ b/tests/snapshot/bytecode/expression/yield_star.exp
@@ -86,59 +86,58 @@
      29: CheckIteratorResultObject r6
      31: GetNamedProperty r7, r6, c0
      35: JumpTrue r7, 5 (.L2)
-     38: Jump 125 (.L15)
+     38: Jump 125 (.L14)
   .L2:
      40: GetNamedProperty r1, r6, c1
-     44: JumpConstant c5 (.L4)
+     44: JumpConstant c5 (.L15)
   .L3:
-     46: JumpNotUndefined r5, 55 (.L9)
-  .L4:
+     46: JumpNotUndefined r5, 55 (.L8)
      49: GetMethod r8, r2, c3
-     53: JumpNotUndefined r8, 15 (.L6)
+     53: JumpNotUndefined r8, 15 (.L5)
      56: Await r4, r9, r0, r4
-     61: JumpTrue r9, 5 (.L5)
+     61: JumpTrue r9, 5 (.L4)
      64: Throw r4
-  .L5:
+  .L4:
      66: Ret r4
-  .L6:
+  .L5:
      68: CallWithReceiver r6, r8, r2, r4, 1
      74: Await r6, r8, r0, r6
-     79: JumpTrue r8, 5 (.L7)
+     79: JumpTrue r8, 5 (.L6)
      82: Throw r6
-  .L7:
+  .L6:
      84: CheckIteratorResultObject r6
      86: GetNamedProperty r7, r6, c0
-     90: JumpTrue r7, 5 (.L8)
-     93: Jump 70 (.L15)
-  .L8:
+     90: JumpTrue r7, 5 (.L7)
+     93: Jump 70 (.L14)
+  .L7:
      95: GetNamedProperty r8, r6, c1
      99: Ret r8
-  .L9:
+  .L8:
     101: GetMethod r8, r2, c2
-    105: JumpNotUndefined r8, 25 (.L12)
+    105: JumpNotUndefined r8, 25 (.L11)
     108: AsyncIteratorCloseStart r10, r9, r2
-    112: JumpFalse r9, 15 (.L11)
+    112: JumpFalse r9, 15 (.L10)
     115: Await r10, r11, r0, r10
-    120: JumpTrue r11, 5 (.L10)
+    120: JumpTrue r11, 5 (.L9)
     123: Throw r10
-  .L10:
+  .L9:
     125: AsyncIteratorCloseFinish r10
-  .L11:
+  .L10:
     127: ThrowNewError 1, c4
-  .L12:
+  .L11:
     130: CallWithReceiver r6, r8, r2, r4, 1
     136: Await r6, r8, r0, r6
-    141: JumpTrue r8, 5 (.L13)
+    141: JumpTrue r8, 5 (.L12)
     144: Throw r6
-  .L13:
+  .L12:
     146: CheckIteratorResultObject r6
     148: GetNamedProperty r7, r6, c0
-    152: JumpTrue r7, 5 (.L14)
-    155: Jump 8 (.L15)
-  .L14:
+    152: JumpTrue r7, 5 (.L13)
+    155: Jump 8 (.L14)
+  .L13:
     157: GetNamedProperty r1, r6, c1
-    161: Jump 35 (.L16)
-  .L15:
+    161: Jump 35 (.L15)
+  .L14:
     163: GetNamedProperty r8, r6, c1
     167: Yield r4, r5, r0, r8
     172: JumpNotUndefined (Wide) r5, -162 (.L0)
@@ -146,11 +145,11 @@
     183: JumpNullish (Wide) r5, -173 (.L0)
     190: LoadUndefined r5
     192: Jump (Wide) -182 (.L0)
-  .L16:
+  .L15:
     196: Await r1, r2, r0, r1
-    201: JumpTrue r2, 5 (.L17)
+    201: JumpTrue r2, 5 (.L16)
     204: Throw r1
-  .L17:
+  .L16:
     206: Ret r1
   Constant Table:
     0: [String: done]


### PR DESCRIPTION
## Summary

The `get_jump_offset` function was not handling jump constant instruction's whose offset is stored in the constant table. This was leading to the wrong label being used when printing bytecode for these instructions.

## Tests

- Updated affected bytecode snapshot tests, verified that jump constant labels are now correct