### PR TITLE
[common][bytecode] Generate Graphviz DOT files for JS bytecode

### DIFF
--- a/src/js/common/graphviz.rs
+++ b/src/js/common/graphviz.rs
@@ -10,12 +10,14 @@ pub struct DotGraphBuilder {
     graph_attributes: Vec<(String, String)>,
     node_default_attributes: Vec<(String, String)>,
     edge_default_attributes: Vec<(String, String)>,
+    graph_label_text_align: DotTextAlign,
 }
 
 /// A node in a DotGraphBuilder. Nodes are identified by their `id` field.
 pub struct DotNode {
     id: String,
     attributes: Vec<(String, String)>,
+    text_align: DotTextAlign,
 }
 
 /// A directed edge in a DotGraphBuilder.
@@ -23,6 +25,12 @@ pub struct DotEdge {
     from: String,
     to: String,
     attributes: Vec<(String, String)>,
+}
+
+#[derive(Clone, Copy)]
+pub enum DotTextAlign {
+    Left,
+    Center,
 }
 
 impl DotGraphBuilder {
@@ -34,16 +42,19 @@ impl DotGraphBuilder {
             graph_attributes: vec![],
             node_default_attributes: vec![],
             edge_default_attributes: vec![],
+            graph_label_text_align: DotTextAlign::Center,
         }
     }
 
     /// Add and return a node with the given id.
     pub fn add_node(&mut self, id: &str) -> &mut DotNode {
-        let had_entry = self
-            .nodes
-            .insert(id.to_owned(), DotNode { id: id.to_owned(), attributes: vec![] })
-            .is_some();
+        let node = DotNode {
+            id: id.to_owned(),
+            attributes: vec![],
+            text_align: DotTextAlign::Center,
+        };
 
+        let had_entry = self.nodes.insert(id.to_owned(), node).is_some();
         assert!(!had_entry, "Duplicate graphviz node id");
 
         self.nodes.get_mut(id).unwrap()
@@ -81,12 +92,24 @@ impl DotGraphBuilder {
             .push((key.to_owned(), value.to_owned()));
         self
     }
+
+    /// Set the text alignment of the graph's label.
+    pub fn set_graph_label_text_align(&mut self, text_align: DotTextAlign) -> &mut Self {
+        self.graph_label_text_align = text_align;
+        self
+    }
 }
 
 impl DotNode {
     /// Attach an attribute to this node.
     pub fn attribute(&mut self, key: &str, value: &str) -> &mut Self {
         self.attributes.push((key.to_owned(), value.to_owned()));
+        self
+    }
+
+    /// Set text alignment for this node's label.
+    pub fn text_align(&mut self, text_align: DotTextAlign) -> &mut Self {
+        self.text_align = text_align;
         self
     }
 }
@@ -104,7 +127,13 @@ impl fmt::Display for DotGraphBuilder {
         writeln!(f, "digraph {} {{", quote(&self.name))?;
 
         for (key, value) in &self.graph_attributes {
-            writeln!(f, "  {key}={};", quote(value))?;
+            let text_align = if key == "label" {
+                self.graph_label_text_align
+            } else {
+                DotTextAlign::Center
+            };
+
+            writeln!(f, "  {key}={};", quote_with_text_align(value, text_align))?;
         }
 
         if !self.node_default_attributes.is_empty() {
@@ -125,7 +154,7 @@ impl fmt::Display for DotGraphBuilder {
 
         for (_, node) in node_entries {
             write!(f, "  {}", quote(&node.id))?;
-            write_attributes(f, &node.attributes)?;
+            write_node_attributes(f, node)?;
             writeln!(f, ";")?;
         }
 
@@ -154,16 +183,46 @@ fn write_attributes(f: &mut fmt::Formatter<'_>, attributes: &[(String, String)])
     write!(f, "]")
 }
 
+fn write_node_attributes(f: &mut fmt::Formatter<'_>, node: &DotNode) -> fmt::Result {
+    if node.attributes.is_empty() {
+        return Ok(());
+    }
+
+    write!(f, " [")?;
+    for (i, (key, value)) in node.attributes.iter().enumerate() {
+        if i > 0 {
+            write!(f, ", ")?;
+        }
+
+        // Node text alignment applies only to label attribute
+        let text_align = if key == "label" {
+            node.text_align
+        } else {
+            DotTextAlign::Center
+        };
+
+        write!(f, "{key}={}", quote_with_text_align(value, text_align))?;
+    }
+    write!(f, "]")
+}
+
 /// Wrap a string in double quotes and escape the necessary characters for the DOT language.
-fn quote(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 2);
+fn quote(str: &str) -> String {
+    quote_with_text_align(str, DotTextAlign::Center)
+}
+
+fn quote_with_text_align(str: &str, text_align: DotTextAlign) -> String {
+    let mut out = String::with_capacity(str.len() + 2);
     out.push('"');
 
-    for c in s.chars() {
+    for c in str.chars() {
         match c {
             '"' => out.push_str("\\\""),
             '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
+            '\n' => match text_align {
+                DotTextAlign::Left => out.push_str("\\l"),
+                DotTextAlign::Center => out.push_str("\\n"),
+            },
             _ => out.push(c),
         }
     }

--- a/src/js/common/options.rs
+++ b/src/js/common/options.rs
@@ -18,23 +18,6 @@ use crate::common::{
 #[derive(Parser)]
 #[command(about)]
 pub struct Args {
-    /// Print the AST the console
-    #[arg(long, default_value_t = false)]
-    pub print_ast: bool,
-
-    /// Print the bytecode to the console
-    #[arg(long, default_value_t = false)]
-    pub print_bytecode: bool,
-
-    /// Print the bytecode for all RegExps to the console
-    #[arg(long, default_value_t = false)]
-    pub print_regexp_bytecode: bool,
-
-    /// Save a Graphviz DOT file of the bytecode for all RegExps into the given directory. Defaults
-    /// to the "dotfiles" directory.
-    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = DEFAULT_REGEXP_DOTFILE_DIRECTORY)]
-    pub save_regexp_bytecode_dotfiles: Option<String>,
-
     /// Parse as module instead of script
     #[arg(short, long, default_value_t = false)]
     pub module: bool,
@@ -69,6 +52,28 @@ pub struct Args {
     #[arg(long, default_value_t = false)]
     pub parse_stats: bool,
 
+    /// Print the AST the console
+    #[arg(long, default_value_t = false)]
+    pub print_ast: bool,
+
+    /// Print the bytecode for all functions to the console
+    #[arg(long, default_value_t = false)]
+    pub print_bytecode: bool,
+
+    /// Print the bytecode for all RegExps to the console
+    #[arg(long, default_value_t = false)]
+    pub print_regexp_bytecode: bool,
+
+    /// Save a Graphviz DOT file of the bytecode for all functions into the given directory.
+    /// Defaults to the "dotfiles" directory.
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = DEFAULT_DOTFILE_DIRECTORY)]
+    pub save_bytecode_dotfiles: Option<String>,
+
+    /// Save a Graphviz DOT file of the bytecode for all RegExps into the given directory. Defaults
+    /// to the "dotfiles" directory.
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = DEFAULT_DOTFILE_DIRECTORY)]
+    pub save_regexp_bytecode_dotfiles: Option<String>,
+
     #[arg(required = true)]
     pub files: Vec<String>,
 }
@@ -83,6 +88,9 @@ pub struct Options {
 
     /// Print the bytecode to the console
     pub print_bytecode: bool,
+
+    /// Output directory for Graphviz function bytecode dotfiles, if any.
+    pub bytecode_dotfile_directory: Option<PathBuf>,
 
     /// Print the bytecode for all RegExps to the console
     pub print_regexp_bytecode: bool,
@@ -138,6 +146,7 @@ impl OptionsBuilder {
             annex_b: cfg!(feature = "annex_b"),
             print_ast: false,
             print_bytecode: false,
+            bytecode_dotfile_directory: None,
             print_regexp_bytecode: false,
             regexp_dotfile_directory: None,
             dump_buffer: None,
@@ -151,6 +160,7 @@ impl OptionsBuilder {
 
     /// Create new options from command line arguments.
     pub fn new_from_args(args: &Args) -> Self {
+        let bytecode_dotfile_directory = args.save_bytecode_dotfiles.as_ref().map(PathBuf::from);
         let regexp_dotfile_directory = args
             .save_regexp_bytecode_dotfiles
             .as_ref()
@@ -160,6 +170,7 @@ impl OptionsBuilder {
             .annex_b(args.annex_b)
             .print_ast(args.print_ast)
             .print_bytecode(args.print_bytecode)
+            .bytecode_dotfile_directory(bytecode_dotfile_directory)
             .print_regexp_bytecode(args.print_regexp_bytecode)
             .regexp_dotfile_directory(regexp_dotfile_directory)
             .min_heap_size(args.min_heap_size.unwrap_or(DEFAULT_MIN_HEAP_SIZE))
@@ -202,6 +213,11 @@ impl OptionsBuilder {
 
     pub fn print_bytecode(mut self, print_bytecode: bool) -> Self {
         self.0.print_bytecode = print_bytecode;
+        self
+    }
+
+    pub fn bytecode_dotfile_directory(mut self, directory: Option<PathBuf>) -> Self {
+        self.0.bytecode_dotfile_directory = directory;
         self
     }
 
@@ -249,7 +265,7 @@ impl OptionsBuilder {
     }
 }
 
-const DEFAULT_REGEXP_DOTFILE_DIRECTORY: &str = "dotfiles";
+const DEFAULT_DOTFILE_DIRECTORY: &str = "dotfiles";
 
 fn parse_min_heap_size_arg(size_arg: &str) -> Result<usize, String> {
     let size = parse_heap_size_arg(size_arg)

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -1,6 +1,7 @@
 use std::{mem::size_of, ops::Range};
 
 use crate::{
+    common::graphviz::DotGraphBuilder,
     extend_object, field_offset, must_a,
     parser::loc::Pos,
     runtime::{
@@ -8,7 +9,8 @@ use crate::{
         alloc_error::AllocResult,
         bytecode::{
             constant_table::ConstantTable, exception_handlers::ExceptionHandlers,
-            instruction::debug_format_instructions, source_map::BytecodeSourceMap,
+            graphviz::bytecode_function_to_dot_graph, instruction::debug_format_instructions,
+            source_map::BytecodeSourceMap,
         },
         collections::{array::ByteArray, InlineArray},
         debug_print::{DebugPrint, DebugPrintMode, DebugPrinter},
@@ -443,6 +445,12 @@ impl BytecodeFunction {
     #[inline]
     pub fn runtime_function_id(&self) -> Option<RuntimeFunctionId> {
         self.runtime_function_id
+    }
+}
+
+impl HeapPtr<BytecodeFunction> {
+    pub fn to_dot_graph(&self) -> DotGraphBuilder {
+        bytecode_function_to_dot_graph(*self)
     }
 }
 

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -35,6 +35,7 @@ use crate::{
             constant_table_builder::{ConstantTableBuilder, ConstantTableIndex},
             exception_handlers::{ExceptionHandlerBuilder, ExceptionHandlersBuilder},
             function::{dump_bytecode_function, BytecodeFunction, Closure},
+            graphviz::save_bytecode_dotfile_if_needed,
             instruction::{
                 DecodeInfo, DefinePrivatePropertyFlags, DefinePropertyFlags, EvalFlags, OpCode,
                 ThrowNewErrorKind,
@@ -149,6 +150,8 @@ impl<'a> BytecodeProgramGenerator<'a> {
                 .maybe_grow_for_push(self.cx)?
                 .push_without_growing(*function);
         }
+
+        save_bytecode_dotfile_if_needed(self.cx, *function);
 
         Ok(())
     }

--- a/src/js/runtime/bytecode/graphviz.rs
+++ b/src/js/runtime/bytecode/graphviz.rs
@@ -1,0 +1,270 @@
+use std::{collections::HashSet, fs, ops::Range};
+
+use crate::{
+    common::graphviz::{DotGraphBuilder, DotTextAlign, DOTFILE_EXTENSION},
+    runtime::{
+        bytecode::{
+            function::BytecodeFunction,
+            instruction::{get_jump_offset, Instruction, InstructionIterator},
+        },
+        debug_print::{DebugPrint, DebugPrintMode},
+        Context, HeapPtr,
+    },
+};
+
+/// If the option is set, generate a Graphviz DOT file for a function's bytecode and write to disk.
+pub fn save_bytecode_dotfile_if_needed(context: Context, func: HeapPtr<BytecodeFunction>) {
+    let output_directory = match context.options.bytecode_dotfile_directory.clone() {
+        Some(dir) => dir,
+        None => return,
+    };
+
+    let name = function_name(func);
+
+    let output_path = context.debug_file_name_reserver.reserve_unique_path(
+        &output_directory,
+        &name,
+        DOTFILE_EXTENSION,
+    );
+
+    let dot_graph = func.to_dot_graph();
+    let dot_file = dot_graph.to_string();
+
+    if let Err(error) =
+        fs::create_dir_all(&output_directory).and_then(|()| fs::write(&output_path, dot_file))
+    {
+        eprintln!("Failed to write bytecode dotfile {}: {error}", output_path.display());
+    }
+}
+
+/// Render a Graphviz DOT representation of a function's bytecode.
+pub fn bytecode_function_to_dot_graph(func: HeapPtr<BytecodeFunction>) -> DotGraphBuilder {
+    let mut graph = DotGraphBuilder::new("bytecode");
+
+    add_graph_title(&mut graph, func);
+    add_default_attributes(&mut graph);
+    add_start_node(&mut graph, func);
+    add_exception_handler_nodes(&mut graph, func);
+    add_nodes_and_edges(&mut graph, func);
+
+    graph
+}
+
+/// Each basic block's starting offset can be used as its unique id.
+fn block_to_node_id(block_start_offset: usize) -> String {
+    block_start_offset.to_string()
+}
+
+fn function_name(func: HeapPtr<BytecodeFunction>) -> String {
+    match func.name() {
+        Some(name) => name.format().unwrap_or_default(),
+        None => "<anonymous>".to_owned(),
+    }
+}
+
+fn add_graph_title(graph: &mut DotGraphBuilder, func: HeapPtr<BytecodeFunction>) {
+    let constant_table_string = func
+        .constant_table_ptr()
+        .map(|table| table.debug_print(DebugPrintMode::Verbose))
+        .unwrap_or_default();
+
+    let graph_title = format!(
+        "BytecodeFunction: {}\nParameters: {}, Registers: {}\n{}\n",
+        function_name(func),
+        func.num_parameters(),
+        func.num_registers(),
+        constant_table_string,
+    );
+
+    graph
+        .set_graph_attribute("label", &graph_title)
+        .set_graph_attribute("fontname", "monospace")
+        .set_graph_label_text_align(DotTextAlign::Left);
+}
+
+/// Start node points to the first block. Note that offset may not be zero due to width prefixes.
+fn add_start_node(graph: &mut DotGraphBuilder, func: HeapPtr<BytecodeFunction>) {
+    let (_, start_offset) = InstructionIterator::new(func.bytecode()).next().unwrap();
+
+    graph.add_node("start").attribute("label", "start");
+    graph.add_edge("start", &block_to_node_id(start_offset));
+}
+
+/// Each exception handler has an entrypoint node pointing to its handler.
+fn add_exception_handler_nodes(graph: &mut DotGraphBuilder, func: HeapPtr<BytecodeFunction>) {
+    let Some(exception_handlers) = func.exception_handlers_ptr() else {
+        return;
+    };
+
+    for (i, handler) in exception_handlers.iter().enumerate() {
+        let handler_node_id = &format!("exception_handler_{i}");
+        let handler_node_label =
+            &format!("exception handler ({}-{})", handler.start(), handler.end());
+
+        graph
+            .add_node(handler_node_id)
+            .attribute("label", handler_node_label);
+        graph.add_edge(handler_node_id, &block_to_node_id(handler.handler()));
+    }
+}
+
+fn add_default_attributes(graph: &mut DotGraphBuilder) {
+    graph.set_graph_attribute("labelloc", "t");
+    graph.set_graph_attribute("labeljust", "l");
+    graph.set_node_default_attribute("shape", "box");
+    graph.set_node_default_attribute("fontname", "monospace");
+    graph.set_edge_default_attribute("fontname", "monospace");
+}
+
+/// The absolute offset that a jump instruction at `offset` transfers control to.
+fn get_absolute_jump_target_offset(
+    func: HeapPtr<BytecodeFunction>,
+    instr: &dyn Instruction,
+    offset: usize,
+) -> Option<usize> {
+    let jump_offset = get_jump_offset(func, instr)?;
+    Some(offset.strict_add_signed(jump_offset))
+}
+
+/// Determine boundaries of all basic blocks in the bytecode.
+///
+/// Must reconstruct these boundaries by detecting all entrypoints and jump instruction targets.
+/// Return a vec containing the offsets of the [start, end) of every basic block in the bytecode.
+fn build_basic_block_bounds<'a>(
+    func: HeapPtr<BytecodeFunction>,
+    bytecode: &'a [u8],
+    instructions: &[(&'a dyn Instruction, usize)],
+) -> Vec<usize> {
+    // Determine the offsets that begin a basic block
+    let mut block_bounds = HashSet::new();
+
+    // Note that start of the first block may not be zero due to width prefixes. Last block will
+    // end at the end of the bytecode stream.
+    block_bounds.insert(instructions[0].1);
+    block_bounds.insert(bytecode.len());
+
+    // All exception handler entrypoints begin a basic block
+    if let Some(exception_handlers) = func.exception_handlers_ptr() {
+        for handler in exception_handlers.iter() {
+            block_bounds.insert(handler.handler());
+        }
+    }
+
+    for (i, &(instr, offset)) in instructions.iter().enumerate() {
+        if let Some(jump_target_offset) = get_absolute_jump_target_offset(func, instr, offset) {
+            // Jump target is the start of a basic block
+            block_bounds.insert(jump_target_offset);
+
+            // The instruction following a terminator (if any) begins a new basic block
+            if let Some((_, next_offset)) = instructions.get(i + 1) {
+                block_bounds.insert(*next_offset);
+            }
+        }
+    }
+
+    // Sort deduped basic block boundaries to construct the final list
+    let mut sorted_block_bounds = block_bounds.into_iter().collect::<Vec<_>>();
+    sorted_block_bounds.sort();
+
+    sorted_block_bounds
+}
+
+/// Iterate over all basic blocks in a function's bytecode.
+///
+/// Call `f` for each basic block, passing the block's offset range and the instructions in the
+/// block paired with their absolute offsets.
+fn iter_basic_blocks<'a>(
+    func: HeapPtr<BytecodeFunction>,
+    bytecode: &'a [u8],
+    mut f: impl FnMut(Range<usize>, &[(&'a dyn Instruction, usize)]),
+) {
+    let instructions = InstructionIterator::new(bytecode).collect::<Vec<_>>();
+    let block_bounds = build_basic_block_bounds(func, bytecode, &instructions);
+
+    // Walk the instructions once, slicing out the instructions that fall within each block
+    let mut index = 0;
+    for bounds in block_bounds.windows(2) {
+        let bounds = bounds[0]..bounds[1];
+
+        let block_start_index = index;
+        while index < instructions.len() && instructions[index].1 < bounds.end {
+            index += 1;
+        }
+
+        let block = &instructions[block_start_index..index];
+        if !block.is_empty() {
+            f(bounds, block);
+        }
+    }
+}
+
+fn add_nodes_and_edges(graph: &mut DotGraphBuilder, func: HeapPtr<BytecodeFunction>) {
+    let bytecode = func.bytecode();
+
+    iter_basic_blocks(func, bytecode, |block_bounds, instructions| {
+        let node_id = block_to_node_id(block_bounds.start);
+        graph.add_node(&node_id);
+
+        // Accumulate text for all instructions in the block for the node label
+        let mut node_label = String::new();
+        for &(instruction, offset) in instructions {
+            node_label.push_str(&format!("{offset}: {instruction}\n"));
+        }
+
+        // The last instruction determines all control flow edges out of the block
+        let &(terminator, terminator_offset) = instructions.last().unwrap();
+
+        // Fallthrough block only exists if this is not the last block in the bytecode
+        let fallthrough_node_id = if block_bounds.end != func.bytecode().len() {
+            Some(block_to_node_id(block_bounds.end))
+        } else {
+            None
+        };
+
+        add_node_edges(graph, func, terminator, terminator_offset, &node_id, fallthrough_node_id);
+
+        graph
+            .get_node(&node_id)
+            .attribute("label", &node_label)
+            .text_align(DotTextAlign::Left);
+    });
+}
+
+fn add_node_edges(
+    graph: &mut DotGraphBuilder,
+    func: HeapPtr<BytecodeFunction>,
+    terminator_instr: &dyn Instruction,
+    terminator_offset: usize,
+    node_id: &str,
+    fallthrough_node_id: Option<String>,
+) {
+    let opcode = terminator_instr.opcode();
+
+    if opcode.is_unconditional_jump() {
+        // Unconditional jump only has edge to target block
+        let target_offset =
+            get_absolute_jump_target_offset(func, terminator_instr, terminator_offset).unwrap();
+        let target_node_id = block_to_node_id(target_offset);
+
+        graph.add_edge(node_id, &target_node_id);
+    } else if opcode.is_conditional_jump() {
+        // A conditional jump either jumps to its target block or falls through to the next block
+        let target_offset =
+            get_absolute_jump_target_offset(func, terminator_instr, terminator_offset).unwrap();
+        let target_node_id = block_to_node_id(target_offset);
+
+        graph
+            .add_edge(node_id, &target_node_id)
+            .attribute("label", "T");
+        graph
+            .add_edge(node_id, &fallthrough_node_id.unwrap())
+            .attribute("label", "F");
+    } else {
+        // No control flow instruction means the block was split at a jump target, so fall through
+        // to the next block (unless this is the lsat block in the bytecode).
+
+        if let Some(fallthrough_node_id) = fallthrough_node_id {
+            graph.add_edge(node_id, &fallthrough_node_id);
+        }
+    }
+}

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -2042,7 +2042,7 @@ pub struct InstructionIterator<'a> {
 }
 
 impl<'a> InstructionIterator<'a> {
-    fn new(bytecode: &'a [u8]) -> Self {
+    pub fn new(bytecode: &'a [u8]) -> Self {
         Self { pos: 0, bytecode }
     }
 }
@@ -2165,12 +2165,15 @@ pub fn debug_format_instructions(function: HeapPtr<BytecodeFunction>, printer: &
     }
 }
 
-fn get_jump_offset(function: HeapPtr<BytecodeFunction>, instr: &dyn Instruction) -> Option<isize> {
+pub fn get_jump_offset(
+    function: HeapPtr<BytecodeFunction>,
+    instr: &dyn Instruction,
+) -> Option<isize> {
     let opcode = instr.opcode();
 
-    let offset_operand_index = if opcode == OpCode::Jump || opcode == OpCode::JumpConstant {
+    let offset_operand_index = if opcode.is_unconditional_jump() {
         0
-    } else if opcode >= OpCode::JumpTrue && opcode <= OpCode::JumpNotNullishConstant {
+    } else if opcode.is_conditional_jump() {
         1
     } else {
         return None;
@@ -2182,5 +2185,18 @@ fn get_jump_offset(function: HeapPtr<BytecodeFunction>, instr: &dyn Instruction)
         constant_table.map(|constant_table| constant_table.get_constant_offset(constant_index))
     } else {
         Some(instr.get_raw_operand_signed(offset_operand_index))
+    }
+}
+
+impl OpCode {
+    /// Whether the opcode is an unconditional jump, whose jump offset is its first operand.
+    pub fn is_unconditional_jump(&self) -> bool {
+        *self == OpCode::Jump || *self == OpCode::JumpConstant
+    }
+
+    /// Whether the opcode is a conditional jump, whose jump offset is its second operand. A conditional
+    /// jump either jumps to its target or falls through to the next instruction.
+    pub fn is_conditional_jump(&self) -> bool {
+        *self >= OpCode::JumpTrue && *self <= OpCode::JumpNotNullishConstant
     }
 }

--- a/src/js/runtime/bytecode/mod.rs
+++ b/src/js/runtime/bytecode/mod.rs
@@ -3,6 +3,7 @@ mod constant_table_builder;
 pub mod exception_handlers;
 pub mod function;
 pub mod generator;
+pub mod graphviz;
 pub mod instruction;
 mod instruction_traits;
 mod operand;

--- a/src/js/runtime/regexp/graphviz.rs
+++ b/src/js/runtime/regexp/graphviz.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, fs, ops::Range};
 
 use crate::{
-    common::graphviz::{DotGraphBuilder, DOTFILE_EXTENSION},
+    common::graphviz::{DotGraphBuilder, DotTextAlign, DOTFILE_EXTENSION},
     runtime::{
         regexp::{
             compiled_regexp::CompiledRegExpObject,
@@ -171,7 +171,10 @@ fn add_nodes_and_edges(graph: &mut DotGraphBuilder, regexp: HeapPtr<CompiledRegE
             offset = next_offset;
         }
 
-        graph.get_node(&node_id).attribute("label", &node_label);
+        graph
+            .get_node(&node_id)
+            .attribute("label", &node_label)
+            .text_align(DotTextAlign::Left);
     });
 }
 


### PR DESCRIPTION
## Summary

Use the graphviz DOT file creation utilites added in https://github.com/Hans-Halverson/brimstone/pull/317 to generate DOT files for JS bytecode. This visualizes the control flow graph, with basic blocks as nodes and directed edges between them.

- DOT file generator must parse the bytecode into basic blocks and discover all edges, just like for RegExp bytecode
- Graph label contains extra info about the function such as the constant table
- Some additions to common graphviz utilities to allow for left-justifying labels. Also use for RegExp bytecode DOT files.

## Tests

- CI
- Verified by generating some example graphviz diagrams from bytecode