### PR TITLE
[test] Test harness --reindex option runs tests after reindexing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,7 @@ jobs:
         run: ./tests/test262/install_test262.sh
 
       - name: Run integration tests
-        run: |
-          cargo brimstone-test -- --reindex
-          cargo brimstone-test -- --ignore-unimplemented
+        run: cargo brimstone-test -- --reindex --ignore-unimplemented
 
   # Run all integration tests for implemented features with release build.
   integration-tests-release:
@@ -68,9 +66,7 @@ jobs:
         run: ./tests/test262/install_test262.sh
 
       - name: Run integration tests
-        run: |
-          cargo brimstone-test -- --reindex
-          cargo brimstone-test --release -- --ignore-unimplemented
+        run: cargo brimstone-test --release -- --reindex --ignore-unimplemented
 
   # Run all integration tests for implemented features with GC stress test mode on.
   integration-tests-gc-stress-test:
@@ -85,9 +81,7 @@ jobs:
         run: ./tests/test262/install_test262.sh
 
       - name: Run integration tests
-        run: |
-          cargo brimstone-test -- --reindex
-          cargo brimstone-test --release --features gc_stress_test -- --ignore-unimplemented
+        run: cargo brimstone-test --release --features gc_stress_test -- --reindex --ignore-unimplemented
 
   # Run all integration tests for implemented features with handle tracking mode on.
   integration-tests-handle-tracking:
@@ -102,9 +96,7 @@ jobs:
         run: ./tests/test262/install_test262.sh
 
       - name: Run integration tests
-        run: |
-          cargo brimstone-test -- --reindex
-          cargo brimstone-test --release --features handle_stats -- --ignore-unimplemented
+        run: cargo brimstone-test --release --features handle_stats -- --reindex --ignore-unimplemented
 
   integration-tests-panic-on-oom-nightly:
     runs-on: ubuntu-latest
@@ -124,9 +116,7 @@ jobs:
         run: ./tests/test262/install_test262.sh
 
       - name: Run integration tests on nightly without alloc_error feature enabled
-        run: |
-          cargo brimstone-test -- --reindex
-          cargo brimstone-test --release --no-default-features --features nightly -- --ignore-unimplemented
+        run: cargo brimstone-test --release --no-default-features --features nightly -- --reindex --ignore-unimplemented
     
   build-benchmarks:
     runs-on: ubuntu-latest

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,20 +38,19 @@ Install the test262 repo at the pinned commit by running the following script:
 
 The test runner is run with `cargo brimstone-test` anywhere in the `brimstone` workspace. Run `cargo brimstone-test -- --help` to see the full set of options for the test runner.
 
-Before running any tests, the test runner must first create an index of the all test suites for fast consumption later on. This only needs to be run when the set of tests has changed, e.g. after you pull in a new version of the test262 repo.
+Before running any tests, the test runner must first create an index of the all test suites for fast consumption later on. This only needs to be run when the set of tests has changed, e.g. after you add new tests or pull in a new version of the test262 repo. Pass the `--reindex` option to reindex and then immediately run the specified tests.
 
-```
-cargo brimstone-test -- --reindex
-```
-
-Then the all integration test suites can be run with:
+The integration test suites can be run with:
 
 ```
 # Run all integration test suites
 cargo brimstone-test
 
+# Reindex all tests then run the specified tests
+cargo brimstone-test -- --reindex
+
 # Run only the tests that match a filter string
-cargo run -- language/expressions
+cargo brimstone-test -- language/expressions
 ```
 
 Other important options include:

--- a/tests/harness/src/main.rs
+++ b/tests/harness/src/main.rs
@@ -30,8 +30,8 @@ struct Args {
     #[arg(long, default_value_t = false)]
     ignore_unimplemented: bool,
 
-    /// Reindex the test262 test suite
-    #[arg(long, default_value_t = false)]
+    /// Reindex the test suite before running
+    #[arg(short, long, default_value_t = false)]
     reindex: bool,
 
     /// Number of threads to use in test runner
@@ -80,17 +80,17 @@ fn main_impl() -> GenericResult {
     let index_path = manifest.index_path();
     let test262_root = manifest.test262_repo_path();
 
-    if args.reindex {
+    let index = if args.reindex {
         println!("Indexing test suite...");
         let index = TestIndex::new(&manifest)?;
 
         println!("Finished indexing. Writing index to file.");
         index.write_to_file(&index_path)?;
 
-        return Ok(());
-    }
-
-    let index = TestIndex::load_from_file(&index_path)?;
+        index
+    } else {
+        TestIndex::load_from_file(&index_path)?
+    };
 
     // `--report-test262-progress` should only run the test262 suite
     let suite_filter = if args.report_test262_progress {


### PR DESCRIPTION
## Summary

Small change to improve test ergonomics. The `--reindex` option now can be combined with all other options and runs tests after reindexing instead of requiring an invocation to reindex, then an invocation to run tests.

## Tests

- CI now makes a single call to reindex and run tests, CI passes