### PR TITLE
[regexp] Clear all captures from a quantified term at the start of each iteration

### DIFF
--- a/src/js/runtime/regexp/compiler.rs
+++ b/src/js/runtime/regexp/compiler.rs
@@ -689,9 +689,14 @@ impl CompiledRegExpBuilder {
 
         // Can inline a small number of repetitions otherwise use a loop
         if quantifier.min != 0 && quantifier.min <= MAX_INLINED_REPETITIONS {
-            // Emit term min times for repetitions that must be present
-            for _ in 0..quantifier.min {
-                quantifier_info = self.emit_term(&quantifier.term);
+            // Emit term min times for repetitions that must be present. Clear captures from the
+            // previous iteration (if any).
+            for i in 0..quantifier.min {
+                quantifier_info = if i == 0 {
+                    self.emit_term(&quantifier.term)
+                } else {
+                    self.emit_term_with_cleared_captures(&quantifier.term)
+                };
             }
         } else if quantifier.min > u32::MAX as u64 {
             // The minimum number of repetitions is greater than the max possible string length.
@@ -714,7 +719,7 @@ impl CompiledRegExpBuilder {
                     loop_end_block_id as u32,
                 );
 
-                quantifier_info = this.emit_term(&quantifier.term);
+                quantifier_info = this.emit_term_with_cleared_captures(&quantifier.term);
 
                 this.emit_jump_instruction(loop_block_id);
             });
@@ -747,10 +752,15 @@ impl CompiledRegExpBuilder {
                 for i in quantifier.min..max {
                     let pred_block_id = self.current_block_id;
 
-                    // Emit term block
+                    // Emit term block clearing captures from the previous iteration (if any)
                     let term_block_id = self.new_block();
                     self.set_current_block(term_block_id);
-                    let info = self.emit_term(&quantifier.term);
+
+                    let info = if i == 0 {
+                        self.emit_term(&quantifier.term)
+                    } else {
+                        self.emit_term_with_cleared_captures(&quantifier.term)
+                    };
 
                     // Each optional iteration of quantifier must consume at least one character.
                     // We can ensure this by emitting a progress instruction which checks that
@@ -804,7 +814,7 @@ impl CompiledRegExpBuilder {
                         join_block_id as u32,
                     );
 
-                    let info = this.emit_term(&quantifier.term);
+                    let info = this.emit_term_with_cleared_captures(&quantifier.term);
 
                     // Each optional iteration of quantifier must consume at least one character.
                     // We can ensure this by emitting a progress instruction which checks that
@@ -849,7 +859,7 @@ impl CompiledRegExpBuilder {
 
             // Emit term block
             self.set_current_block(term_block_id);
-            let info = self.emit_term(&quantifier.term);
+            let info = self.emit_term_with_cleared_captures(&quantifier.term);
 
             // Optionally enter term block from predecessor block
             self.in_block(pred_block_id, |this| {
@@ -944,6 +954,27 @@ impl CompiledRegExpBuilder {
         }
 
         self.emit_jump_instruction(join_block_id);
+    }
+
+    /// Emit a term with a prefix that clears all captures in the term.
+    ///
+    /// Used for terms in quantifiers, since all captures are cleared at the start of each
+    /// repetition.
+    fn emit_term_with_cleared_captures(&mut self, term: &Term) -> SubExpressionInfo {
+        let clear_captures_block = self.new_block();
+        let term_block = self.new_block();
+        self.emit_jump_instruction(clear_captures_block);
+        self.set_current_block(term_block);
+
+        let info = self.emit_term(term);
+
+        self.in_block(clear_captures_block, |this| {
+            for capture_index in &info.captures {
+                this.emit_clear_capture_instruction(*capture_index);
+            }
+        });
+
+        info
     }
 
     fn emit_capture_group(&mut self, group: &CaptureGroup) -> SubExpressionInfo {

--- a/tests/integration/regression/000022.js
+++ b/tests/integration/regression/000022.js
@@ -1,0 +1,7 @@
+/*---
+description: Quantifier matches are cleared at the start of every iteration.
+---*/
+
+assert.compareArray(/(?:\1(a)){2,}/.exec("aa"), ["aa", "a"]);
+assert.compareArray(/((\3|b)\2(a)){2,}/.exec("bbaababbabaaaaabbaaaabba"), ["bbaa", "a", "", "a"]);
+

--- a/tests/snapshot/regexp_bytecode/quantifiers/clear_captures_before_term.exp
+++ b/tests/snapshot/regexp_bytecode/quantifiers/clear_captures_before_term.exp
@@ -1,0 +1,202 @@
+[CompiledRegExpObject: /((a)(b)){3}/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: MarkCapturePoint(2)
+    11: MarkCapturePoint(4)
+    13: Literal(a)
+    14: MarkCapturePoint(5)
+    16: MarkCapturePoint(6)
+    18: Literal(b)
+    19: MarkCapturePoint(7)
+    21: MarkCapturePoint(3)
+    23: ClearCapture(2)
+    25: ClearCapture(3)
+    27: ClearCapture(1)
+    29: MarkCapturePoint(2)
+    31: MarkCapturePoint(4)
+    33: Literal(a)
+    34: MarkCapturePoint(5)
+    36: MarkCapturePoint(6)
+    38: Literal(b)
+    39: MarkCapturePoint(7)
+    41: MarkCapturePoint(3)
+    43: ClearCapture(2)
+    45: ClearCapture(3)
+    47: ClearCapture(1)
+    49: MarkCapturePoint(2)
+    51: MarkCapturePoint(4)
+    53: Literal(a)
+    54: MarkCapturePoint(5)
+    56: MarkCapturePoint(6)
+    58: Literal(b)
+    59: MarkCapturePoint(7)
+    61: MarkCapturePoint(3)
+    63: MarkCapturePoint(1)
+    65: Accept
+}
+
+[CompiledRegExpObject: /((a)(b)){100}/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Loop(0, 100, 15)
+    13: Jump(18)
+    15: MarkCapturePoint(1)
+    17: Accept
+    18: ClearCapture(2)
+    20: ClearCapture(3)
+    22: ClearCapture(1)
+    24: MarkCapturePoint(2)
+    26: MarkCapturePoint(4)
+    28: Literal(a)
+    29: MarkCapturePoint(5)
+    31: MarkCapturePoint(6)
+    33: Literal(b)
+    34: MarkCapturePoint(7)
+    36: MarkCapturePoint(3)
+    38: Jump(9)
+}
+
+[CompiledRegExpObject: /((a)(b)){1,2}/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: MarkCapturePoint(2)
+    11: MarkCapturePoint(4)
+    13: Literal(a)
+    14: MarkCapturePoint(5)
+    16: MarkCapturePoint(6)
+    18: Literal(b)
+    19: MarkCapturePoint(7)
+    21: MarkCapturePoint(3)
+    23: Branch(29, 26)
+    26: MarkCapturePoint(1)
+    28: Accept
+    29: ClearCapture(2)
+    31: ClearCapture(3)
+    33: ClearCapture(1)
+    35: MarkCapturePoint(2)
+    37: MarkCapturePoint(4)
+    39: Literal(a)
+    40: MarkCapturePoint(5)
+    42: MarkCapturePoint(6)
+    44: Literal(b)
+    45: MarkCapturePoint(7)
+    47: MarkCapturePoint(3)
+    49: Jump(26)
+}
+
+[CompiledRegExpObject: /((a)(b)){1,100}/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: MarkCapturePoint(2)
+    11: MarkCapturePoint(4)
+    13: Literal(a)
+    14: MarkCapturePoint(5)
+    16: MarkCapturePoint(6)
+    18: Literal(b)
+    19: MarkCapturePoint(7)
+    21: MarkCapturePoint(3)
+    23: Branch(29, 26)
+    26: MarkCapturePoint(1)
+    28: Accept
+    29: Loop(0, 99, 26)
+    33: ClearCapture(2)
+    35: ClearCapture(3)
+    37: ClearCapture(1)
+    39: MarkCapturePoint(2)
+    41: MarkCapturePoint(4)
+    43: Literal(a)
+    44: MarkCapturePoint(5)
+    46: MarkCapturePoint(6)
+    48: Literal(b)
+    49: MarkCapturePoint(7)
+    51: MarkCapturePoint(3)
+    53: Branch(29, 26)
+}
+
+[CompiledRegExpObject: /((a)(b)){1,}/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: MarkCapturePoint(2)
+    11: MarkCapturePoint(4)
+    13: Literal(a)
+    14: MarkCapturePoint(5)
+    16: MarkCapturePoint(6)
+    18: Literal(b)
+    19: MarkCapturePoint(7)
+    21: MarkCapturePoint(3)
+    23: Branch(26, 28)
+    26: Jump(31)
+    28: MarkCapturePoint(1)
+    30: Accept
+    31: ClearCapture(2)
+    33: ClearCapture(3)
+    35: ClearCapture(1)
+    37: MarkCapturePoint(2)
+    39: MarkCapturePoint(4)
+    41: Literal(a)
+    42: MarkCapturePoint(5)
+    44: MarkCapturePoint(6)
+    46: Literal(b)
+    47: MarkCapturePoint(7)
+    49: MarkCapturePoint(3)
+    51: Branch(26, 28)
+}
+
+[CompiledRegExpObject: /((a)(b)){0,1}/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Progress(0)
+    11: Branch(26, 14)
+    14: ClearCaptureIfNoProgress(2, 0)
+    17: ClearCaptureIfNoProgress(3, 0)
+    20: ClearCaptureIfNoProgress(1, 0)
+    23: MarkCapturePoint(1)
+    25: Accept
+    26: MarkCapturePoint(2)
+    28: MarkCapturePoint(4)
+    30: Literal(a)
+    31: MarkCapturePoint(5)
+    33: MarkCapturePoint(6)
+    35: Literal(b)
+    36: MarkCapturePoint(7)
+    38: MarkCapturePoint(3)
+    40: Jump(14)
+}
+
+[CompiledRegExpObject: /((a)(b)){1,1}/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: MarkCapturePoint(2)
+    11: MarkCapturePoint(4)
+    13: Literal(a)
+    14: MarkCapturePoint(5)
+    16: MarkCapturePoint(6)
+    18: Literal(b)
+    19: MarkCapturePoint(7)
+    21: MarkCapturePoint(3)
+    23: MarkCapturePoint(1)
+    25: Accept
+}
+
+[CompiledRegExpObject: /((a)(b)){0,0}/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: MarkCapturePoint(1)
+    11: Accept
+}

--- a/tests/snapshot/regexp_bytecode/quantifiers/clear_captures_before_term.js
+++ b/tests/snapshot/regexp_bytecode/quantifiers/clear_captures_before_term.js
@@ -1,0 +1,19 @@
+// Inlined min repetitions
+/((a)(b)){3}/;
+
+// Loop for min repetitions
+/((a)(b)){100}/;
+
+// Inlined max repetitions
+/((a)(b)){1,2}/;
+
+// Loop for max repetitions
+/((a)(b)){1,100}/;
+
+// Uncapped max repetitions
+/((a)(b)){1,}/;
+
+// Cannot be repeated multiple times, no need to clear
+/((a)(b)){0,1}/;
+/((a)(b)){1,1}/;
+/((a)(b)){0,0}/;


### PR DESCRIPTION
## Summary

The semantics of capture groups in RegExp quantifiers is that all captures are cleared at the start of each iteration of the quantifier. We were not currently enforcing this, meaning a capture in one iteration could be detected in the next (e.g. with a backreference).

The simple fix is to emit clear capture instruct ions before the term when emitting quantifiers. Omits clear captures on the first inlined iteration but there is likely room for more optimization.

## Tests

- Added regexp bytecode snapshot tests for clearing captures in all quantifier term types
- Added regression test for incorrect RegExp matches affected by this bug