### PR TITLE
[regexp] Fix lexer lookahead for two-byte strings in unicode mode

### DIFF
--- a/src/js/parser/lexer_stream.rs
+++ b/src/js/parser/lexer_stream.rs
@@ -735,7 +735,7 @@ impl LexerStream for HeapTwoByteCodePointLexerStream<'_> {
     fn peek_n(&self, n: usize) -> u32 {
         let next_pos = self.pos + n;
         if next_pos < self.buf.len() {
-            let (code_point, _) = self.code_point_at(self.pos);
+            let (code_point, _) = self.code_point_at(next_pos);
             code_point
         } else {
             EOF_CHAR

--- a/tests/integration/regression/000023.js
+++ b/tests/integration/regression/000023.js
@@ -1,0 +1,6 @@
+/*---
+description: Bug where lexer lookahead was incorrect for two-byte strings in unicode mode.
+---*/
+
+assert(new RegExp('☺\\w', 'u').test('☺a'));
+assert(new RegExp("☺[\\w--\\d]", "v").test('☺a'));


### PR DESCRIPTION
## Summary

Silly mistake in `HeapTwoByteCodePointLexerStream::peek_n` where we were actually reading the current code point instead of the peeked code point.

This bug only happened when parsing two-byte JS strings, e.g. via the `RegExp` constructor.

## Tests

- Added regression test for this case - these tests were previously failing