### PR TITLE
[common] Upgrade to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-edition = "2018"
+edition = "2024"
 version = "0.1.0"
 authors = ["hanshalverson <hansghalverson@gmail.com>"]
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,3 +6,6 @@ fn_call_width = 80
 attr_fn_like_width = 80
 struct_lit_width = 60
 struct_variant_width = 60
+
+# TODO: Format with 2024 style
+style_edition = "2021"

--- a/src/brimstone_icu_collections/build.rs
+++ b/src/brimstone_icu_collections/build.rs
@@ -147,10 +147,10 @@ fn gen_all_case_folded_characters<'a>() -> CodePointInversionList<'a> {
     let mut builder = CodePointInversionListBuilder::new();
 
     for i in 0..0x110000u32 {
-        if let Some(c) = char::from_u32(i) {
-            if c == case_mapper.simple_fold(c) {
-                builder.add_char(c);
-            }
+        if let Some(c) = char::from_u32(i)
+            && c == case_mapper.simple_fold(c)
+        {
+            builder.add_char(c);
         }
     }
 

--- a/src/brimstone_macros/src/match_u32.rs
+++ b/src/brimstone_macros/src/match_u32.rs
@@ -36,34 +36,34 @@ impl CharRewriter {
 
 impl VisitMut for CharRewriter {
     fn visit_pat_mut(&mut self, pat: &mut Pat) {
-        if let Pat::Lit(lit) = pat {
-            if let syn::Lit::Char(lit_char) = &lit.lit {
-                let const_ident = self.add_char_constant(lit_char);
+        if let Pat::Lit(lit) = pat
+            && let syn::Lit::Char(lit_char) = &lit.lit
+        {
+            let const_ident = self.add_char_constant(lit_char);
 
-                // Replace the char lit pattern with a reference to the constant
-                let pat_ident = PatIdent {
-                    attrs: vec![],
-                    by_ref: None,
-                    mutability: None,
-                    ident: const_ident,
-                    subpat: None,
-                };
+            // Replace the char lit pattern with a reference to the constant
+            let pat_ident = PatIdent {
+                attrs: vec![],
+                by_ref: None,
+                mutability: None,
+                ident: const_ident,
+                subpat: None,
+            };
 
-                *pat = Pat::Ident(pat_ident);
-            }
+            *pat = Pat::Ident(pat_ident);
         }
 
         visit_mut::visit_pat_mut(self, pat);
     }
 
     fn visit_expr_mut(&mut self, expr: &mut syn::Expr) {
-        if let syn::Expr::Lit(expr_lit) = expr {
-            if let syn::Lit::Char(lit_char) = &expr_lit.lit {
-                let const_ident = self.add_char_constant(lit_char);
+        if let syn::Expr::Lit(expr_lit) = expr
+            && let syn::Lit::Char(lit_char) = &expr_lit.lit
+        {
+            let const_ident = self.add_char_constant(lit_char);
 
-                // Replace the char lit expression with a reference to the constant
-                *expr = syn::parse2(quote! { #const_ident }).unwrap();
-            }
+            // Replace the char lit expression with a reference to the constant
+            *expr = syn::parse2(quote! { #const_ident }).unwrap();
         }
 
         visit_mut::visit_expr_mut(self, expr);

--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -698,7 +698,7 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
         match &mut expr.kind {
             // new.target is treated as a binding that is implicitly created on a parent function
             // scope. Store the scope node of the function that contains this new.target expression.
-            MetaPropertyKind::NewTarget { ref mut scope } => {
+            MetaPropertyKind::NewTarget { scope } => {
                 if self.is_in_non_arrow_function() {
                     self.resolve_new_target_use(scope, expr.loc);
                 } else {

--- a/src/js/parser/ast_visitor.rs
+++ b/src/js/parser/ast_visitor.rs
@@ -480,8 +480,8 @@ pub fn default_visit_function_param<'a, V: AstVisitor<'a>>(
     param: &mut FunctionParam<'a>,
 ) {
     match param {
-        FunctionParam::Pattern { ref mut pattern, .. } => visitor.visit_pattern(pattern),
-        FunctionParam::Rest { ref mut rest, .. } => visitor.visit_rest_element(rest),
+        FunctionParam::Pattern { pattern, .. } => visitor.visit_pattern(pattern),
+        FunctionParam::Rest { rest, .. } => visitor.visit_rest_element(rest),
     }
 }
 
@@ -490,8 +490,8 @@ pub fn default_visit_function_body<'a, V: AstVisitor<'a>>(
     body: &mut FunctionBody<'a>,
 ) {
     match body {
-        FunctionBody::Block(ref mut block_body) => visitor.visit_function_block_body(block_body),
-        FunctionBody::Expression(ref mut expr) => visitor.visit_outer_expression(expr),
+        FunctionBody::Block(block_body) => visitor.visit_function_block_body(block_body),
+        FunctionBody::Expression(expr) => visitor.visit_outer_expression(expr),
     }
 }
 

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -896,7 +896,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
                 }
 
                 let class_fields = match &mut func_node {
-                    PendingFunctionNode::Constructor { ref mut fields, .. } => {
+                    PendingFunctionNode::Constructor { fields, .. } => {
                         std::mem::replace(fields, ClassFieldsInitializer::none())
                     }
                     _ => ClassFieldsInitializer::none(),

--- a/src/js/runtime/intrinsics/iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_prototype.rs
@@ -466,7 +466,7 @@ impl IteratorPrototype {
     }
 
     /// get Iterator.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-get-iterator.prototype-%symbol.tostringtag%)
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub fn iterator_prototype_get_to_string_tag(
         cx: Context,
         _: Handle<Value>,

--- a/src/js/runtime/intrinsics/math_object.rs
+++ b/src/js/runtime/intrinsics/math_object.rs
@@ -549,7 +549,7 @@ impl MathObject {
         _: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let n = cx.rand.gen::<f64>();
+        let n = cx.rand.r#gen::<f64>();
         Ok(cx.number(n))
     }
 

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -784,7 +784,7 @@ impl RuntimeFunction {
 }
 
 /// Rust runtime function that simply returns the `this` argument.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub fn return_this(
     _: Context,
     this_value: Handle<Value>,
@@ -794,7 +794,7 @@ pub fn return_this(
 }
 
 /// Rust runtime function that simply returns `undefined`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub fn return_undefined(
     cx: Context,
     _: Handle<Value>,

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -327,7 +327,7 @@ impl HeapPtr<ObjectValue> {
             Some(hash_code) => hash_code,
             None => {
                 // May be called from std::hash::Hash so cannot pass in Context
-                let hash_code = self.cx().rand.gen::<NonZeroU32>();
+                let hash_code = self.cx().rand.r#gen::<NonZeroU32>();
                 self.hash_code = Some(hash_code);
                 hash_code
             }

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -581,7 +581,7 @@ impl SymbolValue {
 
         set_uninit!(symbol.descriptor, cx.descriptors.get(HeapItemKind::Symbol));
         set_uninit!(symbol.description, description.map(|desc| *desc));
-        set_uninit!(symbol.hash_code, cx.rand.gen::<u32>());
+        set_uninit!(symbol.hash_code, cx.rand.r#gen::<u32>());
         set_uninit!(symbol.is_private, is_private);
 
         Ok(symbol.to_handle())

--- a/tests/fuzz/src/main.rs
+++ b/tests/fuzz/src/main.rs
@@ -21,7 +21,7 @@ use brimstone_core::{
 };
 
 #[link(name = "coverage", kind = "dylib")]
-extern "C" {
+unsafe extern "C" {
     fn __sanitizer_cov_reset_edgeguards();
 }
 

--- a/tests/harness/src/runner.rs
+++ b/tests/harness/src/runner.rs
@@ -105,19 +105,19 @@ impl TestRunner {
             }
 
             // If a filter was provided then skip all tests that do not match the filter
-            if let Some(filter) = &self.filter {
-                if !test.path.contains(filter) {
-                    *num_skipped.entry(test.suite).or_default() += 1;
-                    continue;
-                }
+            if let Some(filter) = &self.filter
+                && !test.path.contains(filter)
+            {
+                *num_skipped.entry(test.suite).or_default() += 1;
+                continue;
             }
 
             // If a feature was specified then skip all tests that do not have that feature
-            if let Some(feature) = &self.feature {
-                if !test.features.contains(feature) {
-                    *num_skipped.entry(test.suite).or_default() += 1;
-                    continue;
-                }
+            if let Some(feature) = &self.feature
+                && !test.features.contains(feature)
+            {
+                *num_skipped.entry(test.suite).or_default() += 1;
+                continue;
             }
 
             if self.ignored[&test.suite].should_fail(test) {
@@ -595,12 +595,12 @@ fn is_error_in_expected_phase(cx: Context, test: &Test, expected_phase: TestPhas
 
 fn to_console_string_test262(cx: Context, value: Handle<Value>) -> String {
     // Extract message for Test262Error, otherwise print to console normally
-    if value.is_object() {
-        if let Ok(message_value) = to_string(cx, value) {
-            let message = message_value.format().unwrap();
-            if message.starts_with("Test262Error") {
-                return message;
-            }
+    if value.is_object()
+        && let Ok(message_value) = to_string(cx, value)
+    {
+        let message = message_value.format().unwrap();
+        if message.starts_with("Test262Error") {
+            return message;
         }
     }
 


### PR DESCRIPTION
## Summary

As per title, upgrade to Rust 2024 edition.

- We can finally use `if let` with guards
- `ref mut` is no longer needed
- `no_mangle` attribute changed to `unsafe(no_mangle)`
- `gen` is now a reserved word, so `rand.#gen()` must be used instead
- `extern` blocks must be marked `unsafe`
- Kept 2021 style override in `rustfmt.toml` to separate out autoformatting changes

## Tests

CI