### PR TITLE
[common] Misc cleanup - rename ArenaVec to AstVec, remove no_mangle attributes

### DIFF
--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -30,7 +30,7 @@ use crate::{
 
 pub type AstAlloc<'a> = &'a Bump;
 
-pub type ArenaVec<'a, T> = alloc::Vec<T, AstAlloc<'a>>;
+pub type AstVec<'a, T> = alloc::Vec<T, AstAlloc<'a>>;
 
 pub type AstStr<'a> = &'a Wtf8Str;
 
@@ -137,10 +137,10 @@ impl<T> DerefMut for AstSlice<'_, T> {
     }
 }
 
-pub struct AstSliceBuilder<'a, T>(ArenaVec<'a, T>);
+pub struct AstSliceBuilder<'a, T>(AstVec<'a, T>);
 
 impl<'a, T> AstSliceBuilder<'a, T> {
-    pub fn new(vec: ArenaVec<'a, T>) -> Self {
+    pub fn new(vec: AstVec<'a, T>) -> Self {
         AstSliceBuilder(vec)
     }
 
@@ -155,7 +155,7 @@ impl<'a, T> AstSliceBuilder<'a, T> {
 }
 
 impl<'a, T> Deref for AstSliceBuilder<'a, T> {
-    type Target = ArenaVec<'a, T>;
+    type Target = AstVec<'a, T>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -293,11 +293,11 @@ impl<'a> Parser<'a> {
     }
 
     fn alloc_vec<U>(&self) -> AstSliceBuilder<'a, U> {
-        AstSliceBuilder::new(ArenaVec::new_in(self.alloc))
+        AstSliceBuilder::new(AstVec::new_in(self.alloc))
     }
 
     fn alloc_vec_with_element<U>(&self, element: U) -> AstSliceBuilder<'a, U> {
-        let mut vec = ArenaVec::new_in(self.alloc);
+        let mut vec = AstVec::new_in(self.alloc);
         vec.push(element);
         AstSliceBuilder::new(vec)
     }

--- a/src/js/parser/regexp_parser.rs
+++ b/src/js/parser/regexp_parser.rs
@@ -23,7 +23,7 @@ use crate::{
     p,
     parser::{
         LocalizedParseError, ParseError, ParseResult,
-        ast::{ArenaVec, AstAlloc, AstPtr, AstSlice, AstSliceBuilder, AstStr, AstString},
+        ast::{AstAlloc, AstPtr, AstSlice, AstSliceBuilder, AstStr, AstString, AstVec},
         lexer_stream::{LexerStream, SavedLexerStreamState},
         loc::Pos,
         regexp::{
@@ -45,7 +45,7 @@ pub struct RegExpParser<'a, T: LexerStream> {
     /// Number of capture groups seen so far
     num_capture_groups: usize,
     /// All capture groups seen so far, with name if a name was specified
-    capture_groups: ArenaVec<'a, Option<AstStr<'a>>>,
+    capture_groups: AstVec<'a, Option<AstStr<'a>>>,
     /// Map of capture group names that have been encountered so far to the index of their last
     /// occurrence in the RegExp.
     capture_group_names: HashMap<AstStr<'a>, CaptureGroupIndex>,

--- a/src/js/parser/scope_tree.rs
+++ b/src/js/parser/scope_tree.rs
@@ -7,8 +7,8 @@ use crate::{
     parser::{
         ParseError,
         ast::{
-            self, ArenaVec, AstAlloc, AstBox, AstHashSet, AstIndexMap, AstPtr, AstSlice,
-            AstSliceBuilder, AstStr, FunctionId, TaggedResolvedScope,
+            self, AstAlloc, AstBox, AstHashSet, AstIndexMap, AstPtr, AstSlice, AstSliceBuilder,
+            AstStr, AstVec, FunctionId, TaggedResolvedScope,
         },
         loc::{Loc, Pos},
     },
@@ -16,8 +16,8 @@ use crate::{
 
 pub struct ScopeTree<'a> {
     #[allow(clippy::vec_box)]
-    ast_nodes: ArenaVec<'a, AstBox<'a, AstScopeNode<'a>>>,
-    vm_nodes: ArenaVec<'a, VMScopeNode<'a>>,
+    ast_nodes: AstVec<'a, AstBox<'a, AstScopeNode<'a>>>,
+    vm_nodes: AstVec<'a, VMScopeNode<'a>>,
     current_node_id: ScopeNodeId,
     alloc: AstAlloc<'a>,
     options: Rc<Options>,
@@ -874,7 +874,7 @@ pub struct AstScopeNode<'a> {
     enclosing_scope: ScopeNodeId,
     /// The set of all descendant AST scope nodes that are enclosed by this AST scope node. Meaning
     /// the set of all scope nodes directly owned by each global and function node. Includes self.
-    enclosed_scopes: ArenaVec<'a, ScopeNodeId>,
+    enclosed_scopes: AstVec<'a, ScopeNodeId>,
     /// If this is global or function AST scope node, the total number of local registers needed for
     /// the locals in all enclosed scopes.
     num_local_registers: usize,

--- a/src/js/runtime/intrinsics/iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_prototype.rs
@@ -466,7 +466,6 @@ impl IteratorPrototype {
     }
 
     /// get Iterator.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-get-iterator.prototype-%symbol.tostringtag%)
-    #[unsafe(no_mangle)]
     pub fn iterator_prototype_get_to_string_tag(
         cx: Context,
         _: Handle<Value>,

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -783,7 +783,6 @@ impl RuntimeFunction {
 }
 
 /// Rust runtime function that simply returns the `this` argument.
-#[unsafe(no_mangle)]
 pub fn return_this(
     _: Context,
     this_value: Handle<Value>,
@@ -793,7 +792,6 @@ pub fn return_this(
 }
 
 /// Rust runtime function that simply returns `undefined`.
-#[unsafe(no_mangle)]
 pub fn return_undefined(
     cx: Context,
     _: Handle<Value>,


### PR DESCRIPTION
## Summary

Misc general cleanup:
- Rename `ArenaVec` to `AstVec` - this was the odd one out
- Remove the `no_mangle` attributes on select rust runtime functions, these were a hack and are no longer needed after https://github.com/Hans-Halverson/brimstone/pull/253

## Tests

CI