### PR TITLE
[regexp] Fix bytecode for quantifiers with bounds that are out of range

### DIFF
--- a/src/js/runtime/regexp/compiler.rs
+++ b/src/js/runtime/regexp/compiler.rs
@@ -8,6 +8,7 @@ use brimstone_icu_collections::{
     all_case_folded_set, get_case_closure_override, has_case_closure_override,
 };
 use icu_collections::codepointinvlist::{CodePointInversionList, CodePointInversionListBuilder};
+use num_traits::ToPrimitive;
 
 use crate::{
     common::{
@@ -633,7 +634,7 @@ impl CompiledRegExpBuilder {
                     self.emit_quantified_term_with_cleared_captures(quantifier)
                 }
             }
-        } else if quantifier.min > u32::MAX as u64 {
+        } else if quantifier.min > u32::MAX as u64 && quantifier.always_consumes {
             // The minimum number of repetitions is greater than the max possible string length.
             // Each repetition must consume at least one character, so we know this quantifier will
             // fail to match.
@@ -646,13 +647,12 @@ impl CompiledRegExpBuilder {
             self.emit_jump_instruction(loop_block_id);
             self.set_current_block(loop_block_id);
 
+            // If min is out of range clamp to the largest allowed number of repetitions
+            let clamped_min = quantifier.min.to_u32().unwrap_or(u32::MAX);
+
             // Loop block consists of loop instruction, term, then loops back to start of block
             let loop_register_index = self.next_loop_register();
-            self.emit_loop_instruction(
-                loop_register_index,
-                quantifier.min as u32,
-                loop_end_block_id as u32,
-            );
+            self.emit_loop_instruction(loop_register_index, clamped_min, loop_end_block_id as u32);
 
             self.emit_quantified_term_with_cleared_captures(quantifier);
             self.emit_jump_instruction(loop_block_id);
@@ -704,11 +704,6 @@ impl CompiledRegExpBuilder {
 
                 // Last term block always proceeds to the join block
                 self.emit_jump_instruction(join_block_id);
-            } else if num_remaining_repetitions > u32::MAX as u64 {
-                // The minimum number of repetitions is greater than the max possible string length.
-                // Each repetition must consume at least one character, so we know this quantifier
-                // will fail to match.
-                self.emit_fail_instruction();
             } else {
                 let loop_block_id = self.new_block();
 
@@ -717,12 +712,15 @@ impl CompiledRegExpBuilder {
 
                 self.emit_quantifier_optional_branch(quantifier, loop_block_id, join_block_id);
 
+                // If min is out of range clamp to the largest allowed number of repetitions
+                let clamped_repetitions = num_remaining_repetitions.to_u32().unwrap_or(u32::MAX);
+
                 // Loop block consists of loop instruction, term, then branches back to start of block
                 self.set_current_block(loop_block_id);
                 let loop_register_index = self.next_loop_register();
                 self.emit_loop_instruction(
                     loop_register_index,
-                    num_remaining_repetitions as u32,
+                    clamped_repetitions,
                     join_block_id as u32,
                 );
 

--- a/tests/integration/built-ins/RegExp/quantifier_bound_too_large.js
+++ b/tests/integration/built-ins/RegExp/quantifier_bound_too_large.js
@@ -1,0 +1,15 @@
+/*---
+description: Quantifiers whose bounds are larger than the max string length.
+---*/
+
+// Optional repetitions with out of range max can still match
+assert.compareArray(/ax{0,100000000000000}b/.exec("axxb"), ['axxb']);
+
+// Required repetitions with out of range max never match
+assert.sameValue(/ax{100000000000000,100000000000001}b/.exec("axxb"), null);
+
+// Optional repetitions that don't always consume can still match
+assert.compareArray(/a(?:x|){0,100000000000000}b/.exec("axxb"), ['axxb']);
+
+// Required repetitions that don't always consume will match normally but overflow stack
+assert.throws(RangeError, () => /a(?:x|){100000000000000,100000000000001}b/.exec("axxb"));

--- a/tests/snapshot/regexp_bytecode/quantifiers/simple.exp
+++ b/tests/snapshot/regexp_bytecode/quantifiers/simple.exp
@@ -160,10 +160,33 @@
      4: Branch(7, 3)
      7: MarkCapturePoint(0)
      9: Literal(a)
-    10: Fail
-    11: Literal(b)
-    12: MarkCapturePoint(1)
-    14: Accept
+    10: Branch(17, 13)
+    13: Literal(b)
+    14: MarkCapturePoint(1)
+    16: Accept
+    17: Loop(0, 4294967295, 13)
+    21: Literal(x)
+    22: Branch(17, 13)
+}
+
+[CompiledRegExpObject: /a(?:x|){0,1000000000000}b/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Literal(a)
+    10: SetProgress(0)
+    12: Branch(19, 15)
+    15: Literal(b)
+    16: MarkCapturePoint(1)
+    18: Accept
+    19: Loop(0, 4294967295, 15)
+    23: Branch(31, 34)
+    26: Progress(0)
+    28: Branch(19, 15)
+    31: Literal(x)
+    32: Jump(26)
+    34: Jump(26)
 }
 
 [CompiledRegExpObject: /ax{1000000000000,1000000000001}b/] {
@@ -179,4 +202,29 @@
     17: Accept
     18: Literal(x)
     19: Jump(14)
+}
+
+[CompiledRegExpObject: /a(?:x|){1000000000000,1000000000001}b/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Literal(a)
+    10: Loop(0, 4294967295, 17)
+    14: Branch(24, 27)
+    17: SetProgress(0)
+    19: Branch(33, 29)
+    22: Jump(10)
+    24: Literal(x)
+    25: Jump(22)
+    27: Jump(22)
+    29: Literal(b)
+    30: MarkCapturePoint(1)
+    32: Accept
+    33: Branch(40, 43)
+    36: Progress(0)
+    38: Jump(29)
+    40: Literal(x)
+    41: Jump(36)
+    43: Jump(36)
 }

--- a/tests/snapshot/regexp_bytecode/quantifiers/simple.js
+++ b/tests/snapshot/regexp_bytecode/quantifiers/simple.js
@@ -23,6 +23,8 @@
 // Loop exact repetitions
 /ax{100}b/;
 
-// TODO: Fix bytecode for too many repetitions
+// Too many repetitions
 /ax{0,1000000000000}b/;
+/a(?:x|){0,1000000000000}b/;
 /ax{1000000000000,1000000000001}b/;
+/a(?:x|){1000000000000,1000000000001}b/;


### PR DESCRIPTION
## Summary

We were previously emitting incorrect bytecode for quantifiers whose bounds were out of range.

- Required (min) repetitions only auto-fails if always consuming, since this would exceed max string length. Otherwise emit a regular loop which will lead to a stack overflow.
- Optional (max) repetitions never auto-fail. If always consuming we will emit a loop and fail to match, if not always consuming then we will succeed due to empty matches.
- Now that we are emitting loops with num repetitions potentially out of the allowed range, clamp to be in u32 range

## Tests

- Added integration and RegExp bytecode snapshot tests for min/max repetitions out of bounds, when both always/not always consuming.