### PR TITLE
[regexp] Start matching at beginning of code point in unicode mode

### DIFF
--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 
 use crate::{
-    common::unicode::{CodePoint, needs_surrogate_pair},
+    common::unicode::{
+        CodePoint, is_high_surrogate_code_unit, is_low_surrogate_code_unit, needs_surrogate_pair,
+    },
     must,
     parser::regexp::RegExpFlags,
     runtime::{
@@ -987,8 +989,15 @@ fn regexp_builtin_exec(
     }
     let last_index = last_index as u32;
 
+    // Matcher starts at the beginning of a code point in unicode mode
+    let matcher_start_index = if flags.has_any_unicode_flag() {
+        snap_index_to_code_point(string_value, last_index)?
+    } else {
+        last_index
+    };
+
     // Run the matching engine on the regexp and input string
-    let match_ = run_matcher(cx, compiled_regexp, string_value, last_index)?;
+    let match_ = run_matcher(cx, compiled_regexp, string_value, matcher_start_index)?;
 
     // Handle match failure, resetting last index under sticky flag
     if match_.is_none() {
@@ -1182,4 +1191,26 @@ pub fn advance_u64_string_index(
     }
 
     Ok(advance_string_index(string_value, prev_index as u32, is_unicode)? as u64)
+}
+
+/// If the index points to the middle of a valid surrogate pair in the given string return the start
+/// of the code point. Otherwise return the original index.
+fn snap_index_to_code_point(string_value: Handle<StringValue>, index: u32) -> AllocResult<u32> {
+    let string_length = string_value.len();
+    if index >= string_length || index == 0 {
+        return Ok(index);
+    }
+
+    let code_unit = string_value.code_unit_at(index)?;
+    if !is_low_surrogate_code_unit(code_unit) {
+        return Ok(index);
+    }
+
+    let prev_index = index - 1;
+    let prev_code_unit = string_value.code_unit_at(prev_index)?;
+    if !is_high_surrogate_code_unit(prev_code_unit) {
+        return Ok(index);
+    }
+
+    Ok(prev_index)
 }

--- a/tests/integration/built-ins/RegExp/unicode_lastindex_surrogate_boundary.js
+++ b/tests/integration/built-ins/RegExp/unicode_lastindex_surrogate_boundary.js
@@ -1,0 +1,92 @@
+/*---
+description: ^
+  In unicode mode if `lastIndex` points to the middle of a valid surrogate pair then snap it to the
+  beginning of the encoded code point.
+---*/
+
+// Code units are "\uD83D\uDE00"
+const str = "a\u{1F600}b";
+
+// RegExp.prototype.exec
+{
+  const regexp = /./gu;
+  regexp.lastIndex = 2;
+  const result = regexp.exec(str);
+  assert.compareArray(result, ["\u{1F600}"]);
+  assert.sameValue(result.index, 1);
+  assert.sameValue(regexp.lastIndex, 3);
+}
+
+// RegExp.prototype.test
+{
+  const regexp = /\u{1F600}/yu;
+  regexp.lastIndex = 2;
+  assert.sameValue(regexp.test(str), true);
+  assert.sameValue(regexp.lastIndex, 3);
+}
+
+// RegExp.prototype.match
+{
+  const regexp = /\u{1F600}/yu;
+  regexp.lastIndex = 2;
+  const result = str.match(regexp);
+  assert.compareArray(result, ["\u{1F600}"]);
+  assert.sameValue(result.index, 1);
+}
+
+// RegExp.prototype.matchAll
+{
+  const regexp = /./gu;
+  regexp.lastIndex = 2;
+  const ms = [...str.matchAll(regexp)];
+  assert.sameValue(ms.length, 2);
+  assert.compareArray(ms[0], ["\u{1F600}"]);
+  assert.sameValue(ms[0].index, 1);
+  assert.compareArray(ms[1], ["b"]);
+  assert.sameValue(ms[1].index, 3);
+}
+
+// RegExp.prototype.replace
+{
+  const regexp = /\u{1F600}/yu;
+  regexp.lastIndex = 2;
+  assert.sameValue(str.replace(regexp, "X"), "aXb");
+}
+
+// Do not snap for unpaired high surrogate
+{
+  const regexp = /./gu;
+  regexp.lastIndex = 1;
+  const result = regexp.exec("a\uD83Db");
+  assert.compareArray(result, ["\uD83D"]);
+  assert.sameValue(result.index, 1);
+  assert.sameValue(regexp.lastIndex, 2);
+}
+
+// Do not snap for unpaired low surrogate
+{
+  const regexp = /./gu;
+  regexp.lastIndex = 1;
+  const result = regexp.exec("a\uDE00b");
+  assert.compareArray(result, ["\uDE00"]);
+  assert.sameValue(result.index, 1);
+  assert.sameValue(regexp.lastIndex, 2);
+}
+
+// Do not snap for pair of low surrogates
+{
+  const regexp = /./yu;
+  regexp.lastIndex = 2;
+  const result = regexp.exec("x\uDE00\uDE00");
+  assert.compareArray(result, ["\uDE00"]);
+  assert.sameValue(result.index, 2);
+}
+
+// Do not snap for pair of high surrogates
+{
+  const regexp = /./yu;
+  regexp.lastIndex = 2;
+  const result = regexp.exec("x\uD83D\uD83D");
+  assert.compareArray(result, ["\uD83D"]);
+  assert.sameValue(result.index, 2);
+}


### PR DESCRIPTION
## Summary

The RegExp matcher must always start at the beginning of a code point in unicode mode. The subtle behavior here is that `lastIndex` can be manually set to the middle of a code point (i.e. in the middle of a valid surrogate pair), and we must snap it back to the start of the code point in this case.

## Tests

- Added integration test for match start snapping in all affected RegExp methods. Also check that snapping only occurs for valid surrogate pairs.