### PR TITLE
[regexp] Error on braced quantifiers at the start of a term in Annex B mode

### DIFF
--- a/src/js/parser/regexp_parser.rs
+++ b/src/js/parser/regexp_parser.rs
@@ -471,10 +471,22 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
                 '*' | '+' | '?' => {
                     return self.error(self.pos(), ParseError::UnexpectedRegExpQuantifier);
                 }
-                // ']', '{', and '}' are only valid pattern characters in Annex B non-unicode mode
-                '{' if !self.in_annex_b_mode || self.is_unicode_aware() => {
-                    return self.error(self.pos(), ParseError::UnexpectedRegExpQuantifier);
+                '{' => {
+                    // '{' may only be a valid pattern character in Annex B non-unicode mode
+                    if !self.in_annex_b_mode || self.is_unicode_aware() {
+                        return self.error(self.pos(), ParseError::UnexpectedRegExpQuantifier);
+                    }
+
+                    // But only if '{' is not the start of a quantifier
+                    let start_pos = self.pos();
+                    let save_state = self.save();
+                    if self.parse_braced_quantifier().is_ok() {
+                        return self.error(start_pos, ParseError::UnexpectedRegExpQuantifier);
+                    }
+
+                    self.restore(&save_state);
                 }
+                // ']' and '}' are only valid pattern characters in Annex B non-unicode mode
                 '}' | ']' if !self.in_annex_b_mode || self.is_unicode_aware() =>
                     return self.error_unexpected_token(self.pos()),
                 // Valid ends to an alternative

--- a/tests/integration/annexB/built-ins/RegExp/invalid_braced_quantifier.js
+++ b/tests/integration/annexB/built-ins/RegExp/invalid_braced_quantifier.js
@@ -1,0 +1,25 @@
+/*---
+description: Braced quantifiers must follow quantifiable terms in Annex B non-unicode mode.
+---*/
+
+// Quantifiers at the start of a term
+assert.throws(SyntaxError, () => new RegExp("{3}"));
+assert.throws(SyntaxError, () => new RegExp("({3})"));
+assert.throws(SyntaxError, () => new RegExp("a|{3}"));
+
+// Still errors for invalid quantifier bounds
+assert.throws(SyntaxError, () => new RegExp("{5,3}"));
+
+// Lookahead is quantifiable
+assert(new RegExp("(?=a){2}").test("a"));
+assert(new RegExp("(?!=a){2}").test("b"));
+
+// Quantifiers on all non-quantifiable terms
+const nonQuantifiableTerms = ["^", "$", "\\b", "\\B", "(?<=a)", "(?<!a)"];
+const bracedQuantifiers = ["{2}", "{2,}", "{2,4}"];
+
+for (const term of nonQuantifiableTerms) {
+  for (const quantifier of bracedQuantifiers) {
+    assert.throws(SyntaxError, () => new RegExp(term + quantifier));
+  }
+}


### PR DESCRIPTION
## Summary

Fix a parser bug around invalid braced quantifiers in Annex B non-unicode mode. We must error if valid braced quantifier syntax appears at the start of a term (i.e. is not following a quantifiable term). We can accomplish this by trying to parse a braced quantifier in this case and erroring if successful.

## Tests

- Added an integration test for braced quantifier syntax that does not directly follow a quantifiable term