### PR TITLE
[regexp] Fix matching of empty strings in string disjunctions

### DIFF
--- a/src/js/parser/regexp_parser.rs
+++ b/src/js/parser/regexp_parser.rs
@@ -19,6 +19,7 @@ use crate::{
             BinaryUnicodeProperty, BinaryUnicodePropertyOfStrings, GeneralCategoryProperty,
             ScriptProperty, UnicodeProperty,
         },
+        wtf_8::Wtf8Str,
     },
     p,
     parser::{
@@ -541,6 +542,9 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
     }
 
     fn parse_term(&mut self) -> ParseResult<ParsedTerm<'a>> {
+        // Character classes are assumed to always consume by default
+        let mut class_always_consumes = true;
+
         // Parse a single atomic term
         let term = match_u32!(match self.current() {
             '.' => {
@@ -557,7 +561,13 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
             }
             '[' => {
                 if self.flags.has_unicode_sets_flag() {
-                    let (character_class, _) = self.parse_unicode_sets_character_class()?;
+                    let (character_class, may_contain_strings) =
+                        self.parse_unicode_sets_character_class()?;
+
+                    // We don't know what strings were included yet but since it's possible for the
+                    // empty string to match we cannot assume this class always consumes input.
+                    class_always_consumes = !may_contain_strings;
+
                     Term::CharacterClass(character_class)
                 } else {
                     self.parse_standard_character_class()?
@@ -728,8 +738,11 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
         });
 
         let info = match &term {
-            Term::Literal(_) | Term::Wildcard | Term::CharacterClass(_) => {
+            Term::Literal(_) | Term::Wildcard => {
                 ExpressionInfo { always_consumes: true, captures: None }
+            }
+            Term::CharacterClass(_) => {
+                ExpressionInfo { always_consumes: class_always_consumes, captures: None }
             }
             Term::Assertion(_) | Term::Backreference(_) => {
                 ExpressionInfo { always_consumes: false, captures: None }
@@ -1775,21 +1788,16 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
         self.advance2();
         self.expect('{')?;
 
-        let mut alternatives = self.alloc_vec();
-
         // Keep track of whether this disjunction contains strings, as opposed to contains only
         // single code points.
         //
-        // Note that this means the empty string is considered a string. So initially check for an
-        // entirely empty disjunction.
-        let mut may_contain_strings = self.current() == '}' as u32;
+        // Note that this means the empty string is considered a string.
+        let mut may_contain_strings = false;
+        let mut alternatives = self.alloc_vec();
 
         while self.current() != '}' as u32 {
             let (alternative, len) = self.parse_string_disjunction_alternative()?;
-
-            if !alternative.is_empty() {
-                alternatives.push(alternative);
-            }
+            alternatives.push(alternative);
 
             if len != 1 {
                 may_contain_strings = true;
@@ -1802,11 +1810,18 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
             // Check for a trailing `|` which means there is a final empty alternative
             if self.current() == '}' as u32 {
                 may_contain_strings = true;
+                alternatives.push(Wtf8Str::from_str(""));
                 break;
             }
         }
 
         self.expect('}')?;
+
+        // An `\q{}` is treated as a single alternative of the empty string
+        if alternatives.is_empty() {
+            may_contain_strings = true;
+            alternatives.push(Wtf8Str::from_str(""));
+        }
 
         Ok((StringDisjunction { alternatives: alternatives.build() }, may_contain_strings))
     }

--- a/src/js/runtime/regexp/compiler.rs
+++ b/src/js/runtime/regexp/compiler.rs
@@ -846,15 +846,27 @@ impl CompiledRegExpBuilder {
 
     fn emit_character_class(&mut self, character_class: &CharacterClass) {
         let flags = self.current_flags();
-        let (set, strings) = self.character_class_to_set(character_class);
+        let (set, mut strings) = self.character_class_to_set(character_class);
 
-        // First check strings if there are any
-        let mut join_block = None;
-        if !strings.is_empty() {
-            let join_block_id = self.new_block();
-            self.emit_class_string_disjunction(&strings, join_block_id);
-            join_block = Some(join_block_id);
+        struct StringDisjunctionInfo {
+            join_block_id: BlockId,
+            has_empty_string: bool,
         }
+
+        // First check non-empty strings if there are any. The empty string is handled separately
+        // from other strings since it must be checked after individual code points.
+        let string_disjunction_info = if !strings.is_empty() {
+            let join_block_id = self.new_block();
+            let has_empty_string = strings.remove(&AnyStr::Str(""));
+
+            if !strings.is_empty() {
+                self.emit_class_string_disjunction(&strings, join_block_id);
+            }
+
+            Some(StringDisjunctionInfo { join_block_id, has_empty_string })
+        } else {
+            None
+        };
 
         // If comparison is case insensitive then expand the set of code points to include the
         // case insensitive closure of all code points in the set.
@@ -867,12 +879,23 @@ impl CompiledRegExpBuilder {
         // In unicode sets mode the set was eagerly inverted instead of inverting at the end
         let is_check_inverted = character_class.is_inverted && !flags.has_unicode_sets_flag();
 
+        // If a string disjunction had the empty string then we will always match the empty string
+        // iff no individual code points match. Note the order since we match longer strings first.
+        if let Some(StringDisjunctionInfo { has_empty_string: true, join_block_id }) =
+            string_disjunction_info
+        {
+            let code_point_check_block = self.new_block();
+            self.emit_branch_instruction(code_point_check_block, join_block_id);
+            self.set_current_block(code_point_check_block);
+        }
+
+        // Check individual code points
         self.emit_code_point_set(&set, is_check_inverted);
 
-        // If there is a join block (needed from string disjunction) then proceed to it
-        if let Some(join_block) = join_block {
-            self.emit_jump_instruction(join_block);
-            self.set_current_block(join_block);
+        // If there is a string disjunction then proceed to the final join block
+        if let Some(StringDisjunctionInfo { join_block_id, .. }) = string_disjunction_info {
+            self.emit_jump_instruction(join_block_id);
+            self.set_current_block(join_block_id);
         }
     }
 

--- a/tests/integration/built-ins/RegExp/unicodeSets/empty_string_disjunctions.js
+++ b/tests/integration/built-ins/RegExp/unicodeSets/empty_string_disjunctions.js
@@ -1,0 +1,41 @@
+/*---
+description: Character class string disjunctions may contain the empty string.
+---*/
+
+// Simple tests for empty string matches
+assert.compareArray(/[\q{}]/v.exec(''), ['']);
+assert(/[\q{}]/v.test('abc'));
+assert.sameValue(/[\q{}]/v.exec('x').index, 0);
+assert.compareArray(/x[\q{}]y/v.exec('xy'), ['xy']);
+
+// Empty alternative may appear alongside non-empty alternatives, still matches
+assert.compareArray(/[\q{|a}]/v.exec('x'), ['']);
+assert.compareArray(/[\q{ab|}]/v.exec('x'), ['']);
+assert.compareArray(/[\q{||}]/v.exec('x'), ['']);
+
+// Empty string unioned with a code point, code point matches first
+assert.compareArray(/[a\q{}]/v.exec(''), ['']);
+assert.compareArray(/[a\q{}]/v.exec('a'), ['a']);
+
+// Empty string unioned with a string, string matches first
+assert.compareArray(/[\q{abc}\q{}]/v.exec(''), ['']);
+assert.compareArray(/[\q{abc}\q{}]/v.exec('abc'), ['abc']);
+
+// Empty string matches at every index unless code point matches first
+const matches = Array.from('babaa'.matchAll(/[\q{a|}]/gv)).map(m => [m[0], m.index]);
+assert.compareArray(matches[0], ['', 0]);
+assert.compareArray(matches[1], ['a', 1]);
+assert.compareArray(matches[2], ['', 2]);
+assert.compareArray(matches[3], ['a', 3]);
+assert.compareArray(matches[4], ['a', 4]);
+assert.compareArray(matches[5], ['', 5]);
+
+// Set operations that resolve to the empty string
+assert.compareArray(/x[\q{}&&\q{|x}]y/v.exec('xy'), ['xy']);
+assert.compareArray(/x[\q{a|}--\q{a}]y/v.exec('xy'), ['xy']);
+
+// Empty string inside of a quantifier
+assert.compareArray(/[\q{}]*/v.exec('ab'), ['']);
+assert.compareArray(/[\q{a|}]*/v.exec('aa'), ['aa']);
+assert.compareArray(/[\q{a|}]+/v.exec('b'), ['']);
+assert.compareArray(/[\q{ab|}]*/v.exec('abab'), ['abab']);

--- a/tests/snapshot/parser/regexp/class_string_disjunction.exp
+++ b/tests/snapshot/parser/regexp/class_string_disjunction.exp
@@ -25,7 +25,9 @@
                   ranges: [
                     {
                       type: "StringDisjunction",
-                      alternatives: [],
+                      alternatives: [
+                        "",
+                      ],
                     },
                   ],
                 },
@@ -202,6 +204,7 @@
                     {
                       type: "StringDisjunction",
                       alternatives: [
+                        "",
                         "a",
                       ],
                     },
@@ -237,6 +240,9 @@
                     {
                       type: "StringDisjunction",
                       alternatives: [
+                        "",
+                        "",
+                        "",
                         "a",
                       ],
                     },
@@ -273,6 +279,7 @@
                       type: "StringDisjunction",
                       alternatives: [
                         "a",
+                        "",
                       ],
                     },
                   ],
@@ -308,6 +315,9 @@
                       type: "StringDisjunction",
                       alternatives: [
                         "a",
+                        "",
+                        "",
+                        "",
                       ],
                     },
                   ],
@@ -341,7 +351,12 @@
                   ranges: [
                     {
                       type: "StringDisjunction",
-                      alternatives: [],
+                      alternatives: [
+                        "",
+                        "",
+                        "",
+                        "",
+                      ],
                     },
                   ],
                 },

--- a/tests/snapshot/regexp_bytecode/class/string_disjunction.exp
+++ b/tests/snapshot/regexp_bytecode/class/string_disjunction.exp
@@ -13,16 +13,6 @@
     20: Jump(12)
 }
 
-[CompiledRegExpObject: /[\q{}]/] {
-     0: Branch(7, 3)
-     3: Wildcard
-     4: Branch(7, 3)
-     7: MarkCapturePoint(0)
-     9: ConsumeIfTrue
-    10: MarkCapturePoint(1)
-    12: Accept
-}
-
 [CompiledRegExpObject: /[\q{ab|abcde|abc}]/] {
      0: Branch(7, 3)
      3: Wildcard
@@ -121,4 +111,115 @@
     17: Jump(12)
     19: ConsumeIfTrue
     20: Jump(12)
+}
+
+[CompiledRegExpObject: /[\q{}]/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Branch(15, 12)
+    12: MarkCapturePoint(1)
+    14: Accept
+    15: ConsumeIfTrue
+    16: Jump(12)
+}
+
+[CompiledRegExpObject: /x[\q{|}]y/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Literal(x)
+    10: Branch(17, 13)
+    13: Literal(y)
+    14: MarkCapturePoint(1)
+    16: Accept
+    17: ConsumeIfTrue
+    18: Jump(13)
+}
+
+[CompiledRegExpObject: /x[\q{abc|}]y/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Literal(x)
+    10: Branch(17, 22)
+    13: Literal(y)
+    14: MarkCapturePoint(1)
+    16: Accept
+    17: Literal(a)
+    18: Literal(b)
+    19: Literal(c)
+    20: Jump(13)
+    22: Branch(25, 13)
+    25: ConsumeIfTrue
+    26: Jump(13)
+}
+
+[CompiledRegExpObject: /x[\q{|abc}]y/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Literal(x)
+    10: Branch(17, 22)
+    13: Literal(y)
+    14: MarkCapturePoint(1)
+    16: Accept
+    17: Literal(a)
+    18: Literal(b)
+    19: Literal(c)
+    20: Jump(13)
+    22: Branch(25, 13)
+    25: ConsumeIfTrue
+    26: Jump(13)
+}
+
+[CompiledRegExpObject: /x[\q{a|}]y/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Literal(x)
+    10: Branch(17, 13)
+    13: Literal(y)
+    14: MarkCapturePoint(1)
+    16: Accept
+    17: Literal(a)
+    18: Jump(13)
+}
+
+[CompiledRegExpObject: /x[\q{|a}]y/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Literal(x)
+    10: Branch(17, 13)
+    13: Literal(y)
+    14: MarkCapturePoint(1)
+    16: Accept
+    17: Literal(a)
+    18: Jump(13)
+}
+
+[CompiledRegExpObject: /x[\q{|a|abc}]y/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Literal(x)
+    10: Branch(17, 22)
+    13: Literal(y)
+    14: MarkCapturePoint(1)
+    16: Accept
+    17: Literal(a)
+    18: Literal(b)
+    19: Literal(c)
+    20: Jump(13)
+    22: Branch(25, 13)
+    25: Literal(a)
+    26: Jump(13)
 }

--- a/tests/snapshot/regexp_bytecode/class/string_disjunction.js
+++ b/tests/snapshot/regexp_bytecode/class/string_disjunction.js
@@ -1,5 +1,4 @@
 /[\q{ab}c]/v;
-/[\q{}]/v;
 
 // Multiple alternatives
 /[\q{ab|abcde|abc}]/v;
@@ -15,3 +14,18 @@
 
 // Subtraction
 /[\q{aa|bb}--\q{aa}]/v;
+
+// Empty strings
+/[\q{}]/v;
+/x[\q{|}]y/v;
+
+// Empty string with other strings
+/x[\q{abc|}]y/v;
+/x[\q{|abc}]y/v;
+
+// Empty string with code points
+/x[\q{a|}]y/v;
+/x[\q{|a}]y/v;
+
+// Empty string, code points, and strings
+/x[\q{|a|abc}]y/v;

--- a/tests/snapshot/regexp_bytecode/quantifiers/captures_maybe_consumes.exp
+++ b/tests/snapshot/regexp_bytecode/quantifiers/captures_maybe_consumes.exp
@@ -306,3 +306,45 @@
     30: Jump(25)
     32: Jump(25)
 }
+
+[CompiledRegExpObject: /a([\q{c|}])*b/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Literal(a)
+    10: Progress(0)
+    12: SetProgress(1)
+    14: Branch(17, 24)
+    17: ClearCapture(1)
+    19: MarkCapturePoint(2)
+    21: Branch(38, 31)
+    24: ClearCaptureIfNoProgress(1, 0)
+    27: Literal(b)
+    28: MarkCapturePoint(1)
+    30: Accept
+    31: MarkCapturePoint(3)
+    33: Progress(1)
+    35: Branch(17, 24)
+    38: Literal(c)
+    39: Jump(31)
+}
+
+[CompiledRegExpObject: /a([\q{c}])*b/] {
+     0: Branch(7, 3)
+     3: Wildcard
+     4: Branch(7, 3)
+     7: MarkCapturePoint(0)
+     9: Literal(a)
+    10: Progress(0)
+    12: Branch(15, 25)
+    15: ClearCapture(1)
+    17: MarkCapturePoint(2)
+    19: Literal(c)
+    20: MarkCapturePoint(3)
+    22: Branch(15, 25)
+    25: ClearCaptureIfNoProgress(1, 0)
+    28: Literal(b)
+    29: MarkCapturePoint(1)
+    31: Accept
+}

--- a/tests/snapshot/regexp_bytecode/quantifiers/captures_maybe_consumes.js
+++ b/tests/snapshot/regexp_bytecode/quantifiers/captures_maybe_consumes.js
@@ -22,3 +22,9 @@
 
 // Loop exact repetitions
 /a(x|){100}b/;
+
+// Empty string does not consume
+/a([\q{c|}])*b/v;
+
+// Any string disjunction conservatively may not consume
+/a([\q{c}])*b/v;


### PR DESCRIPTION
## Summary

Fixes compilation of `v`-mode string disjunctions that contain the empty string.

- Parser now correctly parses all empty strings in disjunctions including the trailing empty string or a completely empty `\q{}`
- Parser doesn't resolve set of strings for the full class, so if any strings are present we conservatively must return `always_consumes = false` since the empty string may be present
- When compiling we must separate out the empty string from the rest of the string checks and instead check for the empty string *after* checking individual code points, since the longest match wins

## Tests

- Added integration tests for empty string disjunctions
- Added RegExp bytecode snapshot tests for empty string disjunctions
- Updated parser snapshot tests from the empty string disjunction parsing fixes