### PR TITLE
[regexp] Fix parsing of `\u{N}` as quantifier in non-unicode Annex B mode

### DIFF
--- a/src/js/parser/regexp_parser.rs
+++ b/src/js/parser/regexp_parser.rs
@@ -1906,17 +1906,16 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
 
         // Unicode escape sequences always start with `\u`
         self.advance();
-
-        let after_slash_state = self.save();
-
         self.expect('u')?;
+
+        let after_u_state = self.save();
 
         // In unicode aware mode the escape sequence \u{digits} is allowed
         if self.eat('{') {
             // If not in unicode aware mode this was an escaped 'u' and following characters should
             // be parsed separately.
             if !is_unicode_aware {
-                self.restore(&after_slash_state);
+                self.restore(&after_u_state);
                 return Ok('u' as u32);
             }
 

--- a/tests/integration/annexB/built-ins/RegExp/non_unicode_escape_quantifier.js
+++ b/tests/integration/annexB/built-ins/RegExp/non_unicode_escape_quantifier.js
@@ -1,0 +1,8 @@
+/*---
+description: In non-unicode Annex B mode a `\u{...}` unicode escape is actually a quantifier.
+---*/
+
+assert(/a\u{2}b/.test("auub"));
+assert(/a\u{1,2}b/.test("aub"));
+assert.sameValue(/a\u{2}b/.test("aub"), false);
+assert.sameValue(/a\u{1,2}b/.test("auuub"), false);

--- a/tests/snapshot/parser/regexp/quantifiers.exp
+++ b/tests/snapshot/parser/regexp/quantifiers.exp
@@ -1,6 +1,6 @@
 {
   type: "Program",
-  loc: "1:1-14:11",
+  loc: "1:1-17:11",
   body: [
     {
       type: "ExpressionStatement",
@@ -391,6 +391,47 @@
                   min: 1,
                   max: 2,
                   is_greedy: false,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "17:1-17:11",
+      kind: {
+        type: "Literal",
+        loc: "17:1-17:10",
+        raw: "/a\u{2}b/",
+        value: {
+          pattern: "a\u{2}b",
+          flags: "",
+        },
+        regexp: {
+          type: "RegExp",
+          alternatives: [
+            {
+              type: "Alternative",
+              terms: [
+                {
+                  type: "Literal",
+                  value: "a",
+                },
+                {
+                  type: "Quantifier",
+                  term: {
+                    type: "Literal",
+                    value: "u",
+                  },
+                  min: 2,
+                  max: 2,
+                  is_greedy: true,
+                },
+                {
+                  type: "Literal",
+                  value: "b",
                 },
               ],
             },

--- a/tests/snapshot/parser/regexp/quantifiers.js
+++ b/tests/snapshot/parser/regexp/quantifiers.js
@@ -12,3 +12,6 @@
 /a{1}?/;
 /a{1,}?/;
 /a{1,2}?/;
+
+// Quantifier, not a unicode escape in Annex B
+/a\u{2}b/;


### PR DESCRIPTION
## Summary

In non-unicode Annex B mode the syntax `\u{N}` is allowed but is parsed as a braced quantifier applied to the identity escape of "u". We had a bug parsing this and were accidentally inserting an extra "u" literal into the AST due to restoring an incorrect save point.

## Tests

- Added parser snapshot test verifying this syntax and that an extra "u" literal no longer appears in the AST
- Added integration tests verifying that this syntax is a quantified "u" not a unicode escape