### PR TITLE
[regexp] Fix parsing of \uNNNN escape followed by \u{...} escape

### DIFF
--- a/src/js/parser/regexp_parser.rs
+++ b/src/js/parser/regexp_parser.rs
@@ -1963,9 +1963,10 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
             // Speculatively parse the next code unit, checking if it forms a surrogate pair. If not
             // then restore to before the next code unit.
             self.advance2();
-            let next_code_unit = self.parse_hex4_digits(start_pos)?;
-            if is_low_surrogate_code_unit(next_code_unit) {
-                return Ok(code_point_from_surrogate_pair(code_unit, next_code_unit));
+            if let Ok(next_code_unit) = self.parse_hex4_digits(start_pos) {
+                if is_low_surrogate_code_unit(next_code_unit) {
+                    return Ok(code_point_from_surrogate_pair(code_unit, next_code_unit));
+                }
             }
 
             self.restore(&save_state);

--- a/tests/integration/regression/000025.js
+++ b/tests/integration/regression/000025.js
@@ -1,0 +1,11 @@
+/*---
+description: RegExp surrogate pairs with different escape formats.
+---*/
+
+// Forms a surrogate pair
+assert(/\ud83d\ude0a/u.test('😊'));
+
+// Not counted as a surrogate pair
+assert.sameValue(/\ud83d\u{de0a}/u.test('😊'), false);
+assert.sameValue(/\u{d83d}\ude0a/u.test('😊'), false);
+assert.sameValue(/\u{d83d}\u{de0a}/u.test('😊'), false);


### PR DESCRIPTION
## Summary

Small bug in RegExp parsing. `\uNNNN\u{...}` was failing to parse due to a bug when speculatively parsing the trailing surrogate. We were erroring if `parse_hex4_digits` failed instead of restoring the save point and continuing parsing as a braced unicode escape.

## Tests

- Added regression test for this case