### PR TITLE
[runtime] Fix overlong encoding checks in decodeURI and decodeURIComponent

### DIFF
--- a/src/js/common/unicode.rs
+++ b/src/js/common/unicode.rs
@@ -27,6 +27,13 @@ const LOW_SURROGATE_START: CodeUnit = 0xDC00;
 /// End of low surrogate range, inclusive
 const LOW_SURROGATE_END: CodeUnit = 0xDFFF;
 
+/// The smallest code point encoded as two bytes in UTF-8.
+pub const MIN_TWO_BYTE_CODE_POINT: CodePoint = 0x80;
+/// The smallest code point encoded as three bytes in UTF-8.
+pub const MIN_THREE_BYTE_CODE_POINT: CodePoint = 0x800;
+/// The smallest code point encoded as four bytes in UTF-8.
+pub const MIN_FOUR_BYTE_CODE_POINT: CodePoint = 0x10000;
+
 #[inline]
 pub fn is_in_unicode_range(code_point: CodePoint) -> bool {
     code_point <= MAX_CODE_POINT

--- a/src/js/runtime/intrinsics/global_object.rs
+++ b/src/js/runtime/intrinsics/global_object.rs
@@ -2,7 +2,10 @@ use brimstone_macros::match_u32;
 
 use crate::{
     common::{
-        unicode::{encode_utf8_codepoint, get_hex_value, is_continuation_byte},
+        unicode::{
+            MIN_FOUR_BYTE_CODE_POINT, MIN_THREE_BYTE_CODE_POINT, MIN_TWO_BYTE_CODE_POINT,
+            encode_utf8_codepoint, get_hex_value, is_continuation_byte,
+        },
         wtf_8::Wtf8String,
     },
     handle_scope, handle_scope_guard,
@@ -454,25 +457,25 @@ fn decode<const INCLUDE_URI_UNESCAPED: bool>(
                 // Two byte UTF-8 sequence
                 let mut code_point = (first_byte as u32 & 0x1F) << 6;
 
+                code_point |= parse_hex_continuation_byte!() as u32 & 0x3F;
+
                 // Check for overlong encoding
-                if code_point == 0 {
+                if code_point < MIN_TWO_BYTE_CODE_POINT {
                     return uri_error(cx, "invalid URI escape sequence");
                 }
-
-                code_point |= parse_hex_continuation_byte!() as u32 & 0x3F;
 
                 decoded_string.push(code_point);
             } else if (first_byte & 0xF0) == 0xE0 {
                 // Three byte UTF-8 sequence
                 let mut code_point = (first_byte as u32 & 0x0F) << 12;
 
-                // Check for overlong encoding
-                if code_point == 0 {
-                    return uri_error(cx, "invalid URI escape sequence");
-                }
-
                 code_point |= (parse_hex_continuation_byte!() as u32 & 0x3F) << 6;
                 code_point |= parse_hex_continuation_byte!() as u32 & 0x3F;
+
+                // Check for overlong encoding
+                if code_point < MIN_THREE_BYTE_CODE_POINT {
+                    return uri_error(cx, "invalid URI escape sequence");
+                }
 
                 // Check for surrogate code points
                 if char::from_u32(code_point).is_none() {
@@ -484,17 +487,17 @@ fn decode<const INCLUDE_URI_UNESCAPED: bool>(
                 // Four byte UTF-8 sequence
                 let mut code_point = (first_byte as u32 & 0x07) << 18;
 
-                // Check for overlong encoding
-                if code_point == 0 {
-                    return uri_error(cx, "invalid URI escape sequence");
-                }
-
                 code_point |= (parse_hex_continuation_byte!() as u32 & 0x3F) << 12;
                 code_point |= (parse_hex_continuation_byte!() as u32 & 0x3F) << 6;
                 code_point |= parse_hex_continuation_byte!() as u32 & 0x3F;
 
                 // Verify code point is in range
                 if char::from_u32(code_point).is_none() {
+                    return uri_error(cx, "invalid URI escape sequence");
+                }
+
+                // Check for overlong encoding
+                if code_point < MIN_FOUR_BYTE_CODE_POINT {
                     return uri_error(cx, "invalid URI escape sequence");
                 }
 


### PR DESCRIPTION
## Summary

Fix inaccurate overlong encoding checks in `decodeURI` and `decodeURIComponent`.

These were hidden since the failing test262 tests were marked slow.

## Tests

Fixes the following test262 tests:
- `built-ins/decodeURI/S15.1.3.1_A2.4_T1.js`
- `built-ins/decodeURI/S15.1.3.1_A2.5_T1.js`
- `built-ins/decodeURIComponent/S15.1.3.2_A2.4_T1.js`
- `built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js`