### PR TITLE
[parser] Error on overlong WTF-8 encodings in source text

### DIFF
--- a/src/js/common/unicode.rs
+++ b/src/js/common/unicode.rs
@@ -407,6 +407,11 @@ pub fn decode_wtf8_codepoint(buf: &[u8]) -> Result<(CodePoint, usize), usize> {
         let mut codepoint = (b1 as u32 & 0x1F) << 6;
         codepoint |= b2 as u32 & 0x3F;
 
+        // Reject overlong encodings
+        if codepoint < MIN_TWO_BYTE_CODE_POINT {
+            return Err(2);
+        }
+
         Ok((codepoint, 2))
     } else if (b1 & 0xF0) == 0xE0 && buf.len() >= 3 {
         // Three byte sequence
@@ -420,6 +425,11 @@ pub fn decode_wtf8_codepoint(buf: &[u8]) -> Result<(CodePoint, usize), usize> {
         let mut codepoint = (b1 as u32 & 0x0F) << 12;
         codepoint |= (b2 as u32 & 0x3F) << 6;
         codepoint |= b3 as u32 & 0x3F;
+
+        // Reject overlong encodings
+        if codepoint < MIN_THREE_BYTE_CODE_POINT {
+            return Err(3);
+        }
 
         Ok((codepoint, 3))
     } else if (b1 & 0xF8) == 0xF0 && buf.len() >= 4 {
@@ -436,6 +446,11 @@ pub fn decode_wtf8_codepoint(buf: &[u8]) -> Result<(CodePoint, usize), usize> {
         codepoint |= (b2 as u32 & 0x3F) << 12;
         codepoint |= (b3 as u32 & 0x3F) << 6;
         codepoint |= b4 as u32 & 0x3F;
+
+        // Reject overlong encodings
+        if codepoint < MIN_FOUR_BYTE_CODE_POINT {
+            return Err(4);
+        }
 
         Ok((codepoint, 4))
     } else {

--- a/tests/rust/mod.rs
+++ b/tests/rust/mod.rs
@@ -1,1 +1,1 @@
-
+mod parser;

--- a/tests/rust/parser.rs
+++ b/tests/rust/parser.rs
@@ -1,0 +1,56 @@
+use std::rc::Rc;
+
+use brimstone_core::{
+    common::{options::OptionsBuilder, wtf_8::Wtf8String},
+    parser::{ParseContext, ParseError, parse_script, source::Source},
+};
+
+/// Parse a raw buffer of source bytes and assert the parser rejects it as invalid unicode.
+fn assert_rejected_as_invalid_unicode(bytes: &[u8]) {
+    let options = Rc::new(OptionsBuilder::new().build().unwrap());
+    let wtf8_string = Wtf8String::from_bytes_unchecked(bytes);
+    let source = Rc::new(Source::new_for_string("<test>", wtf8_string).unwrap());
+    let pcx = ParseContext::new(source);
+
+    let Err(err) = parse_script(&pcx, options) else {
+        panic!("expected parser error")
+    };
+
+    assert!(matches!(err.error, ParseError::InvalidUnicode));
+}
+
+#[test]
+fn overlong_two_byte_min() {
+    // 0xC0 0x80 is an overlong two-byte encoding of U+0000.
+    assert_rejected_as_invalid_unicode(&[0xC0, 0x80]);
+}
+
+#[test]
+fn overlong_two_byte_max() {
+    // 0xC1 0xBF is the largest overlong two-byte encoding, of U+007F.
+    assert_rejected_as_invalid_unicode(&[0xC1, 0xBF]);
+}
+
+#[test]
+fn overlong_three_byte_min() {
+    // 0xE0 0x80 0x80 is an overlong three-byte encoding of U+0000.
+    assert_rejected_as_invalid_unicode(&[0xE0, 0x80, 0x80]);
+}
+
+#[test]
+fn overlong_three_byte_max() {
+    // 0xE0 0x9F 0xBF is the largest overlong three-byte encoding, of U+07FF.
+    assert_rejected_as_invalid_unicode(&[0xE0, 0x9F, 0xBF]);
+}
+
+#[test]
+fn overlong_four_byte_min() {
+    // 0xF0 0x80 0x80 0x80 is an overlong four-byte encoding of U+0000.
+    assert_rejected_as_invalid_unicode(&[0xF0, 0x80, 0x80, 0x80]);
+}
+
+#[test]
+fn overlong_four_byte_max() {
+    // 0xF0 0x8F 0xBF 0xBF is the largest overlong four-byte encoding, of U+FFFF.
+    assert_rejected_as_invalid_unicode(&[0xF0, 0x8F, 0xBF, 0xBF]);
+}


### PR DESCRIPTION
## Summary

We have been protected from overlong UTF-8 encodings so far because all exposed source inputs have gone through Rust strings which enforce UTF-8 validity.

Let's be defensive and check for overlong encodings in the parser itself, that way we are protected if raw bytes are provided to the APIs or if this changes in the future.

## Tests

Can't use any existing tests for this since they all go through Rust strings which enforce UTF-8 validity. Instead introduce parser tests in `tests/rust/parser.rs` and verify that directly parsing overlong WTF-8 errors.