### PR TITLE
[runtime] Set methods throw RangeError if size is negative

### DIFF
--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -6,7 +6,7 @@ use crate::{
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         collections::BsIndexSetField,
-        error::type_error,
+        error::{range_error, type_error},
         eval_result::EvalResult,
         function::get_argument,
         get,
@@ -677,7 +677,7 @@ fn get_set_record(cx: Context, value: Handle<Value>, method_name: &str) -> EvalR
 
     let int_size = must!(to_integer_or_infinity(cx, num_size));
     if int_size < 0.0 {
-        return type_error(
+        return range_error(
             cx,
             &format!("Set.prototype.{method_name} `size` property must not be negative"),
         );

--- a/tests/integration/built-ins/Set/method_size_validation.js
+++ b/tests/integration/built-ins/Set/method_size_validation.js
@@ -1,0 +1,45 @@
+/*---
+description: Set methods that check the argument's `size` property properly validate it.
+---*/
+
+const set = new Set();
+
+const missingSize = {};
+
+assert.throws(TypeError, () => set.difference(missingSize));
+assert.throws(TypeError, () => set.intersection(missingSize));
+assert.throws(TypeError, () => set.isDisjointFrom(missingSize));
+assert.throws(TypeError, () => set.isSubsetOf(missingSize));
+assert.throws(TypeError, () => set.isSupersetOf(missingSize));
+assert.throws(TypeError, () => set.symmetricDifference(missingSize));
+assert.throws(TypeError, () => set.union(missingSize));
+
+const incorrectSizeType = { size: {} };
+
+assert.throws(TypeError, () => set.difference(incorrectSizeType));
+assert.throws(TypeError, () => set.intersection(incorrectSizeType));
+assert.throws(TypeError, () => set.isDisjointFrom(incorrectSizeType));
+assert.throws(TypeError, () => set.isSubsetOf(incorrectSizeType));
+assert.throws(TypeError, () => set.isSupersetOf(incorrectSizeType));
+assert.throws(TypeError, () => set.symmetricDifference(incorrectSizeType));
+assert.throws(TypeError, () => set.union(incorrectSizeType));
+
+const nanSize = { size: NaN };
+
+assert.throws(TypeError, () => set.difference(nanSize));
+assert.throws(TypeError, () => set.intersection(nanSize));
+assert.throws(TypeError, () => set.isDisjointFrom(nanSize));
+assert.throws(TypeError, () => set.isSubsetOf(nanSize));
+assert.throws(TypeError, () => set.isSupersetOf(nanSize));
+assert.throws(TypeError, () => set.symmetricDifference(nanSize));
+assert.throws(TypeError, () => set.union(nanSize));
+
+const negativeSize = { size: -1 };
+
+assert.throws(RangeError, () => set.difference(negativeSize));
+assert.throws(RangeError, () => set.intersection(negativeSize));
+assert.throws(RangeError, () => set.isDisjointFrom(negativeSize));
+assert.throws(RangeError, () => set.isSubsetOf(negativeSize));
+assert.throws(RangeError, () => set.isSupersetOf(negativeSize));
+assert.throws(RangeError, () => set.symmetricDifference(negativeSize));
+assert.throws(RangeError, () => set.union(negativeSize));


### PR DESCRIPTION
## Summary

We were throwing a `TypeError` instead of a `RangeError` when a `Set` method's argument had a negative `size` property. Fix this to match the spec.

## Tests

- Added a new integration test for `Set` method argument `size` validation across all affected methods. Tests a missing size, incorrect size type, NaN size, and negative size.