### PR TITLE
[common] Error source location column is number of code points not byte offset

### DIFF
--- a/src/js/common/error.rs
+++ b/src/js/common/error.rs
@@ -50,7 +50,7 @@ impl SourceInfo {
 
         // Find line and column number for the start of the source location
         let offsets = source.line_offsets();
-        let (line, col) = find_line_col_for_pos(pos, offsets);
+        let (line, col) = find_line_col_for_pos(source.contents.as_bytes(), pos, offsets);
 
         // Extract the full line as a snippet
         let snippet = source.get_line((line - 1) as u32);

--- a/src/js/parser/loc.rs
+++ b/src/js/parser/loc.rs
@@ -1,5 +1,7 @@
 use std::ops::Range;
 
+use crate::common::unicode::{CodePoint, decode_wtf8_codepoint, is_ascii};
+
 /// Start and end positions are byte offsets in the source file.
 pub type Pos = usize;
 
@@ -47,15 +49,43 @@ pub fn calculate_line_offsets(source: &[u8]) -> Vec<u32> {
 
 /// Return the line and column number to report for a Pos. Line and column number are intended for
 /// display and are 1-indexed.
-pub fn find_line_col_for_pos(pos: Pos, line_offsets: &[u32]) -> (usize, usize) {
+///
+/// Column is the number of code points in the line up to the pos (not number of bytes).
+pub fn find_line_col_for_pos(buf: &[u8], pos: Pos, line_offsets: &[u32]) -> (usize, usize) {
     // Binary search to find the largest line start offset that is smaller than the pos. This is
     // the line number.
     let line = find_largest_offset_less_than_or_equal(pos, line_offsets);
 
-    // Column is the byte offset from the line (col is number of bytes since Unicode is not yet supported)
-    let col = pos - line_offsets[line] as usize;
+    let line_start = line_offsets[line] as usize;
+    let line_slice = &buf[line_start..pos];
+    let col = best_effort_count_code_points(line_slice);
 
     (line + 1, col + 1)
+}
+
+/// Best-effort count of code points in a buffer. Check validity, returning the number of valid code
+/// points if invalid WTF-8 is encountered.
+fn best_effort_count_code_points(buf: &[u8]) -> usize {
+    let mut num_code_points = 0;
+    let mut slice = buf;
+
+    while !slice.is_empty() {
+        let num_bytes = if is_ascii(slice[0] as CodePoint) {
+            1
+        } else {
+            match decode_wtf8_codepoint(slice) {
+                Ok((_, num_bytes)) => num_bytes,
+                // Invalid WTF-8, return number of code points parsed so far
+                Err(_) => return num_code_points,
+            }
+        };
+
+        num_code_points += 1;
+        slice = &slice[num_bytes..];
+    }
+
+    // Reached end of buffer, string is valid WTF-8
+    num_code_points
 }
 
 fn find_largest_offset_less_than_or_equal(target: Pos, line_offsets: &[u32]) -> Pos {

--- a/src/js/parser/parse_error.rs
+++ b/src/js/parser/parse_error.rs
@@ -507,7 +507,8 @@ impl LocalizedParseError {
             None => self.error.to_string(),
             Some((loc, source)) => {
                 let offsets = source.line_offsets();
-                let (line, col) = find_line_col_for_pos(loc.start, offsets);
+                let (line, col) =
+                    find_line_col_for_pos(source.contents.as_bytes(), loc.start, offsets);
                 format!("{}:{}:{} {}", source.display_name(), line, col, self.error)
             }
         }
@@ -589,7 +590,8 @@ fn format_localized_parse_errors(errors: &[LocalizedParseError], opts: &FormatOp
             }
             Some((loc, source)) => {
                 let offsets = source.line_offsets();
-                let (line, col) = find_line_col_for_pos(loc.start, offsets);
+                let (line, col) =
+                    find_line_col_for_pos(source.contents.as_bytes(), loc.start, offsets);
                 errors_with_loc.push((error, source, line, col))
             }
         }

--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -83,9 +83,10 @@ impl<'a> Printer<'a> {
         self.property("type", name, Printer::print_str);
 
         // Calculate line/column offsets for loc
+        let contents = self.source.contents.as_bytes();
         let line_offsets = self.source.line_offsets();
-        let (start_line, start_col) = find_line_col_for_pos(loc.start, line_offsets);
-        let (end_line, end_col) = find_line_col_for_pos(loc.end, line_offsets);
+        let (start_line, start_col) = find_line_col_for_pos(contents, loc.start, line_offsets);
+        let (end_line, end_col) = find_line_col_for_pos(contents, loc.end, line_offsets);
 
         // Write loc as string in concise format
         self.indent();

--- a/src/js/runtime/source_file.rs
+++ b/src/js/runtime/source_file.rs
@@ -21,7 +21,7 @@ pub struct SourceFile {
     display_name: Option<HeapPtr<FlatString>>,
     /// Lazily generated array of line offsets for the source file
     line_offsets: Option<HeapPtr<LineOffsetArray>>,
-    /// Inlined source file contents as a WTF8 string
+    /// Inlined source file contents as a WTF-8 string
     contents: InlineArray<u8>,
 }
 

--- a/src/js/runtime/stack_trace.rs
+++ b/src/js/runtime/stack_trace.rs
@@ -155,8 +155,11 @@ pub fn create_stack_trace(
                 // line offsets were already generated in `prepare_for_stack_trace`.
                 let source_file = func.source_file_ptr().unwrap();
                 let line_offsets = source_file.line_offsets_ptr_raw().unwrap();
-                let (line, column) =
-                    find_line_col_for_pos(source_position, line_offsets.as_slice());
+                let (line, column) = find_line_col_for_pos(
+                    source_file.contents_as_slice(),
+                    source_position,
+                    line_offsets.as_slice(),
+                );
 
                 // Append the line and column to the function name
                 stack_trace.push_str(&format!(":{line}:{column}"));

--- a/tests/snapshot/error/regexp/source_location_non_unicode.exp
+++ b/tests/snapshot/error/regexp/source_location_non_unicode.exp
@@ -1,5 +1,5 @@
 SyntaxError: Invalid quantifier bounds in regular expression
-  ┌ regexp/source_location_non_unicode.js:2:6
+  ┌ regexp/source_location_non_unicode.js:2:3
   |
 2 | /😂{2,1}/;
-  |      ^
+  |   ^

--- a/tests/snapshot/error/regexp/source_location_unicode.exp
+++ b/tests/snapshot/error/regexp/source_location_unicode.exp
@@ -1,5 +1,5 @@
 SyntaxError: Invalid quantifier bounds in regular expression
-  ┌ regexp/source_location_unicode.js:2:6
+  ┌ regexp/source_location_unicode.js:2:3
   |
 2 | /😂{2,1}/u;
-  |      ^
+  |   ^

--- a/tests/snapshot/error/source_locations/syntax/eval_unicode_offsets.exp
+++ b/tests/snapshot/error/source_locations/syntax/eval_unicode_offsets.exp
@@ -1,0 +1,8 @@
+TypeError: expected a function
+  ┌ <eval>:1:16
+  |
+1 | var foo = '☺'; null();
+  |                ^
+Stack trace:
+  at <eval> (<eval>:1:16)
+  at <global> (source_locations/syntax/eval_unicode_offsets.js:1:1)

--- a/tests/snapshot/error/source_locations/syntax/eval_unicode_offsets.js
+++ b/tests/snapshot/error/source_locations/syntax/eval_unicode_offsets.js
@@ -1,0 +1,1 @@
+eval("var foo = '☺'; null();");

--- a/tests/snapshot/error/source_locations/syntax/unicode_offsets.exp
+++ b/tests/snapshot/error/source_locations/syntax/unicode_offsets.exp
@@ -1,0 +1,7 @@
+TypeError: expected a function
+  ┌ source_locations/syntax/unicode_offsets.js:1:16
+  |
+1 | var foo = "☺"; null();
+  |                ^
+Stack trace:
+  at <global> (source_locations/syntax/unicode_offsets.js:1:16)

--- a/tests/snapshot/error/source_locations/syntax/unicode_offsets.js
+++ b/tests/snapshot/error/source_locations/syntax/unicode_offsets.js
@@ -1,0 +1,1 @@
+var foo = "☺"; null();

--- a/tests/snapshot/parser/regexp/groups.exp
+++ b/tests/snapshot/parser/regexp/groups.exp
@@ -1,6 +1,6 @@
 {
   type: "Program",
-  loc: "1:1-21:22",
+  loc: "1:1-21:13",
   body: [
     {
       type: "ExpressionStatement",
@@ -394,10 +394,10 @@
     },
     {
       type: "ExpressionStatement",
-      loc: "20:1-20:21",
+      loc: "20:1-20:12",
       kind: {
         type: "Literal",
-        loc: "20:1-20:20",
+        loc: "20:1-20:11",
         raw: "/(?<𝑓𝑜𝑥>)/",
         value: {
           pattern: "(?<𝑓𝑜𝑥>)",
@@ -428,10 +428,10 @@
     },
     {
       type: "ExpressionStatement",
-      loc: "21:1-21:22",
+      loc: "21:1-21:13",
       kind: {
         type: "Literal",
-        loc: "21:1-21:21",
+        loc: "21:1-21:12",
         raw: "/(?<𝑓𝑜𝑥>)/u",
         value: {
           pattern: "(?<𝑓𝑜𝑥>)",

--- a/tests/snapshot/parser/regexp/unicode.exp
+++ b/tests/snapshot/parser/regexp/unicode.exp
@@ -1,13 +1,13 @@
 {
   type: "Program",
-  loc: "1:1-3:10",
+  loc: "1:1-3:7",
   body: [
     {
       type: "ExpressionStatement",
-      loc: "2:1-2:8",
+      loc: "2:1-2:5",
       kind: {
         type: "Literal",
-        loc: "2:1-2:7",
+        loc: "2:1-2:4",
         raw: "/𠮷/",
         value: {
           pattern: "𠮷",
@@ -31,10 +31,10 @@
     },
     {
       type: "ExpressionStatement",
-      loc: "3:1-3:10",
+      loc: "3:1-3:7",
       kind: {
         type: "Literal",
-        loc: "3:1-3:9",
+        loc: "3:1-3:6",
         raw: "/[𠮷]/",
         value: {
           pattern: "[𠮷]",


### PR DESCRIPTION
## Summary

Errors report a line and column where the column is currently the byte offset within the line. Instead let's report the column as the number of code points in the line.

This requires having the source buffer available in `find_line_col_for_pos` and creating a routine to count code points. Perform a best effort count returning the number parsed if invalid WTF-8 is encountered (should only happen when parsing invalid WTF-8 and reports where the invalid code point starts).

## Tests

- Added snapshot tests verifying column number in error message after non-ASCII code points. Test both directly and in eval.