### PR TITLE
[tests] Mock current time during tests

### DIFF
--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -13,6 +13,7 @@ use crate::{
         filesystem::FileNameReserver,
         options::Options,
         serialized_heap::SerializedHeap,
+        time::get_current_unix_time,
         wtf_8::{Wtf8Str, Wtf8String},
     },
     eval_err, handle_scope, must_a,
@@ -123,6 +124,9 @@ pub struct ContextCell {
 
     /// Random number generator used within this context.
     pub rand: StdRng,
+
+    /// If set, this is returned instead of the current unix time.
+    pub mocked_unix_time: Option<f64>,
 }
 
 type GlobalSymbolRegistry = BsHashMap<HeapPtr<FlatString>, HeapPtr<SymbolValue>>;
@@ -159,6 +163,7 @@ impl Context {
             // We want the initial heap generation to be deterministic so use seeded PRNG. After
             // initial heap has been set up switch to a PRNG seeded from a random source.
             rand: StdRng::from_seed([0; 32]),
+            mocked_unix_time: None,
         });
 
         let mut cx = unsafe { Context::from_ptr(NonNull::new_unchecked(Box::leak(cx_cell))) };
@@ -442,6 +447,11 @@ impl Context {
         GlobalSymbolRegistryField
     }
 
+    /// Returns the current unix time, which may be mocked.
+    pub fn current_unix_time(self) -> f64 {
+        self.mocked_unix_time.unwrap_or_else(get_current_unix_time)
+    }
+
     pub fn print_or_add_to_dump_buffer(&self, str: &str) {
         if let Some(mut buffer) = self.options.dump_buffer() {
             if !buffer.is_empty() {
@@ -639,11 +649,12 @@ impl DerefMut for Context {
 
 pub struct ContextBuilder {
     options: Option<Rc<Options>>,
+    mocked_unix_time: Option<f64>,
 }
 
 impl ContextBuilder {
     pub fn new() -> Self {
-        Self { options: None }
+        Self { options: None, mocked_unix_time: None }
     }
 
     pub fn build(self) -> AllocResult<Context> {
@@ -651,11 +662,20 @@ impl ContextBuilder {
         let options = self.options.unwrap_or_else(|| Rc::new(Options::default()));
 
         // Create default realm if one was not provided
-        Context::new(options)
+        let mut cx = Context::new(options)?;
+
+        cx.mocked_unix_time = self.mocked_unix_time;
+
+        Ok(cx)
     }
 
     pub fn set_options(mut self, options: Rc<Options>) -> Self {
         self.options = Some(options);
+        self
+    }
+
+    pub fn mock_unix_time(mut self, time: f64) -> Self {
+        self.mocked_unix_time = Some(time);
         self
     }
 }

--- a/src/js/runtime/intrinsics/date_constructor.rs
+++ b/src/js/runtime/intrinsics/date_constructor.rs
@@ -1,26 +1,21 @@
-use crate::{
-    common::time::get_current_unix_time,
-    runtime::{
-        Context, Value,
-        alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
-        eval_result::EvalResult,
-        function::get_argument,
-        gc::Handle,
-        intrinsics::{
-            date_object::{
-                DateObject, make_date, make_day, make_full_year, make_time, time_clip, utc,
-            },
-            date_prototype::{to_date_string, validate_date_value},
-            intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
-        },
-        object_value::ObjectValue,
-        realm::Realm,
-        string_parsing::parse_string_to_date,
-        to_string,
-        type_utilities::{ToPrimitivePreferredType, to_number, to_primitive},
+use crate::runtime::{
+    Context, Value,
+    alloc_error::AllocResult,
+    builtin_function::BuiltinFunction,
+    eval_result::EvalResult,
+    function::get_argument,
+    gc::Handle,
+    intrinsics::{
+        date_object::{DateObject, make_date, make_day, make_full_year, make_time, time_clip, utc},
+        date_prototype::{to_date_string, validate_date_value},
+        intrinsics::Intrinsic,
+        rust_runtime::RuntimeFunction,
     },
+    object_value::ObjectValue,
+    realm::Realm,
+    string_parsing::parse_string_to_date,
+    to_string,
+    type_utilities::{ToPrimitivePreferredType, to_number, to_primitive},
 };
 
 pub struct DateConstructor;
@@ -65,13 +60,13 @@ impl DateConstructor {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
-            return Ok(to_date_string(cx, get_current_unix_time())?.as_value());
+            return Ok(to_date_string(cx, cx.current_unix_time())?.as_value());
         };
 
         let number_of_args = arguments.len();
 
         let date_value = if number_of_args == 0 {
-            get_current_unix_time()
+            cx.current_unix_time()
         } else if number_of_args == 1 {
             let date_value =
                 if let Some(date_value_arg) = validate_date_value(get_argument(cx, arguments, 0)) {
@@ -147,7 +142,7 @@ impl DateConstructor {
 
     /// Date.now (https://tc39.es/ecma262/#sec-date.now)
     pub fn now(cx: Context, _: Handle<Value>, _: &[Handle<Value>]) -> EvalResult<Handle<Value>> {
-        Ok(Value::from(get_current_unix_time()).to_handle(cx))
+        Ok(Value::from(cx.current_unix_time()).to_handle(cx))
     }
 
     /// Date.parse (https://tc39.es/ecma262/#sec-date.parse)

--- a/tests/harness/src/runner.rs
+++ b/tests/harness/src/runner.rs
@@ -50,6 +50,9 @@ const RUNNER_THREAD_STACK_SIZE: usize = 1 << 23;
 /// Size of the heap for each test. Use a small value since most tests do not require a large heap.
 const HEAP_SIZE: usize = MEGABYTE_BYTES;
 
+/// Fixed unix time to use during tests
+const MOCKED_UNIX_TIME: f64 = 1_000_000_000_000.0;
+
 impl TestRunner {
     pub fn new(
         manifest: TestManifest,
@@ -239,6 +242,7 @@ fn run_single_test(
     // Each test is executed in its own realm
     let cx = ContextBuilder::new()
         .set_options(Rc::new(options))
+        .mock_unix_time(MOCKED_UNIX_TIME)
         .build()
         .unwrap();
     let options = cx.options.clone();


### PR DESCRIPTION
## Summary

We've seen sporadic CI failures that appear to be integration tests checking the current time twice (e.g. two `new Date()`'s and getting different results.

Let's make the time deterministic during tests by allowing it to be mocked to a fixed time in the `Context`. Hopefully we don't see this sporadic failures anymore.

## Tests

- CI