### PR TITLE
[runtime] Fix and simplify BigInt.{asIntN, asUintN} arthmetic

### DIFF
--- a/src/js/runtime/intrinsics/bigint_constructor.rs
+++ b/src/js/runtime/intrinsics/bigint_constructor.rs
@@ -1,6 +1,6 @@
 use std::mem::size_of;
 
-use num_bigint::{BigInt, Sign};
+use num_bigint::BigInt;
 use num_traits::FromPrimitive;
 
 use crate::{
@@ -135,26 +135,19 @@ impl BigIntConstructor {
         let bigint_arg = get_argument(cx, arguments, 1);
         let bigint = to_bigint(cx, bigint_arg)?;
 
-        // Convert BigInt to its representation as bits
-        let mut bytes = bigint.bigint().to_signed_bytes_le();
+        // Applying 2^n modulus is equivalent to masking by 2^n - 1
+        let modulus = BigInt::from(1) << bits;
+        let mask = &modulus - BigInt::from(1);
+        let unsigned_bigint = bigint.bigint() & &mask;
 
-        // Keep all the bytes that have some bits in the range to keep
-        let num_full_bytes = bits / 8;
-        bytes.truncate(num_full_bytes + 1);
+        // Unsigned values >= 2^(n - 1) should be negative signed values
+        let signed_bigint = if bits > 0 && unsigned_bigint.bit(bits as u64 - 1) {
+            unsigned_bigint - &modulus
+        } else {
+            unsigned_bigint
+        };
 
-        // Clear the unused bits in the last byte that was kept
-        let num_bits_to_remove = 8 - bits % 8;
-        if num_bits_to_remove == 8 {
-            bytes.pop();
-        } else if !bytes.is_empty() {
-            // Be sure to sign extend from the new highest bit
-            let last_byte = bytes.last_mut().unwrap();
-            *last_byte <<= num_bits_to_remove;
-            *last_byte = ((*last_byte as i8) >> num_bits_to_remove) as u8;
-        }
-
-        let new_bigint = BigInt::from_signed_bytes_le(&bytes);
-        Ok(BigIntValue::new(cx, new_bigint)?.into())
+        Ok(BigIntValue::new(cx, signed_bigint)?.into())
     }
 
     /// BigInt.asUintN (https://tc39.es/ecma262/#sec-bigint.asuintn)
@@ -169,24 +162,10 @@ impl BigIntConstructor {
         let bigint_arg = get_argument(cx, arguments, 1);
         let bigint = to_bigint(cx, bigint_arg)?;
 
-        // Convert BigInt to its representation as bits
-        let mut bytes = bigint.bigint().to_signed_bytes_le();
+        // Applying 2^n modulus is equivalent to masking by 2^n - 1
+        let mask = (BigInt::from(1) << bits) - BigInt::from(1);
+        let new_bigint = bigint.bigint() & &mask;
 
-        // Keep all the bytes that have some bits in the range to keep
-        let num_full_bytes = bits / 8;
-        bytes.truncate(num_full_bytes + 1);
-
-        // Clear the unused bits in the last byte that was kept
-        let num_bits_to_remove = 8 - bits % 8;
-        if num_bits_to_remove == 8 {
-            bytes.pop();
-        } else if !bytes.is_empty() {
-            let last_byte = bytes.last_mut().unwrap();
-            *last_byte <<= num_bits_to_remove;
-            *last_byte >>= num_bits_to_remove;
-        }
-
-        let new_bigint = BigInt::from_bytes_le(Sign::Plus, &bytes);
         Ok(BigIntValue::new(cx, new_bigint)?.into())
     }
 }

--- a/tests/integration/built-ins/BigInt/as_int_n.js
+++ b/tests/integration/built-ins/BigInt/as_int_n.js
@@ -1,0 +1,53 @@
+/*---
+description: BigInt.asIntN arithemtic.
+---*/
+
+// Zero-width window always returns 0n.
+assert.sameValue(BigInt.asIntN(0, 5n), 0n);
+assert.sameValue(BigInt.asIntN(0, -5n), 0n);
+
+// Single-bit window: only 0n and -1n are representable.
+assert.sameValue(BigInt.asIntN(1, 0n), 0n);
+assert.sameValue(BigInt.asIntN(1, 1n), -1n);
+assert.sameValue(BigInt.asIntN(1, -1n), -1n);
+
+// 4-bit window (non-multiple of 8): signed range [-8, 7].
+assert.sameValue(BigInt.asIntN(4, 7n), 7n);
+assert.sameValue(BigInt.asIntN(4, 8n), -8n);
+assert.sameValue(BigInt.asIntN(4, -1n), -1n);
+assert.sameValue(BigInt.asIntN(4, -9n), 7n);
+
+// 12-bit window (non-multiple, two bytes): signed range [-2048, 2047].
+assert.sameValue(BigInt.asIntN(12, 5n), 5n);
+assert.sameValue(BigInt.asIntN(12, 2048n), -2048n);
+assert.sameValue(BigInt.asIntN(12, -1n), -1n);
+assert.sameValue(BigInt.asIntN(12, -2049n), 2047n);
+
+// 60-bit window (non-multiple, eight bytes): signed range [-2^59, 2^59-1].
+assert.sameValue(BigInt.asIntN(60, 5n), 5n);
+assert.sameValue(BigInt.asIntN(60, 2n ** 59n), -576460752303423488n);
+assert.sameValue(BigInt.asIntN(60, -1n), -1n);
+
+// 8-bit window: signed range [-128, 127].
+assert.sameValue(BigInt.asIntN(8, 5n), 5n);
+assert.sameValue(BigInt.asIntN(8, 128n), -128n);
+assert.sameValue(BigInt.asIntN(8, -1n), -1n);
+assert.sameValue(BigInt.asIntN(8, -129n), 127n);
+
+// 24-bit window (byte-aligned, non-power-of-2): signed range [-8388608, 8388607].
+assert.sameValue(BigInt.asIntN(24, 5n), 5n);
+assert.sameValue(BigInt.asIntN(24, 8388608n), -8388608n);
+assert.sameValue(BigInt.asIntN(24, -1n), -1n);
+
+// 64-bit window: signed range [-2^63, 2^63-1].
+assert.sameValue(BigInt.asIntN(64, 5n), 5n);
+assert.sameValue(BigInt.asIntN(64, -1n), -1n);
+assert.sameValue(BigInt.asIntN(64, 2n ** 63n - 1n), 9223372036854775807n);
+assert.sameValue(BigInt.asIntN(64, 2n ** 63n), -9223372036854775808n);
+assert.sameValue(BigInt.asIntN(64, -(2n ** 63n) - 1n), 9223372036854775807n);
+
+// 128-bit window: signed range [-2^127, 2^127-1].
+assert.sameValue(BigInt.asIntN(128, 5n), 5n);
+assert.sameValue(BigInt.asIntN(128, -1n), -1n);
+assert.sameValue(BigInt.asIntN(128, 2n ** 127n), -170141183460469231731687303715884105728n);
+assert.sameValue(BigInt.asIntN(128, 2n ** 200n + 1n), 1n);

--- a/tests/integration/built-ins/BigInt/as_uint_n.js
+++ b/tests/integration/built-ins/BigInt/as_uint_n.js
@@ -1,0 +1,56 @@
+/*---
+description: BigInt.asUintN arithmetic.
+---*/
+
+// Zero-width window always returns 0n.
+assert.sameValue(BigInt.asUintN(0, 5n), 0n);
+assert.sameValue(BigInt.asUintN(0, -5n), 0n);
+
+// Single-bit window: only 0n and 1n are representable.
+assert.sameValue(BigInt.asUintN(1, 0n), 0n);
+assert.sameValue(BigInt.asUintN(1, 1n), 1n);
+assert.sameValue(BigInt.asUintN(1, -1n), 1n);
+
+// 4-bit window (non-multiple of 8): range [0, 15].
+assert.sameValue(BigInt.asUintN(4, 9n), 9n);
+assert.sameValue(BigInt.asUintN(4, 15n), 15n);
+assert.sameValue(BigInt.asUintN(4, 16n), 0n);
+assert.sameValue(BigInt.asUintN(4, -1n), 15n);
+
+// 9-bit window (non-multiple, two bytes): range [0, 511].
+assert.sameValue(BigInt.asUintN(9, 5n), 5n);
+assert.sameValue(BigInt.asUintN(9, 511n), 511n);
+assert.sameValue(BigInt.asUintN(9, 512n), 0n);
+assert.sameValue(BigInt.asUintN(9, -1n), 511n);
+
+// 60-bit window (non-multiple, eight bytes): range [0, 2^60-1].
+assert.sameValue(BigInt.asUintN(60, 5n), 5n);
+assert.sameValue(BigInt.asUintN(60, 2n ** 60n - 1n), 1152921504606846975n);
+assert.sameValue(BigInt.asUintN(60, 2n ** 60n), 0n);
+assert.sameValue(BigInt.asUintN(60, -1n), 1152921504606846975n);
+
+// 8-bit window: range [0, 255].
+assert.sameValue(BigInt.asUintN(8, 5n), 5n);
+assert.sameValue(BigInt.asUintN(8, 255n), 255n);
+assert.sameValue(BigInt.asUintN(8, 256n), 0n);
+assert.sameValue(BigInt.asUintN(8, -1n), 255n);
+assert.sameValue(BigInt.asUintN(8, -128n), 128n);
+
+// 24-bit window (byte-aligned, non-power-of-2): range [0, 16777215].
+assert.sameValue(BigInt.asUintN(24, 5n), 5n);
+assert.sameValue(BigInt.asUintN(24, 16777215n), 16777215n);
+assert.sameValue(BigInt.asUintN(24, 16777216n), 0n);
+assert.sameValue(BigInt.asUintN(24, -1n), 16777215n);
+
+// 64-bit window: range [0, 2^64-1].
+assert.sameValue(BigInt.asUintN(64, 5n), 5n);
+assert.sameValue(BigInt.asUintN(64, 2n ** 64n - 1n), 18446744073709551615n);
+assert.sameValue(BigInt.asUintN(64, 2n ** 64n), 0n);
+assert.sameValue(BigInt.asUintN(64, -1n), 18446744073709551615n);
+assert.sameValue(BigInt.asUintN(64, -(2n ** 63n)), 9223372036854775808n);
+
+// 128-bit window: range [0, 2^128-1].
+assert.sameValue(BigInt.asUintN(128, 5n), 5n);
+assert.sameValue(BigInt.asUintN(128, -1n), 340282366920938463463374607431768211455n);
+assert.sameValue(BigInt.asUintN(128, 2n ** 128n), 0n);
+assert.sameValue(BigInt.asUintN(128, 2n ** 200n + 1n), 1n);


### PR DESCRIPTION
## Summary

Reimplement the arithmetic in `BigInt.asIntN` and `BigInt.asUintN` to be simpler and fix multiple correctness bugs. Now apply the modulus (via a bit mask) and convert to signed if necessary instead of performing operations on the underlying byte vector representation. This is slightly less efficient but much clearer and actually correct.

## Tests

- Added (LLM-generated) integration tests covering many cases for these two methods, including cases that were failing before