### PR TITLE
[bytecode] Avoid assignment hazards with update expressions

### DIFF
--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -381,23 +381,23 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
     }
 
     fn visit_outer_expression(&mut self, expr: &mut OuterExpression<'a>) {
-        // Outer expressions are in their own "has assignment expression" context
         self.enter_has_assign_expr_context();
-        self.visit_expression(&mut expr.expr);
-        expr.has_assign_expr = self.exit_has_assign_expr_context();
-    }
 
-    fn visit_expression_statement(&mut self, stmt: &mut ExpressionStatement<'a>) {
-        if let Expression::Assign(assign) = &mut stmt.expr.expr {
-            // Top level assignment expression "has assignment expression" context refers to whether
-            // the left or right side of the assignment expression has an assignment expression, and
-            // is not trivially true.
-            self.enter_has_assign_expr_context();
-            default_visit_assignment_expression(self, assign);
-            stmt.expr.has_assign_expr = self.exit_has_assign_expr_context();
-        } else {
-            default_visit_expression_statement(self, stmt);
+        match &mut expr.expr {
+            // Avoid trivially flagging a top-level assignment or update expression as
+            // "has assignment expression". Still flag if a nested assignment expression appears.
+            Expression::Assign(assign) => {
+                default_visit_assignment_expression(self, assign);
+            }
+            Expression::Update(update) => {
+                default_visit_update_expression(self, update);
+            }
+            _ => {
+                self.visit_expression(&mut expr.expr);
+            }
         }
+
+        expr.has_assign_expr = self.exit_has_assign_expr_context();
     }
 
     fn visit_switch_statement(&mut self, stmt: &mut SwitchStatement<'a>) {
@@ -627,6 +627,13 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
         self.has_assign_expr = true;
 
         default_visit_assignment_expression(self, expr);
+    }
+
+    fn visit_update_expression(&mut self, expr: &mut UpdateExpression<'a>) {
+        // Update expressions assign so mark the current context as having an assignment expression
+        self.has_assign_expr = true;
+
+        default_visit_update_expression(self, expr);
     }
 
     fn visit_object_expression(&mut self, expr: &mut ObjectExpression<'a>) {

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -5068,12 +5068,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     self.gen_mov_reg_to_dest(old_value, dest)
                 }
             } else {
-                // Postfix operations return the old value, so we must make sure it is saved and
-                // not clobbered. It is safe to overwrite with ToNumeric since inc/dec cannot fail.
                 let dest = self.allocate_destination(dest)?;
-                let old_value = self.gen_load_identifier(id, old_value_dest)?;
-                self.writer
-                    .to_numeric_instruction(old_value, old_value, pos);
 
                 // If id is at a fixed register which matches the destination then writing the
                 // modified value to the id's location would clobber the old value. But in this case
@@ -5081,9 +5076,16 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 // need to perform the in-place numeric conversion.
                 if let ExprDest::Fixed(fixed_id_reg) = self.expr_dest_for_id(id, store_flags) {
                     if fixed_id_reg == dest {
+                        self.writer.to_numeric_instruction(dest, dest, pos);
                         return Ok(dest);
                     }
                 }
+
+                // Postfix operations return the old value, so we must make sure it is saved and
+                // not clobbered. It is safe to overwrite with ToNumeric since inc/dec cannot fail.
+                let old_value = self.gen_load_identifier(id, old_value_dest)?;
+                self.writer
+                    .to_numeric_instruction(old_value, old_value, pos);
 
                 // Save the old value to be returned later
                 self.write_mov_instruction(dest, old_value);

--- a/tests/integration/language/expression/update/assign_hazard.js
+++ b/tests/integration/language/expression/update/assign_hazard.js
@@ -1,0 +1,24 @@
+/*---
+description: Assignment hazards in expression containing update expressions.
+---*/
+
+function prefixIncHazard(param) {
+  return param + (++param);
+}
+
+function prefixDecHazard(param) {
+  return param + (--param);
+}
+
+function postfixIncHazard(param) {
+  return param + (param++);
+}
+
+function postfixDecHazard(param) {
+  return param + (param--);
+}
+
+assert.sameValue(prefixIncHazard(10), 21);
+assert.sameValue(prefixDecHazard(10), 19);
+assert.sameValue(postfixIncHazard(10), 20);
+assert.sameValue(postfixDecHazard(10), 20);

--- a/tests/snapshot/bytecode/bytecode/assign_hazard.exp
+++ b/tests/snapshot/bytecode/bytecode/assign_hazard.exp
@@ -18,8 +18,18 @@
     45: StoreGlobal r0, c15
     48: NewClosure r0, c16
     51: StoreGlobal r0, c17
-    54: LoadUndefined r0
-    56: Ret r0
+    54: NewClosure r0, c18
+    57: StoreGlobal r0, c19
+    60: NewClosure r0, c20
+    63: StoreGlobal r0, c21
+    66: NewClosure r0, c22
+    69: StoreGlobal r0, c23
+    72: NewClosure r0, c24
+    75: StoreGlobal r0, c25
+    78: NewClosure r0, c26
+    81: StoreGlobal r0, c27
+    84: LoadUndefined r0
+    86: Ret r0
   Constant Table:
     0: [BytecodeFunction: simpleAssignHazard]
     1: [String: simpleAssignHazard]
@@ -39,6 +49,16 @@
     15: [String: toplevelAssignExpressions]
     16: [BytecodeFunction: nestedFunctionOrClass]
     17: [String: nestedFunctionOrClass]
+    18: [BytecodeFunction: prefixIncHazard]
+    19: [String: prefixIncHazard]
+    20: [BytecodeFunction: prefixDecHazard]
+    21: [String: prefixDecHazard]
+    22: [BytecodeFunction: postfixIncHazard]
+    23: [String: postfixIncHazard]
+    24: [BytecodeFunction: postfixDecHazard]
+    25: [String: postfixDecHazard]
+    26: [BytecodeFunction: toplevelUpdateExpressions]
+    27: [String: toplevelUpdateExpressions]
 }
 
 [BytecodeFunction: simpleAssignHazard] {
@@ -185,4 +205,70 @@
     0: LoadImmediate a0, 3
     3: LoadUndefined r0
     5: Ret r0
+}
+
+[BytecodeFunction: prefixIncHazard] {
+  Parameters: 1, Registers: 2
+     0: Mov r0, a0
+     3: Mov r1, a0
+     6: ToNumeric r1, r1
+     9: Inc r1
+    11: Mov a0, r1
+    14: Add r0, r0, r1
+    18: Ret r0
+}
+
+[BytecodeFunction: prefixDecHazard] {
+  Parameters: 1, Registers: 2
+     0: Mov r0, a0
+     3: Mov r1, a0
+     6: ToNumeric r1, r1
+     9: Dec r1
+    11: Mov a0, r1
+    14: Add r0, r0, r1
+    18: Ret r0
+}
+
+[BytecodeFunction: postfixIncHazard] {
+  Parameters: 1, Registers: 3
+     0: Mov r0, a0
+     3: Mov r2, a0
+     6: ToNumeric r2, r2
+     9: Mov r1, r2
+    12: Inc r2
+    14: Mov a0, r2
+    17: Add r0, r0, r1
+    21: Ret r0
+}
+
+[BytecodeFunction: postfixDecHazard] {
+  Parameters: 1, Registers: 3
+     0: Mov r0, a0
+     3: Mov r2, a0
+     6: ToNumeric r2, r2
+     9: Mov r1, r2
+    12: Dec r2
+    14: Mov a0, r2
+    17: Add r0, r0, r1
+    21: Ret r0
+}
+
+[BytecodeFunction: toplevelUpdateExpressions] {
+  Parameters: 2, Registers: 4
+     0: ToNumeric a0, a0
+     3: Mov r0, a0
+     6: Inc a0
+     8: Mov r1, a1
+    11: Mov r3, a1
+    14: ToNumeric r3, r3
+    17: Mov r2, r3
+    20: Inc r3
+    22: Mov a1, r3
+    25: GetProperty r0, r1, r2
+    29: ToNumeric r0, r0
+    32: Mov r3, r0
+    35: Inc r3
+    37: SetProperty r1, r2, r3
+    41: LoadUndefined r0
+    43: Ret r0
 }

--- a/tests/snapshot/bytecode/bytecode/assign_hazard.js
+++ b/tests/snapshot/bytecode/bytecode/assign_hazard.js
@@ -37,8 +37,6 @@ function toplevelAssignExpressions(p1, p2) {
 
   // Is a direct assignment, no hazard
   p2 = (p1 = 3);
-
-
 }
 
 function nestedFunctionOrClass(p1, p2) {
@@ -46,4 +44,28 @@ function nestedFunctionOrClass(p1, p2) {
   p1 = p2 + ((x) => { x = 1 });
   p1 = p2 + function (x) { x = 2 };
   p1 = p2 + { f(x) { x = 3} };
+}
+
+function prefixIncHazard(param) {
+  return param + (++param);
+}
+
+function prefixDecHazard(param) {
+  return param + (--param);
+}
+
+function postfixIncHazard(param) {
+  return param + (param++);
+}
+
+function postfixDecHazard(param) {
+  return param + (param--);
+}
+
+function toplevelUpdateExpressions(p1, p2) {
+  // Not an assignment hazard at top level
+  p1++;
+
+  // Treated as assignment hazard
+  (p2[p2++])++;
 }

--- a/tests/snapshot/bytecode/expression/update.exp
+++ b/tests/snapshot/bytecode/expression/update.exp
@@ -70,19 +70,23 @@
 [BytecodeFunction: prefixIdAnyDest] {
   Parameters: 1, Registers: 2
      0: LoadImmediate r0, 1
-     3: ToNumeric a0, a0
-     6: Inc a0
-     8: Neg r1, a0
-    11: ToNumeric r0, r0
-    14: Inc r0
-    16: Neg r1, r0
-    19: LoadGlobal r1, c0
-    22: ToNumeric r1, r1
-    25: Inc r1
-    27: StoreGlobal r1, c0
-    30: Neg r1, r1
-    33: LoadUndefined r1
-    35: Ret r1
+     3: Mov r1, a0
+     6: ToNumeric r1, r1
+     9: Inc r1
+    11: Mov a0, r1
+    14: Neg r1, r1
+    17: Mov r1, r0
+    20: ToNumeric r1, r1
+    23: Inc r1
+    25: Mov r0, r1
+    28: Neg r1, r1
+    31: LoadGlobal r1, c0
+    34: ToNumeric r1, r1
+    37: Inc r1
+    39: StoreGlobal r1, c0
+    42: Neg r1, r1
+    45: LoadUndefined r1
+    47: Ret r1
   Constant Table:
     0: [String: global]
 }
@@ -90,17 +94,19 @@
 [BytecodeFunction: prefixIdFixedDest] {
   Parameters: 1, Registers: 2
      0: LoadImmediate r0, 1
-     3: ToNumeric a0, a0
-     6: Inc a0
-     8: Mov r0, a0
-    11: ToNumeric r0, r0
-    14: Inc r0
-    16: LoadGlobal r1, c0
-    19: ToNumeric r0, r1
-    22: Inc r0
-    24: StoreGlobal r0, c0
-    27: LoadUndefined r1
-    29: Ret r1
+     3: Mov r1, a0
+     6: ToNumeric r0, r1
+     9: Inc r0
+    11: Mov a0, r0
+    14: Mov r1, r0
+    17: ToNumeric r0, r1
+    20: Inc r0
+    22: LoadGlobal r1, c0
+    25: ToNumeric r0, r1
+    28: Inc r0
+    30: StoreGlobal r0, c0
+    33: LoadUndefined r1
+    35: Ret r1
   Constant Table:
     0: [String: global]
 }
@@ -109,23 +115,25 @@
   Parameters: 1, Registers: 3
      0: LoadImmediate r0, 1
      3: LoadGlobal r1, c0
-     6: ToNumeric a0, a0
-     9: Inc a0
-    11: Mov r2, a0
-    14: Call r1, r1, r2, 1
-    19: LoadGlobal r1, c0
-    22: ToNumeric r0, r0
-    25: Inc r0
-    27: Mov r2, r0
-    30: Call r1, r1, r2, 1
-    35: LoadGlobal r1, c0
-    38: LoadGlobal r2, c1
-    41: ToNumeric r2, r2
-    44: Inc r2
-    46: StoreGlobal r2, c1
-    49: Call r1, r1, r2, 1
-    54: LoadUndefined r1
-    56: Ret r1
+     6: Mov r2, a0
+     9: ToNumeric r2, r2
+    12: Inc r2
+    14: Mov a0, r2
+    17: Call r1, r1, r2, 1
+    22: LoadGlobal r1, c0
+    25: Mov r2, r0
+    28: ToNumeric r2, r2
+    31: Inc r2
+    33: Mov r0, r2
+    36: Call r1, r1, r2, 1
+    41: LoadGlobal r1, c0
+    44: LoadGlobal r2, c1
+    47: ToNumeric r2, r2
+    50: Inc r2
+    52: StoreGlobal r2, c1
+    55: Call r1, r1, r2, 1
+    60: LoadUndefined r1
+    62: Ret r1
   Constant Table:
     0: [String: use]
     1: [String: global]
@@ -134,22 +142,26 @@
 [BytecodeFunction: postfixIdAnyDest] {
   Parameters: 1, Registers: 3
      0: LoadImmediate r0, 1
-     3: ToNumeric a0, a0
-     6: Mov r1, a0
-     9: Inc a0
-    11: Neg r1, r1
-    14: ToNumeric r0, r0
-    17: Mov r1, r0
-    20: Inc r0
-    22: Neg r1, r1
-    25: LoadGlobal r2, c0
-    28: ToNumeric r2, r2
-    31: Mov r1, r2
-    34: Inc r2
-    36: StoreGlobal r2, c0
-    39: Neg r1, r1
-    42: LoadUndefined r1
-    44: Ret r1
+     3: Mov r2, a0
+     6: ToNumeric r2, r2
+     9: Mov r1, r2
+    12: Inc r2
+    14: Mov a0, r2
+    17: Neg r1, r1
+    20: Mov r2, r0
+    23: ToNumeric r2, r2
+    26: Mov r1, r2
+    29: Inc r2
+    31: Mov r0, r2
+    34: Neg r1, r1
+    37: LoadGlobal r2, c0
+    40: ToNumeric r2, r2
+    43: Mov r1, r2
+    46: Inc r2
+    48: StoreGlobal r2, c0
+    51: Neg r1, r1
+    54: LoadUndefined r1
+    56: Ret r1
   Constant Table:
     0: [String: global]
 }
@@ -157,17 +169,19 @@
 [BytecodeFunction: postfixIdFixedDest] {
   Parameters: 1, Registers: 2
      0: LoadImmediate r0, 1
-     3: ToNumeric a0, a0
-     6: Mov r0, a0
-     9: Inc a0
-    11: ToNumeric r0, r0
-    14: LoadGlobal r1, c0
-    17: ToNumeric r1, r1
-    20: Mov r0, r1
-    23: Inc r1
-    25: StoreGlobal r1, c0
-    28: LoadUndefined r1
-    30: Ret r1
+     3: Mov r1, a0
+     6: ToNumeric r1, r1
+     9: Mov r0, r1
+    12: Inc r1
+    14: Mov a0, r1
+    17: ToNumeric r0, r0
+    20: LoadGlobal r1, c0
+    23: ToNumeric r1, r1
+    26: Mov r0, r1
+    29: Inc r1
+    31: StoreGlobal r1, c0
+    34: LoadUndefined r1
+    36: Ret r1
   Constant Table:
     0: [String: global]
 }
@@ -176,76 +190,86 @@
   Parameters: 1, Registers: 4
      0: LoadImmediate r0, 1
      3: LoadGlobal r1, c0
-     6: ToNumeric a0, a0
-     9: Mov r2, a0
-    12: Inc a0
-    14: Call r1, r1, r2, 1
-    19: LoadGlobal r1, c0
-    22: ToNumeric r0, r0
-    25: Mov r2, r0
-    28: Inc r0
-    30: Call r1, r1, r2, 1
-    35: LoadGlobal r1, c0
-    38: LoadGlobal r3, c1
-    41: ToNumeric r3, r3
-    44: Mov r2, r3
-    47: Inc r3
-    49: StoreGlobal r3, c1
-    52: Call r1, r1, r2, 1
-    57: LoadUndefined r1
-    59: Ret r1
+     6: Mov r3, a0
+     9: ToNumeric r3, r3
+    12: Mov r2, r3
+    15: Inc r3
+    17: Mov a0, r3
+    20: Call r1, r1, r2, 1
+    25: LoadGlobal r1, c0
+    28: Mov r3, r0
+    31: ToNumeric r3, r3
+    34: Mov r2, r3
+    37: Inc r3
+    39: Mov r0, r3
+    42: Call r1, r1, r2, 1
+    47: LoadGlobal r1, c0
+    50: LoadGlobal r3, c1
+    53: ToNumeric r3, r3
+    56: Mov r2, r3
+    59: Inc r3
+    61: StoreGlobal r3, c1
+    64: Call r1, r1, r2, 1
+    69: LoadUndefined r1
+    71: Ret r1
   Constant Table:
     0: [String: use]
     1: [String: global]
 }
 
 [BytecodeFunction: prefixMember] {
-  Parameters: 2, Registers: 2
-     0: GetNamedProperty r0, a0, c0
-     4: ToNumeric r0, r0
-     7: Inc r0
-     9: SetNamedProperty a0, c0, r0
-    13: Neg r0, r0
-    16: LoadImmediate r1, 0
-    19: GetProperty r0, a0, r1
-    23: ToNumeric r0, r0
-    26: Inc r0
-    28: SetProperty a0, r1, r0
-    32: Neg r0, r0
-    35: GetNamedProperty r0, a0, c0
-    39: ToNumeric r0, r0
-    42: Inc r0
-    44: SetNamedProperty a0, c0, r0
-    48: Mov a1, r0
-    51: LoadUndefined r0
-    53: Ret r0
+  Parameters: 2, Registers: 3
+     0: Mov r1, a0
+     3: GetNamedProperty r0, r1, c0
+     7: ToNumeric r0, r0
+    10: Inc r0
+    12: SetNamedProperty r1, c0, r0
+    16: Neg r0, r0
+    19: Mov r1, a0
+    22: LoadImmediate r2, 0
+    25: GetProperty r0, r1, r2
+    29: ToNumeric r0, r0
+    32: Inc r0
+    34: SetProperty r1, r2, r0
+    38: Neg r0, r0
+    41: Mov r1, a0
+    44: GetNamedProperty r0, r1, c0
+    48: ToNumeric r0, r0
+    51: Inc r0
+    53: SetNamedProperty r1, c0, r0
+    57: Mov a1, r0
+    60: LoadUndefined r0
+    62: Ret r0
   Constant Table:
     0: [String: prop]
 }
 
 [BytecodeFunction: postfixMember] {
-  Parameters: 2, Registers: 3
-     0: GetNamedProperty r0, a0, c0
-     4: ToNumeric r0, r0
-     7: Mov r1, r0
-    10: Inc r1
-    12: SetNamedProperty a0, c0, r1
-    16: Neg r0, r0
-    19: LoadImmediate r1, 0
-    22: GetProperty r0, a0, r1
-    26: ToNumeric r0, r0
-    29: Mov r2, r0
-    32: Inc r2
-    34: SetProperty a0, r1, r2
-    38: Neg r0, r0
-    41: GetNamedProperty r0, a0, c0
-    45: ToNumeric r0, r0
-    48: Mov r1, r0
-    51: Inc r1
-    53: SetNamedProperty a0, c0, r1
-    57: Mov a1, r0
-    60: LoadUndefined r0
-    62: Ret r0
+  Parameters: 2, Registers: 4
+     0: Mov r1, a0
+     3: GetNamedProperty r0, r1, c0
+     7: ToNumeric r0, r0
+    10: Mov r2, r0
+    13: Inc r2
+    15: SetNamedProperty r1, c0, r2
+    19: Neg r0, r0
+    22: Mov r1, a0
+    25: LoadImmediate r2, 0
+    28: GetProperty r0, r1, r2
+    32: ToNumeric r0, r0
+    35: Mov r3, r0
+    38: Inc r3
+    40: SetProperty r1, r2, r3
+    44: Neg r0, r0
+    47: Mov r1, a0
+    50: GetNamedProperty r0, r1, c0
+    54: ToNumeric r0, r0
+    57: Mov r2, r0
+    60: Inc r2
+    62: SetNamedProperty r1, c0, r2
+    66: Mov a1, r0
+    69: LoadUndefined r0
+    71: Ret r0
   Constant Table:
     0: [String: prop]
 }


### PR DESCRIPTION
## Summary

The system to avoid assignment hazards in generated bytecode for expressions was only considering assignment expression, not update expressions, even though update expressions also assign a value. Let's extend this system to also flag update expressions with the `has_assign_expr` flag.

Also refactor to avoid marking trivial top-level assignment or update expressions as assignment hazards unless they contain a child assignment expression. This was previously only done for assignment expressions at the top of expression statements, but we can actually do it for all outer expressions.

Also fixes a bug where we were failing to release an allocated register in an early return of `gen_update_expression`.

## Tests

- Added bytecode snapshot and integration tests for basic cases of assignment hazards due to update expressions
- Updated some other affected bytecode snapshot tests. Note that many of the destination-type update expression tests are significantly changed due to now containing assignment hazards.