### PR TITLE
[parser] Disallow await expression as LHS of exponentiation expression

### DIFF
--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -2309,6 +2309,11 @@ impl<'a> Parser<'a> {
         let argument = self.parse_expression_with_precedence(Precedence::Unary)?;
         let loc = self.mark_loc(start_pos);
 
+        // Unary expressions cannot be followed directly by an exponentiation expression
+        if self.token == Token::Exponent {
+            return self.error(loc, ParseError::ExponentLHSUnary);
+        }
+
         Ok(Expression::Await(p!(self, AwaitExpression { loc, argument })))
     }
 

--- a/tests/snapshot/error/parser/expression/exponent_lhs_await.exp
+++ b/tests/snapshot/error/parser/expression/exponent_lhs_await.exp
@@ -1,0 +1,5 @@
+SyntaxError: Unparenthesized unary expression cannot appear on the left hand side of `**`
+  ┌ parser/expression/exponent_lhs_await.js:1:22
+  |
+1 | async function f() { await 1 ** 2; }
+  |                      ^

--- a/tests/snapshot/error/parser/expression/exponent_lhs_await.js
+++ b/tests/snapshot/error/parser/expression/exponent_lhs_await.js
@@ -1,0 +1,1 @@
+async function f() { await 1 ** 2; }


### PR DESCRIPTION
## Summary

As per title. We were erroring on all other unary expressions as the LHS of exponentiation but missed await expressions since they take a different path in the parser.

## Tests

- Added error snapshot test for this case