### PR TITLE
[bytecode] Fix super member expressions in class extends clauses

### DIFF
--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -97,6 +97,8 @@ enum AllowSuperStackEntry {
     Allow {
         /// Whether the super member expression references the static home object.
         is_static: bool,
+        /// The scope node containing the home object binding, if one is known.
+        home_object_scope: Option<ScopeNodeId>,
     },
     Disallow,
 }
@@ -743,12 +745,18 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
 
     fn visit_super_member_expression(&mut self, expr: &mut SuperMemberExpression<'a>) {
         match self.allow_super_member_stack.last() {
-            Some(AllowSuperStackEntry::Allow { is_static }) => {
+            Some(AllowSuperStackEntry::Allow { is_static, home_object_scope }) => {
                 expr.is_static = *is_static;
 
-                // Resolve home object
                 let home_object_name = expr.home_object_name();
-                self.resolve_use(&mut expr.home_object_scope, home_object_name, expr.super_);
+
+                // Home object is resolved in the attached scope if present
+                let home_object_scope = home_object_scope
+                    .unwrap_or_else(|| self.scope_stack.last().unwrap().as_ref().id());
+                let (def_scope, _) =
+                    self.scope_tree
+                        .resolve_use(home_object_scope, home_object_name, expr.super_);
+                expr.home_object_scope = def_scope;
 
                 // Also resolve `this` which may be used by the super member expression
                 self.resolve_this_use(expr.loc, |scope| expr.this_scope = Some(scope));
@@ -1071,7 +1079,9 @@ impl<'a> Analyzer<'a> {
         if !is_arrow_function {
             let entry = if is_method {
                 let is_static = is_static_method || is_static_initializer;
-                AllowSuperStackEntry::Allow { is_static }
+                let home_object_scope = self.scope_stack.last().map(|s| s.as_ref().id());
+
+                AllowSuperStackEntry::Allow { is_static, home_object_scope }
             } else {
                 AllowSuperStackEntry::Disallow
             };
@@ -1438,12 +1448,13 @@ impl<'a> Analyzer<'a> {
 
         // Class field initializers are in their own function scope. Class field initializer bodies
         // are treated as (potentially static) methods.
+        let home_object_scope = self.scope_stack.last().map(|s| s.as_ref().id());
         if let Some(init_scope) = init_scope {
             self.enter_scope(init_scope);
         }
 
         self.allow_super_member_stack
-            .push(AllowSuperStackEntry::Allow { is_static: prop.is_static });
+            .push(AllowSuperStackEntry::Allow { is_static: prop.is_static, home_object_scope });
         self.function_stack.push(FunctionStackEntry {
             is_arrow_function: false,
             is_method: true,
@@ -1759,7 +1770,10 @@ pub fn analyze_for_eval<'a>(
         if in_method || in_class_field_initializer {
             analyzer
                 .allow_super_member_stack
-                .push(AllowSuperStackEntry::Allow { is_static: in_static });
+                .push(AllowSuperStackEntry::Allow {
+                    is_static: in_static,
+                    home_object_scope: None,
+                });
         }
     }
 

--- a/tests/integration/language/class/super_member_in_extends.js
+++ b/tests/integration/language/class/super_member_in_extends.js
@@ -1,0 +1,59 @@
+/*---
+description: Super member expressions in extends clauses.
+---*/
+
+class Base {
+  class() { return Right; }
+  static class() { return RightStatic; }
+}
+
+class Right {}
+class Wrong {}
+class RightStatic {}
+
+// Super references parent class
+class C1 extends Base {
+  class() { return Wrong; }
+
+  method() {
+    return class extends (super.class()) {}
+  }
+}
+
+const class1 = (new C1()).method();
+assert(new class1() instanceof Right);
+
+// Super in arrow function references parent class
+class C2 extends Base {
+  class() { return Wrong; }
+
+  method() {
+    return class extends (() => super.class())() {}
+  }
+}
+
+const class2 = (new C2()).method();
+assert(new class2() instanceof Right);
+
+// Super in static method references parent class
+class C3 extends Base {
+  class() { return Wrong; }
+
+  static method() {
+    return class extends (super.class()) {}
+  }
+}
+
+const class3 = C3.method();
+assert(new class3() instanceof RightStatic);
+
+// Super in method reference parent object
+const object = {
+  __proto__: { prop: Right },
+  method() {
+    return class extends (super.prop) {}
+  }
+};
+
+const class4 = object.method();
+assert(new class4() instanceof Right);

--- a/tests/snapshot/bytecode/class/super_member.exp
+++ b/tests/snapshot/bytecode/class/super_member.exp
@@ -1,19 +1,44 @@
 [BytecodeFunction: <global>] {
   Parameters: 0, Registers: 4
-     0: PushLexicalScope c0
-     2: LoadGlobal r1, c1
-     5: NewClosure r2, c2
-     8: NewClosure r3, c3
-    11: NewClass r0, c5, c4, r1, r2
-    17: PopScope 
-    18: StoreToScope r0, 1, 0
-    22: PushLexicalScope c6
-    24: LoadGlobal r1, c1
-    27: NewClass r0, c8, c7, r1, r0
-    33: PopScope 
-    34: StoreToScope r0, 2, 0
-    38: LoadUndefined r0
-    40: Ret r0
+      0: PushLexicalScope c0
+      2: LoadGlobal r1, c1
+      5: NewClosure r2, c2
+      8: NewClosure r3, c3
+     11: NewClass r0, c5, c4, r1, r2
+     17: PopScope 
+     18: StoreToScope r0, 1, 0
+     22: PushLexicalScope c6
+     24: LoadGlobal r1, c1
+     27: NewClass r0, c8, c7, r1, r0
+     33: PopScope 
+     34: StoreToScope r0, 2, 0
+     38: PushLexicalScope c9
+     40: LoadGlobal r1, c10
+     43: NewClosure r2, c11
+     46: NewClass r0, c13, c12, r1, r2
+     52: PopScope 
+     53: StoreToScope r0, 3, 0
+     57: PushLexicalScope c14
+     59: LoadGlobal r1, c10
+     62: NewClosure r2, c15
+     65: NewClass r0, c17, c16, r1, r2
+     71: PopScope 
+     72: StoreToScope r0, 4, 0
+     76: PushLexicalScope c18
+     78: LoadGlobal r1, c10
+     81: NewClosure r2, c19
+     84: NewClass r0, c21, c20, r1, r2
+     90: PopScope 
+     91: StoreToScope r0, 5, 0
+     95: PushLexicalScope c22
+     97: NewObject r0
+     99: StoreToScope r0, 0, 0
+    103: NewClosure r1, c24
+    106: DefineNamedProperty r0, c23, r1
+    110: PopScope 
+    111: StoreToScope r0, 6, 0
+    115: LoadUndefined r0
+    117: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: String]
@@ -24,6 +49,22 @@
     6: [ScopeNames]
     7: [BytecodeFunction: C2]
     8: [ClassNames]
+    9: [ScopeNames]
+    10: [String: Object]
+    11: [BytecodeFunction: method]
+    12: [BytecodeFunction: C3]
+    13: [ClassNames]
+    14: [ScopeNames]
+    15: [BytecodeFunction: method]
+    16: [BytecodeFunction: C4]
+    17: [ClassNames]
+    18: [ScopeNames]
+    19: [BytecodeFunction: method]
+    20: [BytecodeFunction: C5]
+    21: [ClassNames]
+    22: [ScopeNames]
+    23: [String: method]
+    24: [BytecodeFunction: method]
 }
 
 [BytecodeFunction: C1] {
@@ -92,4 +133,118 @@
     21: CheckSuperAlreadyCalled r1
     23: StoreToScope r0, 0, 0
     27: Ret r0
+}
+
+[BytecodeFunction: C3] {
+  Parameters: 0, Registers: 1
+    0: DefaultSuperCall 
+    1: CheckThisInitialized <this>
+    3: Ret <this>
+}
+
+[BytecodeFunction: method] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r1, 0, 0
+     4: GetNamedSuperProperty r1, r1, <this>, c0
+     9: NewClass r0, c2, c1, r1, r0
+    15: LoadUndefined r1
+    17: Ret r1
+  Constant Table:
+    0: [String: foo]
+    1: [BytecodeFunction: Inner]
+    2: [ClassNames]
+}
+
+[BytecodeFunction: Inner] {
+  Parameters: 0, Registers: 1
+    0: DefaultSuperCall 
+    1: CheckThisInitialized <this>
+    3: Ret <this>
+}
+
+[BytecodeFunction: C4] {
+  Parameters: 0, Registers: 1
+    0: DefaultSuperCall 
+    1: CheckThisInitialized <this>
+    3: Ret <this>
+}
+
+[BytecodeFunction: method] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: StoreToScope <this>, 0, 0
+     6: NewClosure r1, c1
+     9: Call r1, r1, r1, 0
+    14: NewClass r0, c3, c2, r1, r0
+    20: LoadUndefined r1
+    22: Ret r1
+  Constant Table:
+    0: [ScopeNames]
+    1: [BytecodeFunction: <anonymous>]
+    2: [BytecodeFunction: Inner]
+    3: [ClassNames]
+}
+
+[BytecodeFunction: Inner] {
+  Parameters: 0, Registers: 1
+    0: DefaultSuperCall 
+    1: CheckThisInitialized <this>
+    3: Ret <this>
+}
+
+[BytecodeFunction: <anonymous>] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r0, 0, 0
+     4: LoadFromScope r1, 0, 1
+     8: GetNamedSuperProperty r0, r1, r0, c0
+    13: Ret r0
+  Constant Table:
+    0: [String: foo]
+}
+
+[BytecodeFunction: C5] {
+  Parameters: 0, Registers: 1
+    0: DefaultSuperCall 
+    1: CheckThisInitialized <this>
+    3: Ret <this>
+}
+
+[BytecodeFunction: method] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r1, 0, 0
+     4: GetNamedSuperProperty r1, r1, <this>, c0
+     9: NewClass r0, c2, c1, r1, r0
+    15: LoadUndefined r1
+    17: Ret r1
+  Constant Table:
+    0: [String: foo]
+    1: [BytecodeFunction: Inner]
+    2: [ClassNames]
+}
+
+[BytecodeFunction: Inner] {
+  Parameters: 0, Registers: 1
+    0: DefaultSuperCall 
+    1: CheckThisInitialized <this>
+    3: Ret <this>
+}
+
+[BytecodeFunction: method] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r1, 0, 0
+     4: GetNamedSuperProperty r1, r1, <this>, c0
+     9: NewClass r0, c2, c1, r1, r0
+    15: LoadUndefined r1
+    17: Ret r1
+  Constant Table:
+    0: [String: foo]
+    1: [BytecodeFunction: Inner]
+    2: [ClassNames]
+}
+
+[BytecodeFunction: Inner] {
+  Parameters: 0, Registers: 1
+    0: DefaultSuperCall 
+    1: CheckThisInitialized <this>
+    3: Ret <this>
 }

--- a/tests/snapshot/bytecode/class/super_member.js
+++ b/tests/snapshot/bytecode/class/super_member.js
@@ -21,3 +21,31 @@ class C2 extends String {
     super.x;
   }
 }
+
+class C3 extends Object {
+  method() {
+    // Super references parent class
+    class Inner extends (super.foo) {}
+  }
+}
+
+class C4 extends Object {
+  method() {
+    // Super references parent class
+    class Inner extends (() => super.foo)() {}
+  }
+}
+
+class C5 extends Object {
+  static method() {
+    // Super references parent class
+    class Inner extends (super.foo) {}
+  }
+}
+
+const obj = {
+  method() {
+    // Super references parent object
+    class Inner extends (super.foo) {}
+  }
+};


### PR DESCRIPTION
## Summary

Super member expressions in class extends clauses were referencing the wrong home object.

This traces back to setup of the scope tree: we include the extends clause in the class's scope so that it can reference its own name and private names. But this also makes the home object for super member expressions reference the class instead of being inherited from the surrounding environment (which may be another class or object method).

A correct and minimally invasive way to fix this is to store the exact home object scope to use in `AllowSuperStackEntry::Allow`.

## Tests

- Added bytecode and integration tests for the following cases of home object resolution in class extends clauses: super members, static super members, super members in arrow functions, super members from an object method