### PR TITLE
[bytecode] Call ToPropertyKey only once on computed properties before a rest element

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -6413,16 +6413,20 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 Property::Computed(key, key_pos) => {
                     // If there is a rest element then we must ensure key is a property key and save
                     // it in the reserved registers.
-                    if has_rest_element {
+                    let property_key = if has_rest_element {
+                        let property_key = saved_keys[i];
                         self.writer
-                            .to_property_key_instruction(saved_keys[i], *key, *key_pos);
-                    }
+                            .to_property_key_instruction(property_key, *key, *key_pos);
+                        property_key
+                    } else {
+                        *key
+                    };
 
                     // Read computed property from object
                     self.writer.get_property_instruction(
                         property_value,
                         object_value,
-                        *key,
+                        property_key,
                         property_start_pos,
                     );
                 }

--- a/tests/integration/language/pattern/object_rest.js
+++ b/tests/integration/language/pattern/object_rest.js
@@ -1,0 +1,18 @@
+/*---
+description: Tests for object destructuring with a rest element.
+---*/
+
+// ToPropertyKey on a computed property is called exactly once
+(function ComputedSingleToPropertyKey() {
+  let count = 0;
+  const probe = {
+    toString() {
+      count++;
+      return "f";
+    }
+  }
+
+  const { [probe]: x, ...y } = {};
+
+  assert.sameValue(count, 1);  
+})();

--- a/tests/integration/regression/000030.js
+++ b/tests/integration/regression/000030.js
@@ -13,6 +13,6 @@ a.push("one");
 a.unshift("two");
 a.unshift("three", "four");
 
-console.log(a[0], "three");
-console.log(a[1], "four");
-console.log(a[2], "two");
+assert.sameValue(a[0], "three");
+assert.sameValue(a[1], "four");
+assert.sameValue(a[2], "two");

--- a/tests/snapshot/bytecode/pattern/basic.exp
+++ b/tests/snapshot/bytecode/pattern/basic.exp
@@ -13,7 +13,7 @@
     32: StoreGlobal r4, c6
     35: LoadImmediate r5, 2
     38: ToPropertyKey r3, r5
-    41: GetProperty r4, r0, r5
+    41: GetProperty r4, r0, r3
     45: StoreGlobal r4, c7
     48: ToObject r5, r0
     51: NewObject r4
@@ -51,7 +51,7 @@
     13: GetNamedProperty r1, r4, c1
     17: LoadImmediate r8, 2
     20: ToPropertyKey r7, r8
-    23: GetProperty r2, r4, r8
+    23: GetProperty r2, r4, r7
     27: ToObject r8, r4
     30: NewObject r3
     32: CopyDataProperties r3, r4, r5, 3

--- a/tests/snapshot/bytecode/pattern/object_destructuring.exp
+++ b/tests/snapshot/bytecode/pattern/object_destructuring.exp
@@ -216,10 +216,10 @@
     37: GetNamedProperty r0, a0, c0
     41: LoadImmediate r8, 1
     44: ToPropertyKey r6, r8
-    47: GetProperty r1, a0, r8
+    47: GetProperty r1, a0, r6
     51: LoadImmediate r8, 2
     54: ToPropertyKey r7, r8
-    57: GetProperty r3, a0, r8
+    57: GetProperty r3, a0, r7
     61: ToObject r8, a0
     64: NewObject r4
     66: CopyDataProperties r4, a0, r5, 3


### PR DESCRIPTION
## Summary

We were incorrectly calling `ToPropertyKey` twice on computed properties before a rest element in object destructuring. This was happening because we emitted a `ToPropertyKey` instruction (for the key passed to `CopyDataProperties`) immediately followed by the regular `GetProperty` instruction, but weren't passing the result of `ToPropertyKey` into `GetProperty`.

## Tests

- Added integration test for this case, counting number of times `ToPropertyKey` is called
- Updated affected bytecode snapshot tests