### PR TITLE
[runtime] More fixes to String padding method validation order

### DIFF
--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -796,16 +796,24 @@ impl StringPrototype {
         let int_max_length = to_length(cx, max_length_arg)?;
         let string_length = string.len();
 
+        // No need to pad as string already has max length
+        if int_max_length <= string_length as u64 {
+            return Ok(string.as_value());
+        }
+
         let fill_string = if fill_string_arg.is_undefined() {
             cx.names.space().as_string()
         } else {
             to_string(cx, fill_string_arg)?
         };
 
-        // No need to pad as string already has max length
-        if int_max_length <= string_length as u64 {
+        // Check for an empty padding string which would have no effect
+        let fill_string_length = fill_string.len();
+        if fill_string_length == 0 {
             return Ok(string.as_value());
-        } else if int_max_length > u32::MAX as u64 {
+        }
+
+        if int_max_length > u32::MAX as u64 {
             return range_error(
                 cx,
                 &format!(
@@ -816,14 +824,7 @@ impl StringPrototype {
         }
 
         let int_max_length = int_max_length as u32;
-
         let fill_length = int_max_length - string_length;
-        let fill_string_length = fill_string.len();
-
-        // Check for an empty padding string which would have no effect
-        if fill_string_length == 0 {
-            return Ok(string.as_value());
-        }
 
         // Find the number of whole pad strings we can fit into the padding length
         let num_whole_repetitions = fill_length / fill_string_length;

--- a/tests/integration/built-ins/String/pad_start.js
+++ b/tests/integration/built-ins/String/pad_start.js
@@ -2,5 +2,12 @@
 description: String.prototype.padStart.
 ---*/
 
+// ToString(fillString) performed before validating new string length
 const poisoned = { toString() { throw new Test262Error(); } };
 assert.throws(Test262Error, () => 'a'.padStart(Infinity, poisoned));
+
+// ToString(fillString) not performed if string already has max length
+assert.sameValue('abcde'.padStart(3, poisoned), 'abcde');
+
+// Do not error for new string length if empty string is being added
+assert.sameValue('abc'.padStart(Infinity, ''), 'abc');


### PR DESCRIPTION
## Summary

More fixes to `String.prototype.{padStart, padEnd}` validation order missed in https://github.com/Hans-Halverson/brimstone/pull/371.

- `ToString(fillString)` not performed if string already has requested max length
- Never error for new string length if `fillString` is the empty string

## Tests

- Added integration tests for new cases