### PR TITLE
[runtime] Dynamically look up this from eval within arrow functions

### DIFF
--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -820,6 +820,15 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
                     expr.maybe_eval_in_class_field_initializer =
                         current_func.is_class_field_initializer;
                 }
+
+                // Mark if immediately enclosing function is an arrow function and add a use of
+                // `this` so that it can be dynamically looked up at runtime.
+                if let Some(f) = self.function_stack.last()
+                    && f.is_arrow_function
+                {
+                    expr.maybe_eval_in_arrow_function = true;
+                    self.resolve_this_use(expr.loc, |_| {});
+                }
             }
             _ => {}
         }

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -1308,6 +1308,8 @@ pub struct CallExpression<'a> {
     /// Whether the function is potentially a direct eval and inside a class field initializer,
     /// meaning accessing the arguments binding is not allowed.
     pub maybe_eval_in_class_field_initializer: bool,
+    /// Whether the function is potentially a direct eval and directly inside an arrow function.
+    pub maybe_eval_in_arrow_function: bool,
 }
 
 impl<'a> CallExpression<'a> {
@@ -1328,6 +1330,7 @@ impl<'a> CallExpression<'a> {
             maybe_eval_in_derived_constructor: false,
             maybe_eval_in_static_initializer: false,
             maybe_eval_in_class_field_initializer: false,
+            maybe_eval_in_arrow_function: false,
         }
     }
 }

--- a/src/js/parser/scope_tree.rs
+++ b/src/js/parser/scope_tree.rs
@@ -425,7 +425,10 @@ impl<'a> ScopeTree<'a> {
 
                 // Var bindings in sloppy direct evals are added to the parent var scope, which
                 // requires a dynamic lookup at runtime.
-                if is_sloppy_eval_scope && !binding.kind().is_lexically_scoped() {
+                if is_sloppy_eval_scope
+                    && !binding.kind().is_lexically_scoped()
+                    && !binding.kind().is_implicit_this()
+                {
                     return (TaggedResolvedScope::unresolved_dynamic(), false);
                 }
 
@@ -1283,7 +1286,7 @@ impl<'a> Binding<'a> {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum VMLocation {
     /// Var binding in the global scope.
     Global,

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -3631,6 +3631,10 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             flags |= EvalFlags::IN_CLASS_FIELD_INITIALIZER;
         }
 
+        if expr.maybe_eval_in_arrow_function {
+            flags |= EvalFlags::IN_ARROW_FUNCTION;
+        }
+
         flags
     }
 

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1995,6 +1995,8 @@ bitflags! {
         const IN_STATIC_INITIALIZER = 1 << 4;
         /// Whether eval is in a class field initializer meaning `arguments` is not allowed.
         const IN_CLASS_FIELD_INITIALIZER = 1 << 5;
+        /// Whether eval is directly inside an arrow function.
+        const IN_ARROW_FUNCTION = 1 << 6;
     }
 }
 

--- a/src/js/runtime/eval/eval.rs
+++ b/src/js/runtime/eval/eval.rs
@@ -104,8 +104,14 @@ pub fn perform_eval(
 
     // Determine the receiver for the eval function call
     let receiver: Handle<Value> = if is_direct {
-        // Direct evals inherit their receiver from the caller
-        cx.vm().receiver().to_handle(cx)
+        if flags.contains(EvalFlags::IN_ARROW_FUNCTION) {
+            // Eval is directly inside an arrow function. Arrow functions do not have the current
+            // receiver register set so we must look up captured `this` from scope chain.
+            Scope::lookup_this_for_eval(cx, *direct_scope.unwrap()).to_handle(cx)
+        } else {
+            // Direct evals inherit their receiver from the caller
+            cx.vm().receiver().to_handle(cx)
+        }
     } else {
         // For indirect evals receiver is the global object
         closure.global_object().into()

--- a/src/js/runtime/scope.rs
+++ b/src/js/runtime/scope.rs
@@ -141,6 +141,22 @@ impl Scope {
         self.slots.as_slice()[index]
     }
 
+    /// Dynamically look up the `this` binding in this scope, walking the scope chain until found.
+    pub fn lookup_this_for_eval(cx: Context, mut scope: HeapPtr<Self>) -> Value {
+        loop {
+            for (i, name_ptr) in scope.scope_names_ptr().name_ptrs().iter().enumerate() {
+                if name_ptr.eq_str("this") {
+                    return scope.get_slot(i);
+                }
+            }
+
+            match scope.parent {
+                Some(parent) => scope = parent,
+                None => return cx.current_realm_ptr().global_object_ptr().as_value(),
+            }
+        }
+    }
+
     #[inline]
     pub fn set_slot(&mut self, index: usize, value: Value) {
         self.slots.as_mut_slice()[index] = value;

--- a/tests/integration/language/expression/arrow/this_in_eval.js
+++ b/tests/integration/language/expression/arrow/this_in_eval.js
@@ -1,0 +1,69 @@
+/*---
+description: Accessing `this` from eval within arrow functions.
+---*/
+
+const sentinel = {};
+const sentinel2 = {};
+
+// Arrow functions which inherit global `this`
+assert.sameValue((() => eval('this'))(), this);
+assert.sameValue((() => eval('this')).call(sentinel), this);
+assert.sameValue((() => eval('this')).apply(sentinel, []), this);
+assert.sameValue((() => (() => eval('this')).call(sentinel2)).call(sentinel), this);
+
+// Arrow functions which inherit parent function's `this`
+function outer1() {
+    return (() => eval('this'))();
+}
+assert.sameValue(outer1.call(sentinel), sentinel);
+
+function outer2() {
+    return (() => eval('this')).call(sentinel);
+}
+assert.sameValue(outer2.call(sentinel2), sentinel2);
+
+function outer3() {
+    return (() => eval('this')).apply(sentinel, []);
+}
+assert.sameValue(outer3.call(sentinel2), sentinel2);
+
+function outer4() {
+    const nested = () => () => eval('this');
+    return nested().call(sentinel);
+}
+assert.sameValue(outer4.call(sentinel2), sentinel2);
+
+// Accessing `this` within nested eval
+assert.sameValue((() => eval('eval("this")')).call(sentinel), this);
+
+function outer5() {
+    return (() => eval('eval("this")'))();
+}
+assert.sameValue(outer5.call(sentinel), sentinel);
+
+// Indirect eval in an arrow function will return the global `this`
+const indirectEval = eval;
+assert.sameValue((() => indirectEval('this')).call(sentinel), this);
+
+function outer6() {
+    return (() => indirectEval('this')).call(sentinel);
+}
+assert.sameValue(outer6.call(sentinel2), this);
+
+// Accessing `this` inside eval inside arrow function resolving to global `this`
+assert.sameValue(eval("(() => this).call(sentinel)"), this);
+assert.sameValue((() => eval("(() => this).call(sentinel)")).call(sentinel), this);
+
+// Accessing `this` inside eval inside arrow function which inherits parent function's `this`
+function outer7() {
+  return eval("(() => this).call(sentinel2)");
+};
+
+assert.sameValue(outer7.call(sentinel), sentinel);
+
+
+function outer8() {
+  return (() => eval("(() => this)()")).call(sentinel2);
+};
+
+assert.sameValue(outer8.call(sentinel), sentinel);

--- a/tests/snapshot/bytecode/eval/arrow_this.exp
+++ b/tests/snapshot/bytecode/eval/arrow_this.exp
@@ -1,0 +1,97 @@
+[BytecodeFunction: <global>] {
+  Parameters: 0, Registers: 1
+     0: NewClosure r0, c0
+     3: Call r0, r0, r0, 0
+     8: NewClosure r0, c1
+    11: Call r0, r0, r0, 0
+    16: NewClosure r0, c2
+    19: Call r0, r0, r0, 0
+    24: LoadUndefined r0
+    26: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: <anonymous>]
+    1: [BytecodeFunction: <anonymous>]
+    2: [BytecodeFunction: <anonymous>]
+}
+
+[BytecodeFunction: <anonymous>] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: LoadDynamic r0, c1
+     5: LoadConstant r1, c2
+     8: CallMaybeEval r0, r0, r1, 1, 64
+    14: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: this]
+}
+
+[BytecodeFunction: <anonymous>] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: LoadDynamic r0, c1
+     5: LoadConstant r1, c2
+     8: CallMaybeEval r0, r0, r1, 1, 64
+    14: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: () => this]
+}
+
+[BytecodeFunction: <anonymous>] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: LoadDynamic r0, c1
+     5: LoadConstant r1, c2
+     8: CallMaybeEval r0, r0, r1, 1, 64
+    14: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: eval("this")]
+}
+
+[BytecodeFunction: <eval>] {
+  Parameters: 0, Registers: 1
+    0: Mov r0, <this>
+    3: Ret r0
+}
+
+[BytecodeFunction: <eval>] {
+  Parameters: 0, Registers: 1
+    0: PushLexicalScope c0
+    2: StoreToScope <this>, 0, 0
+    6: NewClosure r0, c1
+    9: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [BytecodeFunction: <anonymous>]
+}
+
+[BytecodeFunction: <anonymous>] {
+  Parameters: 0, Registers: 1
+    0: LoadFromScope r0, 0, 0
+    4: Ret r0
+}
+
+[BytecodeFunction: <eval>] {
+  Parameters: 0, Registers: 3
+     0: PushLexicalScope c0
+     2: StoreToScope <this>, 0, 0
+     6: LoadDynamic r1, c1
+     9: LoadConstant r2, c2
+    12: CallMaybeEval r0, r1, r2, 1, 0
+    18: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: this]
+}
+
+[BytecodeFunction: <eval>] {
+  Parameters: 0, Registers: 1
+    0: Mov r0, <this>
+    3: Ret r0
+}

--- a/tests/snapshot/bytecode/eval/arrow_this.js
+++ b/tests/snapshot/bytecode/eval/arrow_this.js
@@ -1,0 +1,7 @@
+// OPTIONS: --run
+
+(() => eval('this'))();
+
+(() => eval('() => this'))();
+
+(() => eval('eval("this")'))();


### PR DESCRIPTION
## Summary

Make arrow function `this` references work correctly when within direct eval.

`this` in evals was always being fetched from the current receiver register, which is initialized from the parent frame at the start of direct eval. However arrow functions do not use this field and it may not be set correctly. Instead syntatically detect if direct eval is called directly within an arrow function, and if so dynamically look up the `this` binding from the scope chain. Also force `this` to be used so that it will be placed in a runtime scope.

Only needed for the first level of eval nesting. A nested eval can correctly inherit `this` directly from its parent frame.

## Tests

- Added integration tests for previously failing cases
- Added bytecode snapshot tests for `this` references in eval in arrow functions