### PR TITLE
[parser] Parse HTML comments in Annex B mode

### DIFF
--- a/src/js/parser/lexer.rs
+++ b/src/js/parser/lexer.rs
@@ -7,6 +7,7 @@ use num_traits::ToPrimitive;
 
 use crate::{
     common::{
+        options::Options,
         unicode::{
             CodePoint, as_id_part, as_id_part_ascii, as_id_part_unicode, as_id_start,
             as_id_start_unicode, decode_wtf8_codepoint, get_binary_value, get_hex_value,
@@ -32,7 +33,11 @@ pub struct Lexer<'a> {
     pos: Pos,
     is_new_line_before_current: bool,
     pub in_strict_mode: bool,
+    pub is_module: bool,
+    in_annex_b_mode: bool,
     pub allow_hashbang_comment: bool,
+    // Whether to allow an HTML close comment `-->` at the start of the source
+    pub allow_html_close_comment_at_start: bool,
     alloc: AstAlloc<'a>,
 }
 
@@ -48,7 +53,7 @@ type LexResult<'a> = ParseResult<(Token<'a>, Loc)>;
 const EOF_CODE_POINT: u32 = 0x110000;
 
 impl<'a> Lexer<'a> {
-    pub fn new(source: &'a Rc<Source>, alloc: AstAlloc<'a>) -> Lexer<'a> {
+    pub fn new(source: &'a Rc<Source>, options: &Options, alloc: AstAlloc<'a>) -> Lexer<'a> {
         let buf = source.contents.as_bytes();
         let current = if buf.is_empty() {
             EOF_CODE_POINT
@@ -63,7 +68,10 @@ impl<'a> Lexer<'a> {
             pos: 0,
             is_new_line_before_current: false,
             in_strict_mode: false,
+            is_module: false,
+            in_annex_b_mode: options.annex_b,
             allow_hashbang_comment: true,
+            allow_html_close_comment_at_start: true,
             alloc,
         }
     }
@@ -175,9 +183,11 @@ impl<'a> Lexer<'a> {
     ];
 
     pub fn next(&mut self) -> LexResult<'a> {
+        let is_source_start = self.pos == 0;
         self.is_new_line_before_current = false;
+
         loop {
-            // Fast pass for skipping ASCII whitespace and newlines
+            // Fast path for skipping ASCII whitespace and newlines
             while let Some(sigil) = Self::ASCII_WHITESPACE_AND_NEWLINES.get(self.current as usize) {
                 if *sigil == 0 {
                     break;
@@ -207,8 +217,21 @@ impl<'a> Lexer<'a> {
                 }),
                 '-' => match_u32!(match self.peek() {
                     '-' => {
-                        self.advance2();
-                        self.emit(Token::Decrement, start_pos)
+                        // Annex B HTML close comments treated as line comments and only allowed in
+                        // scripts. Only allowed before the first token of the line.
+                        if self.in_annex_b_mode
+                            && !self.is_module
+                            && self.peek2() == '>' as u32
+                            && (self.is_new_line_before_current
+                                || (is_source_start && self.allow_html_close_comment_at_start))
+                        {
+                            self.advance3();
+                            self.skip_line_comment()?;
+                            continue;
+                        } else {
+                            self.advance2();
+                            self.emit(Token::Decrement, start_pos)
+                        }
                     }
                     '=' => {
                         self.advance2();
@@ -371,6 +394,22 @@ impl<'a> Lexer<'a> {
                     }
                 }),
                 '<' => match_u32!(match self.peek() {
+                    '!' => {
+                        // Annex B HTML open comments treated as line comments and only allowed in
+                        // scripts.
+                        if self.in_annex_b_mode
+                            && !self.is_module
+                            && self.peek2() == '-' as u32
+                            && self.peek3() == '-' as u32
+                        {
+                            self.advance4();
+                            self.skip_line_comment()?;
+                            continue;
+                        } else {
+                            self.advance();
+                            self.emit(Token::LessThan, start_pos)
+                        }
+                    }
                     '<' => match_u32!(match self.peek2() {
                         '=' => {
                             self.advance3();

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -201,8 +201,11 @@ impl<'a> Parser<'a> {
         self.lexer.in_strict_mode = in_strict_mode;
     }
 
-    fn prevent_hashbang_comment(&mut self) {
+    /// Initialize the parser for parsing the function parameters or body in a dynamically created
+    /// function.
+    fn init_for_dynamic_function_part(&mut self) {
         self.lexer.allow_hashbang_comment = false;
+        self.lexer.allow_html_close_comment_at_start = false;
     }
 
     /// Try parsing, restoring to state before this function was called if an error occurs.
@@ -472,6 +475,7 @@ impl<'a> Parser<'a> {
 
     fn parse_module(mut self) -> ParseResult<ParseProgramResult<'a>> {
         self.program_kind = ProgramKind::Module;
+        self.lexer.is_module = true;
 
         // Modules are always in strict mode
         self.set_in_strict_mode(true);
@@ -5042,7 +5046,7 @@ pub fn parse_script(
 ) -> ParseResult<ParseProgramResult<'_>> {
     // Create and prime parser
     let alloc = pcx.alloc();
-    let lexer = Lexer::new(pcx.source(), alloc);
+    let lexer = Lexer::new(pcx.source(), &options, alloc);
     let mut parser =
         Parser::new(lexer, ScopeTree::new_global(options.clone(), alloc), options, alloc);
 
@@ -5058,7 +5062,7 @@ pub fn parse_module(
 ) -> ParseResult<ParseProgramResult<'_>> {
     // Create and prime parser
     let alloc = pcx.alloc();
-    let lexer = Lexer::new(pcx.source(), alloc);
+    let lexer = Lexer::new(pcx.source(), &options, alloc);
     let mut parser =
         Parser::new(lexer, ScopeTree::new_module(options.clone(), alloc), options, alloc);
     parser.advance()?;
@@ -5074,7 +5078,7 @@ pub fn parse_script_for_eval(
 ) -> ParseResult<ParseProgramResult<'_>> {
     // Create and prime parser
     let alloc = pcx.alloc();
-    let lexer = Lexer::new(pcx.source(), alloc);
+    let lexer = Lexer::new(pcx.source(), &options, alloc);
     let mut parser =
         Parser::new(lexer, ScopeTree::new_eval(options.clone(), is_direct, alloc), options, alloc);
 
@@ -5095,13 +5099,13 @@ pub fn parse_function_params_for_function_constructor(
 ) -> ParseResult<()> {
     // Create and prime parser
     let alloc = pcx.alloc();
-    let lexer = Lexer::new(pcx.source(), alloc);
+    let lexer = Lexer::new(pcx.source(), &options, alloc);
     let mut parser =
         Parser::new(lexer, ScopeTree::new_global(options.clone(), alloc), options, alloc);
 
     parser.allow_await = is_async;
     parser.allow_yield = is_generator;
-    parser.prevent_hashbang_comment();
+    parser.init_for_dynamic_function_part();
 
     parser.advance()?;
 
@@ -5118,13 +5122,13 @@ pub fn parse_function_body_for_function_constructor(
 ) -> ParseResult<()> {
     // Create and prime parser
     let alloc = pcx.alloc();
-    let lexer = Lexer::new(pcx.source(), alloc);
+    let lexer = Lexer::new(pcx.source(), &options, alloc);
     let mut parser =
         Parser::new(lexer, ScopeTree::new_global(options.clone(), alloc), options, alloc);
 
     parser.allow_await = is_async;
     parser.allow_yield = is_generator;
-    parser.prevent_hashbang_comment();
+    parser.init_for_dynamic_function_part();
 
     let initial_state = parser.save();
     parser.advance()?;
@@ -5142,7 +5146,7 @@ pub fn parse_function_for_function_constructor(
     let alloc = pcx.alloc();
     let source = pcx.source();
 
-    let lexer = Lexer::new(source, alloc);
+    let lexer = Lexer::new(source, &options, alloc);
     let mut parser =
         Parser::new(lexer, ScopeTree::new_global(options.clone(), alloc), options.clone(), alloc);
     parser.advance()?;

--- a/tests/integration/language/comment/html_comment_disallowed.js
+++ b/tests/integration/language/comment/html_comment_disallowed.js
@@ -1,0 +1,6 @@
+/*---
+description: HTML comments are not allowed outside Annex B mode.
+---*/
+
+assert.throws(SyntaxError, () => eval('<!-- comment'));
+assert.throws(SyntaxError, () => eval('--> comment'));

--- a/tests/snapshot/parser/annex_b/html_close_comment_at_start_after_comments.exp
+++ b/tests/snapshot/parser/annex_b/html_close_comment_at_start_after_comments.exp
@@ -1,0 +1,17 @@
+{
+  type: "Program",
+  loc: "1:1-2:3",
+  body: [
+    {
+      type: "ExpressionStatement",
+      loc: "2:1-2:3",
+      kind: {
+        type: "Identifier",
+        loc: "2:1-2:2",
+        name: "a",
+      },
+    },
+  ],
+  sourceType: "script",
+  has_use_strict_directive: false,
+}

--- a/tests/snapshot/parser/annex_b/html_close_comment_at_start_after_comments.js
+++ b/tests/snapshot/parser/annex_b/html_close_comment_at_start_after_comments.js
@@ -1,0 +1,2 @@
+  /* comment */ /* comment */ --> commented;
+a;

--- a/tests/snapshot/parser/annex_b/html_close_comments.exp
+++ b/tests/snapshot/parser/annex_b/html_close_comments.exp
@@ -1,0 +1,44 @@
+{
+  type: "Program",
+  loc: "1:1-8:3",
+  body: [
+    {
+      type: "ExpressionStatement",
+      loc: "2:1-2:3",
+      kind: {
+        type: "Identifier",
+        loc: "2:1-2:2",
+        name: "a",
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "4:1-4:3",
+      kind: {
+        type: "Identifier",
+        loc: "4:1-4:2",
+        name: "b",
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "6:1-6:3",
+      kind: {
+        type: "Identifier",
+        loc: "6:1-6:2",
+        name: "c",
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "8:1-8:3",
+      kind: {
+        type: "Identifier",
+        loc: "8:1-8:2",
+        name: "d",
+      },
+    },
+  ],
+  sourceType: "script",
+  has_use_strict_directive: false,
+}

--- a/tests/snapshot/parser/annex_b/html_close_comments.js
+++ b/tests/snapshot/parser/annex_b/html_close_comments.js
@@ -1,0 +1,8 @@
+--> commented
+a;
+--> commented;
+b;
+  --> commented;
+c;
+  /* comment */ /* comment */ --> commented;
+d;

--- a/tests/snapshot/parser/annex_b/html_open_comments.exp
+++ b/tests/snapshot/parser/annex_b/html_open_comments.exp
@@ -1,0 +1,53 @@
+{
+  type: "Program",
+  loc: "1:1-8:3",
+  body: [
+    {
+      type: "ExpressionStatement",
+      loc: "2:1-2:3",
+      kind: {
+        type: "Identifier",
+        loc: "2:1-2:2",
+        name: "a",
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "4:1-4:3",
+      kind: {
+        type: "Identifier",
+        loc: "4:1-4:2",
+        name: "b",
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "6:1-6:3",
+      kind: {
+        type: "Identifier",
+        loc: "6:1-6:2",
+        name: "c",
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "7:1-7:3",
+      kind: {
+        type: "Identifier",
+        loc: "7:1-7:2",
+        name: "d",
+      },
+    },
+    {
+      type: "ExpressionStatement",
+      loc: "8:1-8:3",
+      kind: {
+        type: "Identifier",
+        loc: "8:1-8:2",
+        name: "e",
+      },
+    },
+  ],
+  sourceType: "script",
+  has_use_strict_directive: false,
+}

--- a/tests/snapshot/parser/annex_b/html_open_comments.js
+++ b/tests/snapshot/parser/annex_b/html_open_comments.js
@@ -1,0 +1,8 @@
+<!-- commented
+a;
+  <!-- commented
+b;
+  /*a*/ <!-- commented
+c;
+d; <!-- commented
+e;


### PR DESCRIPTION
## Summary

In Annex B mode we now parse HTML-like comment syntax. Both `<!--` and `-->` are interpreted as the start of a line comment. `-->` can only appear before the first token of a line.

## Tests

- Added parser snapshot tests for the new syntax
- Added integration test verifying syntax is not accepted outside Annex B mode
- All test262 `annexB/language/comments/*` and `annexB/built-ins/Function/*` tests now pass