### PR TITLE
[runtime] Implement more Temporal methods - `since`, `until`, `toPlain*`, `toZonedDateTime`

### DIFF
--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -411,6 +411,7 @@ builtin_names!(
     (parse, "parse"),
     (parse_float, "parseFloat"),
     (parse_int, "parseInt"),
+    (plain_time_, "plainTime"),
     (pop, "pop"),
     (pow, "pow"),
     (prevent_extensions, "preventExtensions"),

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -659,10 +659,6 @@ rust_runtime_functions!(
     (PlainDateTimePrototype_toJSON, PlainDateTimePrototype::to_json),
     (PlainDateTimePrototype_toLocaleString, PlainDateTimePrototype::to_locale_string),
     (PlainDateTimePrototype_toPlainDate, PlainDateTimePrototype::to_plain_date),
-    (
-        PlainDateTimePrototype_toPlainDateTime,
-        PlainDateTimePrototype::to_plain_date_time
-    ),
     (PlainDateTimePrototype_toPlainTime, PlainDateTimePrototype::to_plain_time),
     (PlainDateTimePrototype_toString, PlainDateTimePrototype::to_string),
     (
@@ -705,9 +701,7 @@ rust_runtime_functions!(
     (PlainTimePrototype_subtract, PlainTimePrototype::subtract),
     (PlainTimePrototype_toJSON, PlainTimePrototype::to_json),
     (PlainTimePrototype_toLocaleString, PlainTimePrototype::to_locale_string),
-    (PlainTimePrototype_toPlainDateTime, PlainTimePrototype::to_plain_date_time),
     (PlainTimePrototype_toString, PlainTimePrototype::to_string),
-    (PlainTimePrototype_toZonedDateTime, PlainTimePrototype::to_zoned_date_time),
     (PlainTimePrototype_until, PlainTimePrototype::until),
     (PlainTimePrototype_valueOf, PlainTimePrototype::value_of),
     (PlainTimePrototype_with, PlainTimePrototype::with),

--- a/src/js/runtime/intrinsics/temporal/instant_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_constructor.rs
@@ -191,6 +191,8 @@ pub fn to_temporal_instant(
         let item_object = item.as_object();
         if let Some(instant) = item_object.as_instant_object() {
             return Ok(instant.instant());
+        } else if let Some(zoned_date_time) = item_object.as_zoned_date_time_object() {
+            return Ok(zoned_date_time.zoned_date_time().to_instant());
         }
 
         // Otherwise will treat as a string

--- a/src/js/runtime/intrinsics/temporal/instant_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_prototype.rs
@@ -11,13 +11,14 @@ use crate::runtime::{
         rust_runtime::RuntimeFunction,
         temporal::{
             duration_constructor::to_temporal_duration,
+            duration_object::DurationObject,
             instant_constructor::to_temporal_instant,
             instant_object::InstantObject,
             utils::{
-                get_fractional_second_digits_option, get_rounding_increment_option,
-                get_rounding_mode_option, get_time_zone_option, get_unit_valued_option,
-                map_temporal_result, parse_round_options_argument, to_time_zone_identifier,
-                validate_options_object,
+                DiffOperation, get_difference_settings, get_fractional_second_digits_option,
+                get_rounding_increment_option, get_rounding_mode_option, get_time_zone_option,
+                get_unit_valued_option, map_temporal_result, parse_round_options_argument,
+                to_time_zone_identifier, validate_options_object,
             },
             zoned_date_time_object::ZonedDateTimeObject,
         },
@@ -206,20 +207,44 @@ impl InstantPrototype {
     pub fn until(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_instant(cx, this_value, "Instant.prototype.until")?;
-        unimplemented!("Instant.prototype.until")
+        Self::diff(cx, this_value, arguments, DiffOperation::Until, "Instant.prototype.until")
     }
 
     /// Temporal.Instant.prototype.since (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.since)
     pub fn since(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_instant(cx, this_value, "Instant.prototype.since")?;
-        unimplemented!("Instant.prototype.since")
+        Self::diff(cx, this_value, arguments, DiffOperation::Since, "Instant.prototype.since")
+    }
+
+    fn diff(
+        cx: Context,
+        this_value: Handle<Value>,
+        arguments: &[Handle<Value>],
+        operation: DiffOperation,
+        method_name: &str,
+    ) -> EvalResult<Handle<Value>> {
+        let instant = this_instant(cx, this_value, method_name)?;
+
+        let other_arg = get_argument(cx, arguments, 0);
+        let other = to_temporal_instant(cx, other_arg, method_name)?;
+
+        let options_arg = get_argument(cx, arguments, 1);
+        let options = validate_options_object(cx, options_arg, method_name)?;
+        let difference_settings = get_difference_settings(cx, options, method_name)?;
+
+        let duration_result = match operation {
+            DiffOperation::Until => instant.instant().until(&other, difference_settings),
+            DiffOperation::Since => instant.instant().since(&other, difference_settings),
+        };
+
+        let duration = map_temporal_result(cx, duration_result, method_name)?;
+
+        Ok(DurationObject::new(cx, duration)?.as_value())
     }
 
     /// Temporal.Instant.prototype.round (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.round)

--- a/src/js/runtime/intrinsics/temporal/instant_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_prototype.rs
@@ -16,8 +16,10 @@ use crate::runtime::{
             utils::{
                 get_fractional_second_digits_option, get_rounding_increment_option,
                 get_rounding_mode_option, get_time_zone_option, get_unit_valued_option,
-                map_temporal_result, parse_round_options_argument, validate_options_object,
+                map_temporal_result, parse_round_options_argument, to_time_zone_identifier,
+                validate_options_object,
             },
+            zoned_date_time_object::ZonedDateTimeObject,
         },
     },
     object_value::ObjectValue,
@@ -347,10 +349,19 @@ impl InstantPrototype {
     pub fn to_zoned_date_time_iso(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        argument: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_instant(cx, this_value, "Instant.prototype.toZonedDateTimeISO")?;
-        unimplemented!("Instant.prototype.toZonedDateTimeISO")
+        const NAME: &str = "Instant.prototype.toZonedDateTimeISO";
+
+        let instant = this_instant(cx, this_value, NAME)?;
+
+        let time_zone_arg = get_argument(cx, argument, 0);
+        let time_zone = to_time_zone_identifier(cx, time_zone_arg, NAME)?;
+
+        let zoned_date_time_result = instant.instant().to_zoned_date_time_iso(time_zone);
+        let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, NAME)?;
+
+        Ok(ZonedDateTimeObject::new(cx, zoned_date_time)?.as_value())
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
@@ -5,6 +5,7 @@ use crate::runtime::{
     alloc_error::AllocResult,
     error::type_error,
     function::get_argument,
+    get,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -12,10 +13,15 @@ use crate::runtime::{
             duration_constructor::to_temporal_duration,
             plain_date_constructor::to_temporal_date,
             plain_date_object::PlainDateObject,
+            plain_date_time_object::PlainDateTimeObject,
+            plain_month_day_object::PlainMonthDayObject,
+            plain_time_constructor::to_temporal_time,
+            plain_year_month_object::PlainYearMonthObject,
             utils::{
                 get_overflow_option, get_show_calendar_name_option, map_temporal_result,
-                validate_options_object,
+                to_time_zone_identifier, validate_options_object,
             },
+            zoned_date_time_object::ZonedDateTimeObject,
         },
     },
     object_value::ObjectValue,
@@ -533,10 +539,23 @@ impl PlainDatePrototype {
     pub fn to_plain_date_time(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_date(cx, this_value, "PlainDate.prototype.toPlainDateTime")?;
-        unimplemented!("PlainDate.prototype.toPlainDateTime")
+        const NAME: &str = "PlainDate.prototype.toPlainDateTime";
+
+        let this_date = this_plain_date(cx, this_value, NAME)?;
+
+        let time_arg = get_argument(cx, arguments, 0);
+        let time = if time_arg.is_undefined() {
+            None
+        } else {
+            Some(to_temporal_time(cx, time_arg, NAME)?)
+        };
+
+        let plain_date_time_result = this_date.date().to_plain_date_time(time);
+        let plain_date_time = map_temporal_result(cx, plain_date_time_result, NAME)?;
+
+        Ok(PlainDateTimeObject::new(cx, plain_date_time)?.as_value())
     }
 
     /// Temporal.PlainDate.prototype.toPlainMonthDay (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainmonthday)
@@ -545,8 +564,14 @@ impl PlainDatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_date(cx, this_value, "PlainDate.prototype.toPlainMonthDay")?;
-        unimplemented!("PlainDate.prototype.toPlainMonthDay")
+        const NAME: &str = "PlainDate.prototype.toPlainMonthDay";
+
+        let this_date = this_plain_date(cx, this_value, NAME)?;
+
+        let plain_month_day_result = this_date.date().to_plain_month_day();
+        let plain_month_day = map_temporal_result(cx, plain_month_day_result, NAME)?;
+
+        Ok(PlainMonthDayObject::new(cx, plain_month_day)?.as_value())
     }
 
     /// Temporal.PlainDate.prototype.toPlainYearMonth (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainyearmonth)
@@ -555,18 +580,60 @@ impl PlainDatePrototype {
         this_value: Handle<Value>,
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_date(cx, this_value, "PlainDate.prototype.toPlainYearMonth")?;
-        unimplemented!("PlainDate.prototype.toPlainYearMonth")
+        const NAME: &str = "PlainDate.prototype.toPlainYearMonth";
+
+        let this_date = this_plain_date(cx, this_value, NAME)?;
+
+        let plain_year_month_result = this_date.date().to_plain_year_month();
+        let plain_year_month = map_temporal_result(cx, plain_year_month_result, NAME)?;
+
+        Ok(PlainYearMonthObject::new(cx, plain_year_month)?.as_value())
     }
 
     /// Temporal.PlainDate.prototype.toZonedDateTime (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tozoneddatetime)
     pub fn to_zoned_date_time(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_date(cx, this_value, "PlainDate.prototype.toZonedDateTime")?;
-        unimplemented!("PlainDate.prototype.toZonedDateTime")
+        const NAME: &str = "PlainDate.prototype.toZonedDateTime";
+
+        let this_date = this_plain_date(cx, this_value, NAME)?;
+
+        let item_arg = get_argument(cx, arguments, 0);
+
+        let plain_time_opt;
+        let time_zone;
+
+        // Argument may be a time zone directly or an object that contains a time zone and
+        // optionally a plain time.
+        if item_arg.is_object() {
+            let item_object = item_arg.as_object();
+            let time_zone_like = get(cx, item_object, cx.names.time_zone())?;
+            if time_zone_like.is_undefined() {
+                time_zone = to_time_zone_identifier(cx, item_arg, NAME)?;
+                plain_time_opt = None;
+            } else {
+                time_zone = to_time_zone_identifier(cx, time_zone_like, NAME)?;
+
+                let plain_time_value = get(cx, item_object, cx.names.plain_time_())?;
+                if plain_time_value.is_undefined() {
+                    plain_time_opt = None;
+                } else {
+                    plain_time_opt = Some(to_temporal_time(cx, plain_time_value, NAME)?);
+                }
+            }
+        } else {
+            time_zone = to_time_zone_identifier(cx, item_arg, NAME)?;
+            plain_time_opt = None;
+        };
+
+        let zoned_date_time_result = this_date
+            .date()
+            .to_zoned_date_time(time_zone, plain_time_opt);
+        let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, NAME)?;
+
+        Ok(ZonedDateTimeObject::new(cx, zoned_date_time)?.as_value())
     }
 
     /// Temporal.PlainDate.prototype.toString (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tostring)

--- a/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
@@ -11,6 +11,7 @@ use crate::runtime::{
         rust_runtime::RuntimeFunction,
         temporal::{
             duration_constructor::to_temporal_duration,
+            duration_object::DurationObject,
             plain_date_constructor::to_temporal_date,
             plain_date_object::PlainDateObject,
             plain_date_time_object::PlainDateTimeObject,
@@ -18,8 +19,9 @@ use crate::runtime::{
             plain_time_constructor::to_temporal_time,
             plain_year_month_object::PlainYearMonthObject,
             utils::{
-                get_overflow_option, get_show_calendar_name_option, map_temporal_result,
-                to_time_zone_identifier, validate_options_object,
+                DiffOperation, get_difference_settings, get_overflow_option,
+                get_show_calendar_name_option, map_temporal_result, to_time_zone_identifier,
+                validate_options_object,
             },
             zoned_date_time_object::ZonedDateTimeObject,
         },
@@ -503,20 +505,44 @@ impl PlainDatePrototype {
     pub fn until(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_date(cx, this_value, "PlainDate.prototype.until")?;
-        unimplemented!("PlainDate.prototype.until")
+        Self::diff(cx, this_value, arguments, DiffOperation::Until, "PlainDate.prototype.until")
     }
 
     /// Temporal.PlainDate.prototype.since (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.since)
     pub fn since(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_date(cx, this_value, "PlainDate.prototype.since")?;
-        unimplemented!("PlainDate.prototype.since")
+        Self::diff(cx, this_value, arguments, DiffOperation::Since, "PlainDate.prototype.since")
+    }
+
+    fn diff(
+        cx: Context,
+        this_value: Handle<Value>,
+        arguments: &[Handle<Value>],
+        operation: DiffOperation,
+        method_name: &str,
+    ) -> EvalResult<Handle<Value>> {
+        let this_date = this_plain_date(cx, this_value, method_name)?;
+
+        let other_arg = get_argument(cx, arguments, 0);
+        let other = to_temporal_date(cx, other_arg, method_name)?;
+
+        let options_arg = get_argument(cx, arguments, 1);
+        let options = validate_options_object(cx, options_arg, method_name)?;
+        let difference_settings = get_difference_settings(cx, options, method_name)?;
+
+        let duration_result = match operation {
+            DiffOperation::Until => this_date.date().until(&other, difference_settings),
+            DiffOperation::Since => this_date.date().since(&other, difference_settings),
+        };
+
+        let duration = map_temporal_result(cx, duration_result, method_name)?;
+
+        Ok(DurationObject::new(cx, duration)?.as_value())
     }
 
     /// Temporal.PlainDate.prototype.equals (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.equals)

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
@@ -12,13 +12,15 @@ use crate::runtime::{
         rust_runtime::RuntimeFunction,
         temporal::{
             duration_constructor::to_temporal_duration,
+            duration_object::DurationObject,
             plain_date_object::PlainDateObject,
             plain_date_time_constructor::to_temporal_date_time,
             plain_date_time_object::PlainDateTimeObject,
             plain_time_object::PlainTimeObject,
             utils::{
-                get_disambiguation_option, get_fractional_second_digits_option,
-                get_overflow_option, get_rounding_increment_option, get_rounding_mode_option,
+                DiffOperation, get_difference_settings, get_disambiguation_option,
+                get_fractional_second_digits_option, get_overflow_option,
+                get_rounding_increment_option, get_rounding_mode_option,
                 get_show_calendar_name_option, get_unit_valued_option, map_temporal_result,
                 parse_round_options_argument, to_time_zone_identifier, validate_options_object,
             },
@@ -645,20 +647,48 @@ impl PlainDateTimePrototype {
     pub fn until(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.until")?;
-        unimplemented!("PlainDateTime.prototype.until")
+        Self::diff(cx, this_value, arguments, DiffOperation::Until, "PlainDateTime.prototype.until")
     }
 
     /// Temporal.PlainDateTime.prototype.since (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.since)
     pub fn since(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.since")?;
-        unimplemented!("PlainDateTime.prototype.since")
+        Self::diff(cx, this_value, arguments, DiffOperation::Since, "PlainDateTime.prototype.since")
+    }
+
+    fn diff(
+        cx: Context,
+        this_value: Handle<Value>,
+        arguments: &[Handle<Value>],
+        operation: DiffOperation,
+        method_name: &str,
+    ) -> EvalResult<Handle<Value>> {
+        let plain_date_time = this_plain_date_time(cx, this_value, method_name)?;
+
+        let other_arg = get_argument(cx, arguments, 0);
+        let other = to_temporal_date_time(cx, other_arg, method_name)?;
+
+        let options_arg = get_argument(cx, arguments, 1);
+        let options = validate_options_object(cx, options_arg, method_name)?;
+        let difference_settings = get_difference_settings(cx, options, method_name)?;
+
+        let duration_result = match operation {
+            DiffOperation::Until => plain_date_time
+                .date_time()
+                .until(&other, difference_settings),
+            DiffOperation::Since => plain_date_time
+                .date_time()
+                .since(&other, difference_settings),
+        };
+
+        let duration = map_temporal_result(cx, duration_result, method_name)?;
+
+        Ok(DurationObject::new(cx, duration)?.as_value())
     }
 
     /// Temporal.PlainDateTime.prototype.round (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.round)

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
@@ -17,11 +17,12 @@ use crate::runtime::{
             plain_date_time_object::PlainDateTimeObject,
             plain_time_object::PlainTimeObject,
             utils::{
-                get_fractional_second_digits_option, get_overflow_option,
-                get_rounding_increment_option, get_rounding_mode_option,
+                get_disambiguation_option, get_fractional_second_digits_option,
+                get_overflow_option, get_rounding_increment_option, get_rounding_mode_option,
                 get_show_calendar_name_option, get_unit_valued_option, map_temporal_result,
-                parse_round_options_argument, validate_options_object,
+                parse_round_options_argument, to_time_zone_identifier, validate_options_object,
             },
+            zoned_date_time_object::ZonedDateTimeObject,
         },
     },
     object_value::ObjectValue,
@@ -240,13 +241,6 @@ impl PlainDateTimePrototype {
             cx,
             cx.names.to_plain_time(),
             RuntimeFunction::PlainDateTimePrototype_toPlainTime,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_plain_date_time(),
-            RuntimeFunction::PlainDateTimePrototype_toPlainDateTime,
             0,
             realm,
         )?;
@@ -738,26 +732,29 @@ impl PlainDateTimePrototype {
         Ok(PlainTimeObject::new(cx, plain_time)?.as_value())
     }
 
-    /// Temporal.PlainDateTime.prototype.toPlainDateTime (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaindatetime)
-    pub fn to_plain_date_time(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let this_date_time =
-            this_plain_date_time(cx, this_value, "PlainDateTime.prototype.toPlainDateTime")?;
-
-        Ok(PlainDateTimeObject::new(cx, this_date_time.date_time().clone())?.as_value())
-    }
-
     /// Temporal.PlainDateTime.prototype.toZonedDateTime (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tozoneddatetime)
     pub fn to_zoned_date_time(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.toZonedDateTime")?;
-        unimplemented!("PlainDateTime.prototype.toZonedDateTime")
+        const NAME: &str = "PlainDateTime.prototype.toZonedDateTime";
+
+        let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
+
+        let time_zone_arg = get_argument(cx, arguments, 0);
+        let time_zone = to_time_zone_identifier(cx, time_zone_arg, NAME)?;
+
+        let options_arg = get_argument(cx, arguments, 1);
+        let options = validate_options_object(cx, options_arg, NAME)?;
+        let disambiguation = get_disambiguation_option(cx, options, NAME)?;
+
+        let zoned_date_time_result = this_date_time
+            .date_time()
+            .to_zoned_date_time(time_zone, disambiguation);
+        let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, NAME)?;
+
+        Ok(ZonedDateTimeObject::new(cx, zoned_date_time)?.as_value())
     }
 
     /// Temporal.PlainDateTime.prototype.toString (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tostring)

--- a/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
@@ -157,20 +157,6 @@ impl PlainTimePrototype {
             0,
             realm,
         )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_plain_date_time(),
-            RuntimeFunction::PlainTimePrototype_toPlainDateTime,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_zoned_date_time(),
-            RuntimeFunction::PlainTimePrototype_toZonedDateTime,
-            1,
-            realm,
-        )?;
 
         Ok(object)
     }
@@ -451,26 +437,6 @@ impl PlainTimePrototype {
         _: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         type_error(cx, "PlainTime.prototype.valueOf must not be called")
-    }
-
-    /// Temporal.PlainTime.prototype.toPlainDateTime (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.toplaindatetime)
-    pub fn to_plain_date_time(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_time(cx, this_value, "PlainTime.prototype.toPlainDateTime")?;
-        unimplemented!("PlainTime.prototype.toPlainDateTime")
-    }
-
-    /// Temporal.PlainTime.prototype.toZonedDateTime (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tozoneddatetime)
-    pub fn to_zoned_date_time(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_time(cx, this_value, "PlainTime.prototype.toZonedDateTime")?;
-        unimplemented!("PlainTime.prototype.toZonedDateTime")
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
@@ -10,13 +10,14 @@ use crate::runtime::{
         rust_runtime::RuntimeFunction,
         temporal::{
             duration_constructor::to_temporal_duration,
+            duration_object::DurationObject,
             plain_time_constructor::{to_partial_time_record, to_temporal_time},
             plain_time_object::PlainTimeObject,
             utils::{
-                get_fractional_second_digits_option, get_overflow_option,
-                get_rounding_increment_option, get_rounding_mode_option, get_unit_valued_option,
-                is_partial_temporal_object, map_temporal_result, parse_round_options_argument,
-                validate_options_object,
+                DiffOperation, get_difference_settings, get_fractional_second_digits_option,
+                get_overflow_option, get_rounding_increment_option, get_rounding_mode_option,
+                get_unit_valued_option, is_partial_temporal_object, map_temporal_result,
+                parse_round_options_argument, validate_options_object,
             },
         },
     },
@@ -305,20 +306,44 @@ impl PlainTimePrototype {
     pub fn until(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_time(cx, this_value, "PlainTime.prototype.until")?;
-        unimplemented!("PlainTime.prototype.until")
+        Self::diff(cx, this_value, arguments, DiffOperation::Until, "PlainTime.prototype.until")
     }
 
     /// Temporal.PlainTime.prototype.since (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.since)
     pub fn since(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_time(cx, this_value, "PlainTime.prototype.since")?;
-        unimplemented!("PlainTime.prototype.since")
+        Self::diff(cx, this_value, arguments, DiffOperation::Since, "PlainTime.prototype.since")
+    }
+
+    fn diff(
+        cx: Context,
+        this_value: Handle<Value>,
+        arguments: &[Handle<Value>],
+        operation: DiffOperation,
+        method_name: &str,
+    ) -> EvalResult<Handle<Value>> {
+        let plain_time = this_plain_time(cx, this_value, method_name)?;
+
+        let other_arg = get_argument(cx, arguments, 0);
+        let other = to_temporal_time(cx, other_arg, method_name)?;
+
+        let options_arg = get_argument(cx, arguments, 1);
+        let options = validate_options_object(cx, options_arg, method_name)?;
+        let difference_settings = get_difference_settings(cx, options, method_name)?;
+
+        let duration_result = match operation {
+            DiffOperation::Until => plain_time.time().until(&other, difference_settings),
+            DiffOperation::Since => plain_time.time().since(&other, difference_settings),
+        };
+
+        let duration = map_temporal_result(cx, duration_result, method_name)?;
+
+        Ok(DurationObject::new(cx, duration)?.as_value())
     }
 
     /// Temporal.PlainTime.prototype.round (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.round)

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
@@ -10,11 +10,12 @@ use crate::runtime::{
         rust_runtime::RuntimeFunction,
         temporal::{
             duration_constructor::to_temporal_duration,
+            duration_object::DurationObject,
             plain_year_month_constructor::to_temporal_year_month,
             plain_year_month_object::PlainYearMonthObject,
             utils::{
-                get_overflow_option, get_show_calendar_name_option, map_temporal_result,
-                validate_options_object,
+                DiffOperation, get_difference_settings, get_overflow_option,
+                get_show_calendar_name_option, map_temporal_result, validate_options_object,
             },
         },
     },
@@ -372,20 +373,60 @@ impl PlainYearMonthPrototype {
     pub fn until(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.until")?;
-        unimplemented!("PlainYearMonth.prototype.until")
+        Self::diff(
+            cx,
+            this_value,
+            arguments,
+            DiffOperation::Until,
+            "PlainYearMonth.prototype.until",
+        )
     }
 
     /// Temporal.PlainYearMonth.prototype.since (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.since)
     pub fn since(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.since")?;
-        unimplemented!("PlainYearMonth.prototype.since")
+        Self::diff(
+            cx,
+            this_value,
+            arguments,
+            DiffOperation::Since,
+            "PlainYearMonth.prototype.since",
+        )
+    }
+
+    fn diff(
+        cx: Context,
+        this_value: Handle<Value>,
+        arguments: &[Handle<Value>],
+        operation: DiffOperation,
+        method_name: &str,
+    ) -> EvalResult<Handle<Value>> {
+        let this_year_month = this_plain_year_month(cx, this_value, method_name)?;
+
+        let other_arg = get_argument(cx, arguments, 0);
+        let other = to_temporal_year_month(cx, other_arg, method_name)?;
+
+        let options_arg = get_argument(cx, arguments, 1);
+        let options = validate_options_object(cx, options_arg, method_name)?;
+        let difference_settings = get_difference_settings(cx, options, method_name)?;
+
+        let duration_result = match operation {
+            DiffOperation::Until => this_year_month
+                .year_month()
+                .until(&other, difference_settings),
+            DiffOperation::Since => this_year_month
+                .year_month()
+                .since(&other, difference_settings),
+        };
+
+        let duration = map_temporal_result(cx, duration_result, method_name)?;
+
+        Ok(DurationObject::new(cx, duration)?.as_value())
     }
 
     /// Temporal.PlainYearMonth.prototype.equals (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.equals)

--- a/src/js/runtime/intrinsics/temporal/utils.rs
+++ b/src/js/runtime/intrinsics/temporal/utils.rs
@@ -457,7 +457,7 @@ pub fn clamp_epoch_nanos_to_i128(epoch_nanos: &BigInt) -> i128 {
 }
 
 /// ToTemporalTimeZoneIdentifier (https://tc39.es/proposal-temporal/#sec-temporal-totemporaltimezoneidentifier)
-fn to_time_zone_identifier(
+pub fn to_time_zone_identifier(
     cx: Context,
     value: Handle<Value>,
     method_name: &str,

--- a/src/js/runtime/intrinsics/temporal/utils.rs
+++ b/src/js/runtime/intrinsics/temporal/utils.rs
@@ -6,8 +6,8 @@ use temporal_rs::{
     Calendar, TemporalResult, TimeZone,
     error::ErrorKind,
     options::{
-        Disambiguation, DisplayCalendar, DisplayOffset, DisplayTimeZone, OffsetDisambiguation,
-        Overflow, RelativeTo, RoundingIncrement, RoundingMode, Unit,
+        DifferenceSettings, Disambiguation, DisplayCalendar, DisplayOffset, DisplayTimeZone,
+        OffsetDisambiguation, Overflow, RelativeTo, RoundingIncrement, RoundingMode, Unit,
     },
     parsers::Precision,
     primitive::FiniteF64,
@@ -26,6 +26,12 @@ use crate::{
         type_utilities::to_number,
     },
 };
+
+/// The diff operations `until` and `since`.
+pub enum DiffOperation {
+    Until,
+    Since,
+}
 
 /// Map a temporal result to an equivalent EvalResult.
 pub fn map_temporal_result<T>(
@@ -358,6 +364,26 @@ pub fn get_time_zone_option(
         Some(option_value) => Ok(Some(to_time_zone_identifier(cx, option_value, method_name)?)),
         None => Ok(None),
     }
+}
+
+/// GetDifferenceSettings (https://tc39.es/proposal-temporal/#sec-temporal-getdifferencesettings)
+pub fn get_difference_settings(
+    cx: Context,
+    options: Option<Handle<ObjectValue>>,
+    method_name: &str,
+) -> EvalResult<DifferenceSettings> {
+    let largest_unit = get_unit_valued_option(cx, options, cx.names.largest_unit(), method_name)?;
+    let increment = get_rounding_increment_option(cx, options, method_name)?;
+    let rounding_mode = get_rounding_mode_option(cx, options, RoundingMode::Trunc, method_name)?;
+    let smallest_unit = get_unit_valued_option(cx, options, cx.names.smallest_unit(), method_name)?;
+
+    let mut settings = DifferenceSettings::default();
+    settings.largest_unit = largest_unit;
+    settings.smallest_unit = smallest_unit;
+    settings.increment = Some(increment);
+    settings.rounding_mode = Some(rounding_mode);
+
+    Ok(settings)
 }
 
 /// Parse the options argument for a `round` method. May be a string which is shorthand for the

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
@@ -14,13 +14,14 @@ use crate::runtime::{
         rust_runtime::RuntimeFunction,
         temporal::{
             duration_constructor::to_temporal_duration,
+            duration_object::DurationObject,
             instant_object::InstantObject,
             plain_date_object::PlainDateObject,
             plain_date_time_object::PlainDateTimeObject,
             plain_time_object::PlainTimeObject,
             utils::{
-                get_fractional_second_digits_option, get_overflow_option,
-                get_rounding_increment_option, get_rounding_mode_option,
+                DiffOperation, get_difference_settings, get_fractional_second_digits_option,
+                get_overflow_option, get_rounding_increment_option, get_rounding_mode_option,
                 get_show_calendar_name_option, get_show_offset_option,
                 get_show_time_zone_name_option, get_unit_valued_option, map_temporal_result,
                 parse_round_options_argument, validate_options_object,
@@ -784,20 +785,48 @@ impl ZonedDateTimePrototype {
     pub fn until(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.until")?;
-        unimplemented!("ZonedDateTime.prototype.until")
+        Self::diff(cx, this_value, arguments, DiffOperation::Until, "ZonedDateTime.prototype.until")
     }
 
     /// Temporal.ZonedDateTime.prototype.since (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.since)
     pub fn since(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.since")?;
-        unimplemented!("ZonedDateTime.prototype.since")
+        Self::diff(cx, this_value, arguments, DiffOperation::Since, "ZonedDateTime.prototype.since")
+    }
+
+    fn diff(
+        cx: Context,
+        this_value: Handle<Value>,
+        arguments: &[Handle<Value>],
+        operation: DiffOperation,
+        method_name: &str,
+    ) -> EvalResult<Handle<Value>> {
+        let this_zoned_date_time = this_zoned_date_time(cx, this_value, method_name)?;
+
+        let other_arg = get_argument(cx, arguments, 0);
+        let other = to_temporal_zoned_date_time(cx, other_arg, method_name)?;
+
+        let options_arg = get_argument(cx, arguments, 1);
+        let options = validate_options_object(cx, options_arg, method_name)?;
+        let difference_settings = get_difference_settings(cx, options, method_name)?;
+
+        let duration_result = match operation {
+            DiffOperation::Until => this_zoned_date_time
+                .zoned_date_time()
+                .until(&other, difference_settings),
+            DiffOperation::Since => this_zoned_date_time
+                .zoned_date_time()
+                .since(&other, difference_settings),
+        };
+
+        let duration = map_temporal_result(cx, duration_result, method_name)?;
+
+        Ok(DurationObject::new(cx, duration)?.as_value())
     }
 
     /// Temporal.ZonedDateTime.prototype.round (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.round)


### PR DESCRIPTION
## Summary

Implement some remaining `Temporal` Methods

- Various `toPlain*` and `toZonedDateTime` conversion methods across Temporal objects
- `since` and `until` on all Temporal objects

## Tests

- No tests enabled yet, but 3700/4603 of the test262 `built-ins/Temporal/*` tests now pass