### PR TITLE
[runtime] Implement withCalendar, withPlainTime, withTimeZone, and GetCalendarIdentiferWithISODefault

### DIFF
--- a/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
@@ -13,8 +13,8 @@ use crate::runtime::{
         temporal::{
             plain_date_object::PlainDateObject,
             utils::{
-                get_overflow_option, map_temporal_result, parse_calendar_argument,
-                to_integer_with_truncation, validate_options_object,
+                get_calendar_identifier_with_iso_default, get_overflow_option, map_temporal_result,
+                parse_calendar_argument, to_integer_with_truncation, validate_options_object,
             },
         },
     },
@@ -163,6 +163,8 @@ pub fn to_temporal_date_with_options(
             validate_overflow_option(cx, options, method_name)?;
             return Ok(plain_date_time.date_time().to_plain_date());
         }
+
+        let _ = get_calendar_identifier_with_iso_default(cx, item_object, method_name)?;
 
         // Otherwise treat as a "date-like" object
         validate_overflow_option(cx, options, method_name)?;

--- a/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
@@ -20,8 +20,8 @@ use crate::runtime::{
             plain_year_month_object::PlainYearMonthObject,
             utils::{
                 DiffOperation, get_difference_settings, get_overflow_option,
-                get_show_calendar_name_option, map_temporal_result, to_time_zone_identifier,
-                validate_options_object,
+                get_show_calendar_name_option, map_temporal_result,
+                to_temporal_calendar_identifier, to_time_zone_identifier, validate_options_object,
             },
             zoned_date_time_object::ZonedDateTimeObject,
         },
@@ -729,10 +729,18 @@ impl PlainDatePrototype {
     pub fn with_calendar(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_date(cx, this_value, "PlainDate.prototype.withCalendar")?;
-        unimplemented!("PlainDate.prototype.withCalendar")
+        const NAME: &str = "PlainDate.prototype.withCalendar";
+
+        let this_date = this_plain_date(cx, this_value, NAME)?;
+
+        let calendar_arg = get_argument(cx, arguments, 0);
+        let calendar = to_temporal_calendar_identifier(cx, calendar_arg, NAME)?;
+
+        let new_date = this_date.date().with_calendar(calendar);
+
+        Ok(PlainDateObject::new(cx, new_date)?.as_value())
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
@@ -13,9 +13,9 @@ use crate::runtime::{
         temporal::{
             plain_date_time_object::PlainDateTimeObject,
             utils::{
-                get_overflow_option, map_temporal_result, parse_calendar_argument,
-                to_integer_with_truncation, to_integer_with_truncation_or_zero,
-                validate_options_object,
+                get_calendar_identifier_with_iso_default, get_overflow_option, map_temporal_result,
+                parse_calendar_argument, to_integer_with_truncation,
+                to_integer_with_truncation_or_zero, validate_options_object,
             },
         },
     },
@@ -181,6 +181,8 @@ fn to_temporal_date_time_with_options(
 
             return map_temporal_result(cx, plain_date_time_result, method_name);
         }
+
+        let _ = get_calendar_identifier_with_iso_default(cx, item_object, method_name)?;
 
         // Otherwise treat as a date-time-like object
         unimplemented!("ToTemporalDateTime for date-like object")

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
@@ -16,13 +16,15 @@ use crate::runtime::{
             plain_date_object::PlainDateObject,
             plain_date_time_constructor::to_temporal_date_time,
             plain_date_time_object::PlainDateTimeObject,
+            plain_time_constructor::to_temporal_time,
             plain_time_object::PlainTimeObject,
             utils::{
                 DiffOperation, get_difference_settings, get_disambiguation_option,
                 get_fractional_second_digits_option, get_overflow_option,
                 get_rounding_increment_option, get_rounding_mode_option,
                 get_show_calendar_name_option, get_unit_valued_option, map_temporal_result,
-                parse_round_options_argument, to_time_zone_identifier, validate_options_object,
+                parse_round_options_argument, to_temporal_calendar_identifier,
+                to_time_zone_identifier, validate_options_object,
             },
             zoned_date_time_object::ZonedDateTimeObject,
         },
@@ -877,20 +879,41 @@ impl PlainDateTimePrototype {
     pub fn with_plain_time(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.withPlainTime")?;
-        unimplemented!("PlainDateTime.prototype.withPlainTime")
+        const NAME: &str = "PlainDateTime.prototype.withPlainTime";
+
+        let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
+
+        let time_arg = get_argument(cx, arguments, 0);
+        let time = if time_arg.is_undefined() {
+            None
+        } else {
+            Some(to_temporal_time(cx, time_arg, NAME)?)
+        };
+
+        let new_date_time_result = this_date_time.date_time().with_time(time);
+        let new_date_time = map_temporal_result(cx, new_date_time_result, NAME)?;
+
+        Ok(PlainDateTimeObject::new(cx, new_date_time)?.as_value())
     }
 
     /// Temporal.PlainDateTime.prototype.withCalendar (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withcalendar)
     pub fn with_calendar(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.withCalendar")?;
-        unimplemented!("PlainDateTime.prototype.withCalendar")
+        const NAME: &str = "PlainDateTime.prototype.withCalendar";
+
+        let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
+
+        let calendar_arg = get_argument(cx, arguments, 0);
+        let calendar = to_temporal_calendar_identifier(cx, calendar_arg, NAME)?;
+
+        let new_date_time = this_date_time.date_time().with_calendar(calendar);
+
+        Ok(PlainDateTimeObject::new(cx, new_date_time)?.as_value())
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
@@ -12,7 +12,10 @@ use crate::runtime::{
         rust_runtime::RuntimeFunction,
         temporal::{
             plain_month_day_object::PlainMonthDayObject,
-            utils::{map_temporal_result, parse_calendar_argument, to_integer_with_truncation},
+            utils::{
+                get_calendar_identifier_with_iso_default, map_temporal_result,
+                parse_calendar_argument, to_integer_with_truncation,
+            },
         },
     },
     object_value::ObjectValue,
@@ -116,6 +119,8 @@ pub fn to_temporal_month_day(
         if let Some(plain_month_day) = item_object.as_plain_month_day_object() {
             return Ok(plain_month_day.month_day().clone());
         }
+
+        let _ = get_calendar_identifier_with_iso_default(cx, item_object, method_name)?;
 
         // Otherwise treat like a date-like object
         unimplemented!("ToTemporalMonthDay for date-like object")

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
@@ -12,7 +12,10 @@ use crate::runtime::{
         rust_runtime::RuntimeFunction,
         temporal::{
             plain_year_month_object::PlainYearMonthObject,
-            utils::{map_temporal_result, parse_calendar_argument, to_integer_with_truncation},
+            utils::{
+                get_calendar_identifier_with_iso_default, map_temporal_result,
+                parse_calendar_argument, to_integer_with_truncation,
+            },
         },
     },
     object_value::ObjectValue,
@@ -138,6 +141,8 @@ pub fn to_temporal_year_month(
         if let Some(plain_year_month) = item_object.as_plain_year_month_object() {
             return Ok(plain_year_month.year_month().clone());
         }
+
+        let _ = get_calendar_identifier_with_iso_default(cx, item_object, method_name)?;
 
         // Otherwise treat like a date-like object
         unimplemented!("ToTemporalYearMonth for date-like object")

--- a/src/js/runtime/intrinsics/temporal/utils.rs
+++ b/src/js/runtime/intrinsics/temporal/utils.rs
@@ -288,6 +288,8 @@ pub fn get_relative_to_option(
             return Ok(Some(RelativeTo::ZonedDateTime(zoned_date_time.zoned_date_time().clone())));
         }
 
+        let _ = get_calendar_identifier_with_iso_default(cx, option_object, method_name)?;
+
         // Otherwise treat as a "date-like" object
         unimplemented!("GetTemporalRelativeToOption for date-like object")
     } else if !option_value.is_string() {
@@ -384,6 +386,34 @@ pub fn get_difference_settings(
     settings.rounding_mode = Some(rounding_mode);
 
     Ok(settings)
+}
+
+/// GetTemporalCalendarIdentifierWithISODefault (https://tc39.es/proposal-temporal/#sec-temporal-gettemporalcalendarslotvaluewithisodefault)
+pub fn get_calendar_identifier_with_iso_default(
+    cx: Context,
+    item_object: Handle<ObjectValue>,
+    method_name: &str,
+) -> EvalResult<Calendar> {
+    // Use the calendar of a Temporal object
+    if let Some(date) = item_object.as_plain_date_object() {
+        return Ok(date.date().calendar().clone());
+    } else if let Some(date_time) = item_object.as_plain_date_time_object() {
+        return Ok(date_time.date_time().calendar().clone());
+    } else if let Some(month_day) = item_object.as_plain_month_day_object() {
+        return Ok(month_day.month_day().calendar().clone());
+    } else if let Some(year_month) = item_object.as_plain_year_month_object() {
+        return Ok(year_month.year_month().calendar().clone());
+    } else if let Some(zoned_date_time) = item_object.as_zoned_date_time_object() {
+        return Ok(zoned_date_time.zoned_date_time().calendar().clone());
+    }
+
+    let calendar_like = get(cx, item_object, cx.names.calendar())?;
+
+    if calendar_like.is_undefined() {
+        Ok(Calendar::ISO)
+    } else {
+        to_temporal_calendar_identifier(cx, calendar_like, method_name)
+    }
 }
 
 /// Parse the options argument for a `round` method. May be a string which is shorthand for the
@@ -525,6 +555,38 @@ pub fn parse_time_zone_identifier_argument(
     }
 
     range_error(cx, &format!("{method_name} `timeZone` argument must be a valid time zone"))
+}
+
+/// ToTemporalCalendarIdentifier (https://tc39.es/proposal-temporal/#sec-temporal-totemporalcalendaridentifier)
+pub fn to_temporal_calendar_identifier(
+    cx: Context,
+    value: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<Calendar> {
+    // Use the calendar of a Temporal object
+    if value.is_object() {
+        if let Some(plain_date) = value.as_object().as_plain_date_object() {
+            return Ok(plain_date.date().calendar().clone());
+        } else if let Some(plain_date_time) = value.as_object().as_plain_date_time_object() {
+            return Ok(plain_date_time.date_time().calendar().clone());
+        } else if let Some(plain_year_month) = value.as_object().as_plain_year_month_object() {
+            return Ok(plain_year_month.year_month().calendar().clone());
+        } else if let Some(plain_month_day) = value.as_object().as_plain_month_day_object() {
+            return Ok(plain_month_day.month_day().calendar().clone());
+        } else if let Some(zoned_date_time) = value.as_object().as_zoned_date_time_object() {
+            return Ok(zoned_date_time.zoned_date_time().calendar().clone());
+        }
+    }
+
+    // Otherwise parse calendar from string
+    if !value.is_string() {
+        return type_error(cx, &format!("{method_name} `calendar` argument must be a string"));
+    }
+
+    let wtf8_string = value.as_string().to_wtf8_string()?;
+    let parsed_calendar_result = Calendar::try_from_utf8(wtf8_string.as_bytes());
+
+    map_temporal_result(cx, parsed_calendar_result, method_name)
 }
 
 /// IsPartialTemporalObject (https://tc39.es/proposal-temporal/#sec-temporal-ispartialtemporalobject)

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
@@ -16,9 +16,10 @@ use crate::runtime::{
         rust_runtime::RuntimeFunction,
         temporal::{
             utils::{
-                clamp_epoch_nanos_to_i128, get_disambiguation_option, get_offset_option,
-                get_overflow_option, map_temporal_result, parse_calendar_argument,
-                parse_time_zone_identifier_argument, validate_options_object,
+                clamp_epoch_nanos_to_i128, get_calendar_identifier_with_iso_default,
+                get_disambiguation_option, get_offset_option, get_overflow_option,
+                map_temporal_result, parse_calendar_argument, parse_time_zone_identifier_argument,
+                validate_options_object,
             },
             zoned_date_time_object::ZonedDateTimeObject,
         },
@@ -168,6 +169,8 @@ pub fn to_temporal_zoned_date_time_with_options(
             validate_options(cx, options, method_name)?;
             return Ok(zdt.zoned_date_time().clone());
         }
+
+        let _ = get_calendar_identifier_with_iso_default(cx, item_object, method_name)?;
 
         // Otherwise treat like a date-like object
         unimplemented!("ToTemporalZonedDateTime for date-like object")

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
@@ -18,13 +18,15 @@ use crate::runtime::{
             instant_object::InstantObject,
             plain_date_object::PlainDateObject,
             plain_date_time_object::PlainDateTimeObject,
+            plain_time_constructor::to_temporal_time,
             plain_time_object::PlainTimeObject,
             utils::{
                 DiffOperation, get_difference_settings, get_fractional_second_digits_option,
                 get_overflow_option, get_rounding_increment_option, get_rounding_mode_option,
                 get_show_calendar_name_option, get_show_offset_option,
                 get_show_time_zone_name_option, get_unit_valued_option, map_temporal_result,
-                parse_round_options_argument, validate_options_object,
+                parse_round_options_argument, to_temporal_calendar_identifier,
+                to_time_zone_identifier, validate_options_object,
             },
             zoned_date_time_constructor::to_temporal_zoned_date_time,
             zoned_date_time_object::ZonedDateTimeObject,
@@ -1036,30 +1038,65 @@ impl ZonedDateTimePrototype {
     pub fn with_plain_time(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.withPlainTime")?;
-        unimplemented!("ZonedDateTime.prototype.withPlainTime")
+        const NAME: &str = "ZonedDateTime.prototype.withPlainTime";
+
+        let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
+
+        let time_arg = get_argument(cx, arguments, 0);
+        let time = if time_arg.is_undefined() {
+            None
+        } else {
+            Some(to_temporal_time(cx, time_arg, NAME)?)
+        };
+
+        let new_zoned_date_time_result =
+            this_zoned_date_time.zoned_date_time().with_plain_time(time);
+        let new_zoned_date_time = map_temporal_result(cx, new_zoned_date_time_result, NAME)?;
+
+        Ok(ZonedDateTimeObject::new(cx, new_zoned_date_time)?.as_value())
     }
 
     /// Temporal.ZonedDateTime.prototype.withTimeZone (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withtimezone)
     pub fn with_time_zone(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.withTimeZone")?;
-        unimplemented!("ZonedDateTime.prototype.withTimeZone")
+        const NAME: &str = "ZonedDateTime.prototype.withTimeZone";
+
+        let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
+
+        let time_zone_arg = get_argument(cx, arguments, 0);
+        let time_zone = to_time_zone_identifier(cx, time_zone_arg, NAME)?;
+
+        let new_zoned_date_time_result = this_zoned_date_time
+            .zoned_date_time()
+            .with_timezone(time_zone);
+        let new_zoned_date_time = map_temporal_result(cx, new_zoned_date_time_result, NAME)?;
+
+        Ok(ZonedDateTimeObject::new(cx, new_zoned_date_time)?.as_value())
     }
 
     /// Temporal.ZonedDateTime.prototype.withCalendar (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withcalendar)
     pub fn with_calendar(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
-        let _ = this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.withCalendar")?;
-        unimplemented!("ZonedDateTime.prototype.withCalendar")
+        const NAME: &str = "ZonedDateTime.prototype.withCalendar";
+
+        let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
+
+        let calendar_arg = get_argument(cx, arguments, 0);
+        let calendar = to_temporal_calendar_identifier(cx, calendar_arg, NAME)?;
+
+        let new_zoned_date_time = this_zoned_date_time
+            .zoned_date_time()
+            .with_calendar(calendar);
+
+        Ok(ZonedDateTimeObject::new(cx, new_zoned_date_time)?.as_value())
     }
 
     /// Temporal.ZonedDateTime.prototype.startOfDay (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.startofday)


### PR DESCRIPTION
## Summary

As per title, implement all the `withCalendar`, `withPlainTime`, and `withTimeZone` prototype methods for Temporal objects. Also implement `GetCalendarIdentiferWithISODefault` and add all callsites.

## Tests

-  No tests enabled yet, but 3866/4603 of the test262 `built-ins/Temporal/*` tests now pass