### PR TITLE
[runtime] Fix assorted bugs in Temporal proposal

### DIFF
--- a/src/js/Cargo.toml
+++ b/src/js/Cargo.toml
@@ -21,7 +21,7 @@ num-traits.workspace = true
 rand.workspace = true
 ryu-js.workspace = true
 supports-color.workspace = true
-temporal_rs.workspace = true
+temporal_rs = { workspace = true, features = ["float64_representable_durations"] }
 xsum.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/src/js/runtime/intrinsics/temporal/duration_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_constructor.rs
@@ -179,24 +179,6 @@ pub fn to_temporal_partial_duration_record(
 
     let mut partial_duration = PartialDuration::default();
 
-    let years_value = get(cx, object, cx.names.years())?;
-    if !years_value.is_undefined() {
-        let years = to_integer_if_integral(cx, years_value, method_name)?;
-        partial_duration = partial_duration.with_years(years);
-    }
-
-    let months_value = get(cx, object, cx.names.months())?;
-    if !months_value.is_undefined() {
-        let months = to_integer_if_integral(cx, months_value, method_name)?;
-        partial_duration = partial_duration.with_months(months);
-    }
-
-    let weeks_value = get(cx, object, cx.names.weeks())?;
-    if !weeks_value.is_undefined() {
-        let weeks = to_integer_if_integral(cx, weeks_value, method_name)?;
-        partial_duration = partial_duration.with_weeks(weeks);
-    }
-
     let days_value = get(cx, object, cx.names.days())?;
     if !days_value.is_undefined() {
         let days = to_integer_if_integral(cx, days_value, method_name)?;
@@ -209,16 +191,10 @@ pub fn to_temporal_partial_duration_record(
         partial_duration = partial_duration.with_hours(hours);
     }
 
-    let minutes_value = get(cx, object, cx.names.minutes())?;
-    if !minutes_value.is_undefined() {
-        let minutes = to_integer_if_integral(cx, minutes_value, method_name)?;
-        partial_duration = partial_duration.with_minutes(minutes);
-    }
-
-    let seconds_value = get(cx, object, cx.names.seconds())?;
-    if !seconds_value.is_undefined() {
-        let seconds = to_integer_if_integral(cx, seconds_value, method_name)?;
-        partial_duration = partial_duration.with_seconds(seconds);
+    let micros_value = get(cx, object, cx.names.microseconds())?;
+    if !micros_value.is_undefined() {
+        let micros = to_integer_if_integral(cx, micros_value, method_name)?;
+        partial_duration = partial_duration.with_microseconds(micros);
     }
 
     let millis_value = get(cx, object, cx.names.milliseconds())?;
@@ -227,16 +203,40 @@ pub fn to_temporal_partial_duration_record(
         partial_duration = partial_duration.with_milliseconds(millis);
     }
 
-    let micros_value = get(cx, object, cx.names.microseconds())?;
-    if !micros_value.is_undefined() {
-        let micros = to_integer_if_integral(cx, micros_value, method_name)?;
-        partial_duration = partial_duration.with_microseconds(micros);
+    let minutes_value = get(cx, object, cx.names.minutes())?;
+    if !minutes_value.is_undefined() {
+        let minutes = to_integer_if_integral(cx, minutes_value, method_name)?;
+        partial_duration = partial_duration.with_minutes(minutes);
+    }
+
+    let months_value = get(cx, object, cx.names.months())?;
+    if !months_value.is_undefined() {
+        let months = to_integer_if_integral(cx, months_value, method_name)?;
+        partial_duration = partial_duration.with_months(months);
     }
 
     let nanos_value = get(cx, object, cx.names.nanoseconds())?;
     if !nanos_value.is_undefined() {
         let nanos = to_integer_if_integral(cx, nanos_value, method_name)?;
         partial_duration = partial_duration.with_nanoseconds(nanos);
+    }
+
+    let seconds_value = get(cx, object, cx.names.seconds())?;
+    if !seconds_value.is_undefined() {
+        let seconds = to_integer_if_integral(cx, seconds_value, method_name)?;
+        partial_duration = partial_duration.with_seconds(seconds);
+    }
+
+    let weeks_value = get(cx, object, cx.names.weeks())?;
+    if !weeks_value.is_undefined() {
+        let weeks = to_integer_if_integral(cx, weeks_value, method_name)?;
+        partial_duration = partial_duration.with_weeks(weeks);
+    }
+
+    let years_value = get(cx, object, cx.names.years())?;
+    if !years_value.is_undefined() {
+        let years = to_integer_if_integral(cx, years_value, method_name)?;
+        partial_duration = partial_duration.with_years(years);
     }
 
     if partial_duration.is_empty() {

--- a/src/js/runtime/intrinsics/temporal/duration_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_prototype.rs
@@ -9,7 +9,7 @@ use crate::{
         Context, EvalResult, Handle, Realm, Value,
         abstract_operations::create_data_property_or_throw,
         alloc_error::AllocResult,
-        error::type_error,
+        error::{range_error, type_error},
         function::get_argument,
         intrinsics::{
             intrinsics::Intrinsic,
@@ -506,7 +506,7 @@ impl DurationPrototype {
         let relative_to = get_relative_to_option(cx, options, NAME)?;
         let unit = match get_unit_valued_option(cx, options, cx.names.unit(), NAME)? {
             Some(unit) => unit,
-            None => return type_error(cx, "Duration.prototype.total requires a unit option"),
+            None => return range_error(cx, "Duration.prototype.total requires a unit option"),
         };
 
         let total_result = duration.duration().total(unit, relative_to);

--- a/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
@@ -78,7 +78,7 @@ impl PlainDateConstructor {
         let month_arg = get_argument(cx, arguments, 1);
         let day_arg = get_argument(cx, arguments, 2);
 
-        // Convert year, month, and day arguments into truncated integers
+        // Truncation for year, month, and day will trigger an error later in creation
         let year = to_integer_with_truncation(cx, year_arg, NAME)?;
         let month = to_integer_with_truncation(cx, month_arg, NAME)?;
         let day = to_integer_with_truncation(cx, day_arg, NAME)?;

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
@@ -17,6 +17,7 @@ use crate::runtime::{
                 get_overflow_option, map_temporal_result, parse_calendar_argument,
                 prepare_calendar_fields, to_integer_with_truncation,
                 to_integer_with_truncation_or_zero, validate_options_object,
+                validate_time_arguments,
             },
         },
     },
@@ -75,6 +76,7 @@ impl PlainDateTimeConstructor {
             return type_error(cx, "Temporal.PlainDateTime constructor must be called with new");
         };
 
+        // Truncation for year, month, and day will trigger an error later in creation
         let year_arg = get_argument(cx, arguments, 0);
         let year = to_integer_with_truncation(cx, year_arg, NAME)?;
 
@@ -84,26 +86,32 @@ impl PlainDateTimeConstructor {
         let day_arg = get_argument(cx, arguments, 2);
         let day = to_integer_with_truncation(cx, day_arg, NAME)?;
 
+        // Truncate time arguments to signed ints. This effectively clamps the value on the upper
+        // bound (since an error will be triggered later). But the lower bound must be checked
+        // manually later. Signed width is enough to hold the maximum value of each time field.
         let hour_arg = get_argument(cx, arguments, 3);
-        let hour = to_integer_with_truncation_or_zero(cx, hour_arg, NAME)?;
+        let hour = to_integer_with_truncation_or_zero::<i8>(cx, hour_arg, NAME)?;
 
         let minute_arg = get_argument(cx, arguments, 4);
-        let minute = to_integer_with_truncation_or_zero(cx, minute_arg, NAME)?;
+        let minute = to_integer_with_truncation_or_zero::<i8>(cx, minute_arg, NAME)?;
 
         let second_arg = get_argument(cx, arguments, 5);
-        let second = to_integer_with_truncation_or_zero(cx, second_arg, NAME)?;
+        let second = to_integer_with_truncation_or_zero::<i8>(cx, second_arg, NAME)?;
 
         let millis_arg = get_argument(cx, arguments, 6);
-        let millis = to_integer_with_truncation_or_zero(cx, millis_arg, NAME)?;
+        let millis = to_integer_with_truncation_or_zero::<i16>(cx, millis_arg, NAME)?;
 
         let micros_arg = get_argument(cx, arguments, 7);
-        let micros = to_integer_with_truncation_or_zero(cx, micros_arg, NAME)?;
+        let micros = to_integer_with_truncation_or_zero::<i16>(cx, micros_arg, NAME)?;
 
         let nanos_arg = get_argument(cx, arguments, 8);
-        let nanos = to_integer_with_truncation_or_zero(cx, nanos_arg, NAME)?;
+        let nanos = to_integer_with_truncation_or_zero::<i16>(cx, nanos_arg, NAME)?;
 
         let calendar_arg = get_argument(cx, arguments, 9);
         let calendar = parse_calendar_argument(cx, calendar_arg, NAME)?;
+
+        let (hour, minute, second, millis, micros, nanos) =
+            validate_time_arguments(cx, hour, minute, second, millis, micros, nanos, NAME)?;
 
         let plain_date_time_result = PlainDateTime::try_new(
             year, month, day, hour, minute, second, millis, micros, nanos, calendar,

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
@@ -72,6 +72,7 @@ impl PlainMonthDayConstructor {
         let month_arg = get_argument(cx, arguments, 0);
         let day_arg = get_argument(cx, arguments, 1);
 
+        // Truncation for year, month, and day will trigger an error later in creation
         let month = to_integer_with_truncation(cx, month_arg, NAME)?;
         let day = to_integer_with_truncation(cx, day_arg, NAME)?;
 

--- a/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
@@ -1,4 +1,4 @@
-use temporal_rs::{PlainTime, partial::PartialTime};
+use temporal_rs::{PlainTime, options::Overflow, partial::PartialTime};
 
 use crate::runtime::{
     Context, Handle, Realm, Value,
@@ -15,7 +15,10 @@ use crate::runtime::{
             plain_time_object::PlainTimeObject,
             utils::{
                 get_overflow_option, map_temporal_result, to_integer_with_truncation,
-                to_integer_with_truncation_or_zero, validate_options_object,
+                to_integer_with_truncation_or_zero, validate_hour_argument,
+                validate_micro_argument, validate_milli_argument, validate_minute_argument,
+                validate_nano_argument, validate_options_object, validate_second_argument,
+                validate_time_arguments,
             },
         },
     },
@@ -72,25 +75,31 @@ impl PlainTimeConstructor {
             return type_error(cx, "Temporal.PlainTime constructor must be called with new");
         };
 
+        // Truncate time arguments to signed ints. This effectively clamps the value on the upper
+        // bound (since an error will be triggered later). But the lower bound must be checked
+        // manually later. Signed width is enough to hold the maximum value of each time field.
         let hour_arg = get_argument(cx, arguments, 0);
-        let hour = to_integer_with_truncation_or_zero(cx, hour_arg, NAME)?;
+        let hour = to_integer_with_truncation_or_zero::<i8>(cx, hour_arg, NAME)?;
 
         let minute_arg = get_argument(cx, arguments, 1);
-        let minute = to_integer_with_truncation_or_zero(cx, minute_arg, NAME)?;
+        let minute = to_integer_with_truncation_or_zero::<i8>(cx, minute_arg, NAME)?;
 
         let second_arg = get_argument(cx, arguments, 2);
-        let second = to_integer_with_truncation_or_zero(cx, second_arg, NAME)?;
+        let second = to_integer_with_truncation_or_zero::<i8>(cx, second_arg, NAME)?;
 
         let millis_arg = get_argument(cx, arguments, 3);
-        let millis = to_integer_with_truncation_or_zero(cx, millis_arg, NAME)?;
+        let millis = to_integer_with_truncation_or_zero::<i16>(cx, millis_arg, NAME)?;
 
         let micros_arg = get_argument(cx, arguments, 4);
-        let micros = to_integer_with_truncation_or_zero(cx, micros_arg, NAME)?;
+        let micros = to_integer_with_truncation_or_zero::<i16>(cx, micros_arg, NAME)?;
 
         let nanos_arg = get_argument(cx, arguments, 5);
-        let nanos = to_integer_with_truncation_or_zero(cx, nanos_arg, NAME)?;
+        let nanos = to_integer_with_truncation_or_zero::<i16>(cx, nanos_arg, NAME)?;
 
-        let plain_time_result = PlainTime::new(hour, minute, second, millis, micros, nanos);
+        let (hour, minute, second, millis, micros, nanos) =
+            validate_time_arguments(cx, hour, minute, second, millis, micros, nanos, NAME)?;
+
+        let plain_time_result = PlainTime::try_new(hour, minute, second, millis, micros, nanos);
         let plain_time = map_temporal_result(cx, plain_time_result, NAME)?;
 
         Ok(PlainTimeObject::new_from_constructor(cx, new_target, plain_time)?.as_value())
@@ -165,11 +174,13 @@ pub fn to_temporal_time_with_options(
         }
 
         // Otherwise treat item as a partial time object
-        let partial_time = to_partial_time_record(cx, item, method_name)?;
+        let partial_record = to_partial_time_record(cx, item, method_name)?;
 
         // Parse overflow option from options argument
         let options = validate_options_object(cx, options_arg, method_name)?;
         let overflow = get_overflow_option(cx, options, method_name)?;
+
+        let partial_time = partial_record.clamp_and_validate(cx, overflow, method_name)?;
 
         let plain_time_result = PlainTime::from_partial(partial_time, Some(overflow));
 
@@ -190,59 +201,147 @@ pub fn to_temporal_time_with_options(
     Ok(parsed_time)
 }
 
+/// A partial time record with unvalidated fields (clamped to their signed bounds).
+#[derive(Default, PartialEq)]
+pub struct PartialTimeRecord {
+    hour: Option<i8>,
+    minute: Option<i8>,
+    second: Option<i8>,
+    milli: Option<i16>,
+    micro: Option<i16>,
+    nano: Option<i16>,
+}
+
+impl PartialTimeRecord {
+    fn is_empty(&self) -> bool {
+        self == &PartialTimeRecord::default()
+    }
+
+    /// Clamp and validate the partial time record fields, depending on the overflow option.
+    pub fn clamp_and_validate(
+        &self,
+        cx: Context,
+        overflow: Overflow,
+        method_name: &str,
+    ) -> EvalResult<PartialTime> {
+        let hour = if let Some(hour) = self.hour {
+            if overflow == Overflow::Reject {
+                Some(validate_hour_argument(cx, hour, method_name)?)
+            } else {
+                Some(hour.max(0) as u8)
+            }
+        } else {
+            None
+        };
+
+        let minute = if let Some(minute) = self.minute {
+            if overflow == Overflow::Reject {
+                Some(validate_minute_argument(cx, minute, method_name)?)
+            } else {
+                Some(minute.max(0) as u8)
+            }
+        } else {
+            None
+        };
+
+        let second = if let Some(second) = self.second {
+            if overflow == Overflow::Reject {
+                Some(validate_second_argument(cx, second, method_name)?)
+            } else {
+                Some(second.max(0) as u8)
+            }
+        } else {
+            None
+        };
+
+        let milli = if let Some(milli) = self.milli {
+            if overflow == Overflow::Reject {
+                Some(validate_milli_argument(cx, milli, method_name)?)
+            } else {
+                Some(milli.max(0) as u16)
+            }
+        } else {
+            None
+        };
+
+        let micro = if let Some(micro) = self.micro {
+            if overflow == Overflow::Reject {
+                Some(validate_micro_argument(cx, micro, method_name)?)
+            } else {
+                Some(micro.max(0) as u16)
+            }
+        } else {
+            None
+        };
+
+        let nano = if let Some(nano) = self.nano {
+            if overflow == Overflow::Reject {
+                Some(validate_nano_argument(cx, nano, method_name)?)
+            } else {
+                Some(nano.max(0) as u16)
+            }
+        } else {
+            None
+        };
+
+        Ok(PartialTime {
+            hour,
+            minute,
+            second,
+            millisecond: milli,
+            microsecond: micro,
+            nanosecond: nano,
+        })
+    }
+}
+
 /// ToTemporalTimeRecord (https://tc39.es/proposal-temporal/#sec-temporal-totemporaltimerecord)
 pub fn to_partial_time_record(
     cx: Context,
     time_like_object: Handle<Value>,
     method_name: &str,
-) -> EvalResult<PartialTime> {
+) -> EvalResult<PartialTimeRecord> {
     if !time_like_object.is_object() {
         return type_error(cx, &format!("{method_name} time must be an object"));
     }
 
     let object = time_like_object.as_object();
 
-    let mut partial_time = PartialTime::default();
+    let mut record = PartialTimeRecord::default();
 
     let hour_value = get(cx, object, cx.names.hour())?;
     if !hour_value.is_undefined() {
-        let hour = to_integer_with_truncation(cx, hour_value, method_name)?;
-        partial_time = partial_time.with_hour(Some(hour));
+        record.hour = Some(to_integer_with_truncation(cx, hour_value, method_name)?);
     }
 
     let micro_value = get(cx, object, cx.names.microsecond())?;
     if !micro_value.is_undefined() {
-        let micro = to_integer_with_truncation(cx, micro_value, method_name)?;
-        partial_time = partial_time.with_microsecond(Some(micro));
+        record.micro = Some(to_integer_with_truncation(cx, micro_value, method_name)?);
     }
 
     let milli_value = get(cx, object, cx.names.millisecond())?;
     if !milli_value.is_undefined() {
-        let milli = to_integer_with_truncation(cx, milli_value, method_name)?;
-        partial_time = partial_time.with_millisecond(Some(milli));
+        record.milli = Some(to_integer_with_truncation(cx, milli_value, method_name)?);
     }
 
     let minute_value = get(cx, object, cx.names.minute())?;
     if !minute_value.is_undefined() {
-        let minute = to_integer_with_truncation(cx, minute_value, method_name)?;
-        partial_time = partial_time.with_minute(Some(minute));
+        record.minute = Some(to_integer_with_truncation(cx, minute_value, method_name)?);
     }
 
     let nano_value = get(cx, object, cx.names.nanosecond())?;
     if !nano_value.is_undefined() {
-        let nano = to_integer_with_truncation(cx, nano_value, method_name)?;
-        partial_time = partial_time.with_nanosecond(Some(nano));
+        record.nano = Some(to_integer_with_truncation(cx, nano_value, method_name)?);
     }
 
     let second_value = get(cx, object, cx.names.second())?;
     if !second_value.is_undefined() {
-        let second = to_integer_with_truncation(cx, second_value, method_name)?;
-        partial_time = partial_time.with_second(Some(second));
+        record.second = Some(to_integer_with_truncation(cx, second_value, method_name)?);
     }
 
-    if partial_time.is_empty() {
+    if record.is_empty() {
         return type_error(cx, &format!("{method_name} time object is empty"));
     }
 
-    Ok(partial_time)
+    Ok(record)
 }

--- a/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
@@ -290,13 +290,15 @@ impl PlainTimePrototype {
             );
         }
 
-        let partial = to_partial_time_record(cx, time_like_arg, NAME)?;
+        let partial_record = to_partial_time_record(cx, time_like_arg, NAME)?;
 
         let options_arg = get_argument(cx, arguments, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
-        let new_time_result = plain_time.time().with(partial, Some(overflow));
+        let partial_time = partial_record.clamp_and_validate(cx, overflow, NAME)?;
+
+        let new_time_result = plain_time.time().with(partial_time, Some(overflow));
         let new_time = map_temporal_result(cx, new_time_result, NAME)?;
 
         Ok(PlainTimeObject::new(cx, new_time)?.as_value())

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
@@ -77,6 +77,7 @@ impl PlainYearMonthConstructor {
         let year_arg = get_argument(cx, arguments, 0);
         let month_arg = get_argument(cx, arguments, 1);
 
+        // Truncation for year, month, and day will trigger an error later in creation
         let year = to_integer_with_truncation(cx, year_arg, NAME)?;
         let month = to_integer_with_truncation(cx, month_arg, NAME)?;
 

--- a/src/js/runtime/intrinsics/temporal/utils.rs
+++ b/src/js/runtime/intrinsics/temporal/utils.rs
@@ -515,6 +515,7 @@ pub fn parse_calendar_argument(
 
     let wtf8_string = calendar_arg.as_string().to_wtf8_string()?;
     let parsed_calendar_result = Calendar::try_from_utf8(wtf8_string.as_bytes());
+
     map_temporal_result(cx, parsed_calendar_result, method_name)
 }
 
@@ -665,9 +666,16 @@ pub fn to_temporal_calendar_identifier(
     }
 
     let wtf8_string = value.as_string().to_wtf8_string()?;
-    let parsed_calendar_result = Calendar::try_from_utf8(wtf8_string.as_bytes());
 
-    map_temporal_result(cx, parsed_calendar_result, method_name)
+    if let Ok(option_str) = str::from_utf8(wtf8_string.as_bytes()) {
+        let parsed_calendar_result = Calendar::from_str(option_str);
+        return map_temporal_result(cx, parsed_calendar_result, method_name);
+    }
+
+    range_error(
+        cx,
+        &format!("{method_name} `calendar` argument must be a valid calendar identifier"),
+    )
 }
 
 /// IsPartialTemporalObject (https://tc39.es/proposal-temporal/#sec-temporal-ispartialtemporalobject)
@@ -962,4 +970,72 @@ pub fn prepare_calendar_fields(
     }
 
     Ok(PrepareCalendarFieldsResult { partial_date, partial_time, offset, time_zone })
+}
+
+pub fn validate_time_arguments(
+    cx: Context,
+    hour: i8,
+    minute: i8,
+    second: i8,
+    millis: i16,
+    micros: i16,
+    nanos: i16,
+    method_name: &str,
+) -> EvalResult<(u8, u8, u8, u16, u16, u16)> {
+    let hour = validate_hour_argument(cx, hour, method_name)?;
+    let minute = validate_minute_argument(cx, minute, method_name)?;
+    let second = validate_second_argument(cx, second, method_name)?;
+    let millis = validate_milli_argument(cx, millis, method_name)?;
+    let micros = validate_micro_argument(cx, micros, method_name)?;
+    let nanos = validate_nano_argument(cx, nanos, method_name)?;
+
+    Ok((hour, minute, second, millis, micros, nanos))
+}
+
+pub fn validate_hour_argument(cx: Context, hour: i8, method_name: &str) -> EvalResult<u8> {
+    if !(0..=23).contains(&hour) {
+        return range_error(cx, &format!("{method_name} hour must be in range 0-23"));
+    }
+
+    Ok(hour as u8)
+}
+
+pub fn validate_minute_argument(cx: Context, minute: i8, method_name: &str) -> EvalResult<u8> {
+    if !(0..=59).contains(&minute) {
+        return range_error(cx, &format!("{method_name} minute must be in range 0-59"));
+    }
+
+    Ok(minute as u8)
+}
+
+pub fn validate_second_argument(cx: Context, second: i8, method_name: &str) -> EvalResult<u8> {
+    if !(0..=59).contains(&second) {
+        return range_error(cx, &format!("{method_name} second must be in range 0-59"));
+    }
+
+    Ok(second as u8)
+}
+
+pub fn validate_milli_argument(cx: Context, millis: i16, method_name: &str) -> EvalResult<u16> {
+    if !(0..=999).contains(&millis) {
+        return range_error(cx, &format!("{method_name} millisecond must be in range 0-999"));
+    }
+
+    Ok(millis as u16)
+}
+
+pub fn validate_micro_argument(cx: Context, micros: i16, method_name: &str) -> EvalResult<u16> {
+    if !(0..=999).contains(&micros) {
+        return range_error(cx, &format!("{method_name} microsecond must be in range 0-999"));
+    }
+
+    Ok(micros as u16)
+}
+
+pub fn validate_nano_argument(cx: Context, nanos: i16, method_name: &str) -> EvalResult<u16> {
+    if !(0..=999).contains(&nanos) {
+        return range_error(cx, &format!("{method_name} nanosecond must be in range 0-999"));
+    }
+
+    Ok(nanos as u16)
 }

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
@@ -985,8 +985,8 @@ impl ZonedDateTimePrototype {
 
         // Parse display and rounding options from options object
         let display_calendar = get_show_calendar_name_option(cx, options, NAME)?;
-        let display_offset = get_show_offset_option(cx, options, NAME)?;
         let precision = get_fractional_second_digits_option(cx, options, NAME)?;
+        let display_offset = get_show_offset_option(cx, options, NAME)?;
         let rounding_mode = get_rounding_mode_option(cx, options, RoundingMode::Trunc, NAME)?;
         let smallest_unit = get_unit_valued_option(cx, options, cx.names.smallest_unit(), NAME)?;
         let display_time_zone = get_show_time_zone_name_option(cx, options, NAME)?;


### PR DESCRIPTION
## Summary

Fix almost all remaining known bugs in the [Temporal proposal](https://github.com/tc39/proposal-temporal).

- Parse all calendar formats in ToTemporalCalendarIdentifier by switching to Calendar::from_str
- Fix field access order in ToTemporalPartialDurationRecord and ZonedDateTime.prototype.toString
- Fix error type thrown in Duration.prototype.total
- Enable float64_representable_durations for temporal_rs to fix precision
- Ensure all time and date arguments are properly validated to be in range. For some time arguments this requires initially parsing as a larger signed number and then clamping and validating later.

### Tests

- No tests enabled yet, but `4593/4603` of the test262 `built-ins/Temporal/*` tests now pass