### PR TITLE
[runtime] Wrap 16-byte aligned Temporal fields in a HeapUnaligned wrapper

### DIFF
--- a/src/js/runtime/gc/heap.rs
+++ b/src/js/runtime/gc/heap.rs
@@ -232,6 +232,9 @@ impl Heap {
     /// Allocation will have at least the given size and is guaranteed to have 8-byte alignment.
     #[inline]
     pub fn alloc_uninit_with_size<T>(mut cx: Context, size: usize) -> AllocResult<HeapPtr<T>> {
+        // Statically ensure that type is compatible with the heap's alignment.
+        const { assert!(align_of::<T>() <= HEAP_ITEM_ALIGNMENT) };
+
         let alloc_size = Self::alloc_size_for_request_size(size);
 
         // Run a GC on every allocation in stress test mode

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -451,3 +451,19 @@ where
         self.cast()
     }
 }
+
+/// Storage for a value whose natural alignment exceeds the 8-byte alignment of the managed heap.
+#[repr(C, packed(8))]
+pub struct HeapUnaligned<T>(T);
+
+impl<T> HeapUnaligned<T> {
+    #[inline]
+    pub fn new(value: T) -> Self {
+        HeapUnaligned(value)
+    }
+
+    #[inline]
+    pub fn get(&self) -> T {
+        unsafe { std::ptr::read_unaligned(&raw const self.0) }
+    }
+}

--- a/src/js/runtime/gc/mod.rs
+++ b/src/js/runtime/gc/mod.rs
@@ -12,7 +12,7 @@ pub use handle::{
     Escapable, Handle, HandleContents, HandleScope, HandleScopeGuard, ToHandleContents,
 };
 pub use heap::{Heap, HeapInfo};
-pub use heap_item::{AnyHeapItem, HeapItem, IsHeapItem};
+pub use heap_item::{AnyHeapItem, HeapItem, HeapUnaligned, IsHeapItem};
 #[allow(unused)]
 pub use heap_serializer::{HeapRootsDeserializer, HeapSerializer};
 pub use heap_visitor::HeapVisitor;

--- a/src/js/runtime/intrinsics/temporal/duration_object.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_object.rs
@@ -4,7 +4,7 @@ use crate::{
     extend_object,
     runtime::{
         Context, EvalResult, Handle, HeapPtr,
-        gc::{HeapItem, HeapVisitor},
+        gc::{HeapItem, HeapUnaligned, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
@@ -16,7 +16,9 @@ use crate::{
 // Temporal.Duration Objects (https://tc39.es/proposal-temporal/#sec-temporal-duration-objects)
 extend_object! {
     pub struct DurationObject {
-        duration: Duration,
+        // Contains an `u128` field and so is 16-byte aligned. Must only access through the
+        // alignment wrapper.
+        duration: HeapUnaligned<Duration>,
     }
 }
 
@@ -38,13 +40,13 @@ impl DurationObject {
             Intrinsic::DurationPrototype,
         )?;
 
-        set_uninit!(object.duration, duration);
+        set_uninit!(object.duration, HeapUnaligned::new(duration));
 
         Ok(object.to_handle())
     }
 
     pub fn duration(&self) -> Duration {
-        self.duration
+        self.duration.get()
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/instant_object.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_object.rs
@@ -4,7 +4,7 @@ use crate::{
     extend_object,
     runtime::{
         Context, EvalResult, Handle, HeapPtr,
-        gc::{HeapItem, HeapVisitor},
+        gc::{HeapItem, HeapUnaligned, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
@@ -16,7 +16,9 @@ use crate::{
 // Temporal.Instant Objects (https://tc39.es/proposal-temporal/#sec-temporal-instant-objects)
 extend_object! {
     pub struct InstantObject {
-        instant: Instant,
+        // Contains an `i128` field and so is 16-byte aligned. Must only access through the
+        // alignment wrapper.
+        instant: HeapUnaligned<Instant>,
     }
 }
 
@@ -38,13 +40,13 @@ impl InstantObject {
             Intrinsic::InstantPrototype,
         )?;
 
-        set_uninit!(object.instant, instant);
+        set_uninit!(object.instant, HeapUnaligned::new(instant));
 
         Ok(object.to_handle())
     }
 
     pub fn instant(&self) -> Instant {
-        self.instant
+        self.instant.get()
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
@@ -4,7 +4,7 @@ use crate::{
     extend_object,
     runtime::{
         Context, EvalResult, Handle, HeapPtr,
-        gc::{HeapItem, HeapVisitor},
+        gc::{HeapItem, HeapUnaligned, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
@@ -16,7 +16,9 @@ use crate::{
 // ZonedDateTime Objects (https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects)
 extend_object! {
     pub struct ZonedDateTimeObject {
-        zoned_date_time: ZonedDateTime,
+        // Contains an `i128` field and so is 16-byte aligned. Must only access through the
+        // alignment wrapper.
+        zoned_date_time: HeapUnaligned<ZonedDateTime>,
     }
 }
 
@@ -41,13 +43,13 @@ impl ZonedDateTimeObject {
             Intrinsic::ZonedDateTimePrototype,
         )?;
 
-        set_uninit!(object.zoned_date_time, zoned_date_time);
+        set_uninit!(object.zoned_date_time, HeapUnaligned::new(zoned_date_time));
 
         Ok(object.to_handle())
     }
 
-    pub fn zoned_date_time(&self) -> &ZonedDateTime {
-        &self.zoned_date_time
+    pub fn zoned_date_time(&self) -> ZonedDateTime {
+        self.zoned_date_time.get()
     }
 }
 


### PR DESCRIPTION
## Summary

Running Temporal tests in CI was segfaulting due to unaligned access of 16-byte aligned values (`u128/i128`) stored within `temporal_rs`'s `Instant`, `Duration`, and `ZonedDateTime`. Theses were stored in the brimstone heap which is 8-byte aligned so unaligned accesses could occur.

Let's fix by introducing a `HeapUnaligned` wrapper which has at most 8-byte alignment and copies its contents on reads with `std::ptr::read_unaligned`.

Let's also add a static assert that will prevent trying to allocate >8-byte aligned values on the heap in the future.

## Tests

- This fixes the CI failures in https://github.com/Hans-Halverson/brimstone/pull/390