### PR TITLE
[runtime] All temporal_rs methods use provider from Context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +81,7 @@ dependencies = [
  "supports-color",
  "temporal_rs",
  "tikv-jemallocator",
+ "timezone_provider",
  "xsum",
  "zerotrie",
  "zerovec",
@@ -298,12 +290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "core_maths"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,30 +488,6 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "icu_calendar"
@@ -1216,14 +1178,12 @@ checksum = "b1afc06e45b0d63943c777d0233523fa2e23a12431a73c37b1c0366777b31717"
 dependencies = [
  "calendrical_calculations",
  "core_maths",
- "iana-time-zone",
  "icu_calendar",
  "icu_locale_core",
  "ixdtf",
  "num-traits",
  "timezone_provider",
  "tinystr",
- "web-time",
  "writeable",
 ]
 
@@ -1287,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "timezone_provider"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48f9b04628a2b813051e4dfe97c65281e49625eabd09ec343190e31e399a8c2"
+checksum = "48738555f588bc05b58cb55206843cde9875bb1fde50101dd1a7c50ac6535cd5"
 dependencies = [
  "combine",
  "jiff-tzdb",
@@ -1444,16 +1404,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,65 +1433,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ serde = "1.0.152"
 serde_json = "1.0.91"
 supports-color = "3.0.2"
 syn = "2.0.27"
-temporal_rs = "0.2.4"
 tikv-jemallocator = "0.6"
 threadpool = "1.8.1"
 xsum = "0.1.6"
@@ -62,6 +61,10 @@ icu_provider_baked = "2.2.0"
 icu_provider_adapters = "2.2.0"
 zerotrie = "0.2.0"
 zerovec = "0.11.3"
+
+# Temporal crates must all be the same version
+temporal_rs = { version = "0.2.4", default-features = false }
+timezone_provider = "0.2.4"
 
 [workspace.lints.clippy]
 collapsible_else_if = "allow"

--- a/src/js/Cargo.toml
+++ b/src/js/Cargo.toml
@@ -21,7 +21,8 @@ num-traits.workspace = true
 rand.workspace = true
 ryu-js.workspace = true
 supports-color.workspace = true
-temporal_rs = { workspace = true, features = ["float64_representable_durations"] }
+temporal_rs = { workspace = true, features = ["float64_representable_durations", "std"] }
+timezone_provider = { workspace = true, features = ["tzif"] }
 xsum.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use rand::{SeedableRng, rngs::StdRng};
+use timezone_provider::tzif::CompiledTzdbProvider;
 
 use crate::{
     common::{
@@ -127,7 +128,10 @@ pub struct ContextCell {
     pub rand: StdRng,
 
     /// If set, this is the unix time in nanoseconds.
-    pub mocked_unix_time_nanos: Option<u128>,
+    mocked_unix_time_nanos: Option<u128>,
+
+    /// Time zone provider used for Temporal operations.
+    temporal_provider: CompiledTzdbProvider,
 }
 
 type GlobalSymbolRegistry = BsHashMap<HeapPtr<FlatString>, HeapPtr<SymbolValue>>;
@@ -165,6 +169,7 @@ impl Context {
             // initial heap has been set up switch to a PRNG seeded from a random source.
             rand: StdRng::from_seed([0; 32]),
             mocked_unix_time_nanos: None,
+            temporal_provider: CompiledTzdbProvider::default(),
         });
 
         let mut cx = unsafe { Context::from_ptr(NonNull::new_unchecked(Box::leak(cx_cell))) };
@@ -464,6 +469,10 @@ impl Context {
         } else {
             get_current_unix_time_nanos()
         }
+    }
+
+    pub fn temporal_provider(&self) -> &CompiledTzdbProvider {
+        &self.temporal_provider
     }
 
     pub fn print_or_add_to_dump_buffer(&self, str: &str) {

--- a/src/js/runtime/intrinsics/temporal/duration_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_constructor.rs
@@ -134,7 +134,8 @@ impl DurationConstructor {
         let options = validate_options_object(cx, options_arg, NAME)?;
         let relative_to = get_relative_to_option(cx, options, NAME)?;
 
-        let ordering_result = duration_1.compare(&duration_2, relative_to);
+        let ordering_result =
+            duration_1.compare_with_provider(&duration_2, relative_to, cx.temporal_provider());
         let ordering = map_temporal_result(cx, ordering_result, NAME)?;
 
         Ok(cx.smi(ordering as i32))

--- a/src/js/runtime/intrinsics/temporal/duration_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_prototype.rs
@@ -471,7 +471,11 @@ impl DurationPrototype {
         rounding_options.rounding_mode = Some(rounding_mode);
         rounding_options.increment = Some(increment);
 
-        let rounded_result = duration.duration().round(rounding_options, relative_to);
+        let rounded_result = duration.duration().round_with_provider(
+            rounding_options,
+            relative_to,
+            cx.temporal_provider(),
+        );
         let rounded = map_temporal_result(cx, rounded_result, NAME)?;
 
         Ok(DurationObject::new(cx, rounded)?.as_value())
@@ -509,7 +513,10 @@ impl DurationPrototype {
             None => return range_error(cx, "Duration.prototype.total requires a unit option"),
         };
 
-        let total_result = duration.duration().total(unit, relative_to);
+        let total_result =
+            duration
+                .duration()
+                .total_with_provider(unit, relative_to, cx.temporal_provider());
         let total = map_temporal_result(cx, total_result, NAME)?;
 
         Ok(cx.number(total.as_inner()))

--- a/src/js/runtime/intrinsics/temporal/instant_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_prototype.rs
@@ -317,9 +317,11 @@ impl InstantPrototype {
             rounding_mode: Some(rounding_mode),
         };
 
-        let instant_string_result = instant
-            .instant()
-            .to_ixdtf_string(timezone, to_string_options);
+        let instant_string_result = instant.instant().to_ixdtf_string_with_provider(
+            timezone,
+            to_string_options,
+            cx.temporal_provider(),
+        );
         let instant_string = map_temporal_result(cx, instant_string_result, NAME)?;
 
         Ok(cx.alloc_string(&instant_string)?.as_value())
@@ -335,9 +337,11 @@ impl InstantPrototype {
 
         let instant = this_instant(cx, this_value, NAME)?;
 
-        let instant_string_result = instant
-            .instant()
-            .to_ixdtf_string(None, ToStringRoundingOptions::default());
+        let instant_string_result = instant.instant().to_ixdtf_string_with_provider(
+            None,
+            ToStringRoundingOptions::default(),
+            cx.temporal_provider(),
+        );
         let instant_string = map_temporal_result(cx, instant_string_result, NAME)?;
 
         Ok(cx.alloc_string(&instant_string)?.as_value())
@@ -353,9 +357,11 @@ impl InstantPrototype {
 
         let instant = this_instant(cx, this_value, NAME)?;
 
-        let instant_string_result = instant
-            .instant()
-            .to_ixdtf_string(None, ToStringRoundingOptions::default());
+        let instant_string_result = instant.instant().to_ixdtf_string_with_provider(
+            None,
+            ToStringRoundingOptions::default(),
+            cx.temporal_provider(),
+        );
         let instant_string = map_temporal_result(cx, instant_string_result, NAME)?;
 
         Ok(cx.alloc_string(&instant_string)?.as_value())
@@ -383,7 +389,9 @@ impl InstantPrototype {
         let time_zone_arg = get_argument(cx, argument, 0);
         let time_zone = to_time_zone_identifier(cx, time_zone_arg, NAME)?;
 
-        let zoned_date_time_result = instant.instant().to_zoned_date_time_iso(time_zone);
+        let zoned_date_time_result = instant
+            .instant()
+            .to_zoned_date_time_iso_with_provider(time_zone, cx.temporal_provider());
         let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, zoned_date_time)?.as_value())

--- a/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
@@ -655,9 +655,11 @@ impl PlainDatePrototype {
             plain_time_opt = None;
         };
 
-        let zoned_date_time_result = this_date
-            .date()
-            .to_zoned_date_time(time_zone, plain_time_opt);
+        let zoned_date_time_result = this_date.date().to_zoned_date_time_with_provider(
+            time_zone,
+            plain_time_opt,
+            cx.temporal_provider(),
+        );
         let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, zoned_date_time)?.as_value())

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
@@ -781,9 +781,11 @@ impl PlainDateTimePrototype {
         let options = validate_options_object(cx, options_arg, NAME)?;
         let disambiguation = get_disambiguation_option(cx, options, NAME)?;
 
-        let zoned_date_time_result = this_date_time
-            .date_time()
-            .to_zoned_date_time(time_zone, disambiguation);
+        let zoned_date_time_result = this_date_time.date_time().to_zoned_date_time_with_provider(
+            time_zone,
+            disambiguation,
+            cx.temporal_provider(),
+        );
         let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, zoned_date_time)?.as_value())

--- a/src/js/runtime/intrinsics/temporal/temporal_now_object.rs
+++ b/src/js/runtime/intrinsics/temporal/temporal_now_object.rs
@@ -101,10 +101,10 @@ impl TemporalNowObject {
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Now.timeZoneId";
 
-        let time_zone_result = Self::now(cx).time_zone();
+        let time_zone_result = Self::now(cx).time_zone_with_provider(cx.temporal_provider());
         let time_zone = map_temporal_result(cx, time_zone_result, NAME)?;
 
-        let time_zone_str_result = time_zone.identifier();
+        let time_zone_str_result = time_zone.identifier_with_provider(cx.temporal_provider());
         let time_zone_str = map_temporal_result(cx, time_zone_str_result, NAME)?;
 
         Ok(cx.alloc_string(&time_zone_str)?.as_value())
@@ -133,7 +133,8 @@ impl TemporalNowObject {
         let time_zone_arg = get_argument(cx, arguments, 0);
         let time_zone = Self::parse_time_zone_argument(cx, time_zone_arg, NAME)?;
 
-        let date_time_result = Self::now(cx).plain_date_time_iso(time_zone);
+        let date_time_result =
+            Self::now(cx).plain_date_time_iso_with_provider(time_zone, cx.temporal_provider());
         let date_time = map_temporal_result(cx, date_time_result, NAME)?;
 
         Ok(PlainDateTimeObject::new(cx, date_time)?.as_value())
@@ -150,7 +151,8 @@ impl TemporalNowObject {
         let time_zone_arg = get_argument(cx, arguments, 0);
         let time_zone = Self::parse_time_zone_argument(cx, time_zone_arg, NAME)?;
 
-        let zoned_date_time_result = Self::now(cx).zoned_date_time_iso(time_zone);
+        let zoned_date_time_result =
+            Self::now(cx).zoned_date_time_iso_with_provider(time_zone, cx.temporal_provider());
         let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, zoned_date_time)?.as_value())
@@ -167,7 +169,8 @@ impl TemporalNowObject {
         let time_zone_arg = get_argument(cx, arguments, 0);
         let time_zone = Self::parse_time_zone_argument(cx, time_zone_arg, NAME)?;
 
-        let date_result = Self::now(cx).plain_date_iso(time_zone);
+        let date_result =
+            Self::now(cx).plain_date_iso_with_provider(time_zone, cx.temporal_provider());
         let date = map_temporal_result(cx, date_result, NAME)?;
 
         Ok(PlainDateObject::new(cx, date)?.as_value())
@@ -184,7 +187,8 @@ impl TemporalNowObject {
         let time_zone_arg = get_argument(cx, arguments, 0);
         let time_zone = Self::parse_time_zone_argument(cx, time_zone_arg, NAME)?;
 
-        let time_result = Self::now(cx).plain_time_iso(time_zone);
+        let time_result =
+            Self::now(cx).plain_time_iso_with_provider(time_zone, cx.temporal_provider());
         let time = map_temporal_result(cx, time_result, NAME)?;
 
         Ok(PlainTimeObject::new(cx, time)?.as_value())

--- a/src/js/runtime/intrinsics/temporal/utils.rs
+++ b/src/js/runtime/intrinsics/temporal/utils.rs
@@ -335,8 +335,13 @@ pub fn get_relative_to_option(
             fields: prepared_fields.into_partial_zoned_date_time(),
         };
 
-        let zoned_date_time_result =
-            ZonedDateTime::from_partial(partial_zoned_date_time, None, None, None);
+        let zoned_date_time_result = ZonedDateTime::from_partial_with_provider(
+            partial_zoned_date_time,
+            None,
+            None,
+            None,
+            cx.temporal_provider(),
+        );
         let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, method_name)?;
 
         return Ok(Some(RelativeTo::ZonedDateTime(zoned_date_time)));
@@ -350,7 +355,8 @@ pub fn get_relative_to_option(
     let wtf8_string = option_value.as_string().to_wtf8_string()?;
 
     if let Ok(option_str) = str::from_utf8(wtf8_string.as_bytes()) {
-        let parsed_option_result = RelativeTo::try_from_str(option_str);
+        let parsed_option_result =
+            RelativeTo::try_from_str_with_provider(option_str, cx.temporal_provider());
         let parsed_option = map_temporal_result(cx, parsed_option_result, method_name)?;
 
         return Ok(Some(parsed_option));
@@ -613,7 +619,8 @@ pub fn to_time_zone_identifier(
     let wtf8_string = value.as_string().to_wtf8_string()?;
 
     if let Ok(option_str) = str::from_utf8(wtf8_string.as_bytes()) {
-        let parsed_time_zone_result = TimeZone::try_from_str(option_str);
+        let parsed_time_zone_result =
+            TimeZone::try_from_str_with_provider(option_str, cx.temporal_provider());
         return map_temporal_result(cx, parsed_time_zone_result, method_name);
     }
 
@@ -632,7 +639,8 @@ pub fn parse_time_zone_identifier_argument(
     let wtf8_string = value.as_string().to_wtf8_string()?;
 
     if let Ok(str) = str::from_utf8(wtf8_string.as_bytes()) {
-        let parsed_time_zone_result = TimeZone::try_from_identifier_str(str);
+        let parsed_time_zone_result =
+            TimeZone::try_from_identifier_str_with_provider(str, cx.temporal_provider());
         return map_temporal_result(cx, parsed_time_zone_result, method_name);
     }
 

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
@@ -92,7 +92,12 @@ impl ZonedDateTimeConstructor {
         let calendar_arg = get_argument(cx, arguments, 2);
         let calendar = parse_calendar_argument(cx, calendar_arg, NAME)?;
 
-        let zoned_date_time_result = ZonedDateTime::try_new(epoch_nanos_i128, time_zone, calendar);
+        let zoned_date_time_result = ZonedDateTime::try_new_with_provider(
+            epoch_nanos_i128,
+            time_zone,
+            calendar,
+            cx.temporal_provider(),
+        );
         let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new_from_constructor(cx, new_target, zoned_date_time)?.as_value())
@@ -206,11 +211,12 @@ pub fn to_temporal_zoned_date_time_with_options(
             fields: prepared_fields.into_partial_zoned_date_time(),
         };
 
-        let zoned_date_time_result = ZonedDateTime::from_partial(
+        let zoned_date_time_result = ZonedDateTime::from_partial_with_provider(
             partial_zoned_date_time,
             Some(overflow),
             Some(disambiguation),
             Some(offset),
+            cx.temporal_provider(),
         );
 
         return map_temporal_result(cx, zoned_date_time_result, method_name);
@@ -225,12 +231,20 @@ pub fn to_temporal_zoned_date_time_with_options(
     }
 
     let wtf8_string = item.as_string().to_wtf8_string()?;
-    let parsed_result = ParsedZonedDateTime::from_utf8(wtf8_string.as_bytes());
+    let parsed_result = ParsedZonedDateTime::from_utf8_with_provider(
+        wtf8_string.as_bytes(),
+        cx.temporal_provider(),
+    );
     let parsed = map_temporal_result(cx, parsed_result, method_name)?;
 
     let (disambiguation, offset, _) = validate_options(cx, options, method_name)?;
 
-    let zoned_date_time_result = ZonedDateTime::from_parsed(parsed, disambiguation, offset);
+    let zoned_date_time_result = ZonedDateTime::from_parsed_with_provider(
+        parsed,
+        disambiguation,
+        offset,
+        cx.temporal_provider(),
+    );
     let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, method_name)?;
 
     Ok(zoned_date_time)

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
@@ -410,7 +410,7 @@ impl ZonedDateTimePrototype {
         let time_zone_id_result = this_zoned_date_time
             .zoned_date_time()
             .time_zone()
-            .identifier();
+            .identifier_with_provider(cx.temporal_provider());
         let time_zone_id = map_temporal_result(cx, time_zone_id_result, NAME)?;
 
         Ok(cx.alloc_string(&time_zone_id)?.as_value())
@@ -762,7 +762,9 @@ impl ZonedDateTimePrototype {
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let hours_in_day_result = this_zoned_date_time.zoned_date_time().hours_in_day();
+        let hours_in_day_result = this_zoned_date_time
+            .zoned_date_time()
+            .hours_in_day_with_provider(cx.temporal_provider());
         let hours_in_day = map_temporal_result(cx, hours_in_day_result, NAME)?;
 
         Ok(cx.number(hours_in_day))
@@ -785,9 +787,11 @@ impl ZonedDateTimePrototype {
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
-        let new_zoned_date_time_result = this_zoned_date_time
-            .zoned_date_time()
-            .add(&duration, Some(overflow));
+        let new_zoned_date_time_result = this_zoned_date_time.zoned_date_time().add_with_provider(
+            &duration,
+            Some(overflow),
+            cx.temporal_provider(),
+        );
         let new_zoned_date_time = map_temporal_result(cx, new_zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, new_zoned_date_time)?.as_value())
@@ -812,7 +816,7 @@ impl ZonedDateTimePrototype {
 
         let new_zoned_date_time_result = this_zoned_date_time
             .zoned_date_time()
-            .subtract(&duration, Some(overflow));
+            .subtract_with_provider(&duration, Some(overflow), cx.temporal_provider());
         let new_zoned_date_time = map_temporal_result(cx, new_zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, new_zoned_date_time)?.as_value())
@@ -853,12 +857,16 @@ impl ZonedDateTimePrototype {
         let difference_settings = get_difference_settings(cx, options, method_name)?;
 
         let duration_result = match operation {
-            DiffOperation::Until => this_zoned_date_time
-                .zoned_date_time()
-                .until(&other, difference_settings),
-            DiffOperation::Since => this_zoned_date_time
-                .zoned_date_time()
-                .since(&other, difference_settings),
+            DiffOperation::Until => this_zoned_date_time.zoned_date_time().until_with_provider(
+                &other,
+                difference_settings,
+                cx.temporal_provider(),
+            ),
+            DiffOperation::Since => this_zoned_date_time.zoned_date_time().since_with_provider(
+                &other,
+                difference_settings,
+                cx.temporal_provider(),
+            ),
         };
 
         let duration = map_temporal_result(cx, duration_result, method_name)?;
@@ -891,7 +899,7 @@ impl ZonedDateTimePrototype {
 
         let rounded_result = this_zoned_date_time
             .zoned_date_time()
-            .round(rounding_options);
+            .round_with_provider(rounding_options, cx.temporal_provider());
         let rounded = map_temporal_result(cx, rounded_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, rounded)?.as_value())
@@ -912,7 +920,7 @@ impl ZonedDateTimePrototype {
 
         let is_equal_result = this_zoned_date_time
             .zoned_date_time()
-            .equals(&other_zoned_date_time);
+            .equals_with_provider(&other_zoned_date_time, cx.temporal_provider());
         let is_equal = map_temporal_result(cx, is_equal_result, NAME)?;
 
         Ok(cx.bool(is_equal))
@@ -997,12 +1005,15 @@ impl ZonedDateTimePrototype {
             rounding_mode: Some(rounding_mode),
         };
 
-        let zoned_date_time_string_result = this_zoned_date_time.zoned_date_time().to_ixdtf_string(
-            display_offset,
-            display_time_zone,
-            display_calendar,
-            to_string_options,
-        );
+        let zoned_date_time_string_result = this_zoned_date_time
+            .zoned_date_time()
+            .to_ixdtf_string_with_provider(
+                display_offset,
+                display_time_zone,
+                display_calendar,
+                to_string_options,
+                cx.temporal_provider(),
+            );
         let zoned_date_time_string = map_temporal_result(cx, zoned_date_time_string_result, NAME)?;
 
         Ok(cx.alloc_string(&zoned_date_time_string)?.as_value())
@@ -1018,12 +1029,15 @@ impl ZonedDateTimePrototype {
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let zoned_date_time_string_result = this_zoned_date_time.zoned_date_time().to_ixdtf_string(
-            DisplayOffset::default(),
-            DisplayTimeZone::default(),
-            DisplayCalendar::default(),
-            ToStringRoundingOptions::default(),
-        );
+        let zoned_date_time_string_result = this_zoned_date_time
+            .zoned_date_time()
+            .to_ixdtf_string_with_provider(
+                DisplayOffset::default(),
+                DisplayTimeZone::default(),
+                DisplayCalendar::default(),
+                ToStringRoundingOptions::default(),
+                cx.temporal_provider(),
+            );
         let zoned_date_time_string = map_temporal_result(cx, zoned_date_time_string_result, NAME)?;
 
         Ok(cx.alloc_string(&zoned_date_time_string)?.as_value())
@@ -1039,12 +1053,15 @@ impl ZonedDateTimePrototype {
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let zoned_date_time_string_result = this_zoned_date_time.zoned_date_time().to_ixdtf_string(
-            DisplayOffset::default(),
-            DisplayTimeZone::default(),
-            DisplayCalendar::default(),
-            ToStringRoundingOptions::default(),
-        );
+        let zoned_date_time_string_result = this_zoned_date_time
+            .zoned_date_time()
+            .to_ixdtf_string_with_provider(
+                DisplayOffset::default(),
+                DisplayTimeZone::default(),
+                DisplayCalendar::default(),
+                ToStringRoundingOptions::default(),
+                cx.temporal_provider(),
+            );
         let zoned_date_time_string = map_temporal_result(cx, zoned_date_time_string_result, NAME)?;
 
         Ok(cx.alloc_string(&zoned_date_time_string)?.as_value())
@@ -1107,11 +1124,12 @@ impl ZonedDateTimePrototype {
         let offset = get_offset_option(cx, options, OffsetDisambiguation::Prefer, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
-        let new_zoned_date_time_result = this_zoned_date_time.zoned_date_time().with(
+        let new_zoned_date_time_result = this_zoned_date_time.zoned_date_time().with_with_provider(
             prepared_fields.into_partial_zoned_date_time(),
             Some(disambiguation),
             Some(offset),
             Some(overflow),
+            cx.temporal_provider(),
         );
         let new_zoned_date_time = map_temporal_result(cx, new_zoned_date_time_result, NAME)?;
 
@@ -1135,8 +1153,9 @@ impl ZonedDateTimePrototype {
             Some(to_temporal_time(cx, time_arg, NAME)?)
         };
 
-        let new_zoned_date_time_result =
-            this_zoned_date_time.zoned_date_time().with_plain_time(time);
+        let new_zoned_date_time_result = this_zoned_date_time
+            .zoned_date_time()
+            .with_plain_time_and_provider(time, cx.temporal_provider());
         let new_zoned_date_time = map_temporal_result(cx, new_zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, new_zoned_date_time)?.as_value())
@@ -1157,7 +1176,7 @@ impl ZonedDateTimePrototype {
 
         let new_zoned_date_time_result = this_zoned_date_time
             .zoned_date_time()
-            .with_timezone(time_zone);
+            .with_time_zone_with_provider(time_zone, cx.temporal_provider());
         let new_zoned_date_time = map_temporal_result(cx, new_zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, new_zoned_date_time)?.as_value())
@@ -1193,7 +1212,9 @@ impl ZonedDateTimePrototype {
 
         let zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let start_of_day_result = zoned_date_time.zoned_date_time().start_of_day();
+        let start_of_day_result = zoned_date_time
+            .zoned_date_time()
+            .start_of_day_with_provider(cx.temporal_provider());
         let start_of_day = map_temporal_result(cx, start_of_day_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, start_of_day)?.as_value())
@@ -1229,7 +1250,7 @@ impl ZonedDateTimePrototype {
 
         let new_zoned_date_time_result = this_zoned_date_time
             .zoned_date_time()
-            .get_time_zone_transition(direction);
+            .get_time_zone_transition_with_provider(direction, cx.temporal_provider());
 
         match map_temporal_result(cx, new_zoned_date_time_result, NAME)? {
             Some(new_zoned_date_time) => {


### PR DESCRIPTION
## Summary

Instead of using the default `compiled` feature of `temporal_rs`, turn off default features and instead pass a provider to each temporal method that requires it.

Store the temporal provider on the context. Still use baked-in temporal data for now. This allows us to easily change the provider in the future or make it configurable.

## Tests

- All tests pass