### PR TITLE
[runtime] Properly perform delayed validation of PrepareCalendarFields result

### DIFF
--- a/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
@@ -184,11 +184,9 @@ pub fn to_temporal_date_with_options(
 
         let overflow = validate_overflow_option(cx, options, method_name)?;
 
-        let partial_date = PartialDate {
-            calendar,
-            calendar_fields: prepared_fields.into_partial_date(),
-        };
+        let calendar_fields = prepared_fields.into_validated_date_fields();
 
+        let partial_date = PartialDate { calendar, calendar_fields };
         let new_date = PlainDate::from_partial(partial_date, Some(overflow));
 
         return map_temporal_result(cx, new_date, method_name);

--- a/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
@@ -753,9 +753,9 @@ impl PlainDatePrototype {
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
-        let new_date_result = this_date
-            .date()
-            .with(prepared_fields.into_partial_date(), Some(overflow));
+        let fields = prepared_fields.into_validated_date_fields();
+
+        let new_date_result = this_date.date().with(fields, Some(overflow));
         let new_date = map_temporal_result(cx, new_date_result, NAME)?;
 
         Ok(PlainDateObject::new(cx, new_date)?.as_value())

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
@@ -218,9 +218,9 @@ fn to_temporal_date_time_with_options(
         let options = validate_options_object(cx, options, method_name)?;
         let overflow = get_overflow_option(cx, options, method_name)?;
 
-        let partial_date_time =
-            PartialDateTime { calendar, fields: prepared_fields.into_partial_date_time() };
+        let fields = prepared_fields.into_validated_date_time_fields(cx, overflow, method_name)?;
 
+        let partial_date_time = PartialDateTime { calendar, fields };
         let date_time_result = PlainDateTime::from_partial(partial_date_time, Some(overflow));
 
         return map_temporal_result(cx, date_time_result, method_name);

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
@@ -912,9 +912,9 @@ impl PlainDateTimePrototype {
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
-        let new_date_time_result = this_date_time
-            .date_time()
-            .with(prepared_fields.into_partial_date_time(), Some(overflow));
+        let fields = prepared_fields.into_validated_date_time_fields(cx, overflow, NAME)?;
+
+        let new_date_time_result = this_date_time.date_time().with(fields, Some(overflow));
         let new_date_time = map_temporal_result(cx, new_date_time_result, NAME)?;
 
         Ok(PlainDateTimeObject::new(cx, new_date_time)?.as_value())

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
@@ -153,11 +153,9 @@ pub fn to_temporal_month_day(
         let options = validate_options_object(cx, options_arg, method_name)?;
         let overflow = get_overflow_option(cx, options, method_name)?;
 
-        let partial_date = PartialDate {
-            calendar,
-            calendar_fields: prepared_fields.into_partial_date(),
-        };
+        let calendar_fields = prepared_fields.into_validated_date_fields();
 
+        let partial_date = PartialDate { calendar, calendar_fields };
         let month_day_result = PlainMonthDay::from_partial(partial_date, Some(overflow));
 
         return map_temporal_result(cx, month_day_result, method_name);

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
@@ -200,9 +200,9 @@ impl PlainMonthDayPrototype {
             NAME,
         )?;
 
-        let plain_date_result = this_month_day
-            .month_day()
-            .to_plain_date(Some(prepared_fields.into_partial_date()));
+        let fields = prepared_fields.into_validated_date_fields();
+
+        let plain_date_result = this_month_day.month_day().to_plain_date(Some(fields));
         let plain_date = map_temporal_result(cx, plain_date_result, NAME)?;
 
         Ok(PlainDateObject::new(cx, plain_date)?.as_value())
@@ -304,9 +304,9 @@ impl PlainMonthDayPrototype {
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
-        let new_month_day_result = this_month_day
-            .month_day()
-            .with(prepared_fields.into_partial_date(), Some(overflow));
+        let fields = prepared_fields.into_validated_date_fields();
+
+        let new_month_day_result = this_month_day.month_day().with(fields, Some(overflow));
         let new_month_day = map_temporal_result(cx, new_month_day_result, NAME)?;
 
         Ok(PlainMonthDayObject::new(cx, new_month_day)?.as_value())

--- a/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
@@ -1,4 +1,4 @@
-use temporal_rs::{PlainTime, options::Overflow, partial::PartialTime};
+use temporal_rs::PlainTime;
 
 use crate::runtime::{
     Context, Handle, Realm, Value,
@@ -7,18 +7,14 @@ use crate::runtime::{
     error::type_error,
     eval_result::EvalResult,
     function::get_argument,
-    get,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
         temporal::{
             plain_time_object::PlainTimeObject,
             utils::{
-                get_overflow_option, map_temporal_result, to_integer_with_truncation,
-                to_integer_with_truncation_or_zero, validate_hour_argument,
-                validate_micro_argument, validate_milli_argument, validate_minute_argument,
-                validate_nano_argument, validate_options_object, validate_second_argument,
-                validate_time_arguments,
+                get_overflow_option, map_temporal_result, to_integer_with_truncation_or_zero,
+                to_partial_time_record, validate_options_object, validate_time_arguments,
             },
         },
     },
@@ -199,149 +195,4 @@ pub fn to_temporal_time_with_options(
     get_overflow_option(cx, options, method_name)?;
 
     Ok(parsed_time)
-}
-
-/// A partial time record with unvalidated fields (clamped to their signed bounds).
-#[derive(Default, PartialEq)]
-pub struct PartialTimeRecord {
-    hour: Option<i8>,
-    minute: Option<i8>,
-    second: Option<i8>,
-    milli: Option<i16>,
-    micro: Option<i16>,
-    nano: Option<i16>,
-}
-
-impl PartialTimeRecord {
-    fn is_empty(&self) -> bool {
-        self == &PartialTimeRecord::default()
-    }
-
-    /// Clamp and validate the partial time record fields, depending on the overflow option.
-    pub fn clamp_and_validate(
-        &self,
-        cx: Context,
-        overflow: Overflow,
-        method_name: &str,
-    ) -> EvalResult<PartialTime> {
-        let hour = if let Some(hour) = self.hour {
-            if overflow == Overflow::Reject {
-                Some(validate_hour_argument(cx, hour, method_name)?)
-            } else {
-                Some(hour.max(0) as u8)
-            }
-        } else {
-            None
-        };
-
-        let minute = if let Some(minute) = self.minute {
-            if overflow == Overflow::Reject {
-                Some(validate_minute_argument(cx, minute, method_name)?)
-            } else {
-                Some(minute.max(0) as u8)
-            }
-        } else {
-            None
-        };
-
-        let second = if let Some(second) = self.second {
-            if overflow == Overflow::Reject {
-                Some(validate_second_argument(cx, second, method_name)?)
-            } else {
-                Some(second.max(0) as u8)
-            }
-        } else {
-            None
-        };
-
-        let milli = if let Some(milli) = self.milli {
-            if overflow == Overflow::Reject {
-                Some(validate_milli_argument(cx, milli, method_name)?)
-            } else {
-                Some(milli.max(0) as u16)
-            }
-        } else {
-            None
-        };
-
-        let micro = if let Some(micro) = self.micro {
-            if overflow == Overflow::Reject {
-                Some(validate_micro_argument(cx, micro, method_name)?)
-            } else {
-                Some(micro.max(0) as u16)
-            }
-        } else {
-            None
-        };
-
-        let nano = if let Some(nano) = self.nano {
-            if overflow == Overflow::Reject {
-                Some(validate_nano_argument(cx, nano, method_name)?)
-            } else {
-                Some(nano.max(0) as u16)
-            }
-        } else {
-            None
-        };
-
-        Ok(PartialTime {
-            hour,
-            minute,
-            second,
-            millisecond: milli,
-            microsecond: micro,
-            nanosecond: nano,
-        })
-    }
-}
-
-/// ToTemporalTimeRecord (https://tc39.es/proposal-temporal/#sec-temporal-totemporaltimerecord)
-pub fn to_partial_time_record(
-    cx: Context,
-    time_like_object: Handle<Value>,
-    method_name: &str,
-) -> EvalResult<PartialTimeRecord> {
-    if !time_like_object.is_object() {
-        return type_error(cx, &format!("{method_name} time must be an object"));
-    }
-
-    let object = time_like_object.as_object();
-
-    let mut record = PartialTimeRecord::default();
-
-    let hour_value = get(cx, object, cx.names.hour())?;
-    if !hour_value.is_undefined() {
-        record.hour = Some(to_integer_with_truncation(cx, hour_value, method_name)?);
-    }
-
-    let micro_value = get(cx, object, cx.names.microsecond())?;
-    if !micro_value.is_undefined() {
-        record.micro = Some(to_integer_with_truncation(cx, micro_value, method_name)?);
-    }
-
-    let milli_value = get(cx, object, cx.names.millisecond())?;
-    if !milli_value.is_undefined() {
-        record.milli = Some(to_integer_with_truncation(cx, milli_value, method_name)?);
-    }
-
-    let minute_value = get(cx, object, cx.names.minute())?;
-    if !minute_value.is_undefined() {
-        record.minute = Some(to_integer_with_truncation(cx, minute_value, method_name)?);
-    }
-
-    let nano_value = get(cx, object, cx.names.nanosecond())?;
-    if !nano_value.is_undefined() {
-        record.nano = Some(to_integer_with_truncation(cx, nano_value, method_name)?);
-    }
-
-    let second_value = get(cx, object, cx.names.second())?;
-    if !second_value.is_undefined() {
-        record.second = Some(to_integer_with_truncation(cx, second_value, method_name)?);
-    }
-
-    if record.is_empty() {
-        return type_error(cx, &format!("{method_name} time object is empty"));
-    }
-
-    Ok(record)
 }

--- a/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
@@ -11,13 +11,13 @@ use crate::runtime::{
         temporal::{
             duration_constructor::to_temporal_duration,
             duration_object::DurationObject,
-            plain_time_constructor::{to_partial_time_record, to_temporal_time},
+            plain_time_constructor::to_temporal_time,
             plain_time_object::PlainTimeObject,
             utils::{
                 DiffOperation, get_difference_settings, get_fractional_second_digits_option,
                 get_overflow_option, get_rounding_increment_option, get_rounding_mode_option,
                 get_unit_valued_option, is_partial_temporal_object, map_temporal_result,
-                parse_round_options_argument, validate_options_object,
+                parse_round_options_argument, to_partial_time_record, validate_options_object,
             },
         },
     },

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
@@ -168,11 +168,9 @@ pub fn to_temporal_year_month(
         let options = validate_options_object(cx, options_arg, method_name)?;
         let overflow = get_overflow_option(cx, options, method_name)?;
 
-        let partial_date = PartialYearMonth {
-            calendar,
-            calendar_fields: prepared_fields.into_partial_date().into(),
-        };
+        let calendar_fields = prepared_fields.into_validated_date_fields().into();
 
+        let partial_date = PartialYearMonth { calendar, calendar_fields };
         let year_month_result = PlainYearMonth::from_partial(partial_date, Some(overflow));
 
         return map_temporal_result(cx, year_month_result, method_name);

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
@@ -474,9 +474,9 @@ impl PlainYearMonthPrototype {
             NAME,
         )?;
 
-        let plain_date_result = this_year_month
-            .year_month()
-            .to_plain_date(Some(prepared_fields.into_partial_date()));
+        let fields = prepared_fields.into_validated_date_fields();
+
+        let plain_date_result = this_year_month.year_month().to_plain_date(Some(fields));
         let plain_date = map_temporal_result(cx, plain_date_result, NAME)?;
 
         Ok(PlainDateObject::new(cx, plain_date)?.as_value())
@@ -575,9 +575,9 @@ impl PlainYearMonthPrototype {
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
-        let new_year_month_result = this_year_month
-            .year_month()
-            .with(prepared_fields.into_partial_date().into(), Some(overflow));
+        let fields = prepared_fields.into_validated_date_fields().into();
+
+        let new_year_month_result = this_year_month.year_month().with(fields, Some(overflow));
         let new_year_month = map_temporal_result(cx, new_year_month_result, NAME)?;
 
         Ok(PlainYearMonthObject::new(cx, new_year_month)?.as_value())

--- a/src/js/runtime/intrinsics/temporal/utils.rs
+++ b/src/js/runtime/intrinsics/temporal/utils.rs
@@ -319,21 +319,21 @@ pub fn get_relative_to_option(
 
         // If no time zone is present interpret as a PlainDate
         let Some(time_zone) = prepared_fields.time_zone else {
-            let partial_date = PartialDate {
-                calendar,
-                calendar_fields: prepared_fields.into_partial_date(),
-            };
+            let calendar_fields = prepared_fields.into_validated_date_fields();
+            let partial_date = PartialDate { calendar, calendar_fields };
             let date_result = PlainDate::from_partial(partial_date, None);
             let date = map_temporal_result(cx, date_result, method_name)?;
 
             return Ok(Some(RelativeTo::PlainDate(date)));
         };
 
-        let partial_zoned_date_time = PartialZonedDateTime {
-            calendar,
-            timezone: Some(time_zone),
-            fields: prepared_fields.into_partial_zoned_date_time(),
-        };
+        // If time zone is present interpret as a ZonedDateTime
+        let overflow = Overflow::Constrain;
+        let fields =
+            prepared_fields.into_validated_zoned_date_time_fields(cx, overflow, method_name)?;
+
+        let partial_zoned_date_time =
+            PartialZonedDateTime { calendar, timezone: Some(time_zone), fields };
 
         let zoned_date_time_result = ZonedDateTime::from_partial_with_provider(
             partial_zoned_date_time,
@@ -808,30 +808,124 @@ const FIELD_ITERATION_ORDER: &[CalendarField] = &[
     CalendarField::Date(DateField::Year),
 ];
 
-pub struct PrepareCalendarFieldsResult {
+/// A partial time record with unvalidated fields (clamped to their signed bounds).
+#[derive(Default, PartialEq)]
+pub struct PartialTimeRecord {
+    hour: Option<i8>,
+    minute: Option<i8>,
+    second: Option<i8>,
+    milli: Option<i16>,
+    micro: Option<i16>,
+    nano: Option<i16>,
+}
+
+impl PartialTimeRecord {
+    pub fn is_empty(&self) -> bool {
+        self == &PartialTimeRecord::default()
+    }
+
+    /// Clamp and validate the partial time record fields, depending on the overflow option.
+    pub fn clamp_and_validate(
+        &self,
+        cx: Context,
+        overflow: Overflow,
+        method_name: &str,
+    ) -> EvalResult<PartialTime> {
+        let hour = if let Some(hour) = self.hour {
+            Some(validate_hour_argument(cx, hour, overflow, method_name)?)
+        } else {
+            None
+        };
+
+        let minute = if let Some(minute) = self.minute {
+            Some(validate_minute_argument(cx, minute, overflow, method_name)?)
+        } else {
+            None
+        };
+
+        let second = if let Some(second) = self.second {
+            Some(validate_second_argument(cx, second, overflow, method_name)?)
+        } else {
+            None
+        };
+
+        let milli = if let Some(milli) = self.milli {
+            Some(validate_milli_argument(cx, milli, overflow, method_name)?)
+        } else {
+            None
+        };
+
+        let micro = if let Some(micro) = self.micro {
+            Some(validate_micro_argument(cx, micro, overflow, method_name)?)
+        } else {
+            None
+        };
+
+        let nano = if let Some(nano) = self.nano {
+            Some(validate_nano_argument(cx, nano, overflow, method_name)?)
+        } else {
+            None
+        };
+
+        Ok(PartialTime {
+            hour,
+            minute,
+            second,
+            millisecond: milli,
+            microsecond: micro,
+            nanosecond: nano,
+        })
+    }
+}
+
+pub struct PreparedCalendarFields {
+    /// Unvalidated date fields. Clamped to bounds, which triggers correct validation error later.
     pub partial_date: CalendarFields,
-    pub partial_time: PartialTime,
+    /// Unvalidated time fields. Clamped to signed bounds and requires manual validation.
+    pub partial_time_record: PartialTimeRecord,
     pub offset: Option<UtcOffset>,
     pub time_zone: Option<TimeZone>,
 }
 
-impl PrepareCalendarFieldsResult {
-    pub fn into_partial_date(self) -> CalendarFields {
+impl PreparedCalendarFields {
+    fn to_validated_partial_time(
+        &self,
+        cx: Context,
+        overflow: Overflow,
+        method_name: &str,
+    ) -> EvalResult<PartialTime> {
+        self.partial_time_record
+            .clamp_and_validate(cx, overflow, method_name)
+    }
+
+    pub fn into_validated_date_fields(self) -> CalendarFields {
         self.partial_date
     }
 
-    pub fn into_partial_date_time(self) -> DateTimeFields {
-        DateTimeFields::new()
+    pub fn into_validated_date_time_fields(
+        self,
+        cx: Context,
+        overflow: Overflow,
+        method_name: &str,
+    ) -> EvalResult<DateTimeFields> {
+        let partial_time = self.to_validated_partial_time(cx, overflow, method_name)?;
+        Ok(DateTimeFields::new()
             .with_partial_date(self.partial_date)
-            .with_partial_time(self.partial_time)
+            .with_partial_time(partial_time))
     }
 
-    pub fn into_partial_zoned_date_time(self) -> ZonedDateTimeFields {
-        ZonedDateTimeFields {
+    pub fn into_validated_zoned_date_time_fields(
+        self,
+        cx: Context,
+        overflow: Overflow,
+        method_name: &str,
+    ) -> EvalResult<ZonedDateTimeFields> {
+        let partial_time = self.to_validated_partial_time(cx, overflow, method_name)?;
+        Ok(ZonedDateTimeFields {
             calendar_fields: self.partial_date,
-            time: self.partial_time,
+            time: partial_time,
             offset: self.offset,
-        }
+        })
     }
 }
 
@@ -843,9 +937,9 @@ pub fn prepare_calendar_fields(
     time_fields: &[TimeField],
     required: RequiredFieldNames,
     method_name: &str,
-) -> EvalResult<PrepareCalendarFieldsResult> {
+) -> EvalResult<PreparedCalendarFields> {
     let mut partial_date = CalendarFields::new();
-    let mut partial_time = PartialTime::new();
+    let mut partial_time_record = PartialTimeRecord::default();
     let mut offset = None;
     let mut time_zone = None;
 
@@ -886,28 +980,28 @@ pub fn prepare_calendar_fields(
             CalendarField::Time(TimeField::Hour) if time_fields.contains(&TimeField::Hour) => {
                 let value = get(cx, object, cx.names.hour())?;
                 if !value.is_undefined() {
-                    let converted_value = to_integer_with_truncation(cx, value, method_name)?;
-                    partial_time.hour = Some(converted_value);
+                    partial_time_record.hour =
+                        Some(to_integer_with_truncation(cx, value, method_name)?);
                 } else if required.provides_defaults() {
-                    partial_time.hour = Some(0);
+                    partial_time_record.hour = Some(0);
                 }
             }
             CalendarField::Time(TimeField::Minute) if time_fields.contains(&TimeField::Minute) => {
                 let value = get(cx, object, cx.names.minute())?;
                 if !value.is_undefined() {
-                    let converted_value = to_integer_with_truncation(cx, value, method_name)?;
-                    partial_time.minute = Some(converted_value);
+                    partial_time_record.minute =
+                        Some(to_integer_with_truncation(cx, value, method_name)?);
                 } else if required.provides_defaults() {
-                    partial_time.minute = Some(0);
+                    partial_time_record.minute = Some(0);
                 }
             }
             CalendarField::Time(TimeField::Second) if time_fields.contains(&TimeField::Second) => {
                 let value = get(cx, object, cx.names.second())?;
                 if !value.is_undefined() {
-                    let converted_value = to_integer_with_truncation(cx, value, method_name)?;
-                    partial_time.second = Some(converted_value);
+                    partial_time_record.second =
+                        Some(to_integer_with_truncation(cx, value, method_name)?);
                 } else if required.provides_defaults() {
-                    partial_time.second = Some(0);
+                    partial_time_record.second = Some(0);
                 }
             }
             CalendarField::Time(TimeField::Millisecond)
@@ -915,10 +1009,10 @@ pub fn prepare_calendar_fields(
             {
                 let value = get(cx, object, cx.names.millisecond())?;
                 if !value.is_undefined() {
-                    let converted_value = to_integer_with_truncation(cx, value, method_name)?;
-                    partial_time.millisecond = Some(converted_value);
+                    partial_time_record.milli =
+                        Some(to_integer_with_truncation(cx, value, method_name)?);
                 } else if required.provides_defaults() {
-                    partial_time.millisecond = Some(0);
+                    partial_time_record.milli = Some(0);
                 }
             }
             CalendarField::Time(TimeField::Microsecond)
@@ -926,10 +1020,10 @@ pub fn prepare_calendar_fields(
             {
                 let value = get(cx, object, cx.names.microsecond())?;
                 if !value.is_undefined() {
-                    let converted_value = to_integer_with_truncation(cx, value, method_name)?;
-                    partial_time.microsecond = Some(converted_value);
+                    partial_time_record.micro =
+                        Some(to_integer_with_truncation(cx, value, method_name)?);
                 } else if required.provides_defaults() {
-                    partial_time.microsecond = Some(0);
+                    partial_time_record.micro = Some(0);
                 }
             }
             CalendarField::Time(TimeField::Nanosecond)
@@ -937,10 +1031,10 @@ pub fn prepare_calendar_fields(
             {
                 let value = get(cx, object, cx.names.nanosecond())?;
                 if !value.is_undefined() {
-                    let converted_value = to_integer_with_truncation(cx, value, method_name)?;
-                    partial_time.nanosecond = Some(converted_value);
+                    partial_time_record.nano =
+                        Some(to_integer_with_truncation(cx, value, method_name)?);
                 } else if required.provides_defaults() {
-                    partial_time.nanosecond = Some(0);
+                    partial_time_record.nano = Some(0);
                 }
             }
             CalendarField::Time(TimeField::Offset) if time_fields.contains(&TimeField::Offset) => {
@@ -970,14 +1064,65 @@ pub fn prepare_calendar_fields(
 
     if !required.provides_defaults()
         && partial_date.is_empty()
-        && partial_time.is_empty()
+        && partial_time_record.is_empty()
         && offset.is_none()
         && time_zone.is_none()
     {
         return type_error(cx, &format!("{method_name} date-like object is empty"));
     }
 
-    Ok(PrepareCalendarFieldsResult { partial_date, partial_time, offset, time_zone })
+    Ok(PreparedCalendarFields { partial_date, partial_time_record, offset, time_zone })
+}
+
+/// ToTemporalTimeRecord (https://tc39.es/proposal-temporal/#sec-temporal-totemporaltimerecord)
+pub fn to_partial_time_record(
+    cx: Context,
+    time_like_object: Handle<Value>,
+    method_name: &str,
+) -> EvalResult<PartialTimeRecord> {
+    if !time_like_object.is_object() {
+        return type_error(cx, &format!("{method_name} time must be an object"));
+    }
+
+    let object = time_like_object.as_object();
+
+    let mut record = PartialTimeRecord::default();
+
+    let hour_value = get(cx, object, cx.names.hour())?;
+    if !hour_value.is_undefined() {
+        record.hour = Some(to_integer_with_truncation(cx, hour_value, method_name)?);
+    }
+
+    let micro_value = get(cx, object, cx.names.microsecond())?;
+    if !micro_value.is_undefined() {
+        record.micro = Some(to_integer_with_truncation(cx, micro_value, method_name)?);
+    }
+
+    let milli_value = get(cx, object, cx.names.millisecond())?;
+    if !milli_value.is_undefined() {
+        record.milli = Some(to_integer_with_truncation(cx, milli_value, method_name)?);
+    }
+
+    let minute_value = get(cx, object, cx.names.minute())?;
+    if !minute_value.is_undefined() {
+        record.minute = Some(to_integer_with_truncation(cx, minute_value, method_name)?);
+    }
+
+    let nano_value = get(cx, object, cx.names.nanosecond())?;
+    if !nano_value.is_undefined() {
+        record.nano = Some(to_integer_with_truncation(cx, nano_value, method_name)?);
+    }
+
+    let second_value = get(cx, object, cx.names.second())?;
+    if !second_value.is_undefined() {
+        record.second = Some(to_integer_with_truncation(cx, second_value, method_name)?);
+    }
+
+    if record.is_empty() {
+        return type_error(cx, &format!("{method_name} time object is empty"));
+    }
+
+    Ok(record)
 }
 
 pub fn validate_time_arguments(
@@ -990,60 +1135,104 @@ pub fn validate_time_arguments(
     nanos: i16,
     method_name: &str,
 ) -> EvalResult<(u8, u8, u8, u16, u16, u16)> {
-    let hour = validate_hour_argument(cx, hour, method_name)?;
-    let minute = validate_minute_argument(cx, minute, method_name)?;
-    let second = validate_second_argument(cx, second, method_name)?;
-    let millis = validate_milli_argument(cx, millis, method_name)?;
-    let micros = validate_micro_argument(cx, micros, method_name)?;
-    let nanos = validate_nano_argument(cx, nanos, method_name)?;
+    let overflow = Overflow::Reject;
+
+    let hour = validate_hour_argument(cx, hour, overflow, method_name)?;
+    let minute = validate_minute_argument(cx, minute, overflow, method_name)?;
+    let second = validate_second_argument(cx, second, overflow, method_name)?;
+    let millis = validate_milli_argument(cx, millis, overflow, method_name)?;
+    let micros = validate_micro_argument(cx, micros, overflow, method_name)?;
+    let nanos = validate_nano_argument(cx, nanos, overflow, method_name)?;
 
     Ok((hour, minute, second, millis, micros, nanos))
 }
 
-pub fn validate_hour_argument(cx: Context, hour: i8, method_name: &str) -> EvalResult<u8> {
-    if !(0..=23).contains(&hour) {
-        return range_error(cx, &format!("{method_name} hour must be in range 0-23"));
+pub fn validate_hour_argument(
+    cx: Context,
+    hour: i8,
+    overflow: Overflow,
+    method_name: &str,
+) -> EvalResult<u8> {
+    match overflow {
+        Overflow::Reject if !(0..=23).contains(&hour) => {
+            range_error(cx, &format!("{method_name} hour must be in range 0-23"))
+        }
+        Overflow::Reject => Ok(hour as u8),
+        Overflow::Constrain => Ok(hour.max(0) as u8),
     }
-
-    Ok(hour as u8)
 }
 
-pub fn validate_minute_argument(cx: Context, minute: i8, method_name: &str) -> EvalResult<u8> {
-    if !(0..=59).contains(&minute) {
-        return range_error(cx, &format!("{method_name} minute must be in range 0-59"));
+pub fn validate_minute_argument(
+    cx: Context,
+    minute: i8,
+    overflow: Overflow,
+    method_name: &str,
+) -> EvalResult<u8> {
+    match overflow {
+        Overflow::Reject if !(0..=59).contains(&minute) => {
+            range_error(cx, &format!("{method_name} minute must be in range 0-59"))
+        }
+        Overflow::Reject => Ok(minute as u8),
+        Overflow::Constrain => Ok(minute.max(0) as u8),
     }
-
-    Ok(minute as u8)
 }
 
-pub fn validate_second_argument(cx: Context, second: i8, method_name: &str) -> EvalResult<u8> {
-    if !(0..=59).contains(&second) {
-        return range_error(cx, &format!("{method_name} second must be in range 0-59"));
+pub fn validate_second_argument(
+    cx: Context,
+    second: i8,
+    overflow: Overflow,
+    method_name: &str,
+) -> EvalResult<u8> {
+    match overflow {
+        Overflow::Reject if !(0..=59).contains(&second) => {
+            range_error(cx, &format!("{method_name} second must be in range 0-59"))
+        }
+        Overflow::Reject => Ok(second as u8),
+        Overflow::Constrain => Ok(second.max(0) as u8),
     }
-
-    Ok(second as u8)
 }
 
-pub fn validate_milli_argument(cx: Context, millis: i16, method_name: &str) -> EvalResult<u16> {
-    if !(0..=999).contains(&millis) {
-        return range_error(cx, &format!("{method_name} millisecond must be in range 0-999"));
+pub fn validate_milli_argument(
+    cx: Context,
+    millis: i16,
+    overflow: Overflow,
+    method_name: &str,
+) -> EvalResult<u16> {
+    match overflow {
+        Overflow::Reject if !(0..=999).contains(&millis) => {
+            range_error(cx, &format!("{method_name} millisecond must be in range 0-999"))
+        }
+        Overflow::Reject => Ok(millis as u16),
+        Overflow::Constrain => Ok(millis.max(0) as u16),
     }
-
-    Ok(millis as u16)
 }
 
-pub fn validate_micro_argument(cx: Context, micros: i16, method_name: &str) -> EvalResult<u16> {
-    if !(0..=999).contains(&micros) {
-        return range_error(cx, &format!("{method_name} microsecond must be in range 0-999"));
+pub fn validate_micro_argument(
+    cx: Context,
+    micros: i16,
+    overflow: Overflow,
+    method_name: &str,
+) -> EvalResult<u16> {
+    match overflow {
+        Overflow::Reject if !(0..=999).contains(&micros) => {
+            range_error(cx, &format!("{method_name} microsecond must be in range 0-999"))
+        }
+        Overflow::Reject => Ok(micros as u16),
+        Overflow::Constrain => Ok(micros.max(0) as u16),
     }
-
-    Ok(micros as u16)
 }
 
-pub fn validate_nano_argument(cx: Context, nanos: i16, method_name: &str) -> EvalResult<u16> {
-    if !(0..=999).contains(&nanos) {
-        return range_error(cx, &format!("{method_name} nanosecond must be in range 0-999"));
+pub fn validate_nano_argument(
+    cx: Context,
+    nanos: i16,
+    overflow: Overflow,
+    method_name: &str,
+) -> EvalResult<u16> {
+    match overflow {
+        Overflow::Reject if !(0..=999).contains(&nanos) => {
+            range_error(cx, &format!("{method_name} nanosecond must be in range 0-999"))
+        }
+        Overflow::Reject => Ok(nanos as u16),
+        Overflow::Constrain => Ok(nanos.max(0) as u16),
     }
-
-    Ok(nanos as u16)
 }

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
@@ -205,12 +205,12 @@ pub fn to_temporal_zoned_date_time_with_options(
 
         let (disambiguation, offset, overflow) = validate_options(cx, options, method_name)?;
 
-        let partial_zoned_date_time = PartialZonedDateTime {
-            calendar,
-            timezone: prepared_fields.time_zone,
-            fields: prepared_fields.into_partial_zoned_date_time(),
-        };
+        let time_zone = prepared_fields.time_zone;
+        let fields =
+            prepared_fields.into_validated_zoned_date_time_fields(cx, overflow, method_name)?;
 
+        let partial_zoned_date_time =
+            PartialZonedDateTime { calendar, timezone: time_zone, fields };
         let zoned_date_time_result = ZonedDateTime::from_partial_with_provider(
             partial_zoned_date_time,
             Some(overflow),

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
@@ -1124,8 +1124,10 @@ impl ZonedDateTimePrototype {
         let offset = get_offset_option(cx, options, OffsetDisambiguation::Prefer, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
+        let fields = prepared_fields.into_validated_zoned_date_time_fields(cx, overflow, NAME)?;
+
         let new_zoned_date_time_result = this_zoned_date_time.zoned_date_time().with_with_provider(
-            prepared_fields.into_partial_zoned_date_time(),
+            fields,
             Some(disambiguation),
             Some(offset),
             Some(overflow),

--- a/tests/integration/built-ins/Temporal/PlainDate/from/validate_field_range.js
+++ b/tests/integration/built-ins/Temporal/PlainDate/from/validate_field_range.js
@@ -1,0 +1,35 @@
+/*---
+description: Temporal.PlainDate.from errors for out of bounds date fields.
+---*/
+
+// Day out of range
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 2000, month: 1, day: 0 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 2000, month: 1, day: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 2000, month: 1, day: 32 }, { overflow: 'reject' }));
+
+// Month out of range
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 2000, month: 0, day: 1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 2000, month: -1, day: 1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 2000, month: 13, day: 1 }, { overflow: 'reject' }));
+
+// Year out of range
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: -271822, month: 12, day: 31 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: -999999, month: 1, day: 1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 275761, month: 1, day: 1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDate.from({ year: 999999, month: 1, day: 1 }, { overflow: 'reject' }));
+
+// Valid minimum bounds
+const minFields = Temporal.PlainDate.from({ year: 2000, month: 1, day: 1 }, { overflow: 'reject' });
+assert.sameValue(minFields.month, 1);
+assert.sameValue(minFields.day, 1);
+
+const minYear = Temporal.PlainDate.from({ year: -271821, month: 12, day: 31 }, { overflow: 'reject' });
+assert.sameValue(minYear.year, -271821);
+
+// Valid maximum bounds
+const maxFields = Temporal.PlainDate.from({ year: 2000, month: 12, day: 31 }, { overflow: 'reject' });
+assert.sameValue(maxFields.month, 12);
+assert.sameValue(maxFields.day, 31);
+
+const maxYear = Temporal.PlainDate.from({ year: 275760, month: 1, day: 1 }, { overflow: 'reject' });
+assert.sameValue(maxYear.year, 275760);

--- a/tests/integration/built-ins/Temporal/PlainDate/prototype/with/validate_field_range.js
+++ b/tests/integration/built-ins/Temporal/PlainDate/prototype/with/validate_field_range.js
@@ -1,0 +1,38 @@
+/*---
+description: Temporal.PlainDate.prototype.with errors for out of bounds date fields.
+---*/
+
+const yearStart = new Temporal.PlainDate(2000, 1, 1);
+const yearEnd = new Temporal.PlainDate(2000, 12, 31);
+
+// Day out of range
+assert.throws(RangeError, () => yearStart.with({ day: 0 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ day: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ day: 32 }, { overflow: 'reject' }));
+
+// Month out of range
+assert.throws(RangeError, () => yearStart.with({ month: 0 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ month: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ month: 13 }, { overflow: 'reject' }));
+
+// Year out of range
+assert.throws(RangeError, () => yearEnd.with({ year: -271822 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ year: -999999 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ year: 275761 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ year: 999999 }, { overflow: 'reject' }));
+
+// Valid minimum bounds
+const minFields = yearStart.with({ month: 1, day: 1 }, { overflow: 'reject' });
+assert.sameValue(minFields.month, 1);
+assert.sameValue(minFields.day, 1);
+
+const minYear = yearEnd.with({ year: -271821 }, { overflow: 'reject' });
+assert.sameValue(minYear.year, -271821);
+
+// Valid maximum bounds
+const maxFields = yearStart.with({ month: 12, day: 31 }, { overflow: 'reject' });
+assert.sameValue(maxFields.month, 12);
+assert.sameValue(maxFields.day, 31);
+
+const maxYear = yearStart.with({ year: 275760 }, { overflow: 'reject' });
+assert.sameValue(maxYear.year, 275760);

--- a/tests/integration/built-ins/Temporal/PlainDateTime/from/validate_field_range.js
+++ b/tests/integration/built-ins/Temporal/PlainDateTime/from/validate_field_range.js
@@ -1,0 +1,77 @@
+/*---
+description: Temporal.PlainDateTime.from errors for out of bounds time and date fields.
+---*/
+
+// Hour out of range
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 1, hour: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 1, hour: 24 }, { overflow: 'reject' }));
+
+// Minute out of range
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 1, minute: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 1, minute: 60 }, { overflow: 'reject' }));
+
+// Second out of range
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 1, second: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 1, second: 60 }, { overflow: 'reject' }));
+
+// Millisecond out of range
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 1, millisecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 1, millisecond: 1000 }, { overflow: 'reject' }));
+
+// Microsecond out of range
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 1, microsecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 1, microsecond: 1000 }, { overflow: 'reject' }));
+
+// Nanosecond out of range
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 1, nanosecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 1, nanosecond: 1000 }, { overflow: 'reject' }));
+
+// Day out of range
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 0 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 1, day: 32 }, { overflow: 'reject' }));
+
+// Month out of range
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 0, day: 1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: -1, day: 1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 2020, month: 13, day: 1 }, { overflow: 'reject' }));
+
+// Year out of range
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: -271822, month: 12, day: 31 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: -999999, month: 1, day: 1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 275761, month: 1, day: 1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainDateTime.from({ year: 999999, month: 1, day: 1 }, { overflow: 'reject' }));
+
+// Valid minimum bounds
+const minFields = Temporal.PlainDateTime.from(
+    { year: 2020, month: 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 },
+    { overflow: 'reject' }
+);
+assert.sameValue(minFields.month, 1);
+assert.sameValue(minFields.day, 1);
+assert.sameValue(minFields.hour, 0);
+assert.sameValue(minFields.minute, 0);
+assert.sameValue(minFields.second, 0);
+assert.sameValue(minFields.millisecond, 0);
+assert.sameValue(minFields.microsecond, 0);
+assert.sameValue(minFields.nanosecond, 0);
+
+const minYear = Temporal.PlainDateTime.from({ year: -271821, month: 12, day: 31 }, { overflow: 'reject' });
+assert.sameValue(minYear.year, -271821);
+
+// Valid maximum bounds
+const maxFields = Temporal.PlainDateTime.from(
+    { year: 2020, month: 12, day: 31, hour: 23, minute: 59, second: 59, millisecond: 999, microsecond: 999, nanosecond: 999 },
+    { overflow: 'reject' }
+);
+assert.sameValue(maxFields.month, 12);
+assert.sameValue(maxFields.day, 31);
+assert.sameValue(maxFields.hour, 23);
+assert.sameValue(maxFields.minute, 59);
+assert.sameValue(maxFields.second, 59);
+assert.sameValue(maxFields.millisecond, 999);
+assert.sameValue(maxFields.microsecond, 999);
+assert.sameValue(maxFields.nanosecond, 999);
+
+const maxYear = Temporal.PlainDateTime.from({ year: 275760, month: 1, day: 1 }, { overflow: 'reject' });
+assert.sameValue(maxYear.year, 275760);

--- a/tests/integration/built-ins/Temporal/PlainDateTime/prototype/with/validate_field_range.js
+++ b/tests/integration/built-ins/Temporal/PlainDateTime/prototype/with/validate_field_range.js
@@ -1,0 +1,80 @@
+/*---
+description: Temporal.PlainDateTime.prototype.with errors for out of bounds time and date fields.
+---*/
+
+const yearStart = Temporal.PlainDateTime.from('2020-01-01T00:00:00');
+const yearEnd   = Temporal.PlainDateTime.from('2020-12-31T00:00:00');
+
+// Hour out of range
+assert.throws(RangeError, () => yearStart.with({ hour: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ hour: 24 }, { overflow: 'reject' }));
+
+// Minute out of range
+assert.throws(RangeError, () => yearStart.with({ minute: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ minute: 60 }, { overflow: 'reject' }));
+
+// Second out of range
+assert.throws(RangeError, () => yearStart.with({ second: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ second: 60 }, { overflow: 'reject' }));
+
+// Millisecond out of range
+assert.throws(RangeError, () => yearStart.with({ millisecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ millisecond: 1000 }, { overflow: 'reject' }));
+
+// Microsecond out of range
+assert.throws(RangeError, () => yearStart.with({ microsecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ microsecond: 1000 }, { overflow: 'reject' }));
+
+// Nanosecond out of range
+assert.throws(RangeError, () => yearStart.with({ nanosecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ nanosecond: 1000 }, { overflow: 'reject' }));
+
+// Day out of range
+assert.throws(RangeError, () => yearStart.with({ day: 0 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ day: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ day: 32 }, { overflow: 'reject' }));
+
+// Month out of range
+assert.throws(RangeError, () => yearStart.with({ month: 0 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ month: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ month: 13 }, { overflow: 'reject' }));
+
+// Year out of range
+assert.throws(RangeError, () => yearEnd.with({ year: -271822 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ year: -999999 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ year: 275761 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ year: 999999 }, { overflow: 'reject' }));
+
+// Valid minimum bounds
+const minFields = yearStart.with(
+    { month: 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 },
+    { overflow: 'reject' }
+);
+assert.sameValue(minFields.month, 1);
+assert.sameValue(minFields.day, 1);
+assert.sameValue(minFields.hour, 0);
+assert.sameValue(minFields.minute, 0);
+assert.sameValue(minFields.second, 0);
+assert.sameValue(minFields.millisecond, 0);
+assert.sameValue(minFields.microsecond, 0);
+assert.sameValue(minFields.nanosecond, 0);
+
+const minYear = yearEnd.with({ year: -271821 }, { overflow: 'reject' });
+assert.sameValue(minYear.year, -271821);
+
+// Valid maximum bounds
+const maxFields = yearStart.with(
+    { month: 12, day: 31, hour: 23, minute: 59, second: 59, millisecond: 999, microsecond: 999, nanosecond: 999 },
+    { overflow: 'reject' }
+);
+assert.sameValue(maxFields.month, 12);
+assert.sameValue(maxFields.day, 31);
+assert.sameValue(maxFields.hour, 23);
+assert.sameValue(maxFields.minute, 59);
+assert.sameValue(maxFields.second, 59);
+assert.sameValue(maxFields.millisecond, 999);
+assert.sameValue(maxFields.microsecond, 999);
+assert.sameValue(maxFields.nanosecond, 999);
+
+const maxYear = yearStart.with({ year: 275760 }, { overflow: 'reject' });
+assert.sameValue(maxYear.year, 275760);

--- a/tests/integration/built-ins/Temporal/PlainMonthDay/from/validate_field_range.js
+++ b/tests/integration/built-ins/Temporal/PlainMonthDay/from/validate_field_range.js
@@ -1,0 +1,23 @@
+/*---
+description: Temporal.PlainMonthDay.from errors for out of bounds date fields.
+---*/
+
+// Day out of range
+assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ month: 1, day: 0 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ month: 1, day: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ month: 1, day: 32 }, { overflow: 'reject' }));
+
+// Month out of range
+assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ month: 0, day: 1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ month: -1, day: 1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainMonthDay.from({ month: 13, day: 1 }, { overflow: 'reject' }));
+
+// Valid minimum bounds
+const minDay = Temporal.PlainMonthDay.from({ month: 1, day: 1 }, { overflow: 'reject' });
+assert.sameValue(minDay.monthCode, "M01");
+assert.sameValue(minDay.day, 1);
+
+// Valid maximum bounds
+const maxDay = Temporal.PlainMonthDay.from({ month: 12, day: 31 }, { overflow: 'reject' });
+assert.sameValue(maxDay.monthCode, "M12");
+assert.sameValue(maxDay.day, 31);

--- a/tests/integration/built-ins/Temporal/PlainMonthDay/prototype/with/validate_field_range.js
+++ b/tests/integration/built-ins/Temporal/PlainMonthDay/prototype/with/validate_field_range.js
@@ -1,0 +1,25 @@
+/*---
+description: Temporal.PlainMonthDay.prototype.with errors for out of bounds date fields.
+---*/
+
+const base = Temporal.PlainMonthDay.from({ month: 1, day: 1 });
+
+// Day out of range
+assert.throws(RangeError, () => base.with({ day: 0 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => base.with({ day: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => base.with({ day: 32 }, { overflow: 'reject' }));
+
+// Month out of range
+assert.throws(RangeError, () => base.with({ month: 0 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => base.with({ month: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => base.with({ month: 13 }, { overflow: 'reject' }));
+
+// Valid minimum bounds
+const minDay = base.with({ month: 1, day: 1 }, { overflow: 'reject' });
+assert.sameValue(minDay.monthCode, "M01");
+assert.sameValue(minDay.day, 1);
+
+// Valid maximum bounds
+const maxDay = base.with({ month: 12, day: 31 }, { overflow: 'reject' });
+assert.sameValue(maxDay.monthCode, "M12");
+assert.sameValue(maxDay.day, 31);

--- a/tests/integration/built-ins/Temporal/PlainTime/from/validate_field_range.js
+++ b/tests/integration/built-ins/Temporal/PlainTime/from/validate_field_range.js
@@ -1,0 +1,51 @@
+/*---
+description: Temporal.PlainTime.from errors for out of bounds time fields.
+---*/
+
+// Hour out of range
+assert.throws(RangeError, () => Temporal.PlainTime.from({ hour: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainTime.from({ hour: 24 }, { overflow: 'reject' }));
+
+// Minute out of range
+assert.throws(RangeError, () => Temporal.PlainTime.from({ minute: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainTime.from({ minute: 60 }, { overflow: 'reject' }));
+
+// Second out of range
+assert.throws(RangeError, () => Temporal.PlainTime.from({ second: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainTime.from({ second: 60 }, { overflow: 'reject' }));
+
+// Millisecond out of range
+assert.throws(RangeError, () => Temporal.PlainTime.from({ millisecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainTime.from({ millisecond: 1000 }, { overflow: 'reject' }));
+
+// Microsecond out of range
+assert.throws(RangeError, () => Temporal.PlainTime.from({ microsecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainTime.from({ microsecond: 1000 }, { overflow: 'reject' }));
+
+// Nanosecond out of range
+assert.throws(RangeError, () => Temporal.PlainTime.from({ nanosecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainTime.from({ nanosecond: 1000 }, { overflow: 'reject' }));
+
+// Valid minimum bounds
+const minFields = Temporal.PlainTime.from(
+    { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 },
+    { overflow: 'reject' }
+);
+assert.sameValue(minFields.hour, 0);
+assert.sameValue(minFields.minute, 0);
+assert.sameValue(minFields.second, 0);
+assert.sameValue(minFields.millisecond, 0);
+assert.sameValue(minFields.microsecond, 0);
+assert.sameValue(minFields.nanosecond, 0);
+
+// Valid maximum bounds
+const maxFields = Temporal.PlainTime.from(
+    { hour: 23, minute: 59, second: 59, millisecond: 999, microsecond: 999, nanosecond: 999 },
+    { overflow: 'reject' }
+);
+assert.sameValue(maxFields.hour, 23);
+assert.sameValue(maxFields.minute, 59);
+assert.sameValue(maxFields.second, 59);
+assert.sameValue(maxFields.millisecond, 999);
+assert.sameValue(maxFields.microsecond, 999);
+assert.sameValue(maxFields.nanosecond, 999);

--- a/tests/integration/built-ins/Temporal/PlainTime/prototype/with/validate_field_range.js
+++ b/tests/integration/built-ins/Temporal/PlainTime/prototype/with/validate_field_range.js
@@ -1,0 +1,53 @@
+/*---
+description: Temporal.PlainTime.prototype.with errors for out of bounds time fields.
+---*/
+
+const base = Temporal.PlainTime.from('12:30:45.100200300');
+
+// Hour out of range
+assert.throws(RangeError, () => base.with({ hour: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => base.with({ hour: 24 }, { overflow: 'reject' }));
+
+// Minute out of range
+assert.throws(RangeError, () => base.with({ minute: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => base.with({ minute: 60 }, { overflow: 'reject' }));
+
+// Second out of range
+assert.throws(RangeError, () => base.with({ second: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => base.with({ second: 60 }, { overflow: 'reject' }));
+
+// Millisecond out of range
+assert.throws(RangeError, () => base.with({ millisecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => base.with({ millisecond: 1000 }, { overflow: 'reject' }));
+
+// Microsecond out of range
+assert.throws(RangeError, () => base.with({ microsecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => base.with({ microsecond: 1000 }, { overflow: 'reject' }));
+
+// Nanosecond out of range
+assert.throws(RangeError, () => base.with({ nanosecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => base.with({ nanosecond: 1000 }, { overflow: 'reject' }));
+
+// Valid minimum bounds
+const minFields = base.with(
+    { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 },
+    { overflow: 'reject' }
+);
+assert.sameValue(minFields.hour, 0);
+assert.sameValue(minFields.minute, 0);
+assert.sameValue(minFields.second, 0);
+assert.sameValue(minFields.millisecond, 0);
+assert.sameValue(minFields.microsecond, 0);
+assert.sameValue(minFields.nanosecond, 0);
+
+// Valid maximum bounds
+const maxFields = base.with(
+    { hour: 23, minute: 59, second: 59, millisecond: 999, microsecond: 999, nanosecond: 999 },
+    { overflow: 'reject' }
+);
+assert.sameValue(maxFields.hour, 23);
+assert.sameValue(maxFields.minute, 59);
+assert.sameValue(maxFields.second, 59);
+assert.sameValue(maxFields.millisecond, 999);
+assert.sameValue(maxFields.microsecond, 999);
+assert.sameValue(maxFields.nanosecond, 999);

--- a/tests/integration/built-ins/Temporal/PlainYearMonth/from/validate_field_range.js
+++ b/tests/integration/built-ins/Temporal/PlainYearMonth/from/validate_field_range.js
@@ -1,0 +1,28 @@
+/*---
+description: Temporal.PlainYearMonth.from errors for out of bounds date fields.
+---*/
+
+// Month out of range
+assert.throws(RangeError, () => Temporal.PlainYearMonth.from({ year: 2020, month: 0 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainYearMonth.from({ year: 2020, month: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainYearMonth.from({ year: 2020, month: 13 }, { overflow: 'reject' }));
+
+// Year out of range
+assert.throws(RangeError, () => Temporal.PlainYearMonth.from({ year: -271822, month: 1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainYearMonth.from({ year: -999999, month: 1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainYearMonth.from({ year: 275761, month: 1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.PlainYearMonth.from({ year: 999999, month: 1 }, { overflow: 'reject' }));
+
+// Valid minimum bounds
+const minMonth = Temporal.PlainYearMonth.from({ year: 2020, month: 1 }, { overflow: 'reject' });
+assert.sameValue(minMonth.month, 1);
+
+const minYear = Temporal.PlainYearMonth.from({ year: -271821, month: 12 }, { overflow: 'reject' });
+assert.sameValue(minYear.year, -271821);
+
+// Valid maximum bounds
+const maxMonth = Temporal.PlainYearMonth.from({ year: 2020, month: 12 }, { overflow: 'reject' });
+assert.sameValue(maxMonth.month, 12);
+
+const maxYear = Temporal.PlainYearMonth.from({ year: 275760, month: 1 }, { overflow: 'reject' });
+assert.sameValue(maxYear.year, 275760);

--- a/tests/integration/built-ins/Temporal/PlainYearMonth/prototype/with/validate_field_range.js
+++ b/tests/integration/built-ins/Temporal/PlainYearMonth/prototype/with/validate_field_range.js
@@ -1,0 +1,31 @@
+/*---
+description: Temporal.PlainYearMonth.prototype.with errors for out of bounds date fields.
+---*/
+
+const yearStart = Temporal.PlainYearMonth.from('2020-01');
+const yearEnd   = Temporal.PlainYearMonth.from('2020-12');
+
+// Month out of range
+assert.throws(RangeError, () => yearStart.with({ month: 0 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ month: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ month: 13 }, { overflow: 'reject' }));
+
+// Year out of range
+assert.throws(RangeError, () => yearEnd.with({ year: -271822 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ year: -999999 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ year: 275761 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ year: 999999 }, { overflow: 'reject' }));
+
+// Valid minimum bounds
+const minMonth = yearStart.with({ month: 1 }, { overflow: 'reject' });
+assert.sameValue(minMonth.month, 1);
+
+const minYear = yearEnd.with({ year: -271821 }, { overflow: 'reject' });
+assert.sameValue(minYear.year, -271821);
+
+// Valid maximum bounds
+const maxMonth = yearStart.with({ month: 12 }, { overflow: 'reject' });
+assert.sameValue(maxMonth.month, 12);
+
+const maxYear = yearStart.with({ year: 275760 }, { overflow: 'reject' });
+assert.sameValue(maxYear.year, 275760);

--- a/tests/integration/built-ins/Temporal/ZonedDateTime/from/validate_field_range.js
+++ b/tests/integration/built-ins/Temporal/ZonedDateTime/from/validate_field_range.js
@@ -1,0 +1,77 @@
+/*---
+description: Temporal.ZonedDateTime.from errors for out of bounds time and date fields.
+---*/
+
+// Hour out of range
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'UTC', hour: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'UTC', hour: 24 }, { overflow: 'reject' }));
+
+// Minute out of range
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'UTC', minute: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'UTC', minute: 60 }, { overflow: 'reject' }));
+
+// Second out of range
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'UTC', second: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'UTC', second: 60 }, { overflow: 'reject' }));
+
+// Millisecond out of range
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'UTC', millisecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'UTC', millisecond: 1000 }, { overflow: 'reject' }));
+
+// Microsecond out of range
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'UTC', microsecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'UTC', microsecond: 1000 }, { overflow: 'reject' }));
+
+// Nanosecond out of range
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'UTC', nanosecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 1, timeZone: 'UTC', nanosecond: 1000 }, { overflow: 'reject' }));
+
+// Day out of range
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 0, timeZone: 'UTC' }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: -1, timeZone: 'UTC' }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 1, day: 32, timeZone: 'UTC' }, { overflow: 'reject' }));
+
+// Month out of range
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 0, day: 1, timeZone: 'UTC' }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: -1, day: 1, timeZone: 'UTC' }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 2020, month: 13, day: 1, timeZone: 'UTC' }, { overflow: 'reject' }));
+
+// Year out of range
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: -271822, month: 12, day: 31, timeZone: 'UTC' }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: -999999, month: 1, day: 1, timeZone: 'UTC' }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 275761, month: 1, day: 1, timeZone: 'UTC' }, { overflow: 'reject' }));
+assert.throws(RangeError, () => Temporal.ZonedDateTime.from({ year: 999999, month: 1, day: 1, timeZone: 'UTC' }, { overflow: 'reject' }));
+
+// Valid minimum bounds
+const minFields = Temporal.ZonedDateTime.from(
+    { year: 2020, month: 1, day: 1, timeZone: 'UTC', hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 },
+    { overflow: 'reject' }
+);
+assert.sameValue(minFields.month, 1);
+assert.sameValue(minFields.day, 1);
+assert.sameValue(minFields.hour, 0);
+assert.sameValue(minFields.minute, 0);
+assert.sameValue(minFields.second, 0);
+assert.sameValue(minFields.millisecond, 0);
+assert.sameValue(minFields.microsecond, 0);
+assert.sameValue(minFields.nanosecond, 0);
+
+const minYear = Temporal.ZonedDateTime.from({ year: -271821, month: 12, day: 31, timeZone: 'UTC' }, { overflow: 'reject' });
+assert.sameValue(minYear.year, -271821);
+
+// Valid maximum bounds
+const maxFields = Temporal.ZonedDateTime.from(
+    { year: 2020, month: 12, day: 31, timeZone: 'UTC', hour: 23, minute: 59, second: 59, millisecond: 999, microsecond: 999, nanosecond: 999 },
+    { overflow: 'reject' }
+);
+assert.sameValue(maxFields.month, 12);
+assert.sameValue(maxFields.day, 31);
+assert.sameValue(maxFields.hour, 23);
+assert.sameValue(maxFields.minute, 59);
+assert.sameValue(maxFields.second, 59);
+assert.sameValue(maxFields.millisecond, 999);
+assert.sameValue(maxFields.microsecond, 999);
+assert.sameValue(maxFields.nanosecond, 999);
+
+const maxYear = Temporal.ZonedDateTime.from({ year: 275760, month: 1, day: 1, timeZone: 'UTC' }, { overflow: 'reject' });
+assert.sameValue(maxYear.year, 275760);

--- a/tests/integration/built-ins/Temporal/ZonedDateTime/prototype/with/validate_field_range.js
+++ b/tests/integration/built-ins/Temporal/ZonedDateTime/prototype/with/validate_field_range.js
@@ -1,0 +1,80 @@
+/*---
+description: Temporal.ZonedDateTime.prototype.with errors for out of bounds time and date fields.
+---*/
+
+const yearStart = Temporal.ZonedDateTime.from('2020-01-01T00:00:00[UTC]');
+const yearEnd   = Temporal.ZonedDateTime.from('2020-12-31T00:00:00[UTC]');
+
+// Hour out of range
+assert.throws(RangeError, () => yearStart.with({ hour: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ hour: 24 }, { overflow: 'reject' }));
+
+// Minute out of range
+assert.throws(RangeError, () => yearStart.with({ minute: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ minute: 60 }, { overflow: 'reject' }));
+
+// Second out of range
+assert.throws(RangeError, () => yearStart.with({ second: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ second: 60 }, { overflow: 'reject' }));
+
+// Millisecond out of range
+assert.throws(RangeError, () => yearStart.with({ millisecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ millisecond: 1000 }, { overflow: 'reject' }));
+
+// Microsecond out of range
+assert.throws(RangeError, () => yearStart.with({ microsecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ microsecond: 1000 }, { overflow: 'reject' }));
+
+// Nanosecond out of range
+assert.throws(RangeError, () => yearStart.with({ nanosecond: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ nanosecond: 1000 }, { overflow: 'reject' }));
+
+// Day out of range
+assert.throws(RangeError, () => yearStart.with({ day: 0 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ day: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ day: 32 }, { overflow: 'reject' }));
+
+// Month out of range
+assert.throws(RangeError, () => yearStart.with({ month: 0 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ month: -1 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ month: 13 }, { overflow: 'reject' }));
+
+// Year out of range
+assert.throws(RangeError, () => yearEnd.with({ year: -271822 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ year: -999999 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ year: 275761 }, { overflow: 'reject' }));
+assert.throws(RangeError, () => yearStart.with({ year: 999999 }, { overflow: 'reject' }));
+
+// Valid minimum bounds
+const minFields = yearStart.with(
+    { month: 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 },
+    { overflow: 'reject' }
+);
+assert.sameValue(minFields.month, 1);
+assert.sameValue(minFields.day, 1);
+assert.sameValue(minFields.hour, 0);
+assert.sameValue(minFields.minute, 0);
+assert.sameValue(minFields.second, 0);
+assert.sameValue(minFields.millisecond, 0);
+assert.sameValue(minFields.microsecond, 0);
+assert.sameValue(minFields.nanosecond, 0);
+
+const minYear = yearEnd.with({ year: -271821 }, { overflow: 'reject' });
+assert.sameValue(minYear.year, -271821);
+
+// Valid maximum bounds
+const maxFields = yearStart.with(
+    { month: 12, day: 31, hour: 23, minute: 59, second: 59, millisecond: 999, microsecond: 999, nanosecond: 999 },
+    { overflow: 'reject' }
+);
+assert.sameValue(maxFields.month, 12);
+assert.sameValue(maxFields.day, 31);
+assert.sameValue(maxFields.hour, 23);
+assert.sameValue(maxFields.minute, 59);
+assert.sameValue(maxFields.second, 59);
+assert.sameValue(maxFields.millisecond, 999);
+assert.sameValue(maxFields.microsecond, 999);
+assert.sameValue(maxFields.nanosecond, 999);
+
+const maxYear = yearStart.with({ year: 275760 }, { overflow: 'reject' });
+assert.sameValue(maxYear.year, 275760);


### PR DESCRIPTION
## Summary

We were failing to perform proper clamping and optional validation of `PrepareCalendarFields` in all cases. This affects the Temporal `from` and `with` methods.

We should be returning fields directly from `PrepareCalendarFields` and then validating them later before constructing the time, depending on an overflow argument. This is only needed for times fields, so let's reuse `PartialTimeRecord` to represent this. This also lets us clean up centralize time field validation.

## Tests

- Added integration tests for `with` and `from` field validation for all Temporal objects, testing limits of each bound