### PR TITLE
[runtime] Make Value::smi and Value::number handle all numeric types using new Numeric trait

### DIFF
--- a/src/js/common/macros.rs
+++ b/src/js/common/macros.rs
@@ -1,8 +1,16 @@
-/// Assert a condition at compile time
+/// Assert a condition at compile time as a toplevel item.
 #[macro_export]
 macro_rules! static_assert {
     ($expr:expr) => {
         const _: () = std::assert!($expr);
+    };
+}
+
+/// Assert a condition at compile time within a function body.
+#[macro_export]
+macro_rules! const_assert {
+    ($expr:expr) => {
+        const { std::assert!($expr) };
     };
 }
 

--- a/src/js/common/mod.rs
+++ b/src/js/common/mod.rs
@@ -8,6 +8,7 @@ mod icu_data;
 pub mod macros;
 pub mod math;
 pub mod memory;
+pub mod numeric;
 pub mod options;
 pub mod serialized_heap;
 pub mod string;

--- a/src/js/common/numeric.rs
+++ b/src/js/common/numeric.rs
@@ -1,0 +1,100 @@
+use num_traits::AsPrimitive;
+
+/// Utility trait for primitive Rust numeric types. Marks additional trait bounds as well as
+/// adds const min/max values and const type identification.
+pub trait Numeric:
+    AsPrimitive<f64>
+    + AsPrimitive<i32>
+    + AsPrimitive<u32>
+    + AsPrimitive<u64>
+    + AsPrimitive<i64>
+    + AsPrimitive<usize>
+    + AsPrimitive<isize>
+{
+    const CONST_MIN: Self;
+    const CONST_MAX: Self;
+
+    const IS_I8: bool;
+    const IS_U8: bool;
+    const IS_I16: bool;
+    const IS_U16: bool;
+    const IS_I32: bool;
+    const IS_U32: bool;
+    const IS_I64: bool;
+    const IS_U64: bool;
+    const IS_I128: bool;
+    const IS_U128: bool;
+    const IS_ISIZE: bool;
+    const IS_USIZE: bool;
+    const IS_F32: bool;
+    const IS_F64: bool;
+
+    /// Numbers where all values can be losslessly represented as a smi (aka i32).
+    const IS_SAFE_SMI: bool;
+}
+
+macro_rules! impl_numeric {
+    ($t:ty, $kind:path) => {
+        impl Numeric for $t {
+            const CONST_MIN: Self = <$t>::MIN;
+            const CONST_MAX: Self = <$t>::MAX;
+
+            const IS_I8: bool = matches!($kind, NumberKind::I8);
+            const IS_U8: bool = matches!($kind, NumberKind::U8);
+            const IS_I16: bool = matches!($kind, NumberKind::I16);
+            const IS_U16: bool = matches!($kind, NumberKind::U16);
+            const IS_I32: bool = matches!($kind, NumberKind::I32);
+            const IS_U32: bool = matches!($kind, NumberKind::U32);
+            const IS_I64: bool = matches!($kind, NumberKind::I64);
+            const IS_U64: bool = matches!($kind, NumberKind::U64);
+            const IS_I128: bool = matches!($kind, NumberKind::I128);
+            const IS_U128: bool = matches!($kind, NumberKind::U128);
+            const IS_ISIZE: bool = matches!($kind, NumberKind::Isize);
+            const IS_USIZE: bool = matches!($kind, NumberKind::Usize);
+            const IS_F32: bool = matches!($kind, NumberKind::F32);
+            const IS_F64: bool = matches!($kind, NumberKind::F64);
+
+            const IS_SAFE_SMI: bool = matches!(
+                $kind,
+                NumberKind::I8
+                    | NumberKind::U8
+                    | NumberKind::I16
+                    | NumberKind::U16
+                    | NumberKind::I32
+            );
+        }
+    };
+}
+
+impl_numeric!(i8, NumberKind::I8);
+impl_numeric!(u8, NumberKind::U8);
+impl_numeric!(i16, NumberKind::I16);
+impl_numeric!(u16, NumberKind::U16);
+impl_numeric!(i32, NumberKind::I32);
+impl_numeric!(u32, NumberKind::U32);
+impl_numeric!(i64, NumberKind::I64);
+impl_numeric!(u64, NumberKind::U64);
+impl_numeric!(i128, NumberKind::I128);
+impl_numeric!(u128, NumberKind::U128);
+impl_numeric!(isize, NumberKind::Isize);
+impl_numeric!(usize, NumberKind::Usize);
+impl_numeric!(f32, NumberKind::F32);
+impl_numeric!(f64, NumberKind::F64);
+
+/// Each numeric type in an enum that can be matched at const time.
+enum NumberKind {
+    I8,
+    U8,
+    I16,
+    U16,
+    I32,
+    U32,
+    I64,
+    U64,
+    I128,
+    U128,
+    Isize,
+    Usize,
+    F32,
+    F64,
+}

--- a/src/js/runtime/abstract_operations.rs
+++ b/src/js/runtime/abstract_operations.rs
@@ -625,7 +625,7 @@ pub fn group_by(
     let mut k_handle: Handle<Value> = Handle::empty(cx);
 
     iter_iterator_values(cx, items, &mut |cx, item| {
-        k_handle.replace(Value::from(k));
+        k_handle.replace(Value::number(k));
 
         let key = match call_object(cx, callback, cx.undefined(), &[item, k_handle]) {
             Ok(key) => key,

--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -117,7 +117,7 @@ impl MappedArgumentsObject {
         }
 
         // Set length property
-        let length_value = Value::from(arguments.len()).to_handle(cx);
+        let length_value = cx.number(arguments.len());
         let length_desc = PropertyDescriptor::data(length_value, true, false, true);
         must!(define_property_or_throw(cx, object.into(), cx.names.length(), length_desc));
 
@@ -286,7 +286,7 @@ pub fn create_unmapped_arguments_object(
     let object = UnmappedArgumentsObject::new(cx)?;
 
     // Set length property
-    let length_value = cx.smi(arguments.len() as i32);
+    let length_value = cx.number(arguments.len());
     let length_desc = PropertyDescriptor::data(length_value, true, false, true);
     must!(define_property_or_throw(cx, object, cx.names.length(), length_desc));
 

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -84,8 +84,7 @@ impl VirtualObject for Handle<ArrayObject> {
         key: Handle<PropertyKey>,
     ) -> EvalResult<Option<PropertyDescriptor>> {
         if key.is_string() && key.as_string().equals(&cx.names.length().as_string())? {
-            let length_value =
-                Value::from(self.as_object().array_properties_length()).to_handle(cx);
+            let length_value = cx.number(self.as_object().array_properties_length());
             return Ok(Some(PropertyDescriptor::data(
                 length_value,
                 self.is_length_writable,
@@ -137,15 +136,15 @@ pub fn array_create_in_realm(
     length: u64,
     proto: Option<Handle<ObjectValue>>,
 ) -> EvalResult<Handle<ArrayObject>> {
-    if length > (u32::MAX as u64) {
+    let Ok(length) = u32::try_from(length) else {
         return range_error(cx, "array length out of range");
-    }
+    };
 
     let proto = proto.unwrap_or_else(|| realm.get_intrinsic(Intrinsic::ArrayPrototype));
 
     let mut array_object = ArrayObject::new(cx, proto)?;
 
-    let length_value = Value::from(length as u32).to_handle(cx);
+    let length_value = cx.number(length);
     let length_desc = PropertyDescriptor::data(length_value, true, false, false);
     must!(array_object.define_own_property(cx, cx.names.length(), length_desc));
 
@@ -196,7 +195,7 @@ pub fn array_species_create(
         return type_error(cx, "expected an Array constructor");
     }
 
-    let length_value = Value::from(length).to_handle(cx);
+    let length_value = cx.number(length);
     construct(cx, constructor.as_object(), &[length_value], None)
 }
 

--- a/src/js/runtime/bytecode/constant_table_builder.rs
+++ b/src/js/runtime/bytecode/constant_table_builder.rs
@@ -312,7 +312,7 @@ impl ConstantTableBuilder {
     }
 
     pub fn add_double(&mut self, double: f64) -> EmitResult<ConstantTableIndex> {
-        let double = ConstantTableEntry::Double(Value::from(double));
+        let double = ConstantTableEntry::Double(Value::number(double));
         self.insert_if_missing(double)
     }
 

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -3135,7 +3135,7 @@ impl VM {
             if smi_value < i32::MAX {
                 Value::smi(smi_value + 1)
             } else {
-                Value::from(i32::MAX as f64 + 1.0)
+                Value::number(i32::MAX as f64 + 1.0)
             }
         } else if !value.is_pointer() {
             Value::number(value.as_number() + 1.0)
@@ -3163,7 +3163,7 @@ impl VM {
             if smi_value > i32::MIN {
                 Value::smi(smi_value - 1)
             } else {
-                Value::from(i32::MIN as f64 - 1.0)
+                Value::number(i32::MIN as f64 - 1.0)
             }
         } else if !value.is_pointer() {
             Value::number(value.as_number() - 1.0)

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -13,6 +13,7 @@ use crate::{
     common::{
         constants::NANOSECONDS_IN_ONE_MILLISECOND,
         filesystem::FileNameReserver,
+        numeric::Numeric,
         options::Options,
         serialized_heap::SerializedHeap,
         time::{get_current_unix_time_millis, get_current_unix_time_nanos},
@@ -590,12 +591,12 @@ impl Context {
     }
 
     #[inline]
-    pub fn smi(&self, value: i32) -> Handle<Value> {
+    pub fn smi<T: Numeric>(&self, value: T) -> Handle<Value> {
         Value::smi(value).to_handle(*self)
     }
 
     #[inline]
-    pub fn number(&self, value: f64) -> Handle<Value> {
+    pub fn number<T: Numeric>(&self, value: T) -> Handle<Value> {
         Value::number(value).to_handle(*self)
     }
 

--- a/src/js/runtime/eval/expression.rs
+++ b/src/js/runtime/eval/expression.rs
@@ -550,7 +550,7 @@ pub fn eval_shift_right_logical(
     // Shift modulus 32
     let shift = right_u32 & 0x1F;
 
-    Ok(Value::from(left_smi >> shift).to_handle(cx))
+    Ok(cx.number(left_smi >> shift))
 }
 
 /// InstanceofOperator (https://tc39.es/ecma262/#sec-instanceofoperator)

--- a/src/js/runtime/function.rs
+++ b/src/js/runtime/function.rs
@@ -68,7 +68,7 @@ pub fn build_function_name(
 
 /// SetFunctionLength (https://tc39.es/ecma262/#sec-setfunctionlength)
 pub fn set_function_length(cx: Context, func: Handle<ObjectValue>, length: u32) -> AllocResult<()> {
-    let length_value = Value::from(length).to_handle(cx);
+    let length_value = cx.number(length);
     let desc = PropertyDescriptor::data(length_value, false, false, true);
     must_a!(define_property_or_throw(cx, func, cx.names.length(), desc));
 
@@ -82,7 +82,7 @@ pub fn set_function_length_maybe_infinity(
     length: Option<usize>,
 ) -> EvalResult<()> {
     let length = if let Some(length) = length {
-        Value::from(length).to_handle(cx)
+        cx.number(length)
     } else {
         cx.number(f64::INFINITY)
     };

--- a/src/js/runtime/gc/heap.rs
+++ b/src/js/runtime/gc/heap.rs
@@ -4,6 +4,7 @@ use std::{alloc::Layout, mem::size_of, ops::Range, ptr::NonNull};
 use crate::runtime::alloc_error::AllocError;
 use crate::{
     common::{constants::GIGABYTE_BYTES, serialized_heap::SerializedHeap},
+    const_assert,
     runtime::{
         Context,
         alloc_error::AllocResult,
@@ -233,7 +234,7 @@ impl Heap {
     #[inline]
     pub fn alloc_uninit_with_size<T>(mut cx: Context, size: usize) -> AllocResult<HeapPtr<T>> {
         // Statically ensure that type is compatible with the heap's alignment.
-        const { assert!(align_of::<T>() <= HEAP_ITEM_ALIGNMENT) };
+        const_assert!(align_of::<T>() <= HEAP_ITEM_ALIGNMENT);
 
         let alloc_size = Self::alloc_size_for_request_size(size);
 

--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -101,7 +101,7 @@ impl ArrayBufferPrototype {
         let array_buffer = require_array_buffer(cx, this_value, "byteLength")?;
 
         // Detached array buffers have byte length set to 0
-        Ok(Value::from(array_buffer.byte_length()).to_handle(cx))
+        Ok(cx.number(array_buffer.byte_length()))
     }
 
     /// get ArrayBuffer.prototype.detached (https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.detached)
@@ -127,7 +127,7 @@ impl ArrayBufferPrototype {
             .max_byte_length()
             .unwrap_or(array_buffer.byte_length());
 
-        Ok(Value::from(max_byte_length).to_handle(cx))
+        Ok(cx.number(max_byte_length))
     }
 
     /// get ArrayBuffer.prototype.resizable (https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.resizable)
@@ -223,7 +223,7 @@ impl ArrayBufferPrototype {
         };
 
         let new_length = end_index.saturating_sub(start_index);
-        let new_length_value = Value::from(new_length).to_handle(cx);
+        let new_length_value = cx.number(new_length);
 
         // Call species constructor to create new array buffer with the given length
         let constructor =

--- a/src/js/runtime/intrinsics/array_constructor.rs
+++ b/src/js/runtime/intrinsics/array_constructor.rs
@@ -100,7 +100,7 @@ impl ArrayConstructor {
                 1
             };
 
-            let int_len_value = Value::from(int_len).to_handle(cx);
+            let int_len_value = cx.number(int_len);
             must!(set(cx, array.into(), cx.names.length(), int_len_value, true));
 
             Ok(array.as_value())
@@ -162,7 +162,7 @@ impl ArrayConstructor {
                 }
 
                 let value = if let Some(map_function) = map_function {
-                    index_value.replace(Value::from(i));
+                    index_value.replace(Value::number(i));
 
                     // Apply map function if present, returning if abnormal completion
                     let result = call_object(cx, map_function, this_arg, &[value, index_value]);
@@ -191,7 +191,7 @@ impl ArrayConstructor {
                 None
             })?;
 
-            let length_value = Value::from(i).to_handle(cx);
+            let length_value = cx.number(i);
             set(cx, array, cx.names.length(), length_value, true)?;
 
             return Ok(array.as_value());
@@ -200,7 +200,7 @@ impl ArrayConstructor {
         // Otherwise assume items arg is array like and copy elements from it
         let array_like = must!(to_object(cx, items_arg));
         let length = length_of_array_like(cx, array_like)?;
-        let length_value = Value::from(length).to_handle(cx);
+        let length_value = cx.number(length);
 
         let array = if is_constructor_value(this_value) {
             construct(cx, this_value.as_object(), &[length_value], None)?
@@ -220,7 +220,7 @@ impl ArrayConstructor {
 
             // Apply map function if present
             if let Some(map_function) = map_function {
-                index_value.replace(Value::from(i));
+                index_value.replace(Value::number(i));
                 value = call_object(cx, map_function, this_arg, &[value, index_value])?;
             }
 
@@ -259,7 +259,7 @@ impl ArrayConstructor {
         arguments: &[Handle<Value>],
     ) -> EvalResult<Handle<Value>> {
         let length = arguments.len();
-        let length_value = Value::from(length).to_handle(cx);
+        let length_value = cx.number(length);
 
         let array = if is_constructor_value(this_value) {
             construct(cx, this_value.as_object(), &[length_value], None)?

--- a/src/js/runtime/intrinsics/array_from_async_generator.rs
+++ b/src/js/runtime/intrinsics/array_from_async_generator.rs
@@ -158,7 +158,7 @@ impl ArrayFromAsyncGenerator {
             let array_like = must!(to_object(cx, items_arg));
 
             let length = length_of_array_like(cx, array_like)?;
-            let length_value = Value::from(length).to_handle(cx);
+            let length_value = cx.number(length);
 
             let array = if is_constructor_value(this_value) {
                 construct(cx, this_value.as_object(), &[length_value], None)?
@@ -278,7 +278,7 @@ impl ArrayFromAsyncGenerator {
 
             // Reached the end of the iterator, we are done building the array
             if iterator_complete(cx, iterator_result)? {
-                let length_value = Value::from(index).to_handle(cx);
+                let length_value = cx.number(index);
                 set(cx, array, cx.names.length(), length_value, true)?;
 
                 return Ok(BuiltinGeneratorCompletion::Returned(array.as_value()));
@@ -288,7 +288,7 @@ impl ArrayFromAsyncGenerator {
 
             // If a mapper is present then call it and await the return value
             if let Some(mapper) = mapper {
-                let key_value = Value::from(index).to_handle(cx);
+                let key_value = cx.number(index);
                 let mapped_completion =
                     call_object(cx, mapper, mapper_this_value, &[next_value, key_value]);
 
@@ -377,7 +377,7 @@ impl ArrayFromAsyncGenerator {
         // If a mapper is present then call it and await the return value
         if !is_mapped_await {
             if let Some(mapper) = mapper {
-                let key_value = Value::from(index).to_handle(cx);
+                let key_value = cx.number(index);
                 let mapped_value =
                     call_object(cx, mapper, mapper_this_value, &[awaited_value, key_value])?;
 
@@ -403,7 +403,7 @@ impl ArrayFromAsyncGenerator {
 
         // Reached the end of the source array, we are done building the result array
         if next_index >= length {
-            let length_value = Value::from(length).to_handle(cx);
+            let length_value = cx.number(length);
             set(cx, array, cx.names.length(), length_value, true)?;
 
             return Ok(BuiltinGeneratorCompletion::Returned(array.as_value()));

--- a/src/js/runtime/intrinsics/array_iterator.rs
+++ b/src/js/runtime/intrinsics/array_iterator.rs
@@ -154,7 +154,7 @@ impl ArrayIteratorPrototype {
 
         match array_iterator.kind {
             ArrayIteratorKind::Key => {
-                let key = Value::from(current_index).to_handle(cx);
+                let key = cx.number(current_index);
                 Ok(create_iter_result_object(cx, key, false)?)
             }
             ArrayIteratorKind::Value => {
@@ -163,7 +163,7 @@ impl ArrayIteratorPrototype {
                 Ok(create_iter_result_object(cx, value, false)?)
             }
             ArrayIteratorKind::KeyAndValue => {
-                let key = Value::from(current_index).to_handle(cx);
+                let key = cx.number(current_index);
                 let property_key = PropertyKey::from_u64_handle(cx, current_index)?;
                 let value = array.get(cx, property_key, array.into())?;
 

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -357,7 +357,7 @@ impl ArrayPrototype {
             Self::apply_concat_to_element(cx, *element, array, &mut n)?;
         }
 
-        let new_length_value = Value::from(n).to_handle(cx);
+        let new_length_value = cx.number(n);
         set(cx, array, cx.names.length(), new_length_value, true)?;
 
         Ok(array.as_value())
@@ -539,7 +539,7 @@ impl ArrayPrototype {
             if has_property(cx, object, index_key)? {
                 let value = get(cx, object, index_key)?;
 
-                index_value.replace(Value::from(i));
+                index_value.replace(Value::number(i));
                 let arguments = [value, index_value, object.into()];
 
                 let test_result = call_object(cx, callback_function, this_arg, &arguments)?;
@@ -614,7 +614,7 @@ impl ArrayPrototype {
             if has_property(cx, object, index_key)? {
                 let value = get(cx, object, index_key)?;
 
-                index_value.replace(Value::from(i));
+                index_value.replace(Value::number(i));
                 let arguments = [value, index_value, object.into()];
 
                 let is_selected = call_object(cx, callback_function, this_arg, &arguments)?;
@@ -794,7 +794,7 @@ impl ArrayPrototype {
                 let mut element = get(cx, source, source_key)?;
 
                 if let Some(mapper_function) = mapper_function {
-                    let index_value = Value::from(i).to_handle(cx);
+                    let index_value = cx.number(i);
                     let arguments = [element, index_value, source.into()];
                     element = call(cx, mapper_function, this_arg, &arguments)?;
                 }
@@ -904,7 +904,7 @@ impl ArrayPrototype {
             if has_property(cx, object, index_key)? {
                 let value = get(cx, object, index_key)?;
 
-                index_value.replace(Value::from(i));
+                index_value.replace(Value::number(i));
                 let arguments = [value, index_value, object.into()];
 
                 call_object(cx, callback_function, this_arg, &arguments)?;
@@ -973,7 +973,7 @@ impl ArrayPrototype {
             if has_property(cx, object, key)? {
                 let element = get(cx, object, key)?;
                 if is_strictly_equal(search_element, element)? {
-                    return Ok(Value::from(i).to_handle(cx));
+                    return Ok(cx.number(i));
                 }
             }
         }
@@ -1074,7 +1074,7 @@ impl ArrayPrototype {
             if has_property(cx, object, key)? {
                 let element = get(cx, object, key)?;
                 if is_strictly_equal(search_element, element)? {
-                    return Ok(Value::from(i).to_handle(cx));
+                    return Ok(cx.number(i));
                 }
             }
         }
@@ -1110,7 +1110,7 @@ impl ArrayPrototype {
             if has_property(cx, object, index_key)? {
                 let value = get(cx, object, index_key)?;
 
-                index_value.replace(Value::from(i));
+                index_value.replace(Value::number(i));
                 let arguments = [value, index_value, object.into()];
 
                 let mapped_value = call_object(cx, callback_function, this_arg, &arguments)?;
@@ -1142,7 +1142,7 @@ impl ArrayPrototype {
         let element = get(cx, object, index_key)?;
         delete_property_or_throw(cx, object, index_key)?;
 
-        let new_length_value = Value::from(new_length).to_handle(cx);
+        let new_length_value = cx.number(new_length);
         set(cx, object, cx.names.length(), new_length_value, true)?;
 
         Ok(element)
@@ -1170,7 +1170,7 @@ impl ArrayPrototype {
             set(cx, object, key, *argument, true)?;
         }
 
-        let new_length_value = Value::from(new_length).to_handle(cx);
+        let new_length_value = cx.number(new_length);
         set(cx, object, cx.names.length(), new_length_value, true)?;
 
         Ok(new_length_value)
@@ -1228,7 +1228,7 @@ impl ArrayPrototype {
             if has_property(cx, object, index_key)? {
                 let value = get(cx, object, index_key)?;
 
-                index_value.replace(Value::from(i));
+                index_value.replace(Value::number(i));
                 let arguments = [accumulator, value, index_value, object.into()];
 
                 accumulator = call_object(cx, callback_function, cx.undefined(), &arguments)?;
@@ -1289,7 +1289,7 @@ impl ArrayPrototype {
             if has_property(cx, object, index_key)? {
                 let value = get(cx, object, index_key)?;
 
-                index_value.replace(Value::from(i));
+                index_value.replace(Value::number(i));
                 let arguments = [accumulator, value, index_value, object.into()];
 
                 accumulator = call_object(cx, callback_function, cx.undefined(), &arguments)?;
@@ -1393,7 +1393,7 @@ impl ArrayPrototype {
         let last_key = PropertyKey::from_u64_handle(cx, length - 1)?;
         delete_property_or_throw(cx, object, last_key)?;
 
-        let new_length_value = Value::from(length - 1).to_handle(cx);
+        let new_length_value = cx.number(length - 1);
         set(cx, object, cx.names.length(), new_length_value, true)?;
 
         Ok(first)
@@ -1441,7 +1441,7 @@ impl ArrayPrototype {
             to_index += 1;
         }
 
-        let to_index_value = Value::from(to_index).to_handle(cx);
+        let to_index_value = cx.number(to_index);
         set(cx, array, cx.names.length(), to_index_value, true)?;
 
         Ok(array.as_value())
@@ -1473,7 +1473,7 @@ impl ArrayPrototype {
             if has_property(cx, object, index_key)? {
                 let value = get(cx, object, index_key)?;
 
-                index_value.replace(Value::from(i));
+                index_value.replace(Value::number(i));
                 let arguments = [value, index_value, object.into()];
 
                 let test_result = call_object(cx, callback_function, this_arg, &arguments)?;
@@ -1570,7 +1570,7 @@ impl ArrayPrototype {
             }
         }
 
-        let actual_delete_count_value = Value::from(actual_delete_count).to_handle(cx);
+        let actual_delete_count_value = cx.number(actual_delete_count);
         set(cx, array, cx.names.length(), actual_delete_count_value, true)?;
 
         // Move existing items in array to make space for inserted items
@@ -1611,7 +1611,7 @@ impl ArrayPrototype {
             set(cx, object, to_key, *item, true)?;
         }
 
-        let new_length_value = Value::from(new_length).to_handle(cx);
+        let new_length_value = cx.number(new_length);
         set(cx, object, cx.names.length(), new_length_value, true)?;
 
         Ok(array.as_value())
@@ -1830,7 +1830,7 @@ impl ArrayPrototype {
             }
         }
 
-        let new_length = Value::from(length + num_arguments).to_handle(cx);
+        let new_length = cx.number(length + num_arguments);
         set(cx, object, cx.names.length(), new_length, true)?;
 
         Ok(new_length)
@@ -1940,7 +1940,7 @@ pub fn find_via_predicate(
         index_key.replace(PropertyKey::from_u64(cx, i)?);
         let value = get(cx, object, index_key)?;
 
-        index_value.replace(Value::from(i));
+        index_value.replace(Value::number(i));
         let arguments = [value, index_value, object.into()];
 
         let test_result = call_object(cx, predicate, this_arg, &arguments)?;

--- a/src/js/runtime/intrinsics/data_view_prototype.rs
+++ b/src/js/runtime/intrinsics/data_view_prototype.rs
@@ -242,7 +242,7 @@ impl DataViewPrototype {
 
         let byte_length = get_view_byte_length(&data_view_record);
 
-        Ok(Value::from(byte_length).to_handle(cx))
+        Ok(cx.number(byte_length))
     }
 
     /// get DataView.prototype.byteOffset (https://tc39.es/ecma262/#sec-get-dataview.prototype.byteoffset)
@@ -258,7 +258,7 @@ impl DataViewPrototype {
             return type_error(cx, "DataView.prototype.byteOffset DataView is out of bounds");
         }
 
-        Ok(Value::from(data_view.byte_offset()).to_handle(cx))
+        Ok(cx.number(data_view.byte_offset()))
     }
 
     /// DataView.prototype.getBigInt64 (https://tc39.es/ecma262/#sec-dataview.prototype.getbigint64)

--- a/src/js/runtime/intrinsics/date_constructor.rs
+++ b/src/js/runtime/intrinsics/date_constructor.rs
@@ -142,7 +142,7 @@ impl DateConstructor {
 
     /// Date.now (https://tc39.es/ecma262/#sec-date.now)
     pub fn now(cx: Context, _: Handle<Value>, _: &[Handle<Value>]) -> EvalResult<Handle<Value>> {
-        Ok(Value::from(cx.current_unix_time_millis() as f64).to_handle(cx))
+        Ok(cx.number(cx.current_unix_time_millis() as f64))
     }
 
     /// Date.parse (https://tc39.es/ecma262/#sec-date.parse)
@@ -155,7 +155,7 @@ impl DateConstructor {
         let string = to_string(cx, string_arg)?;
 
         if let Some(date_value) = parse_string_to_date(string)? {
-            Ok(Value::from(date_value).to_handle(cx))
+            Ok(cx.number(date_value))
         } else {
             Ok(cx.nan())
         }
@@ -220,6 +220,6 @@ impl DateConstructor {
         let final_time = make_time(hour, minute, second, millisecond);
         let final_date = make_date(final_day, final_time);
 
-        Ok(Value::from(time_clip(final_date)).to_handle(cx))
+        Ok(cx.number(time_clip(final_date)))
     }
 }

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -418,7 +418,7 @@ impl DatePrototype {
 
         let date = date_from_time(local_time(date_value));
 
-        Ok(Value::from(date).to_handle(cx))
+        Ok(cx.number(date))
     }
 
     /// Date.prototype.getDay (https://tc39.es/ecma262/#sec-date.prototype.getday)
@@ -435,7 +435,7 @@ impl DatePrototype {
 
         let day = week_day(local_time(date_value));
 
-        Ok(Value::from(day).to_handle(cx))
+        Ok(cx.number(day))
     }
 
     /// Date.prototype.getFullYear (https://tc39.es/ecma262/#sec-date.prototype.getfullyear)
@@ -452,7 +452,7 @@ impl DatePrototype {
 
         let year = year_from_time(local_time(date_value));
 
-        Ok(Value::from(year).to_handle(cx))
+        Ok(cx.number(year))
     }
 
     /// Date.prototype.getHours (https://tc39.es/ecma262/#sec-date.prototype.gethours)
@@ -469,7 +469,7 @@ impl DatePrototype {
 
         let hour = hour_from_time(local_time(date_value));
 
-        Ok(Value::from(hour).to_handle(cx))
+        Ok(cx.number(hour))
     }
 
     /// Date.prototype.getMilliseconds (https://tc39.es/ecma262/#sec-date.prototype.getmilliseconds)
@@ -486,7 +486,7 @@ impl DatePrototype {
 
         let millisecond = millisecond_from_time(local_time(date_value));
 
-        Ok(Value::from(millisecond).to_handle(cx))
+        Ok(cx.number(millisecond))
     }
 
     /// Date.prototype.getMinutes (https://tc39.es/ecma262/#sec-date.prototype.getminutes)
@@ -503,7 +503,7 @@ impl DatePrototype {
 
         let minute = minute_from_time(local_time(date_value));
 
-        Ok(Value::from(minute).to_handle(cx))
+        Ok(cx.number(minute))
     }
 
     /// Date.prototype.getMonth (https://tc39.es/ecma262/#sec-date.prototype.getmonth)
@@ -520,7 +520,7 @@ impl DatePrototype {
 
         let month = month_from_time(local_time(date_value));
 
-        Ok(Value::from(month).to_handle(cx))
+        Ok(cx.number(month))
     }
 
     /// Date.prototype.getSeconds (https://tc39.es/ecma262/#sec-date.prototype.getseconds)
@@ -537,7 +537,7 @@ impl DatePrototype {
 
         let second = second_from_time(local_time(date_value));
 
-        Ok(Value::from(second).to_handle(cx))
+        Ok(cx.number(second))
     }
 
     /// Date.prototype.getTime (https://tc39.es/ecma262/#sec-date.prototype.gettime)
@@ -548,7 +548,7 @@ impl DatePrototype {
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getTime")?;
 
-        Ok(Value::from(date_value).to_handle(cx))
+        Ok(cx.number(date_value))
     }
 
     /// Date.prototype.getTimezoneOffset (https://tc39.es/ecma262/#sec-date.prototype.gettimezoneoffset)
@@ -565,7 +565,7 @@ impl DatePrototype {
 
         let timezone_offset = (date_value - local_time(date_value)) / MS_PER_MINUTE;
 
-        Ok(Value::from(timezone_offset).to_handle(cx))
+        Ok(cx.number(timezone_offset))
     }
 
     /// Date.prototype.getUTCDate (https://tc39.es/ecma262/#sec-date.prototype.getutcdate)
@@ -582,7 +582,7 @@ impl DatePrototype {
 
         let date = date_from_time(date_value);
 
-        Ok(Value::from(date).to_handle(cx))
+        Ok(cx.number(date))
     }
 
     /// Date.prototype.getUTCDay (https://tc39.es/ecma262/#sec-date.prototype.getutcday)
@@ -599,7 +599,7 @@ impl DatePrototype {
 
         let hour = week_day(date_value);
 
-        Ok(Value::from(hour).to_handle(cx))
+        Ok(cx.number(hour))
     }
 
     /// Date.prototype.getUTCFullYear (https://tc39.es/ecma262/#sec-date.prototype.getutcfullyear)
@@ -616,7 +616,7 @@ impl DatePrototype {
 
         let year = year_from_time(date_value);
 
-        Ok(Value::from(year).to_handle(cx))
+        Ok(cx.number(year))
     }
 
     /// Date.prototype.getUTCHours (https://tc39.es/ecma262/#sec-date.prototype.getutchours)
@@ -633,7 +633,7 @@ impl DatePrototype {
 
         let hour = hour_from_time(date_value);
 
-        Ok(Value::from(hour).to_handle(cx))
+        Ok(cx.number(hour))
     }
 
     /// Date.prototype.getUTCMilliseconds (https://tc39.es/ecma262/#sec-date.prototype.getutcmilliseconds)
@@ -650,7 +650,7 @@ impl DatePrototype {
 
         let millisecond = millisecond_from_time(date_value);
 
-        Ok(Value::from(millisecond).to_handle(cx))
+        Ok(cx.number(millisecond))
     }
 
     /// Date.prototype.getUTCMinutes (https://tc39.es/ecma262/#sec-date.prototype.getutcminutes)
@@ -667,7 +667,7 @@ impl DatePrototype {
 
         let minute = minute_from_time(date_value);
 
-        Ok(Value::from(minute).to_handle(cx))
+        Ok(cx.number(minute))
     }
 
     /// Date.prototype.getUTCMonth (https://tc39.es/ecma262/#sec-date.prototype.getutcmonth)
@@ -684,7 +684,7 @@ impl DatePrototype {
 
         let month = month_from_time(date_value);
 
-        Ok(Value::from(month).to_handle(cx))
+        Ok(cx.number(month))
     }
 
     /// Date.prototype.getUTCSeconds (https://tc39.es/ecma262/#sec-date.prototype.getutcseconds)
@@ -701,7 +701,7 @@ impl DatePrototype {
 
         let second = second_from_time(date_value);
 
-        Ok(Value::from(second).to_handle(cx))
+        Ok(cx.number(second))
     }
 
     /// Date.prototype.setDate (https://tc39.es/ecma262/#sec-date.prototype.setdate)
@@ -728,7 +728,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.setFullYear (https://tc39.es/ecma262/#sec-date.prototype.setfullyear)
@@ -767,7 +767,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.setHours (https://tc39.es/ecma262/#sec-date.prototype.sethours)
@@ -830,7 +830,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.setMilliseconds (https://tc39.es/ecma262/#sec-date.prototype.setmilliseconds)
@@ -862,7 +862,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.setMinutes (https://tc39.es/ecma262/#sec-date.prototype.setminutes)
@@ -913,7 +913,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.setMonth (https://tc39.es/ecma262/#sec-date.prototype.setmonth)
@@ -952,7 +952,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.setSeconds (https://tc39.es/ecma262/#sec-date.prototype.setseconds)
@@ -996,7 +996,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.setTime (https://tc39.es/ecma262/#sec-date.prototype.settime)
@@ -1012,7 +1012,7 @@ impl DatePrototype {
 
         set_date_value(this_value, time_num);
 
-        Ok(Value::from(time_num).to_handle(cx))
+        Ok(cx.number(time_num))
     }
 
     /// Date.prototype.setUTCDate (https://tc39.es/ecma262/#sec-date.prototype.setutcdate)
@@ -1037,7 +1037,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.setUTCFullYear (https://tc39.es/ecma262/#sec-date.prototype.setutcfullyear)
@@ -1074,7 +1074,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.setUTCHours (https://tc39.es/ecma262/#sec-date.prototype.setutchours)
@@ -1133,7 +1133,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.setUTCMilliseconds (https://tc39.es/ecma262/#sec-date.prototype.setutcmilliseconds)
@@ -1163,7 +1163,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.setUTCMinutes (https://tc39.es/ecma262/#sec-date.prototype.setutcminutes)
@@ -1212,7 +1212,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.setUTCMonth (https://tc39.es/ecma262/#sec-date.prototype.setutcmonth)
@@ -1249,7 +1249,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.setUTCSeconds (https://tc39.es/ecma262/#sec-date.prototype.setutcseconds)
@@ -1291,7 +1291,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 
     /// Date.prototype.toDateString (https://tc39.es/ecma262/#sec-date.prototype.todatestring)
@@ -1495,7 +1495,7 @@ impl DatePrototype {
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "valueOf")?;
 
-        Ok(Value::from(date_value).to_handle(cx))
+        Ok(cx.number(date_value))
     }
 
     /// Date.prototype [ @@toPrimitive ] (https://tc39.es/ecma262/#sec-date.prototype-%symbol.toprimitive%)
@@ -1576,7 +1576,7 @@ impl DatePrototype {
 
         set_date_value(this_value, new_date);
 
-        Ok(Value::from(new_date).to_handle(cx))
+        Ok(cx.number(new_date))
     }
 }
 

--- a/src/js/runtime/intrinsics/iterator_helper_object.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_object.rs
@@ -449,7 +449,7 @@ impl Handle<IteratorHelperObject> {
 
             // Convert the counter to a value
             let counter_number = self.as_filter_helper().unwrap().counter;
-            counter_value.replace(Value::from(counter_number));
+            counter_value.replace(Value::number(counter_number));
 
             // Run the predicate function on the value, closing the iterator on error
             let is_selected =
@@ -480,7 +480,7 @@ impl Handle<IteratorHelperObject> {
             helper.counter += 1;
         }
 
-        let counter_value = Value::from(helper.counter).to_handle(cx);
+        let counter_value = cx.number(helper.counter);
 
         // Get the next value from the underlying iterator
         let value = match self.iterator_step_value(cx, &mut self.iterator(cx).unwrap())? {
@@ -531,7 +531,7 @@ impl Handle<IteratorHelperObject> {
                 };
 
                 // Convert the counter to a value
-                counter_value.replace(Value::from(self.as_flat_map_helper().unwrap().counter));
+                counter_value.replace(Value::number(self.as_flat_map_helper().unwrap().counter));
 
                 // Run the mapper function on the value, closing the iterator on error
                 let mapped = match call_object(cx, mapper, cx.undefined(), &[value, counter_value])

--- a/src/js/runtime/intrinsics/iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_prototype.rs
@@ -198,7 +198,7 @@ impl IteratorPrototype {
             };
 
             // Pass value and counter to the predicate function
-            counter_handle.replace(Value::from(counter));
+            counter_handle.replace(Value::number(counter));
             let result = call_object(cx, predicate, cx.undefined(), &[value, counter_handle]);
 
             // Finish iterating if predicate threw or returned false
@@ -253,7 +253,7 @@ impl IteratorPrototype {
             };
 
             // Pass value and counter to the predicate function
-            counter_handle.replace(Value::from(counter));
+            counter_handle.replace(Value::number(counter));
             let result = call_object(cx, predicate, cx.undefined(), &[value, counter_handle]);
 
             // Finish iterating if predicate threw or returned true
@@ -307,7 +307,7 @@ impl IteratorPrototype {
             };
 
             // Pass value and counter to the callback function
-            counter_handle.replace(Value::from(counter));
+            counter_handle.replace(Value::number(counter));
             let result = call_object(cx, callback, cx.undefined(), &[value, counter_handle]);
 
             // Finish iterating if callback threw
@@ -376,7 +376,7 @@ impl IteratorPrototype {
             };
 
             // Pass accumulator, value, and counter to the predicate function
-            counter_handle.replace(Value::from(counter));
+            counter_handle.replace(Value::number(counter));
             let result =
                 call_object(cx, callback, cx.undefined(), &[accumulator, value, counter_handle]);
 
@@ -415,7 +415,7 @@ impl IteratorPrototype {
             };
 
             // Pass value and counter to the predicate function
-            counter_handle.replace(Value::from(counter));
+            counter_handle.replace(Value::number(counter));
             let result = call_object(cx, predicate, cx.undefined(), &[value, counter_handle]);
 
             // Finish iterating if predicate threw or returned true

--- a/src/js/runtime/intrinsics/json_parser.rs
+++ b/src/js/runtime/intrinsics/json_parser.rs
@@ -308,7 +308,7 @@ impl JSONValue {
         let value = match self {
             Self::Null { .. } => cx.null(),
             Self::Boolean { value, .. } => cx.bool(*value),
-            Self::Number { value, .. } => Value::from(*value).to_handle(cx),
+            Self::Number { value, .. } => cx.number(*value),
             Self::String { value, .. } => cx.alloc_wtf8_string(value)?.into(),
             Self::Array { elements, .. } => {
                 let array = must_a!(array_create(cx, 0, None));
@@ -358,7 +358,7 @@ impl JSONValue {
                 Ok(JSONParseRecord::new(bool_value, *loc))
             }
             Self::Number { value, loc } => {
-                let number_value = Value::from(*value).to_handle(cx);
+                let number_value = cx.number(*value);
                 Ok(JSONParseRecord::new(number_value, *loc))
             }
             Self::String { value, loc } => {

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -316,7 +316,7 @@ impl MapPrototype {
     ) -> EvalResult<Handle<Value>> {
         let map = this_map_value(cx, this_value, "size")?;
 
-        Ok(Value::from(map.map_data().num_entries_occupied()).to_handle(cx))
+        Ok(cx.number(map.map_data().num_entries_occupied()))
     }
 
     /// Map.prototype.values (https://tc39.es/ecma262/#sec-map.prototype.values)

--- a/src/js/runtime/intrinsics/math_object.rs
+++ b/src/js/runtime/intrinsics/math_object.rs
@@ -265,7 +265,7 @@ impl MathObject {
     ) -> EvalResult<Handle<Value>> {
         let argument = get_argument(cx, arguments, 0);
         let n = to_uint32(cx, argument)?;
-        Ok(cx.smi(n.leading_zeros() as i32))
+        Ok(cx.smi(n.leading_zeros() as u8))
     }
 
     /// Math.cos (https://tc39.es/ecma262/#sec-math.cos)
@@ -540,7 +540,7 @@ impl MathObject {
         let exponent_arg = get_argument(cx, arguments, 1);
         let exponent = to_number(cx, exponent_arg)?;
 
-        Ok(Value::from(number_exponentiate(base.as_number(), exponent.as_number())).to_handle(cx))
+        Ok(cx.number(number_exponentiate(base.as_number(), exponent.as_number())))
     }
 
     /// Math.random (https://tc39.es/ecma262/#sec-math.random)

--- a/src/js/runtime/intrinsics/number_constructor.rs
+++ b/src/js/runtime/intrinsics/number_constructor.rs
@@ -189,7 +189,7 @@ impl NumberConstructor {
         };
 
         match cx.current_new_target() {
-            None => Ok(Value::from(number_value).to_handle(cx)),
+            None => Ok(cx.number(number_value)),
             Some(new_target) => {
                 Ok(NumberObject::new_from_constructor(cx, new_target, number_value)?.as_value())
             }

--- a/src/js/runtime/intrinsics/promise_constructor.rs
+++ b/src/js/runtime/intrinsics/promise_constructor.rs
@@ -317,7 +317,7 @@ impl PromiseConstructor {
             )?;
 
             // Attach various private properties to the resolve function
-            Self::set_index(cx, promise_all_resolve, Value::from(index))?;
+            Self::set_index(cx, promise_all_resolve, Value::number(index))?;
             Self::set_values(cx, promise_all_resolve, values)?;
             Self::set_capability(cx, promise_all_resolve, capability)?;
             Self::set_remaining_elements(cx, promise_all_resolve, remaining_elements)?;
@@ -434,7 +434,7 @@ impl PromiseConstructor {
 
             // Attach various private properties to the resolve function
             Self::set_already_called(cx, promise_all_settled_resolve, already_called.into())?;
-            Self::set_index(cx, promise_all_settled_resolve, Value::from(index))?;
+            Self::set_index(cx, promise_all_settled_resolve, Value::number(index))?;
             Self::set_values(cx, promise_all_settled_resolve, values)?;
             Self::set_capability(cx, promise_all_settled_resolve, capability)?;
             Self::set_remaining_elements(cx, promise_all_settled_resolve, remaining_elements)?;
@@ -451,7 +451,7 @@ impl PromiseConstructor {
 
             // Attach various private properties to the reject function
             Self::set_already_called(cx, promise_all_settled_reject, already_called.into())?;
-            Self::set_index(cx, promise_all_settled_reject, Value::from(index))?;
+            Self::set_index(cx, promise_all_settled_reject, Value::number(index))?;
             Self::set_values(cx, promise_all_settled_reject, values)?;
             Self::set_capability(cx, promise_all_settled_reject, capability)?;
             Self::set_remaining_elements(cx, promise_all_settled_reject, remaining_elements)?;
@@ -632,7 +632,7 @@ impl PromiseConstructor {
             )?;
 
             // Attach various private properties to the resolve function
-            Self::set_index(cx, promise_any_reject, Value::from(index))?;
+            Self::set_index(cx, promise_any_reject, Value::number(index))?;
             Self::set_values(cx, promise_any_reject, errors)?;
             Self::set_capability(cx, promise_any_reject, capability)?;
             Self::set_remaining_elements(cx, promise_any_reject, remaining_elements)?;

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -354,7 +354,7 @@ impl RegExpPrototype {
                 let last_index = to_length(cx, last_index)?;
 
                 let next_index = advance_u64_string_index(string_value, last_index, is_unicode)?;
-                let next_index_value = Value::from(next_index).to_handle(cx);
+                let next_index_value = cx.number(next_index);
                 set(cx, regexp_object, cx.names.last_index(), next_index_value, true)?;
             }
 
@@ -383,7 +383,7 @@ impl RegExpPrototype {
 
         let last_index = get(cx, regexp_object, cx.names.last_index())?;
         let last_index = to_length(cx, last_index)?;
-        let last_index_value = Value::from(last_index).to_handle(cx);
+        let last_index_value = cx.number(last_index);
 
         set(cx, matcher, cx.names.last_index(), last_index_value, true)?;
 
@@ -473,7 +473,7 @@ impl RegExpPrototype {
                 let this_index = to_length(cx, this_index)?;
 
                 let next_index = advance_u64_string_index(target_string, this_index, is_unicode)?;
-                let next_index_value = Value::from(next_index).to_handle(cx);
+                let next_index_value = cx.number(next_index);
                 set(cx, regexp_object, cx.names.last_index(), next_index_value, true)?;
             }
         }
@@ -526,7 +526,7 @@ impl RegExpPrototype {
                             cx.undefined()
                         }
                     }));
-                    replacer_args.push(Value::from(matched_position).to_handle(cx));
+                    replacer_args.push(cx.number(matched_position));
                     replacer_args.push(target_string.into());
 
                     if !named_captures.is_undefined() {
@@ -717,7 +717,7 @@ impl RegExpPrototype {
         // Keep executing RegExp until there are no more matches or the entire string has been
         // searched.
         while q < size {
-            let q_value = Value::from(q).to_handle(cx);
+            let q_value = cx.number(q);
             set(cx, splitter, cx.names.last_index(), q_value, true)?;
 
             // Execute RegExp at current index, advancing to next index if there is no match
@@ -1016,7 +1016,7 @@ fn regexp_builtin_exec(
 
     // Update last index to point past end of capture
     if is_global || is_sticky {
-        let last_index_value = Value::from(full_capture.end).to_handle(cx);
+        let last_index_value = cx.number(full_capture.end);
         set(cx, regexp_object.into(), cx.names.last_index(), last_index_value, true)?;
     }
 
@@ -1024,7 +1024,7 @@ fn regexp_builtin_exec(
     let result_array = must!(array_create(cx, capture_groups.len() as u64, None)).as_object();
 
     // Mark the start of the full match
-    let index_value = Value::from(full_capture.start).to_handle(cx);
+    let index_value = cx.number(full_capture.start);
     must!(create_data_property_or_throw(cx, result_array, cx.names.index(), index_value));
 
     // Include the input string in the result
@@ -1089,8 +1089,8 @@ fn regexp_builtin_exec(
         // Add capture indices to indices array if present
         let match_index_pair = if let Some((indices_array, indices_groups)) = indices_result {
             let match_index_pair = if let Some(capture) = capture {
-                let start_index = Value::from(capture.start).to_handle(cx);
-                let end_index = Value::from(capture.end).to_handle(cx);
+                let start_index = cx.number(capture.start);
+                let end_index = cx.number(capture.end);
                 create_array_from_list(cx, &[start_index, end_index])?.into()
             } else {
                 cx.undefined()

--- a/src/js/runtime/intrinsics/regexp_string_iterator.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator.rs
@@ -148,7 +148,7 @@ impl RegExpStringIteratorPrototype {
 
             let next_index =
                 advance_u64_string_index(target_string, last_index, regexp_iterator.is_unicode)?;
-            let next_index_value = Value::from(next_index).to_handle(cx);
+            let next_index_value = cx.number(next_index);
             set(cx, regexp_object, cx.names.last_index(), next_index_value, true)?;
         }
 

--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -540,7 +540,7 @@ impl SetPrototype {
     ) -> EvalResult<Handle<Value>> {
         let set = this_set_value(cx, this_value, "size")?;
 
-        Ok(Value::from(set.set_data_ptr().num_entries_occupied()).to_handle(cx))
+        Ok(cx.number(set.set_data_ptr().num_entries_occupied()))
     }
 
     /// Set.prototype.symmetricDifference (https://tc39.es/ecma262/#sec-set.prototype.symmetricdifference)

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -1,5 +1,3 @@
-use std::cmp::Ordering;
-
 use crate::{
     common::{
         icu::ICU,
@@ -428,7 +426,7 @@ impl StringPrototype {
         }
 
         let code_unit = string.code_unit_at(position as u32)?;
-        Ok(cx.smi(code_unit as i32))
+        Ok(cx.smi(code_unit))
     }
 
     /// String.prototype.codePointAt (https://tc39.es/ecma262/#sec-string.prototype.codepointat)
@@ -558,7 +556,7 @@ impl StringPrototype {
 
         match string.find(search_string, pos)? {
             None => Ok(cx.negative_one()),
-            Some(index) => Ok(Value::from(index).to_handle(cx)),
+            Some(index) => Ok(cx.number(index)),
         }
     }
 
@@ -599,7 +597,7 @@ impl StringPrototype {
 
         match string.rfind(search_string, string_end)? {
             None => Ok(cx.negative_one()),
-            Some(index) => Ok(Value::from(index).to_handle(cx)),
+            Some(index) => Ok(cx.number(index)),
         }
     }
 
@@ -622,13 +620,7 @@ impl StringPrototype {
             .as_borrowed()
             .compare_utf8(wtf8_string.as_bytes(), wtf8_other_string.as_bytes());
 
-        let comparison_number = match comparison {
-            Ordering::Less => -1,
-            Ordering::Equal => 0,
-            Ordering::Greater => 1,
-        };
-
-        Ok(cx.smi(comparison_number))
+        Ok(cx.smi(comparison as i8))
     }
 
     /// String.prototype.match (https://tc39.es/ecma262/#sec-string.prototype.match)
@@ -908,7 +900,7 @@ impl StringPrototype {
         let replacement_string = match replace_value {
             // If replace argument is a function, replacement is the result of calling that function
             ReplaceValue::Function(replace_function) => {
-                let matched_position_value = Value::from(matched_position).to_handle(cx);
+                let matched_position_value = cx.number(matched_position);
                 let replacement = call_object(
                     cx,
                     replace_function,
@@ -1020,7 +1012,7 @@ impl StringPrototype {
             let replacement_string = match replace_value {
                 // If replace argument is a function, replacement is the result of calling that function
                 ReplaceValue::Function(replace_function) => {
-                    let matched_position_value = Value::from(matched_position).to_handle(cx);
+                    let matched_position_value = cx.number(matched_position);
                     let replacement = call_object(
                         cx,
                         replace_function,

--- a/src/js/runtime/intrinsics/temporal/duration_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_constructor.rs
@@ -138,7 +138,7 @@ impl DurationConstructor {
             duration_1.compare_with_provider(&duration_2, relative_to, cx.temporal_provider());
         let ordering = map_temporal_result(cx, ordering_result, NAME)?;
 
-        Ok(cx.smi(ordering as i32))
+        Ok(cx.smi(ordering as i8))
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/duration_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_prototype.rs
@@ -213,7 +213,7 @@ impl DurationPrototype {
         let duration = this_duration(cx, this_value, "Duration.prototype.years")?;
         let years = duration.duration().years();
 
-        Ok(Value::from(years).to_handle(cx))
+        Ok(cx.number(years))
     }
 
     /// get Temporal.Duration.prototype.months (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.months)
@@ -225,7 +225,7 @@ impl DurationPrototype {
         let duration = this_duration(cx, this_value, "Duration.prototype.months")?;
         let months = duration.duration().months();
 
-        Ok(Value::from(months).to_handle(cx))
+        Ok(cx.number(months))
     }
 
     /// get Temporal.Duration.prototype.weeks (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.weeks)
@@ -237,7 +237,7 @@ impl DurationPrototype {
         let duration = this_duration(cx, this_value, "Duration.prototype.weeks")?;
         let weeks = duration.duration().weeks();
 
-        Ok(Value::from(weeks).to_handle(cx))
+        Ok(cx.number(weeks))
     }
 
     /// get Temporal.Duration.prototype.days (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.days)
@@ -249,7 +249,7 @@ impl DurationPrototype {
         let duration = this_duration(cx, this_value, "Duration.prototype.days")?;
         let days = duration.duration().days();
 
-        Ok(Value::from(days).to_handle(cx))
+        Ok(cx.number(days))
     }
 
     /// get Temporal.Duration.prototype.hours (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.hours)
@@ -261,7 +261,7 @@ impl DurationPrototype {
         let duration = this_duration(cx, this_value, "Duration.prototype.hours")?;
         let hours = duration.duration().hours();
 
-        Ok(Value::from(hours).to_handle(cx))
+        Ok(cx.number(hours))
     }
 
     /// get Temporal.Duration.prototype.minutes (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.minutes)
@@ -273,7 +273,7 @@ impl DurationPrototype {
         let duration = this_duration(cx, this_value, "Duration.prototype.minutes")?;
         let minutes = duration.duration().minutes();
 
-        Ok(Value::from(minutes).to_handle(cx))
+        Ok(cx.number(minutes))
     }
 
     /// get Temporal.Duration.prototype.seconds (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.seconds)
@@ -285,7 +285,7 @@ impl DurationPrototype {
         let duration = this_duration(cx, this_value, "Duration.prototype.seconds")?;
         let seconds = duration.duration().seconds();
 
-        Ok(Value::from(seconds).to_handle(cx))
+        Ok(cx.number(seconds))
     }
 
     /// get Temporal.Duration.prototype.milliseconds (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.milliseconds)
@@ -297,7 +297,7 @@ impl DurationPrototype {
         let duration = this_duration(cx, this_value, "Duration.prototype.milliseconds")?;
         let millis = duration.duration().milliseconds();
 
-        Ok(Value::from(millis).to_handle(cx))
+        Ok(cx.number(millis))
     }
 
     /// get Temporal.Duration.prototype.microseconds (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.microseconds)
@@ -308,7 +308,7 @@ impl DurationPrototype {
     ) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.microseconds")?;
         let micros = duration.duration().microseconds();
-        Ok(Value::from(micros as f64).to_handle(cx))
+        Ok(cx.number(micros as f64))
     }
 
     /// get Temporal.Duration.prototype.nanoseconds (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.nanoseconds)
@@ -319,7 +319,7 @@ impl DurationPrototype {
     ) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.nanoseconds")?;
         let nanos = duration.duration().nanoseconds();
-        Ok(Value::from(nanos as f64).to_handle(cx))
+        Ok(cx.number(nanos as f64))
     }
 
     /// get Temporal.Duration.prototype.sign (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.sign)
@@ -331,7 +331,7 @@ impl DurationPrototype {
         let duration = this_duration(cx, this_value, "Duration.prototype.sign")?;
         let sign = duration.duration().sign();
 
-        Ok(cx.smi(sign as i32))
+        Ok(cx.smi(sign as i8))
     }
 
     /// get Temporal.Duration.prototype.blank (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.blank)

--- a/src/js/runtime/intrinsics/temporal/instant_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_constructor.rs
@@ -160,7 +160,7 @@ impl InstantConstructor {
         let instant_1 = to_temporal_instant(cx, arg_1, NAME)?;
         let instant_2 = to_temporal_instant(cx, arg_2, NAME)?;
 
-        Ok(cx.smi(instant_1.cmp(&instant_2) as i32))
+        Ok(cx.smi(instant_1.cmp(&instant_2) as i8))
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/instant_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_prototype.rs
@@ -150,7 +150,7 @@ impl InstantPrototype {
         let instant = this_instant(cx, this_value, "Instant.prototype.epochMilliseconds")?;
         let epoch_millis = instant.instant().epoch_milliseconds();
 
-        Ok(Value::from(epoch_millis).to_handle(cx))
+        Ok(cx.number(epoch_millis))
     }
 
     /// get Temporal.Instant.prototype.epochNanoseconds (https://tc39.es/proposal-temporal/#sec-get-temporal.instant.prototype.epochnanoseconds)

--- a/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
@@ -108,7 +108,7 @@ impl PlainDateConstructor {
         let date_1 = to_temporal_date(cx, arg_1, NAME)?;
         let date_2 = to_temporal_date(cx, arg_2, NAME)?;
 
-        Ok(cx.smi(date_1.compare_iso(&date_2) as i32))
+        Ok(cx.smi(date_1.compare_iso(&date_2) as i8))
     }
 
     /// Temporal.PlainDate.from (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.from)

--- a/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
@@ -317,7 +317,7 @@ impl PlainDatePrototype {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.month")?;
         let month_number = this_date.date().month();
 
-        Ok(cx.smi(month_number as i32))
+        Ok(cx.smi(month_number))
     }
 
     /// get Temporal.PlainDate.prototype.monthCode (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.monthcode)
@@ -341,7 +341,7 @@ impl PlainDatePrototype {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.day")?;
         let day_number = this_date.date().day();
 
-        Ok(cx.smi(day_number as i32))
+        Ok(cx.smi(day_number))
     }
 
     /// get Temporal.PlainDate.prototype.dayOfWeek (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.dayofweek)
@@ -353,7 +353,7 @@ impl PlainDatePrototype {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.dayOfWeek")?;
         let day_of_week_number = this_date.date().day_of_week();
 
-        Ok(cx.smi(day_of_week_number as i32))
+        Ok(cx.smi(day_of_week_number))
     }
 
     /// get Temporal.PlainDate.prototype.dayOfYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.dayofyear)
@@ -365,7 +365,7 @@ impl PlainDatePrototype {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.dayOfYear")?;
         let day_of_year_number = this_date.date().day_of_year();
 
-        Ok(cx.smi(day_of_year_number as i32))
+        Ok(cx.smi(day_of_year_number))
     }
 
     /// get Temporal.PlainDate.prototype.weekOfYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.weekofyear)
@@ -378,7 +378,7 @@ impl PlainDatePrototype {
 
         match this_date.date().week_of_year() {
             None => Ok(cx.undefined()),
-            Some(week_number) => Ok(cx.smi(week_number as i32)),
+            Some(week_number) => Ok(cx.smi(week_number)),
         }
     }
 
@@ -405,7 +405,7 @@ impl PlainDatePrototype {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.daysInWeek")?;
         let num_days_in_week = this_date.date().days_in_week();
 
-        Ok(cx.smi(num_days_in_week as i32))
+        Ok(cx.smi(num_days_in_week))
     }
 
     /// get Temporal.PlainDate.prototype.daysInMonth (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinmonth)
@@ -417,7 +417,7 @@ impl PlainDatePrototype {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.daysInMonth")?;
         let num_days_in_month = this_date.date().days_in_month();
 
-        Ok(cx.smi(num_days_in_month as i32))
+        Ok(cx.smi(num_days_in_month))
     }
 
     /// get Temporal.PlainDate.prototype.daysInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinyear)
@@ -429,7 +429,7 @@ impl PlainDatePrototype {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.daysInYear")?;
         let num_days_in_year = this_date.date().days_in_year();
 
-        Ok(cx.smi(num_days_in_year as i32))
+        Ok(cx.smi(num_days_in_year))
     }
 
     /// get Temporal.PlainDate.prototype.monthsInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.monthsinyear)
@@ -441,7 +441,7 @@ impl PlainDatePrototype {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.monthsInYear")?;
         let num_months_in_year = this_date.date().months_in_year();
 
-        Ok(cx.smi(num_months_in_year as i32))
+        Ok(cx.smi(num_months_in_year))
     }
 
     /// get Temporal.PlainDate.prototype.inLeapYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.inleapyear)

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
@@ -150,7 +150,7 @@ impl PlainDateTimeConstructor {
         let date_time_1 = to_temporal_date_time(cx, arg_1, NAME)?;
         let date_time_2 = to_temporal_date_time(cx, arg_2, NAME)?;
 
-        Ok(cx.smi(date_time_1.compare_iso(&date_time_2) as i32))
+        Ok(cx.smi(date_time_1.compare_iso(&date_time_2) as i8))
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
@@ -371,7 +371,7 @@ impl PlainDateTimePrototype {
         let this_date_time = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.month")?;
         let month = this_date_time.date_time().month();
 
-        Ok(cx.smi(month as i32))
+        Ok(cx.smi(month))
     }
 
     /// get Temporal.PlainDateTime.prototype.monthCode (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.monthcode)
@@ -396,7 +396,7 @@ impl PlainDateTimePrototype {
         let this_date_time = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.day")?;
         let day = this_date_time.date_time().day();
 
-        Ok(cx.smi(day as i32))
+        Ok(cx.smi(day))
     }
 
     /// get Temporal.PlainDateTime.prototype.dayOfWeek (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.dayofweek)
@@ -409,7 +409,7 @@ impl PlainDateTimePrototype {
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.dayOfWeek")?;
         let day_of_week = this_date_time.date_time().day_of_week();
 
-        Ok(cx.smi(day_of_week as i32))
+        Ok(cx.smi(day_of_week))
     }
 
     /// get Temporal.PlainDateTime.prototype.dayOfYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.dayofyear)
@@ -422,7 +422,7 @@ impl PlainDateTimePrototype {
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.dayOfYear")?;
         let day_of_year = this_date_time.date_time().day_of_year();
 
-        Ok(cx.smi(day_of_year as i32))
+        Ok(cx.smi(day_of_year))
     }
 
     /// get Temporal.PlainDateTime.prototype.weekOfYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.weekofyear)
@@ -436,7 +436,7 @@ impl PlainDateTimePrototype {
 
         match this_date_time.date_time().week_of_year() {
             None => Ok(cx.undefined()),
-            Some(week_number) => Ok(cx.smi(week_number as i32)),
+            Some(week_number) => Ok(cx.smi(week_number)),
         }
     }
 
@@ -465,7 +465,7 @@ impl PlainDateTimePrototype {
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.daysInWeek")?;
         let days_in_week = this_date_time.date_time().days_in_week();
 
-        Ok(cx.smi(days_in_week as i32))
+        Ok(cx.smi(days_in_week))
     }
 
     /// get Temporal.PlainDateTime.prototype.daysInMonth (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinmonth)
@@ -478,7 +478,7 @@ impl PlainDateTimePrototype {
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.daysInMonth")?;
         let days_in_month = this_date_time.date_time().days_in_month();
 
-        Ok(cx.smi(days_in_month as i32))
+        Ok(cx.smi(days_in_month))
     }
 
     /// get Temporal.PlainDateTime.prototype.daysInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinyear)
@@ -491,7 +491,7 @@ impl PlainDateTimePrototype {
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.daysInYear")?;
         let days_in_year = this_date_time.date_time().days_in_year();
 
-        Ok(cx.smi(days_in_year as i32))
+        Ok(cx.smi(days_in_year))
     }
 
     /// get Temporal.PlainDateTime.prototype.monthsInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.monthsinyear)
@@ -504,7 +504,7 @@ impl PlainDateTimePrototype {
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.monthsInYear")?;
         let months_in_year = this_date_time.date_time().months_in_year();
 
-        Ok(cx.smi(months_in_year as i32))
+        Ok(cx.smi(months_in_year))
     }
 
     /// get Temporal.PlainDateTime.prototype.inLeapYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.inleapyear)
@@ -529,7 +529,7 @@ impl PlainDateTimePrototype {
         let this_date_time = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.hour")?;
         let hour = this_date_time.date_time().hour();
 
-        Ok(cx.smi(hour as i32))
+        Ok(cx.smi(hour))
     }
 
     /// get Temporal.PlainDateTime.prototype.minute (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.minute)
@@ -542,7 +542,7 @@ impl PlainDateTimePrototype {
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.minute")?;
         let minute = this_date_time.date_time().minute();
 
-        Ok(cx.smi(minute as i32))
+        Ok(cx.smi(minute))
     }
 
     /// get Temporal.PlainDateTime.prototype.second (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.second)
@@ -555,7 +555,7 @@ impl PlainDateTimePrototype {
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.second")?;
         let second = this_date_time.date_time().second();
 
-        Ok(cx.smi(second as i32))
+        Ok(cx.smi(second))
     }
 
     /// get Temporal.PlainDateTime.prototype.millisecond (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.millisecond)
@@ -568,7 +568,7 @@ impl PlainDateTimePrototype {
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.millisecond")?;
         let millis = this_date_time.date_time().millisecond();
 
-        Ok(cx.smi(millis as i32))
+        Ok(cx.smi(millis))
     }
 
     /// get Temporal.PlainDateTime.prototype.microsecond (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.microsecond)
@@ -581,7 +581,7 @@ impl PlainDateTimePrototype {
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.microsecond")?;
         let micros = this_date_time.date_time().microsecond();
 
-        Ok(cx.smi(micros as i32))
+        Ok(cx.smi(micros))
     }
 
     /// get Temporal.PlainDateTime.prototype.nanosecond (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.nanosecond)
@@ -594,7 +594,7 @@ impl PlainDateTimePrototype {
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.nanosecond")?;
         let nanos = this_date_time.date_time().nanosecond();
 
-        Ok(cx.smi(nanos as i32))
+        Ok(cx.smi(nanos))
     }
 
     /// Temporal.PlainDateTime.prototype.add (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.add)

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
@@ -154,7 +154,7 @@ impl PlainMonthDayPrototype {
         let this_month_day = this_plain_month_day(cx, this_value, "PlainMonthDay.prototype.day")?;
         let day = this_month_day.month_day().day();
 
-        Ok(cx.smi(day as i32))
+        Ok(cx.smi(day))
     }
 
     /// Temporal.PlainMonthDay.prototype.equals (https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.equals)

--- a/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
@@ -130,7 +130,7 @@ impl PlainTimeConstructor {
         let time_1 = to_temporal_time(cx, arg_1, NAME)?;
         let time_2 = to_temporal_time(cx, arg_2, NAME)?;
 
-        Ok(cx.smi(time_1.cmp(&time_2) as i32))
+        Ok(cx.smi(time_1.cmp(&time_2) as i8))
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
@@ -171,7 +171,7 @@ impl PlainTimePrototype {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.hour")?;
         let hour = this_time.time().hour();
 
-        Ok(cx.smi(hour as i32))
+        Ok(cx.smi(hour))
     }
 
     /// get Temporal.PlainTime.prototype.minute (https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.minute)
@@ -183,7 +183,7 @@ impl PlainTimePrototype {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.minute")?;
         let minute = this_time.time().minute();
 
-        Ok(cx.smi(minute as i32))
+        Ok(cx.smi(minute))
     }
 
     /// get Temporal.PlainTime.prototype.second (https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.second)
@@ -195,7 +195,7 @@ impl PlainTimePrototype {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.second")?;
         let second = this_time.time().second();
 
-        Ok(cx.smi(second as i32))
+        Ok(cx.smi(second))
     }
 
     /// get Temporal.PlainTime.prototype.millisecond (https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.millisecond)
@@ -207,7 +207,7 @@ impl PlainTimePrototype {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.millisecond")?;
         let millis = this_time.time().millisecond();
 
-        Ok(cx.smi(millis as i32))
+        Ok(cx.smi(millis))
     }
 
     /// get Temporal.PlainTime.prototype.microsecond (https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.microsecond)
@@ -219,7 +219,7 @@ impl PlainTimePrototype {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.microsecond")?;
         let micros = this_time.time().microsecond();
 
-        Ok(cx.smi(micros as i32))
+        Ok(cx.smi(micros))
     }
 
     /// get Temporal.PlainTime.prototype.nanosecond (https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.nanosecond)
@@ -231,7 +231,7 @@ impl PlainTimePrototype {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.nanosecond")?;
         let nanos = this_time.time().nanosecond();
 
-        Ok(cx.smi(nanos as i32))
+        Ok(cx.smi(nanos))
     }
 
     /// Temporal.PlainTime.prototype.add (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.add)

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
@@ -130,7 +130,7 @@ impl PlainYearMonthConstructor {
         let year_month_1 = to_temporal_year_month(cx, arg_1, None, NAME)?;
         let year_month_2 = to_temporal_year_month(cx, arg_2, None, NAME)?;
 
-        Ok(cx.smi(year_month_1.compare_iso(&year_month_2) as i32))
+        Ok(cx.smi(year_month_1.compare_iso(&year_month_2) as i8))
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
@@ -257,7 +257,7 @@ impl PlainYearMonthPrototype {
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.month")?;
         let month = this_year_month.year_month().month();
 
-        Ok(cx.smi(month as i32))
+        Ok(cx.smi(month))
     }
 
     /// get Temporal.PlainYearMonth.prototype.monthCode (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthcode)
@@ -283,7 +283,7 @@ impl PlainYearMonthPrototype {
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.daysInYear")?;
         let days_in_year = this_year_month.year_month().days_in_year();
 
-        Ok(cx.smi(days_in_year as i32))
+        Ok(cx.smi(days_in_year))
     }
 
     /// get Temporal.PlainYearMonth.prototype.daysInMonth (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.daysinmonth)
@@ -296,7 +296,7 @@ impl PlainYearMonthPrototype {
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.daysInMonth")?;
         let days_in_month = this_year_month.year_month().days_in_month();
 
-        Ok(cx.smi(days_in_month as i32))
+        Ok(cx.smi(days_in_month))
     }
 
     /// get Temporal.PlainYearMonth.prototype.monthsInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthsinyear)
@@ -309,7 +309,7 @@ impl PlainYearMonthPrototype {
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.monthsInYear")?;
         let months_in_year = this_year_month.year_month().months_in_year();
 
-        Ok(cx.smi(months_in_year as i32))
+        Ok(cx.smi(months_in_year))
     }
 
     /// get Temporal.PlainYearMonth.prototype.inLeapYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.inleapyear)

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
@@ -117,7 +117,7 @@ impl ZonedDateTimeConstructor {
         let zoned_date_time_1 = to_temporal_zoned_date_time(cx, arg_1, NAME)?;
         let zoned_date_time_2 = to_temporal_zoned_date_time(cx, arg_2, NAME)?;
 
-        Ok(cx.smi(zoned_date_time_1.compare_instant(&zoned_date_time_2) as i32))
+        Ok(cx.smi(zoned_date_time_1.compare_instant(&zoned_date_time_2) as i8))
     }
 
     /// Temporal.ZonedDateTime.from (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.from)

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
@@ -426,7 +426,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.epochMilliseconds")?;
         let epoch_millis = this_zoned_date_time.zoned_date_time().epoch_milliseconds();
 
-        Ok(Value::from(epoch_millis).to_handle(cx))
+        Ok(cx.number(epoch_millis))
     }
 
     /// get Temporal.ZonedDateTime.prototype.epochNanoseconds (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochnanoseconds)
@@ -498,7 +498,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.month")?;
         let month = this_zoned_date_time.zoned_date_time().month();
 
-        Ok(cx.smi(month as i32))
+        Ok(cx.smi(month))
     }
 
     /// get Temporal.ZonedDateTime.prototype.monthCode (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.monthcode)
@@ -524,7 +524,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.day")?;
         let day = this_zoned_date_time.zoned_date_time().day();
 
-        Ok(cx.smi(day as i32))
+        Ok(cx.smi(day))
     }
 
     /// get Temporal.ZonedDateTime.prototype.hour (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.hour)
@@ -537,7 +537,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.hour")?;
         let hour = this_zoned_date_time.zoned_date_time().hour();
 
-        Ok(cx.smi(hour as i32))
+        Ok(cx.smi(hour))
     }
 
     /// get Temporal.ZonedDateTime.prototype.minute (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.minute)
@@ -550,7 +550,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.minute")?;
         let minute = this_zoned_date_time.zoned_date_time().minute();
 
-        Ok(cx.smi(minute as i32))
+        Ok(cx.smi(minute))
     }
 
     /// get Temporal.ZonedDateTime.prototype.second (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.second)
@@ -563,7 +563,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.second")?;
         let second = this_zoned_date_time.zoned_date_time().second();
 
-        Ok(cx.smi(second as i32))
+        Ok(cx.smi(second))
     }
 
     /// get Temporal.ZonedDateTime.prototype.millisecond (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.millisecond)
@@ -576,7 +576,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.millisecond")?;
         let millis = this_zoned_date_time.zoned_date_time().millisecond();
 
-        Ok(cx.smi(millis as i32))
+        Ok(cx.smi(millis))
     }
 
     /// get Temporal.ZonedDateTime.prototype.microsecond (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.microsecond)
@@ -589,7 +589,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.microsecond")?;
         let micros = this_zoned_date_time.zoned_date_time().microsecond();
 
-        Ok(cx.smi(micros as i32))
+        Ok(cx.smi(micros))
     }
 
     /// get Temporal.ZonedDateTime.prototype.nanosecond (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.nanosecond)
@@ -602,7 +602,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.nanosecond")?;
         let nanos = this_zoned_date_time.zoned_date_time().nanosecond();
 
-        Ok(cx.smi(nanos as i32))
+        Ok(cx.smi(nanos))
     }
 
     /// get Temporal.ZonedDateTime.prototype.offset (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.offset)
@@ -628,7 +628,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.offsetNanoseconds")?;
         let offset_nanos = this_zoned_date_time.zoned_date_time().offset_nanoseconds();
 
-        Ok(Value::from(offset_nanos).to_handle(cx))
+        Ok(cx.number(offset_nanos))
     }
 
     /// get Temporal.ZonedDateTime.prototype.dayOfWeek (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.dayofweek)
@@ -641,7 +641,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.dayOfWeek")?;
         let day_of_week = this_zoned_date_time.zoned_date_time().day_of_week();
 
-        Ok(cx.smi(day_of_week as i32))
+        Ok(cx.smi(day_of_week))
     }
 
     /// get Temporal.ZonedDateTime.prototype.dayOfYear (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.dayofyear)
@@ -654,7 +654,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.dayOfYear")?;
         let day_of_year = this_zoned_date_time.zoned_date_time().day_of_year();
 
-        Ok(cx.smi(day_of_year as i32))
+        Ok(cx.smi(day_of_year))
     }
 
     /// get Temporal.ZonedDateTime.prototype.weekOfYear (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.weekofyear)
@@ -668,7 +668,7 @@ impl ZonedDateTimePrototype {
 
         match this_zoned_date_time.zoned_date_time().week_of_year() {
             None => Ok(cx.undefined()),
-            Some(week_number) => Ok(cx.smi(week_number as i32)),
+            Some(week_number) => Ok(cx.smi(week_number)),
         }
     }
 
@@ -697,7 +697,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.daysInWeek")?;
         let days_in_week = this_zoned_date_time.zoned_date_time().days_in_week();
 
-        Ok(cx.smi(days_in_week as i32))
+        Ok(cx.smi(days_in_week))
     }
 
     /// get Temporal.ZonedDateTime.prototype.daysInMonth (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinmonth)
@@ -710,7 +710,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.daysInMonth")?;
         let days_in_month = this_zoned_date_time.zoned_date_time().days_in_month();
 
-        Ok(cx.smi(days_in_month as i32))
+        Ok(cx.smi(days_in_month))
     }
 
     /// get Temporal.ZonedDateTime.prototype.daysInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinyear)
@@ -723,7 +723,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.daysInYear")?;
         let days_in_year = this_zoned_date_time.zoned_date_time().days_in_year();
 
-        Ok(cx.smi(days_in_year as i32))
+        Ok(cx.smi(days_in_year))
     }
 
     /// get Temporal.ZonedDateTime.prototype.monthsInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.monthsinyear)
@@ -736,7 +736,7 @@ impl ZonedDateTimePrototype {
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.monthsInYear")?;
         let months_in_year = this_zoned_date_time.zoned_date_time().months_in_year();
 
-        Ok(cx.smi(months_in_year as i32))
+        Ok(cx.smi(months_in_year))
     }
 
     /// get Temporal.ZonedDateTime.prototype.inLeapYear (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.inleapyear)

--- a/src/js/runtime/intrinsics/typed_array.rs
+++ b/src/js/runtime/intrinsics/typed_array.rs
@@ -178,7 +178,7 @@ pub fn to_int8_element(cx: Context, value: Handle<Value>) -> EvalResult<i8> {
 
 #[inline]
 pub fn from_int8_element(cx: Context, element: i8) -> AllocResult<Handle<Value>> {
-    Ok(Value::from(element).to_handle(cx))
+    Ok(cx.number(element))
 }
 
 create_typed_array!(
@@ -200,7 +200,7 @@ pub fn to_uint8_element(cx: Context, value: Handle<Value>) -> EvalResult<u8> {
 
 #[inline]
 pub fn from_uint8_element(cx: Context, element: u8) -> AllocResult<Handle<Value>> {
-    Ok(Value::from(element).to_handle(cx))
+    Ok(cx.number(element))
 }
 
 create_typed_array!(
@@ -222,7 +222,7 @@ pub fn to_uint8_clamped_element(cx: Context, value: Handle<Value>) -> EvalResult
 
 #[inline]
 pub fn from_uint8_clamped_element(cx: Context, element: u8) -> AllocResult<Handle<Value>> {
-    Ok(Value::from(element).to_handle(cx))
+    Ok(cx.number(element))
 }
 
 create_typed_array!(
@@ -244,7 +244,7 @@ pub fn to_int16_element(cx: Context, value: Handle<Value>) -> EvalResult<i16> {
 
 #[inline]
 pub fn from_int16_element(cx: Context, element: i16) -> AllocResult<Handle<Value>> {
-    Ok(Value::from(element).to_handle(cx))
+    Ok(cx.number(element))
 }
 
 create_typed_array!(
@@ -266,7 +266,7 @@ pub fn to_uint16_element(cx: Context, value: Handle<Value>) -> EvalResult<u16> {
 
 #[inline]
 pub fn from_uint16_element(cx: Context, element: u16) -> AllocResult<Handle<Value>> {
-    Ok(Value::from(element).to_handle(cx))
+    Ok(cx.number(element))
 }
 
 create_typed_array!(
@@ -288,7 +288,7 @@ pub fn to_int32_element(cx: Context, value: Handle<Value>) -> EvalResult<i32> {
 
 #[inline]
 pub fn from_int32_element(cx: Context, element: i32) -> AllocResult<Handle<Value>> {
-    Ok(Value::from(element).to_handle(cx))
+    Ok(cx.number(element))
 }
 
 create_typed_array!(
@@ -310,7 +310,7 @@ pub fn to_uint32_element(cx: Context, value: Handle<Value>) -> EvalResult<u32> {
 
 #[inline]
 pub fn from_uint32_element(cx: Context, element: u32) -> AllocResult<Handle<Value>> {
-    Ok(Value::from(element).to_handle(cx))
+    Ok(cx.number(element))
 }
 
 create_typed_array!(
@@ -398,7 +398,7 @@ pub fn to_float16_element(cx: Context, value: Handle<Value>) -> EvalResult<f16> 
 
 #[inline]
 pub fn from_float16_element(cx: Context, element: f16) -> AllocResult<Handle<Value>> {
-    Ok(Value::from(element.to_f64()).to_handle(cx))
+    Ok(cx.number(element.to_f64()))
 }
 
 create_typed_array!(
@@ -421,7 +421,7 @@ pub fn to_float32_element(cx: Context, value: Handle<Value>) -> EvalResult<f32> 
 
 #[inline]
 pub fn from_float32_element(cx: Context, element: f32) -> AllocResult<Handle<Value>> {
-    Ok(Value::from(element).to_handle(cx))
+    Ok(cx.number(element))
 }
 
 create_typed_array!(
@@ -444,7 +444,7 @@ pub fn to_float64_element(cx: Context, value: Handle<Value>) -> EvalResult<f64> 
 
 #[inline]
 pub fn from_float64_element(cx: Context, element: f64) -> AllocResult<Handle<Value>> {
-    Ok(Value::from(element).to_handle(cx))
+    Ok(cx.number(element))
 }
 
 create_typed_array!(

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -144,7 +144,7 @@ impl TypedArrayConstructor {
 
             let length = values.len();
 
-            let length_value = Value::from(length).to_handle(cx);
+            let length_value = cx.number(length);
             let target_object = typed_array_create_from_constructor_object(
                 cx,
                 this_constructor,
@@ -160,7 +160,7 @@ impl TypedArrayConstructor {
                 index_key.replace(PropertyKey::from_u64(cx, i as u64)?);
 
                 let value = if let Some(map_function) = map_function {
-                    index_value.replace(Value::from(i));
+                    index_value.replace(Value::number(i));
                     call_object(cx, map_function, this_argument, &[value, index_value])?
                 } else {
                     value
@@ -176,7 +176,7 @@ impl TypedArrayConstructor {
         let array_like = must!(to_object(cx, source));
         let length = length_of_array_like(cx, array_like)? as usize;
 
-        let length_value = Value::from(length).to_handle(cx);
+        let length_value = cx.number(length);
         let target_object = typed_array_create_from_constructor_object(
             cx,
             this_constructor,
@@ -194,7 +194,7 @@ impl TypedArrayConstructor {
             let value = get(cx, array_like, index_key)?;
 
             let value = if let Some(map_function) = map_function {
-                index_value.replace(Value::from(i));
+                index_value.replace(Value::number(i));
                 call_object(cx, map_function, this_argument, &[value, index_value])?
             } else {
                 value
@@ -289,7 +289,7 @@ impl TypedArrayConstructor {
 
         let this_constructor = this_value.as_object();
         let length = arguments.len();
-        let length_value = Value::from(length).to_handle(cx);
+        let length_value = cx.number(length);
 
         let typed_array = typed_array_create_from_constructor(
             cx,
@@ -743,7 +743,7 @@ macro_rules! create_typed_array_constructor {
                     realm.get_intrinsic(Intrinsic::$prototype).into(),
                 )?;
 
-                let element_size_value = cx.smi(element_size!() as i32);
+                let element_size_value = cx.smi(element_size!() as u8);
                 func.intrinsic_frozen_property(
                     cx,
                     cx.names.bytes_per_element(),

--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -411,7 +411,7 @@ impl TypedArrayPrototype {
 
         let byte_length = typed_array_byte_length(&typed_array_record);
 
-        Ok(Value::from(byte_length).to_handle(cx))
+        Ok(cx.number(byte_length))
     }
 
     /// get %TypedArray%.prototype.byteOffset (https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.byteoffset)
@@ -427,7 +427,7 @@ impl TypedArrayPrototype {
             return Ok(cx.zero());
         }
 
-        Ok(Value::from(typed_array.byte_offset()).to_handle(cx))
+        Ok(cx.number(typed_array.byte_offset()))
     }
 
     /// %TypedArray%.prototype.copyWithin (https://tc39.es/ecma262/#sec-%typedarray%.prototype.copywithin)
@@ -577,7 +577,7 @@ impl TypedArrayPrototype {
             index_key.replace(PropertyKey::from_u64(cx, i)?);
             let value = must!(get(cx, object, index_key));
 
-            index_value.replace(Value::from(i));
+            index_value.replace(Value::number(i));
             let arguments = [value, index_value, object.into()];
 
             let test_result = call_object(cx, callback_function, this_arg, &arguments)?;
@@ -666,7 +666,7 @@ impl TypedArrayPrototype {
             index_key.replace(PropertyKey::from_u64(cx, i)?);
             let value = get(cx, object, index_key)?;
 
-            index_value.replace(Value::from(i));
+            index_value.replace(Value::number(i));
             let arguments = [value, index_value, object.into()];
 
             let is_selected = call_object(cx, callback_function, this_arg, &arguments)?;
@@ -678,7 +678,7 @@ impl TypedArrayPrototype {
 
         // Then create a new array that contains the kept values
         let num_kept_values = kept_values.len();
-        let num_kept_values_value = Value::from(num_kept_values).to_handle(cx);
+        let num_kept_values_value = cx.number(num_kept_values);
         let array =
             typed_array_species_create_object(cx, typed_array, &[num_kept_values_value], "filter")?;
 
@@ -838,7 +838,7 @@ impl TypedArrayPrototype {
             index_key.replace(PropertyKey::from_u64(cx, i)?);
             let value = must!(get(cx, object, index_key));
 
-            index_value.replace(Value::from(i));
+            index_value.replace(Value::number(i));
             let arguments = [value, index_value, object.into()];
 
             call_object(cx, callback_function, this_arg, &arguments)?;
@@ -912,7 +912,7 @@ impl TypedArrayPrototype {
             if must!(has_property(cx, object, key)) {
                 let element = must!(get(cx, object, key));
                 if is_strictly_equal(search_element, element)? {
-                    return Ok(Value::from(i).to_handle(cx));
+                    return Ok(cx.number(i));
                 }
             }
         }
@@ -1021,7 +1021,7 @@ impl TypedArrayPrototype {
             if must!(has_property(cx, object, key)) {
                 let element = must!(get(cx, object, key));
                 if is_strictly_equal(search_element, element)? {
-                    return Ok(Value::from(i).to_handle(cx));
+                    return Ok(cx.number(i));
                 }
             }
         }
@@ -1044,7 +1044,7 @@ impl TypedArrayPrototype {
 
         let length = typed_array_length(&typed_array_record);
 
-        Ok(Value::from(length).to_handle(cx))
+        Ok(cx.number(length))
     }
 
     /// %TypedArray%.prototype.map (https://tc39.es/ecma262/#sec-%typedarray%.prototype.map)
@@ -1067,7 +1067,7 @@ impl TypedArrayPrototype {
         let callback_function = callback_function.as_object();
         let this_arg = get_argument(cx, arguments, 1);
 
-        let length_value = Value::from(length).to_handle(cx);
+        let length_value = cx.number(length);
         let array = typed_array_species_create_object(cx, typed_array, &[length_value], "map")?;
 
         // Shared between iterations
@@ -1078,7 +1078,7 @@ impl TypedArrayPrototype {
             index_key.replace(PropertyKey::from_u64(cx, i as u64)?);
             let value = must!(get(cx, object, index_key));
 
-            index_value.replace(Value::from(i));
+            index_value.replace(Value::number(i));
             let arguments = [value, index_value, object.into()];
 
             let mapped_value = call_object(cx, callback_function, this_arg, &arguments)?;
@@ -1126,7 +1126,7 @@ impl TypedArrayPrototype {
             index_key.replace(PropertyKey::from_u64(cx, i)?);
             let value = must!(get(cx, object, index_key));
 
-            index_value.replace(Value::from(i));
+            index_value.replace(Value::number(i));
             let arguments = [accumulator, value, index_value, object.into()];
 
             accumulator = call_object(cx, callback_function, cx.undefined(), &arguments)?;
@@ -1176,7 +1176,7 @@ impl TypedArrayPrototype {
             index_key.replace(PropertyKey::from_u64(cx, i as u64)?);
             let value = must!(get(cx, object, index_key));
 
-            index_value.replace(Value::from(i));
+            index_value.replace(Value::number(i));
             let arguments = [accumulator, value, index_value, object.into()];
 
             accumulator = call_object(cx, callback_function, cx.undefined(), &arguments)?;
@@ -1454,8 +1454,8 @@ impl TypedArrayPrototype {
         mut typed_array: DynTypedArray,
         decode_result: DecodeResult,
     ) -> EvalResult<Handle<Value>> {
-        let num_bytes_read = Value::from(decode_result.read).to_handle(cx);
-        let num_bytes_written = Value::from(decode_result.bytes.len()).to_handle(cx);
+        let num_bytes_read = cx.number(decode_result.read);
+        let num_bytes_written = cx.number(decode_result.bytes.len());
 
         // Write the encoded bytes into the backing slice of the ArrayBuffer. If there was a
         // decoding error then still write all successfully decoded bytes until the error.
@@ -1507,7 +1507,7 @@ impl TypedArrayPrototype {
         };
 
         let count = end_index.saturating_sub(start_index);
-        let count_value = Value::from(count).to_handle(cx);
+        let count_value = cx.number(count);
         let new_typed_array = typed_array_species_create(cx, typed_array, &[count_value], "slice")?;
         let array = new_typed_array.into_object_value();
 
@@ -1594,7 +1594,7 @@ impl TypedArrayPrototype {
             index_key.replace(PropertyKey::from_u64(cx, i as u64)?);
             let value = must!(get(cx, object, index_key));
 
-            index_value.replace(Value::from(i));
+            index_value.replace(Value::number(i));
             let arguments = [value, index_value, object.into()];
 
             let test_result = call_object(cx, callback_function, this_arg, &arguments)?;
@@ -1673,7 +1673,7 @@ impl TypedArrayPrototype {
         let element_size = typed_array.element_size();
         let source_byte_offset = typed_array.byte_offset();
         let begin_byte_offset = source_byte_offset + (start_index as usize) * element_size;
-        let begin_byte_offset_value = Value::from(begin_byte_offset).to_handle(cx);
+        let begin_byte_offset_value = cx.number(begin_byte_offset);
 
         let subarray = if typed_array.array_length().is_none() && end_argument.is_undefined() {
             typed_array_species_create_object(
@@ -1683,7 +1683,7 @@ impl TypedArrayPrototype {
                 "subarray",
             )?
         } else {
-            let new_length_value = Value::from(new_length).to_handle(cx);
+            let new_length_value = cx.number(new_length);
             typed_array_species_create_object(
                 cx,
                 typed_array,
@@ -1969,7 +1969,7 @@ macro_rules! create_typed_array_prototype {
                 )?;
 
                 // Constructor property is added once TypedArrayConstructor has been created
-                let element_size_value = cx.smi(std::mem::size_of::<$element_type>() as i32);
+                let element_size_value = cx.smi(std::mem::size_of::<$element_type>() as u8);
                 object.intrinsic_frozen_property(
                     cx,
                     cx.names.bytes_per_element(),
@@ -2128,7 +2128,7 @@ fn typed_array_create_same_type(
     };
 
     let constructor = cx.get_intrinsic(constructor_intrinsic);
-    let length_value = Value::from(length).to_handle(cx);
+    let length_value = cx.number(length);
 
     typed_array_create_from_constructor_object(
         cx,

--- a/src/js/runtime/property_key.rs
+++ b/src/js/runtime/property_key.rs
@@ -99,7 +99,7 @@ impl PropertyKey {
         Ok(property_key.to_handle(cx))
     }
 
-    pub const fn from_u8(value: u8) -> PropertyKey {
+    pub fn from_u8(value: u8) -> PropertyKey {
         PropertyKey { value: Value::smi(value as i32) }
     }
 

--- a/src/js/runtime/string_object.rs
+++ b/src/js/runtime/string_object.rs
@@ -111,7 +111,7 @@ impl StringObject {
         length: u32,
     ) -> AllocResult<()> {
         // String objects have an immutable length property
-        let length_value = Value::from(length).to_handle(cx);
+        let length_value = cx.number(length);
         string.as_object().set_property(
             cx,
             cx.names.length(),

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -4,7 +4,8 @@ use num_bigint::{BigInt, Sign};
 use rand::Rng;
 
 use crate::{
-    field_offset,
+    common::numeric::Numeric,
+    const_assert, field_offset,
     runtime::{
         alloc_error::AllocResult,
         context::Context,
@@ -107,16 +108,16 @@ const NULLISH_TAG_MASK: u16 = 0xFFFD;
 
 // Bit patterns for known constants
 const CANONICAL_NAN: u64 = !((NAN_TAG as u64) << TAG_SHIFT);
-const DOUBLE_POSITIVE_ZERO: u64 = Value::double(0.0).as_raw_bits();
-const DOUBLE_NEGATIVE_ZERO: u64 = Value::double(-0.0).as_raw_bits();
-const POSITIVE_INFINITY: u64 = Value::double(f64::INFINITY).as_raw_bits();
+const DOUBLE_POSITIVE_ZERO: u64 = Value::raw_double(0.0).as_raw_bits();
+const DOUBLE_NEGATIVE_ZERO: u64 = Value::raw_double(-0.0).as_raw_bits();
+const POSITIVE_INFINITY: u64 = Value::raw_double(f64::INFINITY).as_raw_bits();
 
 const TRUE: u64 = Value::bool(true).as_raw_bits();
 const FALSE: u64 = Value::bool(false).as_raw_bits();
 
 const SMI_MAX: f64 = i32::MAX as f64;
 const SMI_MIN: f64 = i32::MIN as f64;
-const SMI_ZERO: u64 = Value::smi(0).as_raw_bits();
+const SMI_ZERO: u64 = Value::raw_smi(0).as_raw_bits();
 
 impl Value {
     #[inline]
@@ -329,21 +330,6 @@ impl Value {
     // Constructors
 
     #[inline]
-    pub fn number(value: f64) -> Value {
-        // Check if this number should be converted into a smi
-        if value.trunc() == value
-            && (SMI_MIN..=SMI_MAX).contains(&value)
-            && f64::to_bits(value) != f64::to_bits(-0.0)
-        {
-            return Value::smi(value as i32);
-        } else if value.is_nan() {
-            return Value::nan();
-        }
-
-        Value::double(value)
-    }
-
-    #[inline]
     pub const fn undefined() -> Value {
         Value::from_raw_bits((UNDEFINED_TAG as u64) << TAG_SHIFT)
     }
@@ -364,17 +350,85 @@ impl Value {
     }
 
     #[inline]
-    pub const fn smi(value: i32) -> Value {
-        let smi_value_bits = value.cast_unsigned() as u64;
-        Value::from_raw_bits(((SMI_TAG as u64) << TAG_SHIFT) | smi_value_bits)
+    pub const fn raw_smi(value: i32) -> Value {
+        Value::from_raw_bits(((SMI_TAG as u64) << TAG_SHIFT) | (value as u32 as u64))
     }
 
     #[inline]
-    pub const fn double(value: f64) -> Value {
-        // f64::to_bits is not yet stable as a const fn. We only pass simple values in a const
-        // context so perform a raw transmute until f64::to_bits is const stabilized.
+    const fn raw_double(value: f64) -> Value {
         let double_bits = value.to_bits();
         Value::from_raw_bits(!double_bits)
+    }
+
+    #[inline]
+    pub fn smi<T: Numeric>(value: T) -> Value {
+        // Statically ensure that only safe smi types can be used
+        const_assert!(T::IS_SAFE_SMI);
+
+        Self::raw_smi(value.as_())
+    }
+
+    #[inline]
+    pub fn number<T: Numeric>(value: T) -> Value {
+        // Statically ensure that i128 and u128 are not used, and require external conversion
+        const_assert!(!T::IS_I128 && !T::IS_U128);
+
+        // Fast path for all integer types
+        if T::IS_SAFE_SMI {
+            Value::raw_smi(value.as_())
+        } else if T::IS_U32 {
+            let value_u32: u32 = value.as_();
+            if value_u32 <= i32::MAX as u32 {
+                Value::raw_smi(value.as_())
+            } else {
+                Value::raw_double(value.as_())
+            }
+        } else if T::IS_U64 {
+            let value_u64: u64 = value.as_();
+            if value_u64 <= i32::MAX as u64 {
+                Value::raw_smi(value.as_())
+            } else {
+                Value::raw_double(value.as_())
+            }
+        } else if T::IS_I64 {
+            let value_i64: i64 = value.as_();
+            if (i32::MIN as i64..=i32::MAX as i64).contains(&value_i64) {
+                Value::raw_smi(value.as_())
+            } else {
+                Value::raw_double(value.as_())
+            }
+        } else if T::IS_USIZE {
+            let value_usize: usize = value.as_();
+            if value_usize <= i32::MAX as usize {
+                Value::raw_smi(value.as_())
+            } else {
+                Value::raw_double(value.as_())
+            }
+        } else if T::IS_ISIZE {
+            let value_isize: isize = value.as_();
+            if (i32::MIN as isize..=i32::MAX as isize).contains(&value_isize) {
+                Value::raw_smi(value.as_())
+            } else {
+                Value::raw_double(value.as_())
+            }
+        } else if T::IS_F32 || T::IS_F64 {
+            // Otherwise treat as a double
+            let value_f64: f64 = value.as_();
+
+            // Check if this number should be converted into a smi
+            if value_f64.trunc() == value_f64
+                && (SMI_MIN..=SMI_MAX).contains(&value_f64)
+                && f64::to_bits(value_f64) != f64::to_bits(-0.0)
+            {
+                return Value::raw_smi(value_f64 as i32);
+            } else if value_f64.is_nan() {
+                return Value::nan();
+            }
+
+            Value::raw_double(value_f64)
+        } else {
+            unreachable!("Unsupported numeric type")
+        }
     }
 
     /// Convert any heap item into a Value. Note that only object subtypes, strings, symbols, and
@@ -452,87 +506,6 @@ impl DebugPrint for Value {
 impl From<bool> for Value {
     fn from(value: bool) -> Self {
         Value::bool(value)
-    }
-}
-
-impl From<u8> for Value {
-    fn from(value: u8) -> Self {
-        Value::smi(value as i32)
-    }
-}
-
-impl From<i8> for Value {
-    fn from(value: i8) -> Self {
-        Value::smi(value as i32)
-    }
-}
-
-impl From<u16> for Value {
-    fn from(value: u16) -> Self {
-        Value::smi(value as i32)
-    }
-}
-
-impl From<i16> for Value {
-    fn from(value: i16) -> Self {
-        Value::smi(value as i32)
-    }
-}
-
-impl From<u32> for Value {
-    fn from(value: u32) -> Self {
-        if value > i32::MAX as u32 {
-            return Value::double(value as f64);
-        }
-
-        Value::smi(value as i32)
-    }
-}
-
-impl From<i32> for Value {
-    fn from(value: i32) -> Self {
-        Value::smi(value)
-    }
-}
-
-impl From<u64> for Value {
-    fn from(value: u64) -> Self {
-        if value > i32::MAX as u64 {
-            // TODO: This conversion is lossy
-            return Value::double(value as f64);
-        }
-
-        Value::smi(value as i32)
-    }
-}
-
-impl From<i64> for Value {
-    fn from(value: i64) -> Self {
-        if value > i32::MAX as i64 || value < i32::MIN as i64 {
-            // TODO: This conversion is lossy
-            return Value::double(value as f64);
-        }
-
-        Value::smi(value as i32)
-    }
-}
-
-impl From<usize> for Value {
-    #[inline]
-    fn from(value: usize) -> Self {
-        Value::from(value as u64)
-    }
-}
-
-impl From<f32> for Value {
-    fn from(value: f32) -> Self {
-        Value::number(value as f64)
-    }
-}
-
-impl From<f64> for Value {
-    fn from(value: f64) -> Self {
-        Value::number(value)
     }
 }
 


### PR DESCRIPTION
## Summary

Refactor `Value::{smi, number}` and `Context::{smi, number}` to generically handle all numeric types. This uses a new `Numeric` type which we use to do compile-time dispatch into specialized implementations for each numeric type.

- Replace all uses of `Value::from` for numeric types with `Value::number`
- Use `Context::{smi, number}` everywhere handles are needed
- Remove all unnecessary casts on arguments to one of these functions 

## Tests

- All tests pass

