### PR TITLE
[runtime] Runtime method arguments wrapped in Arguments struct

### DIFF
--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -1,7 +1,7 @@
 use crate::{
     completion_value, eval_err, extend_object, field_offset, must_a,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Arguments, Context, Handle, HeapPtr, Value,
         abstract_operations::call_object,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -12,7 +12,6 @@ use crate::{
         collections::InlineArray,
         error::type_error,
         eval_result::EvalResult,
-        function::get_argument,
         gc::{HeapItem, HeapVisitor},
         generator_object::{GeneratorCompletionType, GeneratorRegister, TGeneratorObject},
         heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
@@ -404,9 +403,9 @@ pub fn async_generator_await_return(
 pub fn await_return_resolve(
     mut cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
-    let value = get_argument(cx, arguments, 0);
+    let value = arguments.get(cx, 0);
 
     let current_function = cx.current_function();
     let mut async_generator = get_async_generator(cx, current_function);
@@ -422,9 +421,9 @@ pub fn await_return_resolve(
 pub fn await_return_reject(
     mut cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
-    let value = get_argument(cx, arguments, 0);
+    let value = arguments.get(cx, 0);
 
     let current_function = cx.current_function();
     let mut async_generator = get_async_generator(cx, current_function);

--- a/src/js/runtime/bound_function_object.rs
+++ b/src/js/runtime/bound_function_object.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    Context, Handle,
+    Arguments, Context, Handle,
     abstract_operations::{call_object, construct, length_of_array_like},
     alloc_error::AllocResult,
     array_object::{ArrayObject, create_array_from_list},
@@ -146,7 +146,7 @@ impl BoundFunctionObject {
     pub fn call(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let bound_function = cx.current_function();
 

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -8,7 +8,8 @@ use crate::{
     common::numeric::Numeric,
     eval_err, handle_scope, handle_scope_guard, must,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, PropertyDescriptor, PropertyKey, Realm, Value,
+        Arguments, Context, EvalResult, Handle, HeapPtr, PropertyDescriptor, PropertyKey, Realm,
+        Value,
         abstract_operations::{
             call, call_object, copy_data_properties, create_data_property_or_throw,
             define_property_or_throw, get_method, get_v, has_property, private_get, private_set,
@@ -2387,7 +2388,7 @@ impl VM {
 
         // Perform the runtime call. May allocate.
         let rust_function = self.cx().rust_runtime_functions.get_function(function_id);
-        let result = rust_function(self.cx, receiver, arguments);
+        let result = rust_function(self.cx, receiver, Arguments::new(arguments));
 
         // Clean up the stack frame
         self.pop_stack_frame();

--- a/src/js/runtime/console.rs
+++ b/src/js/runtime/console.rs
@@ -4,7 +4,7 @@ use crate::{
         terminal::stdout_should_use_colors,
     },
     runtime::{
-        Context, Handle, Value,
+        Arguments, Context, Handle, Value,
         alloc_error::AllocResult,
         eval_result::EvalResult,
         heap_item_descriptor::HeapItemKind,
@@ -69,43 +69,23 @@ impl ConsoleObject {
         Ok(object.to_handle())
     }
 
-    pub fn debug(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn debug(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
         console_method_impl(cx, ConsoleLogLevel::Debug, arguments)
     }
 
-    pub fn error(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn error(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
         console_method_impl(cx, ConsoleLogLevel::Error, arguments)
     }
 
-    pub fn info(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn info(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
         console_method_impl(cx, ConsoleLogLevel::Info, arguments)
     }
 
-    pub fn log(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn log(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
         console_method_impl(cx, ConsoleLogLevel::Log, arguments)
     }
 
-    pub fn warn(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn warn(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
         console_method_impl(cx, ConsoleLogLevel::Warn, arguments)
     }
 }
@@ -113,7 +93,7 @@ impl ConsoleObject {
 fn console_method_impl(
     cx: Context,
     _: ConsoleLogLevel,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
     let use_colors = stdout_should_use_colors(&cx.options);
     let opts = FormatOptions::new(use_colors);

--- a/src/js/runtime/function.rs
+++ b/src/js/runtime/function.rs
@@ -4,7 +4,7 @@ use crate::{
         Context, EvalResult, Handle, abstract_operations::define_property_or_throw,
         alloc_error::AllocResult, object_value::ObjectValue,
         property_descriptor::PropertyDescriptor, property_key::PropertyKey,
-        string_value::StringValue, value::Value,
+        string_value::StringValue,
     },
 };
 
@@ -91,12 +91,4 @@ pub fn set_function_length_maybe_infinity(
     must!(define_property_or_throw(cx, func, cx.names.length(), desc));
 
     Ok(())
-}
-
-pub fn get_argument(cx: Context, arguments: &[Handle<Value>], i: usize) -> Handle<Value> {
-    if i < arguments.len() {
-        arguments[i]
-    } else {
-        cx.undefined()
-    }
 }

--- a/src/js/runtime/gc_object.rs
+++ b/src/js/runtime/gc_object.rs
@@ -1,7 +1,7 @@
 use crate::{
     handle_scope, must_a,
     runtime::{
-        Context, Handle, PropertyDescriptor, Value,
+        Arguments, Context, Handle, PropertyDescriptor, Value,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         eval_result::EvalResult,
@@ -35,7 +35,7 @@ impl GcObject {
         })
     }
 
-    pub fn run(cx: Context, _: Handle<Value>, _: &[Handle<Value>]) -> EvalResult<Handle<Value>> {
+    pub fn run(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         Heap::run_gc(cx, GcType::Normal);
         Ok(cx.undefined())
     }

--- a/src/js/runtime/global_names.rs
+++ b/src/js/runtime/global_names.rs
@@ -3,7 +3,8 @@ use std::collections::HashSet;
 use crate::{
     field_offset,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, PropertyDescriptor, PropertyKey, Realm, Value,
+        Arguments, Context, EvalResult, Handle, HeapPtr, PropertyDescriptor, PropertyKey, Realm,
+        Value,
         abstract_operations::{define_property_or_throw, has_own_property, is_extensible},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -101,7 +102,7 @@ pub fn create_global_declaration_instantiation_intrinsic(
 pub fn global_declaration_instantiation_runtime(
     cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
     let global_names = arguments.first().unwrap().cast::<GlobalNames>();
     let realm = cx.current_realm();

--- a/src/js/runtime/intrinsics/aggregate_error_constructor.rs
+++ b/src/js/runtime/intrinsics/aggregate_error_constructor.rs
@@ -1,7 +1,7 @@
 use crate::{
     must, must_a,
     runtime::{
-        Context, Handle, Value,
+        Arguments, Context, Handle, Value,
         abstract_operations::{
             create_data_property_or_throw, create_non_enumerable_data_property_or_throw,
             define_property_or_throw,
@@ -10,7 +10,6 @@ use crate::{
         array_object::create_array_from_list,
         builtin_function::BuiltinFunction,
         eval_result::EvalResult,
-        function::get_argument,
         intrinsics::{
             error_constructor::{ErrorObject, install_error_cause},
             intrinsics::Intrinsic,
@@ -70,7 +69,7 @@ impl AggregateErrorConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
@@ -85,8 +84,8 @@ impl AggregateErrorConstructor {
             /* skip_current_frame */ true,
         )?;
 
-        let errors = get_argument(cx, arguments, 0);
-        let message = get_argument(cx, arguments, 1);
+        let errors = arguments.get(cx, 0);
+        let message = arguments.get(cx, 1);
         if !message.is_undefined() {
             let message_string = to_string(cx, message)?;
             create_non_enumerable_data_property_or_throw(
@@ -97,7 +96,7 @@ impl AggregateErrorConstructor {
             )?;
         }
 
-        let options_arg = get_argument(cx, arguments, 2);
+        let options_arg = arguments.get(cx, 2);
         install_error_cause(cx, object, options_arg)?;
 
         // Collect errors in iterable and create a new array containing all errors

--- a/src/js/runtime/intrinsics/array_buffer_constructor.rs
+++ b/src/js/runtime/intrinsics/array_buffer_constructor.rs
@@ -3,13 +3,12 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Arguments, Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         collections::{BsArray, array::ByteArray},
         error::{range_error, type_error},
         eval_result::EvalResult,
-        function::get_argument,
         gc::{HeapItem, HeapVisitor},
         get,
         heap_item_descriptor::HeapItemKind,
@@ -192,7 +191,7 @@ impl ArrayBufferConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
@@ -200,10 +199,10 @@ impl ArrayBufferConstructor {
             return type_error(cx, "ArrayBuffer constructor must be called with new");
         };
 
-        let byte_length_arg = get_argument(cx, arguments, 0);
+        let byte_length_arg = arguments.get(cx, 0);
         let byte_length = to_index(cx, byte_length_arg)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let max_byte_length = get_array_buffer_max_byte_length_option(cx, options_arg)?;
 
         Ok(ArrayBufferObject::new(
@@ -220,9 +219,9 @@ impl ArrayBufferConstructor {
     pub fn is_view(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(cx.bool(false));
         }

--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -1,10 +1,9 @@
 use crate::runtime::{
-    Context, EvalResult, Handle, Value,
+    Arguments, Context, EvalResult, Handle, Value,
     abstract_operations::{construct, species_constructor},
     alloc_error::AllocResult,
     collections::BsArray,
     error::{range_error, type_error},
-    function::get_argument,
     heap_item_descriptor::HeapItemKind,
     intrinsics::{
         array_buffer_constructor::{
@@ -96,7 +95,7 @@ impl ArrayBufferPrototype {
     pub fn get_byte_length(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let array_buffer = require_array_buffer(cx, this_value, "byteLength")?;
 
@@ -108,7 +107,7 @@ impl ArrayBufferPrototype {
     pub fn get_detached(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let array_buffer = require_array_buffer(cx, this_value, "detached")?;
         Ok(cx.bool(array_buffer.is_detached()))
@@ -118,7 +117,7 @@ impl ArrayBufferPrototype {
     pub fn get_max_byte_length(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let array_buffer = require_array_buffer(cx, this_value, "maxByteLength")?;
 
@@ -134,7 +133,7 @@ impl ArrayBufferPrototype {
     pub fn get_resizable(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let array_buffer = require_array_buffer(cx, this_value, "resizable")?;
         Ok(cx.bool(!array_buffer.is_fixed_length()))
@@ -144,7 +143,7 @@ impl ArrayBufferPrototype {
     pub fn resize(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let mut array_buffer = require_array_buffer(cx, this_value, "resize")?;
 
@@ -157,7 +156,7 @@ impl ArrayBufferPrototype {
             );
         };
 
-        let new_length_arg = get_argument(cx, arguments, 0);
+        let new_length_arg = arguments.get(cx, 0);
         let new_byte_length = to_index(cx, new_length_arg)?;
 
         throw_if_detached(cx, *array_buffer)?;
@@ -202,7 +201,7 @@ impl ArrayBufferPrototype {
     pub fn slice(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let array_buffer = require_array_buffer(cx, this_value, "slice")?;
 
@@ -211,11 +210,11 @@ impl ArrayBufferPrototype {
         let length = array_buffer.byte_length() as u64;
 
         // Calculate the start index of the slice
-        let start_arg = get_argument(cx, arguments, 0);
+        let start_arg = arguments.get(cx, 0);
         let start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
         // Calculate the end index of the slice
-        let end_argument = get_argument(cx, arguments, 1);
+        let end_argument = arguments.get(cx, 1);
         let end_index = if !end_argument.is_undefined() {
             resolve_relative_index_argument(cx, end_argument, length)?
         } else {
@@ -280,10 +279,10 @@ impl ArrayBufferPrototype {
     pub fn transfer(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let array_buffer = require_array_buffer(cx, this_value, "transfer")?;
-        let new_length = get_argument(cx, arguments, 0);
+        let new_length = arguments.get(cx, 0);
 
         let new_array_buffer =
             array_buffer_copy_and_detach(cx, array_buffer, new_length, /* to_fixed */ false)?;
@@ -295,10 +294,10 @@ impl ArrayBufferPrototype {
     pub fn transfer_to_fixed_length(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let array_buffer = require_array_buffer(cx, this_value, "transferToFixedLength")?;
-        let new_length = get_argument(cx, arguments, 0);
+        let new_length = arguments.get(cx, 0);
 
         let new_array_buffer =
             array_buffer_copy_and_detach(cx, array_buffer, new_length, /* to_fixed */ true)?;

--- a/src/js/runtime/intrinsics/array_constructor.rs
+++ b/src/js/runtime/intrinsics/array_constructor.rs
@@ -2,7 +2,7 @@ use crate::{
     common::numeric::MAX_SAFE_INTEGER_U64,
     must,
     runtime::{
-        Context, EvalResult, Handle, Realm, Value,
+        Arguments, Context, EvalResult, Handle, Realm, Value,
         abstract_operations::{
             call_object, construct, create_data_property_or_throw, get_method,
             length_of_array_like, set,
@@ -11,7 +11,6 @@ use crate::{
         array_object::array_create,
         builtin_function::BuiltinFunction,
         error::{range_error, type_error},
-        function::get_argument,
         get,
         intrinsics::{
             array_from_async_generator::ArrayFromAsyncGenerator, intrinsics::Intrinsic,
@@ -73,7 +72,7 @@ impl ArrayConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = cx
             .current_new_target()
@@ -83,7 +82,7 @@ impl ArrayConstructor {
         if arguments.is_empty() {
             Ok(must!(array_create(cx, 0, Some(proto))).as_value())
         } else if arguments.len() == 1 {
-            let length = get_argument(cx, arguments, 0);
+            let length = arguments.get(cx, 0);
             let array = must!(array_create(cx, 0, Some(proto)));
 
             let int_len = if length.is_number() {
@@ -112,7 +111,7 @@ impl ArrayConstructor {
 
             for index in 0..arguments.len() {
                 key.replace(PropertyKey::array_index(cx, index as u32)?);
-                let value = get_argument(cx, arguments, index);
+                let value = arguments.get(cx, index);
 
                 must!(create_data_property_or_throw(cx, array.into(), key, value));
             }
@@ -125,10 +124,10 @@ impl ArrayConstructor {
     pub fn from(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         // Determine if map function was provided and is callable
-        let map_function_arg = get_argument(cx, arguments, 1);
+        let map_function_arg = arguments.get(cx, 1);
         let map_function = if map_function_arg.is_undefined() {
             None
         } else {
@@ -139,8 +138,8 @@ impl ArrayConstructor {
             Some(map_function_arg.as_object())
         };
 
-        let items_arg = get_argument(cx, arguments, 0);
-        let this_arg = get_argument(cx, arguments, 2);
+        let items_arg = arguments.get(cx, 0);
+        let this_arg = arguments.get(cx, 2);
 
         // If an iterator was supplied use it to create array
         let iterator = get_method(cx, items_arg, cx.well_known_symbols.iterator())?;
@@ -236,7 +235,7 @@ impl ArrayConstructor {
     pub fn from_async(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         ArrayFromAsyncGenerator::start(cx, this_value, arguments)
     }
@@ -245,9 +244,9 @@ impl ArrayConstructor {
     pub fn is_array(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+        let argument = arguments.get(cx, 0);
         let is_array = is_array(cx, argument)?;
         Ok(cx.bool(is_array))
     }
@@ -256,7 +255,7 @@ impl ArrayConstructor {
     pub fn of(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let length = arguments.len();
         let length_value = cx.number(length);
@@ -271,7 +270,7 @@ impl ArrayConstructor {
 
         for index in 0..length {
             key.replace(PropertyKey::array_index(cx, index as u32)?);
-            let value = get_argument(cx, arguments, index);
+            let value = arguments.get(cx, index);
 
             create_data_property_or_throw(cx, array, key, value)?;
         }

--- a/src/js/runtime/intrinsics/array_from_async_generator.rs
+++ b/src/js/runtime/intrinsics/array_from_async_generator.rs
@@ -2,7 +2,7 @@ use crate::{
     common::numeric::MAX_SAFE_INTEGER_U64,
     completion_value, eval_err, must,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, PropertyKey, Value,
+        Arguments, Context, EvalResult, Handle, HeapPtr, PropertyKey, Value,
         abstract_operations::{
             call, call_object, construct, create_data_property_or_throw, get_method,
             length_of_array_like, set,
@@ -10,7 +10,6 @@ use crate::{
         array_object::array_create,
         builtin_generator::{BuiltinGenerator, BuiltinGeneratorCompletion, BuiltinGeneratorState},
         error::{type_error, type_error_value},
-        function::get_argument,
         gc::{AnyHeapItem, HeapVisitor},
         get,
         intrinsics::intrinsics::Intrinsic,
@@ -71,7 +70,7 @@ impl ArrayFromAsyncGenerator {
     pub fn start(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
@@ -97,11 +96,11 @@ impl ArrayFromAsyncGenerator {
         cx: Context,
         capability: Handle<PromiseCapability>,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<BuiltinGeneratorCompletion> {
-        let items_arg = get_argument(cx, arguments, 0);
-        let mapper_arg = get_argument(cx, arguments, 1);
-        let mapper_this_arg = get_argument(cx, arguments, 2);
+        let items_arg = arguments.get(cx, 0);
+        let mapper_arg = arguments.get(cx, 1);
+        let mapper_this_arg = arguments.get(cx, 2);
 
         let has_mapper = !mapper_arg.is_undefined();
         let mapper = if has_mapper {

--- a/src/js/runtime/intrinsics/array_iterator.rs
+++ b/src/js/runtime/intrinsics/array_iterator.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object,
     runtime::{
-        Context, Handle, HeapPtr,
+        Arguments, Context, Handle, HeapPtr,
         abstract_operations::length_of_array_like,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
@@ -128,11 +128,7 @@ impl ArrayIteratorPrototype {
 
     /// %ArrayIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%arrayiteratorprototype%.next)
     /// Adapted from the abstract closure in CreateArrayIterator (https://tc39.es/ecma262/#sec-createarrayiterator)
-    pub fn next(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let mut array_iterator = ArrayIterator::cast_from_value(cx, this_value)?;
         let array = array_iterator.array();
 

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -4,7 +4,7 @@ use crate::{
     common::numeric::MAX_SAFE_INTEGER_U64,
     must, must_a,
     runtime::{
-        Context, EvalResult, Handle, Value,
+        Arguments, Context, EvalResult, Handle, Value,
         abstract_operations::{
             call, call_object, create_data_property_or_throw, delete_property_or_throw,
             has_property, invoke, length_of_array_like, set,
@@ -13,7 +13,6 @@ use crate::{
         array_object::{ArrayObject, array_create, array_species_create},
         builtin_function::BuiltinFunction,
         error::{range_error, type_error},
-        function::get_argument,
         get,
         intrinsics::{
             array_iterator::{ArrayIterator, ArrayIteratorKind},
@@ -315,12 +314,12 @@ impl ArrayPrototype {
     pub fn at(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let index_arg = get_argument(cx, arguments, 0);
+        let index_arg = arguments.get(cx, 0);
         let relative_index = to_integer_or_infinity(cx, index_arg)?;
 
         let key = if relative_index >= 0.0 {
@@ -344,7 +343,7 @@ impl ArrayPrototype {
     pub fn concat(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let array = array_species_create(cx, object, 0)?;
@@ -353,7 +352,7 @@ impl ArrayPrototype {
 
         Self::apply_concat_to_element(cx, object.into(), array, &mut n)?;
 
-        for element in arguments {
+        for element in arguments.iter() {
             Self::apply_concat_to_element(cx, *element, array, &mut n)?;
         }
 
@@ -430,18 +429,18 @@ impl ArrayPrototype {
     pub fn copy_within(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let target_arg = get_argument(cx, arguments, 0);
+        let target_arg = arguments.get(cx, 0);
         let mut to_index = resolve_relative_index_argument(cx, target_arg, length)?;
 
-        let start_arg = get_argument(cx, arguments, 1);
+        let start_arg = arguments.get(cx, 1);
         let mut from_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
-        let end_argument = get_argument(cx, arguments, 2);
+        let end_argument = arguments.get(cx, 2);
         let from_end_index = if !end_argument.is_undefined() {
             resolve_relative_index_argument(cx, end_argument, length)?
         } else {
@@ -507,7 +506,7 @@ impl ArrayPrototype {
     pub fn entries(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         Ok(ArrayIterator::new(cx, object, ArrayIteratorKind::KeyAndValue)?.as_value())
@@ -517,18 +516,18 @@ impl ArrayPrototype {
     pub fn every(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "Array.prototype.every callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         // Shared between iterations
         let mut index_key = PropertyKey::uninit().to_handle(cx);
@@ -556,17 +555,17 @@ impl ArrayPrototype {
     pub fn fill(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
 
-        let start_arg = get_argument(cx, arguments, 1);
+        let start_arg = arguments.get(cx, 1);
         let start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
-        let end_argument = get_argument(cx, arguments, 2);
+        let end_argument = arguments.get(cx, 2);
         let end_index = if !end_argument.is_undefined() {
             resolve_relative_index_argument(cx, end_argument, length)?
         } else {
@@ -588,18 +587,18 @@ impl ArrayPrototype {
     pub fn filter(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "Array.prototype.filter callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         let array = array_species_create(cx, object, 0)?;
 
@@ -638,18 +637,18 @@ impl ArrayPrototype {
     pub fn find(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let predicate_function = get_argument(cx, arguments, 0);
+        let predicate_function = arguments.get(cx, 0);
         if !is_callable(predicate_function) {
             return type_error(cx, "Array.prototype.find callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         let find_result = find_via_predicate(cx, object, 0..length, predicate_function, this_arg)?;
 
@@ -663,18 +662,18 @@ impl ArrayPrototype {
     pub fn find_index(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let predicate_function = get_argument(cx, arguments, 0);
+        let predicate_function = arguments.get(cx, 0);
         if !is_callable(predicate_function) {
             return type_error(cx, "Array.prototype.findIndex callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         let find_result = find_via_predicate(cx, object, 0..length, predicate_function, this_arg)?;
 
@@ -688,18 +687,18 @@ impl ArrayPrototype {
     pub fn find_last(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let predicate_function = get_argument(cx, arguments, 0);
+        let predicate_function = arguments.get(cx, 0);
         if !is_callable(predicate_function) {
             return type_error(cx, "Array.prototype.findLast callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         let find_result =
             find_via_predicate(cx, object, (0..length).rev(), predicate_function, this_arg)?;
@@ -714,18 +713,18 @@ impl ArrayPrototype {
     pub fn find_last_index(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let predicate_function = get_argument(cx, arguments, 0);
+        let predicate_function = arguments.get(cx, 0);
         if !is_callable(predicate_function) {
             return type_error(cx, "Array.prototype.findLastIndex callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         let find_result =
             find_via_predicate(cx, object, (0..length).rev(), predicate_function, this_arg)?;
@@ -740,12 +739,12 @@ impl ArrayPrototype {
     pub fn flat(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let depth = get_argument(cx, arguments, 0);
+        let depth = arguments.get(cx, 0);
         let depth = if depth.is_undefined() {
             1.0
         } else {
@@ -849,13 +848,13 @@ impl ArrayPrototype {
     pub fn flat_map(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let mapper_function = get_argument(cx, arguments, 0);
-        let this_arg = get_argument(cx, arguments, 1);
+        let mapper_function = arguments.get(cx, 0);
+        let this_arg = arguments.get(cx, 1);
 
         if !is_callable(mapper_function) {
             return type_error(cx, "Array.prototype.flatMap mapper must be a function");
@@ -882,18 +881,18 @@ impl ArrayPrototype {
     pub fn for_each(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "Array.prototype.forEach callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         // Shared between iterations
         let mut index_key = PropertyKey::uninit().to_handle(cx);
@@ -918,7 +917,7 @@ impl ArrayPrototype {
     pub fn includes(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -927,9 +926,9 @@ impl ArrayPrototype {
             return Ok(cx.bool(false));
         }
 
-        let search_element = get_argument(cx, arguments, 0);
+        let search_element = arguments.get(cx, 0);
 
-        let n_arg = get_argument(cx, arguments, 1);
+        let n_arg = arguments.get(cx, 1);
         let start_index = resolve_relative_index_argument(cx, n_arg, length)?;
 
         // Property key is shared between iterations
@@ -951,7 +950,7 @@ impl ArrayPrototype {
     pub fn index_of(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -960,9 +959,9 @@ impl ArrayPrototype {
             return Ok(cx.negative_one());
         }
 
-        let search_element = get_argument(cx, arguments, 0);
+        let search_element = arguments.get(cx, 0);
 
-        let n_arg = get_argument(cx, arguments, 1);
+        let n_arg = arguments.get(cx, 1);
         let start_index = resolve_relative_index_argument(cx, n_arg, length)?;
 
         // Property key is shared between iterations
@@ -985,12 +984,12 @@ impl ArrayPrototype {
     pub fn join(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let separator = get_argument(cx, arguments, 0);
+        let separator = arguments.get(cx, 0);
         let separator = if separator.is_undefined() {
             cx.names.comma().as_string()
         } else {
@@ -1020,11 +1019,7 @@ impl ArrayPrototype {
     }
 
     /// Array.prototype.keys (https://tc39.es/ecma262/#sec-array.prototype.keys)
-    pub fn keys(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn keys(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         Ok(ArrayIterator::new(cx, object, ArrayIteratorKind::Key)?.as_value())
     }
@@ -1033,7 +1028,7 @@ impl ArrayPrototype {
     pub fn last_index_of(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1042,10 +1037,10 @@ impl ArrayPrototype {
             return Ok(cx.negative_one());
         }
 
-        let search_element = get_argument(cx, arguments, 0);
+        let search_element = arguments.get(cx, 0);
 
         let start_index = if arguments.len() >= 2 {
-            let start_arg = get_argument(cx, arguments, 1);
+            let start_arg = arguments.get(cx, 1);
             let n = to_integer_or_infinity(cx, start_arg)?;
             if n == f64::NEG_INFINITY {
                 return Ok(cx.negative_one());
@@ -1086,18 +1081,18 @@ impl ArrayPrototype {
     pub fn map(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "Array.prototype.map mapper must be a function");
         }
 
         let callback_function = callback_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         let array = array_species_create(cx, object, length)?;
 
@@ -1122,11 +1117,7 @@ impl ArrayPrototype {
     }
 
     /// Array.prototype.pop (https://tc39.es/ecma262/#sec-array.prototype.pop)
-    pub fn pop(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn pop(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1152,7 +1143,7 @@ impl ArrayPrototype {
     pub fn push(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1180,12 +1171,12 @@ impl ArrayPrototype {
     pub fn reduce(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "Array.prototype.reduce callback must be a function");
         }
@@ -1194,7 +1185,7 @@ impl ArrayPrototype {
         let mut initial_index = 0;
 
         let mut accumulator = if arguments.len() >= 2 {
-            get_argument(cx, arguments, 1)
+            arguments.get(cx, 1)
         } else if length == 0 {
             return type_error(cx, "Array.prototype.reduce does not have an initial value");
         } else {
@@ -1242,12 +1233,12 @@ impl ArrayPrototype {
     pub fn reduce_right(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "Array.prototype.reduceRight callback must be a function");
         }
@@ -1256,7 +1247,7 @@ impl ArrayPrototype {
         let mut initial_index = length as i64 - 1;
 
         let mut accumulator = if arguments.len() >= 2 {
-            get_argument(cx, arguments, 1)
+            arguments.get(cx, 1)
         } else if length == 0 {
             return type_error(cx, "Array.prototype.reduceRight does not have an initial value");
         } else {
@@ -1303,7 +1294,7 @@ impl ArrayPrototype {
     pub fn reverse(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1360,7 +1351,7 @@ impl ArrayPrototype {
     pub fn shift(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1403,15 +1394,15 @@ impl ArrayPrototype {
     pub fn slice(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let start_arg = get_argument(cx, arguments, 0);
+        let start_arg = arguments.get(cx, 0);
         let start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
-        let end_argument = get_argument(cx, arguments, 1);
+        let end_argument = arguments.get(cx, 1);
         let end_index = if !end_argument.is_undefined() {
             resolve_relative_index_argument(cx, end_argument, length)?
         } else {
@@ -1451,18 +1442,18 @@ impl ArrayPrototype {
     pub fn some(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "Array.prototype.some callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         // Shared between iterations
         let mut index_key = PropertyKey::uninit().to_handle(cx);
@@ -1490,9 +1481,9 @@ impl ArrayPrototype {
     pub fn sort(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let compare_function_arg = get_argument(cx, arguments, 0);
+        let compare_function_arg = arguments.get(cx, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
             return type_error(cx, "Array.prototype.sort expects a function");
         };
@@ -1529,12 +1520,12 @@ impl ArrayPrototype {
     pub fn splice(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let start_arg = get_argument(cx, arguments, 0);
+        let start_arg = arguments.get(cx, 0);
         let start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
         let insert_count = (arguments.len() as u64).saturating_sub(2);
@@ -1544,7 +1535,7 @@ impl ArrayPrototype {
         } else if arguments.len() == 1 {
             length - start_index
         } else {
-            let delete_count_arg = get_argument(cx, arguments, 1);
+            let delete_count_arg = arguments.get(cx, 1);
             let delete_count = to_integer_or_infinity(cx, delete_count_arg)?;
             f64::min(f64::max(delete_count, 0.0), (length - start_index) as f64) as u64
         };
@@ -1621,7 +1612,7 @@ impl ArrayPrototype {
     pub fn to_locale_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1655,7 +1646,7 @@ impl ArrayPrototype {
     pub fn to_reversed(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1681,9 +1672,9 @@ impl ArrayPrototype {
     pub fn to_sorted(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let compare_function_arg = get_argument(cx, arguments, 0);
+        let compare_function_arg = arguments.get(cx, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
             return type_error(cx, "Array.prototype.toSorted expects a function");
         };
@@ -1716,13 +1707,13 @@ impl ArrayPrototype {
     pub fn to_spliced(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
         // Determine absolute start index from the relative index argument
-        let start_arg = get_argument(cx, arguments, 0);
+        let start_arg = arguments.get(cx, 0);
         let actual_start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
         let insert_count = (arguments.len() as u64).saturating_sub(2);
@@ -1733,7 +1724,7 @@ impl ArrayPrototype {
         } else if arguments.len() == 1 {
             length - actual_start_index
         } else {
-            let skip_count_arg = get_argument(cx, arguments, 1);
+            let skip_count_arg = arguments.get(cx, 1);
             let skip_count = to_integer_or_infinity(cx, skip_count_arg)?;
             f64::min(f64::max(skip_count, 0.0), (length - actual_start_index) as f64) as u64
         };
@@ -1779,7 +1770,7 @@ impl ArrayPrototype {
     pub fn to_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let array = to_object(cx, this_value)?;
         let func = get(cx, array, cx.names.join())?;
@@ -1797,7 +1788,7 @@ impl ArrayPrototype {
     pub fn unshift(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
@@ -1840,7 +1831,7 @@ impl ArrayPrototype {
     pub fn values(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         Ok(ArrayIterator::new(cx, object, ArrayIteratorKind::Value)?.as_value())
@@ -1850,12 +1841,12 @@ impl ArrayPrototype {
     pub fn with(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
-        let index_arg = get_argument(cx, arguments, 0);
+        let index_arg = arguments.get(cx, 0);
         let relative_index = to_integer_or_infinity(cx, index_arg)?;
 
         // Convert from relative to actual index, making sure index is in range
@@ -1875,7 +1866,7 @@ impl ArrayPrototype {
         };
 
         let array = array_create(cx, length, None)?;
-        let new_value = get_argument(cx, arguments, 1);
+        let new_value = arguments.get(cx, 1);
 
         // Key is shared between iterations
         let mut key = PropertyKey::uninit().to_handle(cx);

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
@@ -1,13 +1,12 @@
 use crate::{
     eval_err, extend_object, if_abrupt_reject_promise, must,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Arguments, Context, Handle, HeapPtr, Value,
         abstract_operations::{call_object, get_method},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::type_error_value,
         eval_result::EvalResult,
-        function::get_argument,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::{
@@ -110,7 +109,7 @@ impl AsyncFromSyncIteratorPrototype {
     pub fn next(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
@@ -121,7 +120,7 @@ impl AsyncFromSyncIteratorPrototype {
         let value = if arguments.is_empty() {
             None
         } else {
-            Some(get_argument(cx, arguments, 0))
+            Some(arguments.get(cx, 0))
         };
 
         let iter_result_completion =
@@ -142,7 +141,7 @@ impl AsyncFromSyncIteratorPrototype {
     pub fn return_(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
@@ -155,7 +154,7 @@ impl AsyncFromSyncIteratorPrototype {
 
         // If there is no return method the promise can immediately be resolved
         if return_method.is_none() {
-            let value = get_argument(cx, arguments, 0);
+            let value = arguments.get(cx, 0);
             let iter_result = create_iter_result_object(cx, value, true)?;
             must!(call_object(cx, capability.resolve(), cx.undefined(), &[iter_result]));
 
@@ -167,7 +166,7 @@ impl AsyncFromSyncIteratorPrototype {
         let return_result_completion = if arguments.is_empty() {
             call_object(cx, return_method, sync_iterator.into(), &[])
         } else {
-            let value = get_argument(cx, arguments, 0);
+            let value = arguments.get(cx, 0);
             call_object(cx, return_method, sync_iterator.into(), &[value])
         };
 
@@ -196,7 +195,7 @@ impl AsyncFromSyncIteratorPrototype {
     pub fn throw(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
@@ -228,7 +227,7 @@ impl AsyncFromSyncIteratorPrototype {
         let throw_result_completion = if arguments.is_empty() {
             call_object(cx, throw_method, sync_iterator.into(), &[])
         } else {
-            let value = get_argument(cx, arguments, 0);
+            let value = arguments.get(cx, 0);
             call_object(cx, throw_method, sync_iterator.into(), &[value])
         };
 
@@ -321,31 +320,31 @@ fn async_from_sync_iterator_continuation(
 pub fn create_continuing_iter_result_object(
     cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
-    let value = get_argument(cx, arguments, 0);
+    let value = arguments.get(cx, 0);
     Ok(create_iter_result_object(cx, value, /* is_done */ false)?)
 }
 
 pub fn create_done_iter_result_object(
     cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
-    let value = get_argument(cx, arguments, 0);
+    let value = arguments.get(cx, 0);
     Ok(create_iter_result_object(cx, value, /* is_done */ true)?)
 }
 
 pub fn async_from_sync_iterator_continuation_on_reject(
     mut cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the iterator passed from the caller
     let current_function = cx.current_function();
     let sync_iterator = get_sync_iterator(cx, current_function);
 
-    let error = get_argument(cx, arguments, 0);
+    let error = arguments.get(cx, 0);
 
     iterator_close(cx, sync_iterator, eval_err!(error))
 }

--- a/src/js/runtime/intrinsics/async_function_constructor.rs
+++ b/src/js/runtime/intrinsics/async_function_constructor.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     eval::create_dynamic_function::create_dynamic_function,
@@ -38,14 +38,14 @@ impl AsyncFunctionConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let constructor = cx.current_function();
         Ok(create_dynamic_function(
             cx,
             constructor,
             cx.current_new_target(),
-            arguments,
+            arguments.as_slice(),
             /* is_async */ true,
             /* is_generator */ false,
         )?

--- a/src/js/runtime/intrinsics/async_generator_function_constructor.rs
+++ b/src/js/runtime/intrinsics/async_generator_function_constructor.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     eval::create_dynamic_function::create_dynamic_function,
@@ -38,14 +38,14 @@ impl AsyncGeneratorFunctionConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let constructor = cx.current_function();
         Ok(create_dynamic_function(
             cx,
             constructor,
             cx.current_new_target(),
-            arguments,
+            arguments.as_slice(),
             /* is_async */ true,
             /* is_generator */ true,
         )?

--- a/src/js/runtime/intrinsics/async_generator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_generator_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     if_abrupt_reject_promise, must,
     runtime::{
-        Context, Handle, Value,
+        Arguments, Context, Handle, Value,
         abstract_operations::{call_object, define_property_or_throw},
         alloc_error::AllocResult,
         async_generator_object::{
@@ -10,7 +10,6 @@ use crate::{
         },
         bytecode::function::Closure,
         eval_result::EvalResult,
-        function::get_argument,
         generator_object::GeneratorCompletionType,
         heap_item_descriptor::HeapItemKind,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
@@ -74,9 +73,9 @@ impl AsyncGeneratorPrototype {
     pub fn next(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
 
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
@@ -111,9 +110,9 @@ impl AsyncGeneratorPrototype {
     pub fn return_(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
 
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
@@ -140,9 +139,9 @@ impl AsyncGeneratorPrototype {
     pub fn throw(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let error = get_argument(cx, arguments, 0);
+        let error = arguments.get(cx, 0);
 
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));

--- a/src/js/runtime/intrinsics/bigint_constructor.rs
+++ b/src/js/runtime/intrinsics/bigint_constructor.rs
@@ -6,12 +6,11 @@ use num_traits::FromPrimitive;
 use crate::{
     extend_object,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Arguments, Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::{range_error, type_error},
         eval_result::EvalResult,
-        function::get_argument,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
@@ -97,13 +96,13 @@ impl BigIntConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if cx.current_new_target().is_some() {
             return type_error(cx, "BigInt constructor cannot be used with new");
         }
 
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         let primitive = to_primitive(cx, value, ToPrimitivePreferredType::Number)?;
 
         if primitive.is_number() {
@@ -117,12 +116,12 @@ impl BigIntConstructor {
     pub fn as_int_n(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let bits_arg = get_argument(cx, arguments, 0);
+        let bits_arg = arguments.get(cx, 0);
         let bits = to_index(cx, bits_arg)?;
 
-        let bigint_arg = get_argument(cx, arguments, 1);
+        let bigint_arg = arguments.get(cx, 1);
         let bigint = to_bigint(cx, bigint_arg)?;
 
         // Applying 2^n modulus is equivalent to masking by 2^n - 1
@@ -144,12 +143,12 @@ impl BigIntConstructor {
     pub fn as_uint_n(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let bits_arg = get_argument(cx, arguments, 0);
+        let bits_arg = arguments.get(cx, 0);
         let bits = to_index(cx, bits_arg)?;
 
-        let bigint_arg = get_argument(cx, arguments, 1);
+        let bigint_arg = arguments.get(cx, 1);
         let bigint = to_bigint(cx, bigint_arg)?;
 
         // Applying 2^n modulus is equivalent to masking by 2^n - 1

--- a/src/js/runtime/intrinsics/bigint_prototype.rs
+++ b/src/js/runtime/intrinsics/bigint_prototype.rs
@@ -1,9 +1,8 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     alloc_error::AllocResult,
     error::{range_error, type_error},
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         bigint_constructor::BigIntObject, intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
     },
@@ -53,11 +52,11 @@ impl BigIntPrototype {
     pub fn to_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let bigint_value = this_bigint_value(cx, this_value, "toString")?;
 
-        let radix = get_argument(cx, arguments, 0);
+        let radix = arguments.get(cx, 0);
         let radix = if radix.is_undefined() {
             10
         } else {
@@ -81,7 +80,7 @@ impl BigIntPrototype {
     pub fn value_of(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Ok(this_bigint_value(cx, this_value, "valueOf")?.into())
     }

--- a/src/js/runtime/intrinsics/boolean_constructor.rs
+++ b/src/js/runtime/intrinsics/boolean_constructor.rs
@@ -3,11 +3,10 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, HeapPtr, Value,
+        Arguments, Context, HeapPtr, Value,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         eval_result::EvalResult,
-        function::get_argument,
         gc::{Handle, HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
@@ -108,9 +107,9 @@ impl BooleanConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let bool_value = to_boolean(*get_argument(cx, arguments, 0));
+        let bool_value = to_boolean(*arguments.get(cx, 0));
 
         match cx.current_new_target() {
             None => Ok(cx.bool(bool_value)),

--- a/src/js/runtime/intrinsics/boolean_prototype.rs
+++ b/src/js/runtime/intrinsics/boolean_prototype.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     alloc_error::AllocResult,
     error::type_error,
     eval_result::EvalResult,
@@ -41,7 +41,7 @@ impl BooleanPrototype {
     pub fn to_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let bool_value = this_boolean_value(cx, this_value, "toString")?;
         let string_value = if bool_value { "true" } else { "false" };
@@ -53,7 +53,7 @@ impl BooleanPrototype {
     pub fn value_of(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let bool_value = this_boolean_value(cx, this_value, "valueOf")?;
         Ok(cx.bool(bool_value))

--- a/src/js/runtime/intrinsics/data_view_constructor.rs
+++ b/src/js/runtime/intrinsics/data_view_constructor.rs
@@ -3,12 +3,11 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Arguments, Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::{range_error, type_error},
         eval_result::EvalResult,
-        function::get_argument,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::{
@@ -101,7 +100,7 @@ impl DataViewConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
@@ -109,7 +108,7 @@ impl DataViewConstructor {
             return type_error(cx, "DataView constructor must be called with new");
         };
 
-        let buffer_argument = get_argument(cx, arguments, 0);
+        let buffer_argument = arguments.get(cx, 0);
         if !buffer_argument.is_object() {
             return type_error(cx, "DataView constructor first argument must be an array buffer");
         }
@@ -121,7 +120,7 @@ impl DataViewConstructor {
 
         let buffer_object = buffer_object.cast::<ArrayBufferObject>();
 
-        let offset_arg = get_argument(cx, arguments, 1);
+        let offset_arg = arguments.get(cx, 1);
         let offset = to_index(cx, offset_arg)?;
 
         throw_if_detached(cx, *buffer_object)?;
@@ -136,7 +135,7 @@ impl DataViewConstructor {
             );
         }
 
-        let byte_length_argument = get_argument(cx, arguments, 2);
+        let byte_length_argument = arguments.get(cx, 2);
         let view_byte_length = if byte_length_argument.is_undefined() {
             if buffer_object.is_fixed_length() {
                 Some(buffer_byte_length - offset)

--- a/src/js/runtime/intrinsics/data_view_prototype.rs
+++ b/src/js/runtime/intrinsics/data_view_prototype.rs
@@ -1,10 +1,9 @@
 use half::f16;
 
 use crate::runtime::{
-    Context, EvalResult, Handle, Value,
+    Arguments, Context, EvalResult, Handle, Value,
     alloc_error::AllocResult,
     error::{range_error, type_error},
-    function::get_argument,
     intrinsics::{
         data_view_constructor::DataViewObject,
         intrinsics::Intrinsic,
@@ -221,7 +220,7 @@ impl DataViewPrototype {
     pub fn get_buffer(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let data_view = this_data_view(cx, this_value, "buffer")?;
         Ok(data_view.viewed_array_buffer().as_value())
@@ -231,7 +230,7 @@ impl DataViewPrototype {
     pub fn get_byte_length(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let data_view = this_data_view(cx, this_value, "byteLength")?;
         let data_view_record = make_data_view_with_buffer_witness_record(data_view);
@@ -249,7 +248,7 @@ impl DataViewPrototype {
     pub fn get_byte_offset(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let data_view = this_data_view(cx, this_value, "byteOffset")?;
         let data_view_record = make_data_view_with_buffer_witness_record(data_view);
@@ -265,7 +264,7 @@ impl DataViewPrototype {
     pub fn get_big_int64(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(
             cx,
@@ -281,7 +280,7 @@ impl DataViewPrototype {
     pub fn get_big_uint64(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(
             cx,
@@ -297,7 +296,7 @@ impl DataViewPrototype {
     pub fn get_float16(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(
             cx,
@@ -313,7 +312,7 @@ impl DataViewPrototype {
     pub fn get_float32(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(
             cx,
@@ -329,7 +328,7 @@ impl DataViewPrototype {
     pub fn get_float64(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(
             cx,
@@ -345,7 +344,7 @@ impl DataViewPrototype {
     pub fn get_int8(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, "getInt8", from_int8_element, |element| element)
     }
@@ -354,7 +353,7 @@ impl DataViewPrototype {
     pub fn get_int16(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, "getInt16", from_int16_element, i16::swap_bytes)
     }
@@ -363,7 +362,7 @@ impl DataViewPrototype {
     pub fn get_int32(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, "getInt32", from_int32_element, i32::swap_bytes)
     }
@@ -372,7 +371,7 @@ impl DataViewPrototype {
     pub fn get_uint8(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, "getUint8", from_uint8_element, |element| element)
     }
@@ -381,7 +380,7 @@ impl DataViewPrototype {
     pub fn get_uint16(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, "getUint16", from_uint16_element, u16::swap_bytes)
     }
@@ -390,7 +389,7 @@ impl DataViewPrototype {
     pub fn get_uint32(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         get_view_value(cx, this_value, arguments, "getUint32", from_uint32_element, u32::swap_bytes)
     }
@@ -399,7 +398,7 @@ impl DataViewPrototype {
     pub fn set_big_int64(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -416,7 +415,7 @@ impl DataViewPrototype {
     pub fn set_big_uint64(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -433,7 +432,7 @@ impl DataViewPrototype {
     pub fn set_float16(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -450,7 +449,7 @@ impl DataViewPrototype {
     pub fn set_float32(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -467,7 +466,7 @@ impl DataViewPrototype {
     pub fn set_float64(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -484,7 +483,7 @@ impl DataViewPrototype {
     pub fn set_int8(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -501,7 +500,7 @@ impl DataViewPrototype {
     pub fn set_int16(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -518,7 +517,7 @@ impl DataViewPrototype {
     pub fn set_int32(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -535,7 +534,7 @@ impl DataViewPrototype {
     pub fn set_uint8(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -552,7 +551,7 @@ impl DataViewPrototype {
     pub fn set_uint16(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -569,7 +568,7 @@ impl DataViewPrototype {
     pub fn set_uint32(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         set_view_value(
             cx,
@@ -609,16 +608,16 @@ fn this_data_view(
 fn get_view_value<T>(
     cx: Context,
     this_value: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
     method_name: &str,
     from_element_fn: fn(Context, T) -> AllocResult<Handle<Value>>,
     swap_element_bytes_fn: fn(T) -> T,
 ) -> EvalResult<Handle<Value>> {
     let data_view = this_data_view(cx, this_value, method_name)?;
 
-    let get_index_arg = get_argument(cx, arguments, 0);
+    let get_index_arg = arguments.get(cx, 0);
     let get_index = to_index(cx, get_index_arg)?;
-    let is_little_endian = to_boolean(*get_argument(cx, arguments, 1));
+    let is_little_endian = to_boolean(*arguments.get(cx, 1));
 
     let data_view_record = make_data_view_with_buffer_witness_record(data_view);
     if is_view_out_of_bounds(&data_view_record) {
@@ -668,7 +667,7 @@ fn get_view_value<T>(
 fn set_view_value<T>(
     cx: Context,
     this_value: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
     method_name: &str,
     content_type: ContentType,
     to_element_fn: fn(Context, Handle<Value>) -> EvalResult<T>,
@@ -676,11 +675,11 @@ fn set_view_value<T>(
 ) -> EvalResult<Handle<Value>> {
     let data_view = this_data_view(cx, this_value, method_name)?;
 
-    let get_index_arg = get_argument(cx, arguments, 0);
+    let get_index_arg = arguments.get(cx, 0);
     let get_index = to_index(cx, get_index_arg)?;
-    let is_little_endian = to_boolean(*get_argument(cx, arguments, 2));
+    let is_little_endian = to_boolean(*arguments.get(cx, 2));
 
-    let value_arg = get_argument(cx, arguments, 1);
+    let value_arg = arguments.get(cx, 1);
     let value = if content_type == ContentType::BigInt {
         to_bigint(cx, value_arg)?.into()
     } else {

--- a/src/js/runtime/intrinsics/date_constructor.rs
+++ b/src/js/runtime/intrinsics/date_constructor.rs
@@ -1,9 +1,8 @@
 use crate::runtime::{
-    Context, Value,
+    Arguments, Context, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     eval_result::EvalResult,
-    function::get_argument,
     gc::Handle,
     intrinsics::{
         date_object::{DateObject, make_date, make_day, make_full_year, make_time, time_clip, utc},
@@ -55,7 +54,7 @@ impl DateConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
@@ -68,59 +67,59 @@ impl DateConstructor {
         let date_value = if number_of_args == 0 {
             cx.current_unix_time_millis() as f64
         } else if number_of_args == 1 {
-            let date_value =
-                if let Some(date_value_arg) = validate_date_value(get_argument(cx, arguments, 0)) {
-                    date_value_arg
-                } else {
-                    let arg = get_argument(cx, arguments, 0);
-                    let primitive_value = to_primitive(cx, arg, ToPrimitivePreferredType::None)?;
+            let date_value = if let Some(date_value_arg) = validate_date_value(arguments.get(cx, 0))
+            {
+                date_value_arg
+            } else {
+                let arg = arguments.get(cx, 0);
+                let primitive_value = to_primitive(cx, arg, ToPrimitivePreferredType::None)?;
 
-                    if primitive_value.is_string() {
-                        let primitive_string = primitive_value.as_string();
-                        parse_string_to_date(primitive_string)?.unwrap_or(f64::NAN)
-                    } else {
-                        to_number(cx, primitive_value)?.as_number()
-                    }
-                };
+                if primitive_value.is_string() {
+                    let primitive_string = primitive_value.as_string();
+                    parse_string_to_date(primitive_string)?.unwrap_or(f64::NAN)
+                } else {
+                    to_number(cx, primitive_value)?.as_number()
+                }
+            };
 
             time_clip(date_value)
         } else {
-            let year_arg = get_argument(cx, arguments, 0);
+            let year_arg = arguments.get(cx, 0);
             let mut year = to_number(cx, year_arg)?.as_number();
 
-            let month_arg = get_argument(cx, arguments, 1);
+            let month_arg = arguments.get(cx, 1);
             let month = to_number(cx, month_arg)?.as_number();
 
             let day = if number_of_args > 2 {
-                let day_arg = get_argument(cx, arguments, 2);
+                let day_arg = arguments.get(cx, 2);
                 to_number(cx, day_arg)?.as_number()
             } else {
                 1.0
             };
 
             let hour = if number_of_args > 3 {
-                let hour_arg = get_argument(cx, arguments, 3);
+                let hour_arg = arguments.get(cx, 3);
                 to_number(cx, hour_arg)?.as_number()
             } else {
                 0.0
             };
 
             let minute = if number_of_args > 4 {
-                let minute_arg = get_argument(cx, arguments, 4);
+                let minute_arg = arguments.get(cx, 4);
                 to_number(cx, minute_arg)?.as_number()
             } else {
                 0.0
             };
 
             let second = if number_of_args > 5 {
-                let second_arg = get_argument(cx, arguments, 5);
+                let second_arg = arguments.get(cx, 5);
                 to_number(cx, second_arg)?.as_number()
             } else {
                 0.0
             };
 
             let millisecond = if number_of_args > 6 {
-                let millisecond_arg = get_argument(cx, arguments, 6);
+                let millisecond_arg = arguments.get(cx, 6);
                 to_number(cx, millisecond_arg)?.as_number()
             } else {
                 0.0
@@ -141,17 +140,13 @@ impl DateConstructor {
     }
 
     /// Date.now (https://tc39.es/ecma262/#sec-date.now)
-    pub fn now(cx: Context, _: Handle<Value>, _: &[Handle<Value>]) -> EvalResult<Handle<Value>> {
+    pub fn now(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         Ok(cx.number(cx.current_unix_time_millis() as f64))
     }
 
     /// Date.parse (https://tc39.es/ecma262/#sec-date.parse)
-    pub fn parse(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let string_arg = get_argument(cx, arguments, 0);
+    pub fn parse(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let string_arg = arguments.get(cx, 0);
         let string = to_string(cx, string_arg)?;
 
         if let Some(date_value) = parse_string_to_date(string)? {
@@ -162,53 +157,49 @@ impl DateConstructor {
     }
 
     /// Date.UTC (https://tc39.es/ecma262/#sec-date.utc)
-    pub fn utc(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn utc(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
         let number_of_args = arguments.len();
 
-        let year_arg = get_argument(cx, arguments, 0);
+        let year_arg = arguments.get(cx, 0);
         let mut year = to_number(cx, year_arg)?.as_number();
 
         let month = if number_of_args > 1 {
-            let month_arg = get_argument(cx, arguments, 1);
+            let month_arg = arguments.get(cx, 1);
             to_number(cx, month_arg)?.as_number()
         } else {
             0.0
         };
 
         let day = if number_of_args > 2 {
-            let day_arg = get_argument(cx, arguments, 2);
+            let day_arg = arguments.get(cx, 2);
             to_number(cx, day_arg)?.as_number()
         } else {
             1.0
         };
 
         let hour = if number_of_args > 3 {
-            let hour_arg = get_argument(cx, arguments, 3);
+            let hour_arg = arguments.get(cx, 3);
             to_number(cx, hour_arg)?.as_number()
         } else {
             0.0
         };
 
         let minute = if number_of_args > 4 {
-            let minute_arg = get_argument(cx, arguments, 4);
+            let minute_arg = arguments.get(cx, 4);
             to_number(cx, minute_arg)?.as_number()
         } else {
             0.0
         };
 
         let second = if number_of_args > 5 {
-            let second_arg = get_argument(cx, arguments, 5);
+            let second_arg = arguments.get(cx, 5);
             to_number(cx, second_arg)?.as_number()
         } else {
             0.0
         };
 
         let millisecond = if number_of_args > 6 {
-            let millisecond_arg = get_argument(cx, arguments, 6);
+            let millisecond_arg = arguments.get(cx, 6);
             to_number(cx, millisecond_arg)?.as_number()
         } else {
             0.0

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -2,12 +2,11 @@ use crate::{
     common::constants::NANOSECONDS_IN_ONE_MILLISECOND,
     must_a,
     runtime::{
-        Context, EvalResult, Handle, PropertyKey, Realm, Value,
+        Arguments, Context, EvalResult, Handle, PropertyKey, Realm, Value,
         abstract_operations::invoke,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::{range_error, type_error},
-        function::get_argument,
         get,
         intrinsics::{
             bigint_constructor::number_to_bigint,
@@ -408,7 +407,7 @@ impl DatePrototype {
     pub fn get_date(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getDate")?;
 
@@ -425,7 +424,7 @@ impl DatePrototype {
     pub fn get_day(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getDay")?;
 
@@ -442,7 +441,7 @@ impl DatePrototype {
     pub fn get_full_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getFullYear")?;
 
@@ -459,7 +458,7 @@ impl DatePrototype {
     pub fn get_hours(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getHours")?;
 
@@ -476,7 +475,7 @@ impl DatePrototype {
     pub fn get_milliseconds(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getMilliseconds")?;
 
@@ -493,7 +492,7 @@ impl DatePrototype {
     pub fn get_minutes(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getMinutes")?;
 
@@ -510,7 +509,7 @@ impl DatePrototype {
     pub fn get_month(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getMonth")?;
 
@@ -527,7 +526,7 @@ impl DatePrototype {
     pub fn get_seconds(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getSeconds")?;
 
@@ -544,7 +543,7 @@ impl DatePrototype {
     pub fn get_time(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getTime")?;
 
@@ -555,7 +554,7 @@ impl DatePrototype {
     pub fn get_timezone_offset(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getTimezoneOffset")?;
 
@@ -572,7 +571,7 @@ impl DatePrototype {
     pub fn get_utc_date(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getUTCDate")?;
 
@@ -589,7 +588,7 @@ impl DatePrototype {
     pub fn get_utc_day(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getUTCDay")?;
 
@@ -606,7 +605,7 @@ impl DatePrototype {
     pub fn get_utc_full_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getUTCFullYear")?;
 
@@ -623,7 +622,7 @@ impl DatePrototype {
     pub fn get_utc_hours(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getUTCHours")?;
 
@@ -640,7 +639,7 @@ impl DatePrototype {
     pub fn get_utc_milliseconds(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getUTCMilliseconds")?;
 
@@ -657,7 +656,7 @@ impl DatePrototype {
     pub fn get_utc_minutes(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getUTCMinutes")?;
 
@@ -674,7 +673,7 @@ impl DatePrototype {
     pub fn get_utc_month(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getUTCMonth")?;
 
@@ -691,7 +690,7 @@ impl DatePrototype {
     pub fn get_utc_seconds(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getUTCSeconds")?;
 
@@ -708,11 +707,11 @@ impl DatePrototype {
     pub fn set_date(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "setDate")?;
 
-        let date_arg = get_argument(cx, arguments, 0);
+        let date_arg = arguments.get(cx, 0);
         let date = to_number(cx, date_arg)?.as_number();
 
         if date_value.is_nan() {
@@ -735,11 +734,11 @@ impl DatePrototype {
     pub fn set_full_year(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let mut date_value = this_date_value(cx, this_value, "setFullYear")?;
 
-        let year_arg = get_argument(cx, arguments, 0);
+        let year_arg = arguments.get(cx, 0);
         let year = to_number(cx, year_arg)?.as_number();
 
         if date_value.is_nan() {
@@ -749,14 +748,14 @@ impl DatePrototype {
         }
 
         let month = if arguments.len() >= 2 {
-            let month_arg = get_argument(cx, arguments, 1);
+            let month_arg = arguments.get(cx, 1);
             to_number(cx, month_arg)?.as_number()
         } else {
             month_from_time(date_value)
         };
 
         let date = if arguments.len() >= 3 {
-            let date_arg = get_argument(cx, arguments, 2);
+            let date_arg = arguments.get(cx, 2);
             to_number(cx, date_arg)?.as_number()
         } else {
             date_from_time(date_value)
@@ -774,11 +773,11 @@ impl DatePrototype {
     pub fn set_hours(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "setHours")?;
 
-        let hours_arg = get_argument(cx, arguments, 0);
+        let hours_arg = arguments.get(cx, 0);
         let hours = to_number(cx, hours_arg)?.as_number();
 
         let has_minutes = arguments.len() >= 2;
@@ -791,17 +790,17 @@ impl DatePrototype {
         let mut milliseconds = 0.0;
 
         if has_minutes {
-            let minutes_arg = get_argument(cx, arguments, 1);
+            let minutes_arg = arguments.get(cx, 1);
             minutes = to_number(cx, minutes_arg)?.as_number();
         }
 
         if has_seconds {
-            let seconds_arg = get_argument(cx, arguments, 2);
+            let seconds_arg = arguments.get(cx, 2);
             seconds = to_number(cx, seconds_arg)?.as_number();
         }
 
         if has_milliseconds {
-            let milliseconds_arg = get_argument(cx, arguments, 3);
+            let milliseconds_arg = arguments.get(cx, 3);
             milliseconds = to_number(cx, milliseconds_arg)?.as_number();
         }
 
@@ -837,11 +836,11 @@ impl DatePrototype {
     pub fn set_milliseconds(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "setMilliseconds")?;
 
-        let milliseconds_arg = get_argument(cx, arguments, 0);
+        let milliseconds_arg = arguments.get(cx, 0);
         let milliseconds = to_number(cx, milliseconds_arg)?.as_number();
 
         if date_value.is_nan() {
@@ -869,11 +868,11 @@ impl DatePrototype {
     pub fn set_minutes(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "setMinutes")?;
 
-        let minutes_arg = get_argument(cx, arguments, 0);
+        let minutes_arg = arguments.get(cx, 0);
         let minutes = to_number(cx, minutes_arg)?.as_number();
 
         let has_seconds = arguments.len() >= 2;
@@ -883,12 +882,12 @@ impl DatePrototype {
         let mut milliseconds = 0.0;
 
         if has_seconds {
-            let seconds_arg = get_argument(cx, arguments, 1);
+            let seconds_arg = arguments.get(cx, 1);
             seconds = to_number(cx, seconds_arg)?.as_number();
         }
 
         if has_milliseconds {
-            let milliseconds_arg = get_argument(cx, arguments, 2);
+            let milliseconds_arg = arguments.get(cx, 2);
             milliseconds = to_number(cx, milliseconds_arg)?.as_number();
         }
 
@@ -920,18 +919,18 @@ impl DatePrototype {
     pub fn set_month(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "setMonth")?;
 
-        let month_arg = get_argument(cx, arguments, 0);
+        let month_arg = arguments.get(cx, 0);
         let month = to_number(cx, month_arg)?.as_number();
 
         let has_date = arguments.len() >= 2;
         let mut date = 1.0;
 
         if has_date {
-            let date_arg = get_argument(cx, arguments, 1);
+            let date_arg = arguments.get(cx, 1);
             date = to_number(cx, date_arg)?.as_number();
         }
 
@@ -959,18 +958,18 @@ impl DatePrototype {
     pub fn set_seconds(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "setSeconds")?;
 
-        let seconds_arg = get_argument(cx, arguments, 0);
+        let seconds_arg = arguments.get(cx, 0);
         let seconds = to_number(cx, seconds_arg)?.as_number();
 
         let has_milliseconds = arguments.len() >= 2;
         let mut milliseconds = 0.0;
 
         if has_milliseconds {
-            let milliseconds_arg = get_argument(cx, arguments, 1);
+            let milliseconds_arg = arguments.get(cx, 1);
             milliseconds = to_number(cx, milliseconds_arg)?.as_number();
         }
 
@@ -1003,11 +1002,11 @@ impl DatePrototype {
     pub fn set_time(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let _ = this_date_value(cx, this_value, "setTime")?;
 
-        let time_arg = get_argument(cx, arguments, 0);
+        let time_arg = arguments.get(cx, 0);
         let time_num = time_clip(to_number(cx, time_arg)?.as_number());
 
         set_date_value(this_value, time_num);
@@ -1019,11 +1018,11 @@ impl DatePrototype {
     pub fn set_utc_date(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "setUTCDate")?;
 
-        let date_arg = get_argument(cx, arguments, 0);
+        let date_arg = arguments.get(cx, 0);
         let date = to_number(cx, date_arg)?.as_number();
 
         if date_value.is_nan() {
@@ -1044,7 +1043,7 @@ impl DatePrototype {
     pub fn set_utc_full_year(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let mut date_value = this_date_value(cx, this_value, "setUTCFullYear")?;
 
@@ -1052,18 +1051,18 @@ impl DatePrototype {
             date_value = 0.0;
         }
 
-        let year_arg = get_argument(cx, arguments, 0);
+        let year_arg = arguments.get(cx, 0);
         let year = to_number(cx, year_arg)?.as_number();
 
         let month = if arguments.len() >= 2 {
-            let month_arg = get_argument(cx, arguments, 1);
+            let month_arg = arguments.get(cx, 1);
             to_number(cx, month_arg)?.as_number()
         } else {
             month_from_time(date_value)
         };
 
         let date = if arguments.len() >= 3 {
-            let date_arg = get_argument(cx, arguments, 2);
+            let date_arg = arguments.get(cx, 2);
             to_number(cx, date_arg)?.as_number()
         } else {
             date_from_time(date_value)
@@ -1081,11 +1080,11 @@ impl DatePrototype {
     pub fn set_utc_hours(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "setUTCHours")?;
 
-        let hours_arg = get_argument(cx, arguments, 0);
+        let hours_arg = arguments.get(cx, 0);
         let hours = to_number(cx, hours_arg)?.as_number();
 
         let has_minutes = arguments.len() >= 2;
@@ -1098,17 +1097,17 @@ impl DatePrototype {
         let mut milliseconds = 0.0;
 
         if has_minutes {
-            let minutes_arg = get_argument(cx, arguments, 1);
+            let minutes_arg = arguments.get(cx, 1);
             minutes = to_number(cx, minutes_arg)?.as_number();
         }
 
         if has_seconds {
-            let seconds_arg = get_argument(cx, arguments, 2);
+            let seconds_arg = arguments.get(cx, 2);
             seconds = to_number(cx, seconds_arg)?.as_number();
         }
 
         if has_milliseconds {
-            let milliseconds_arg = get_argument(cx, arguments, 3);
+            let milliseconds_arg = arguments.get(cx, 3);
             milliseconds = to_number(cx, milliseconds_arg)?.as_number();
         }
 
@@ -1140,11 +1139,11 @@ impl DatePrototype {
     pub fn set_utc_milliseconds(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "setUTCMilliseconds")?;
 
-        let milliseconds_arg = get_argument(cx, arguments, 0);
+        let milliseconds_arg = arguments.get(cx, 0);
         let milliseconds = to_number(cx, milliseconds_arg)?.as_number();
 
         if date_value.is_nan() {
@@ -1170,11 +1169,11 @@ impl DatePrototype {
     pub fn set_utc_minutes(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "setUTCMinutes")?;
 
-        let minutes_arg = get_argument(cx, arguments, 0);
+        let minutes_arg = arguments.get(cx, 0);
         let minutes = to_number(cx, minutes_arg)?.as_number();
 
         let has_seconds = arguments.len() >= 2;
@@ -1184,12 +1183,12 @@ impl DatePrototype {
         let mut milliseconds = 0.0;
 
         if has_seconds {
-            let seconds_arg = get_argument(cx, arguments, 1);
+            let seconds_arg = arguments.get(cx, 1);
             seconds = to_number(cx, seconds_arg)?.as_number();
         }
 
         if has_milliseconds {
-            let milliseconds_arg = get_argument(cx, arguments, 2);
+            let milliseconds_arg = arguments.get(cx, 2);
             milliseconds = to_number(cx, milliseconds_arg)?.as_number();
         }
 
@@ -1219,18 +1218,18 @@ impl DatePrototype {
     pub fn set_utc_month(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "setUTCMonth")?;
 
-        let month_arg = get_argument(cx, arguments, 0);
+        let month_arg = arguments.get(cx, 0);
         let month = to_number(cx, month_arg)?.as_number();
 
         let has_date = arguments.len() >= 2;
         let mut date = 1.0;
 
         if has_date {
-            let date_arg = get_argument(cx, arguments, 1);
+            let date_arg = arguments.get(cx, 1);
             date = to_number(cx, date_arg)?.as_number();
         }
 
@@ -1256,18 +1255,18 @@ impl DatePrototype {
     pub fn set_utc_seconds(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "setUTCSeconds")?;
 
-        let seconds_arg = get_argument(cx, arguments, 0);
+        let seconds_arg = arguments.get(cx, 0);
         let seconds = to_number(cx, seconds_arg)?.as_number();
 
         let has_milliseconds = arguments.len() >= 2;
         let mut milliseconds = 0.0;
 
         if has_milliseconds {
-            let milliseconds_arg = get_argument(cx, arguments, 1);
+            let milliseconds_arg = arguments.get(cx, 1);
             milliseconds = to_number(cx, milliseconds_arg)?.as_number();
         }
 
@@ -1298,7 +1297,7 @@ impl DatePrototype {
     pub fn to_date_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "toDateString")?;
 
@@ -1322,7 +1321,7 @@ impl DatePrototype {
     pub fn to_iso_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "toISOString")?;
 
@@ -1357,7 +1356,7 @@ impl DatePrototype {
     pub fn to_json(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
 
@@ -1374,7 +1373,7 @@ impl DatePrototype {
     pub fn to_locale_date_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "toLocaleDateString")?;
 
@@ -1385,7 +1384,7 @@ impl DatePrototype {
     pub fn to_locale_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "toLocaleString")?;
 
@@ -1396,7 +1395,7 @@ impl DatePrototype {
     pub fn to_locale_time_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "toLocaleTimeString")?;
 
@@ -1407,7 +1406,7 @@ impl DatePrototype {
     pub fn to_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "toString")?;
 
@@ -1418,7 +1417,7 @@ impl DatePrototype {
     pub fn to_temporal_instant(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Date.prototype.toTemporalInstant";
 
@@ -1436,7 +1435,7 @@ impl DatePrototype {
     pub fn to_time_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "toTimeString")?;
 
@@ -1462,7 +1461,7 @@ impl DatePrototype {
     pub fn to_utc_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "toUTCString")?;
 
@@ -1491,7 +1490,7 @@ impl DatePrototype {
     pub fn value_of(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "valueOf")?;
 
@@ -1502,13 +1501,13 @@ impl DatePrototype {
     pub fn to_primitive(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Date.prototype[@@toPrimitive] must be called on an object");
         }
 
-        let hint = get_argument(cx, arguments, 0);
+        let hint = arguments.get(cx, 0);
         if hint.is_string() {
             let hint = hint.as_string().flatten()?;
             if *hint == cx.names.default.as_string().as_flat()
@@ -1538,7 +1537,7 @@ impl DatePrototype {
     pub fn get_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "getYear")?;
 
@@ -1555,11 +1554,11 @@ impl DatePrototype {
     pub fn set_year(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let date_value = this_date_value(cx, this_value, "setYear")?;
 
-        let year_arg = get_argument(cx, arguments, 0);
+        let year_arg = arguments.get(cx, 0);
         let short_year = to_number(cx, year_arg)?;
 
         let time = if date_value.is_nan() {

--- a/src/js/runtime/intrinsics/error_constructor.rs
+++ b/src/js/runtime/intrinsics/error_constructor.rs
@@ -4,12 +4,11 @@ use crate::{
     common::error::SourceInfo,
     extend_object,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Arguments, Context, Handle, HeapPtr, Value,
         abstract_operations::{create_non_enumerable_data_property_or_throw, get, has_property},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         eval_result::EvalResult,
-        function::get_argument,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
@@ -182,7 +181,7 @@ impl ErrorConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
@@ -197,7 +196,7 @@ impl ErrorConstructor {
             /* skip_current_frame */ true,
         )?;
 
-        let message = get_argument(cx, arguments, 0);
+        let message = arguments.get(cx, 0);
         if !message.is_undefined() {
             let message_string = to_string(cx, message)?;
             create_non_enumerable_data_property_or_throw(
@@ -208,7 +207,7 @@ impl ErrorConstructor {
             )?;
         }
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         install_error_cause(cx, object, options_arg)?;
 
         Ok(object.as_value())
@@ -218,9 +217,9 @@ impl ErrorConstructor {
     pub fn is_error(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let arg = get_argument(cx, arguments, 0);
+        let arg = arguments.get(cx, 0);
 
         if !arg.is_object() {
             return Ok(cx.bool(false));

--- a/src/js/runtime/intrinsics/error_prototype.rs
+++ b/src/js/runtime/intrinsics/error_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::error::FormatOptions,
     runtime::{
-        Context, Handle, Value,
+        Arguments, Context, Handle, Value,
         abstract_operations::get,
         alloc_error::AllocResult,
         error::type_error,
@@ -53,7 +53,7 @@ impl ErrorPrototype {
     pub fn to_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Error.prototype.toString must be called on an object");
@@ -88,7 +88,7 @@ impl ErrorPrototype {
     pub fn get_stack(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         // Check that `stack` getter was called on an error object
         if !this_value.is_object() || !this_value.as_object().is_error() {

--- a/src/js/runtime/intrinsics/finalization_registry_constructor.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_constructor.rs
@@ -1,10 +1,9 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         finalization_registry_object::FinalizationRegistryObject, intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -43,7 +42,7 @@ impl FinalizationRegistryConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
@@ -51,7 +50,7 @@ impl FinalizationRegistryConstructor {
             return type_error(cx, "FinalizationRegistry constructor must be called with new");
         };
 
-        let cleanup_callback = get_argument(cx, arguments, 0);
+        let cleanup_callback = arguments.get(cx, 0);
         if !is_callable(cleanup_callback) {
             return type_error(cx, "FinalizationRegistry constructor argument must be a function");
         }

--- a/src/js/runtime/intrinsics/finalization_registry_prototype.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_prototype.rs
@@ -1,9 +1,8 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     alloc_error::AllocResult,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         finalization_registry_object::{
             FinalizationRegistryCell, FinalizationRegistryCells, FinalizationRegistryObject,
@@ -57,13 +56,13 @@ impl FinalizationRegistryPrototype {
     pub fn register(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let registry_object = this_finalization_registry_value(cx, this_value, "register")?;
 
-        let target = get_argument(cx, arguments, 0);
-        let held_value = get_argument(cx, arguments, 1);
-        let unregister_token = get_argument(cx, arguments, 2);
+        let target = arguments.get(cx, 0);
+        let held_value = arguments.get(cx, 1);
+        let unregister_token = arguments.get(cx, 2);
 
         if !can_be_held_weakly(cx, *target) {
             return type_error(
@@ -104,11 +103,11 @@ impl FinalizationRegistryPrototype {
     pub fn unregister(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let registry_object = this_finalization_registry_value(cx, this_value, "unregister")?;
 
-        let unregister_token = get_argument(cx, arguments, 0);
+        let unregister_token = arguments.get(cx, 0);
 
         if !can_be_held_weakly(cx, *unregister_token) {
             return type_error(

--- a/src/js/runtime/intrinsics/function_constructor.rs
+++ b/src/js/runtime/intrinsics/function_constructor.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     eval::create_dynamic_function::create_dynamic_function,
@@ -36,14 +36,14 @@ impl FunctionConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let constructor = cx.current_function();
         Ok(create_dynamic_function(
             cx,
             constructor,
             cx.current_new_target(),
-            arguments,
+            arguments.as_slice(),
             /* is_async */ false,
             /* is_generator */ false,
         )?

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     must,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Arguments, Context, Handle, HeapPtr, Value,
         abstract_operations::{
             call_object, create_list_from_array_like_arguments, has_own_property,
             ordinary_has_instance,
@@ -12,7 +12,7 @@ use crate::{
         bytecode::function::{BytecodeFunction, Closure},
         error::type_error,
         eval_result::EvalResult,
-        function::{get_argument, set_function_length_maybe_infinity, set_function_name},
+        function::{set_function_length_maybe_infinity, set_function_name},
         get,
         heap_item_descriptor::HeapItemKind,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
@@ -123,12 +123,12 @@ impl FunctionPrototype {
     pub fn apply(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_function = this_function_value(cx, this_value, "apply")?;
 
-        let this_arg = get_argument(cx, arguments, 0);
-        let arg_array = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 0);
+        let arg_array = arguments.get(cx, 1);
 
         if arg_array.is_nullish() {
             call_object(cx, this_function, this_arg, &[])
@@ -143,11 +143,11 @@ impl FunctionPrototype {
     pub fn bind(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let target = this_function_value(cx, this_value, "bind")?;
 
-        let this_arg = get_argument(cx, arguments, 0);
+        let this_arg = arguments.get(cx, 0);
         let bound_args = if arguments.is_empty() {
             Vec::new()
         } else {
@@ -195,14 +195,14 @@ impl FunctionPrototype {
     pub fn call_intrinsic(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_function = this_function_value(cx, this_value, "call")?;
 
         if arguments.is_empty() {
             call_object(cx, this_function, cx.undefined(), &[])
         } else {
-            let argument = get_argument(cx, arguments, 0);
+            let argument = arguments.get(cx, 0);
             call_object(cx, this_function, argument, &arguments[1..])
         }
     }
@@ -211,7 +211,7 @@ impl FunctionPrototype {
     pub fn to_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Function.prototype.toString must be called on a function");
@@ -268,9 +268,9 @@ impl FunctionPrototype {
     pub fn has_instance(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+        let argument = arguments.get(cx, 0);
         let has_instance = ordinary_has_instance(cx, this_value, argument)?;
         Ok(cx.bool(has_instance))
     }

--- a/src/js/runtime/intrinsics/generator_function_constructor.rs
+++ b/src/js/runtime/intrinsics/generator_function_constructor.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     eval::create_dynamic_function::create_dynamic_function,
@@ -38,14 +38,14 @@ impl GeneratorFunctionConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let constructor = cx.current_function();
         Ok(create_dynamic_function(
             cx,
             constructor,
             cx.current_new_target(),
-            arguments,
+            arguments.as_slice(),
             /* is_async */ false,
             /* is_generator */ true,
         )?

--- a/src/js/runtime/intrinsics/generator_prototype.rs
+++ b/src/js/runtime/intrinsics/generator_prototype.rs
@@ -1,10 +1,9 @@
 use crate::runtime::{
-    Context, Handle, PropertyDescriptor,
+    Arguments, Context, Handle, PropertyDescriptor,
     abstract_operations::define_property_or_throw,
     alloc_error::AllocResult,
     bytecode::function::Closure,
     eval_result::EvalResult,
-    function::get_argument,
     generator_object::{GeneratorCompletionType, generator_resume, generator_resume_abrupt},
     heap_item_descriptor::HeapItemKind,
     intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
@@ -62,9 +61,9 @@ impl GeneratorPrototype {
     pub fn next(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         generator_resume(cx, this_value, value)
     }
 
@@ -72,9 +71,9 @@ impl GeneratorPrototype {
     pub fn return_(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         generator_resume_abrupt(cx, this_value, value, GeneratorCompletionType::Return)
     }
 
@@ -82,9 +81,9 @@ impl GeneratorPrototype {
     pub fn throw(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let error = get_argument(cx, arguments, 0);
+        let error = arguments.get(cx, 0);
         generator_resume_abrupt(cx, this_value, error, GeneratorCompletionType::Throw)
     }
 

--- a/src/js/runtime/intrinsics/global_object.rs
+++ b/src/js/runtime/intrinsics/global_object.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     handle_scope, handle_scope_guard,
     runtime::{
-        Context, EvalResult, Handle, PropertyKey, Realm, Value,
+        Arguments, Context, EvalResult, Handle, PropertyKey, Realm, Value,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -18,7 +18,6 @@ use crate::{
         console::ConsoleObject,
         error::uri_error,
         eval::eval::perform_eval,
-        function::get_argument,
         gc_object::GcObject,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         property_descriptor::PropertyDescriptor,
@@ -207,34 +206,22 @@ pub fn create_parse_int(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle
 }
 
 /// eval (https://tc39.es/ecma262/#sec-eval-x)
-pub fn eval(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: &[Handle<Value>],
-) -> EvalResult<Handle<Value>> {
-    let code_arg = get_argument(cx, arguments, 0);
+pub fn eval(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    let code_arg = arguments.get(cx, 0);
 
     perform_eval(cx, code_arg, /* is_strict_caller */ false, None, EvalFlags::empty())
 }
 
 /// isFinite (https://tc39.es/ecma262/#sec-isfinite-number)
-pub fn is_finite(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: &[Handle<Value>],
-) -> EvalResult<Handle<Value>> {
-    let argument = get_argument(cx, arguments, 0);
+pub fn is_finite(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    let argument = arguments.get(cx, 0);
     let num = to_number(cx, argument)?;
     Ok(cx.bool(!num.is_nan() && !num.is_infinity()))
 }
 
 /// isNaN (https://tc39.es/ecma262/#sec-isnan-number)
-pub fn is_nan(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: &[Handle<Value>],
-) -> EvalResult<Handle<Value>> {
-    let argument = get_argument(cx, arguments, 0);
+pub fn is_nan(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    let argument = arguments.get(cx, 0);
     let num = to_number(cx, argument)?;
     Ok(cx.bool(num.is_nan()))
 }
@@ -243,9 +230,9 @@ pub fn is_nan(
 pub fn parse_float(
     cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
-    let input_string_arg = get_argument(cx, arguments, 0);
+    let input_string_arg = arguments.get(cx, 0);
     let input_string = to_string(cx, input_string_arg)?;
 
     match parse_float_with_string_lexer(input_string)? {
@@ -262,15 +249,11 @@ fn parse_float_with_string_lexer(string: Handle<StringValue>) -> AllocResult<Opt
 }
 
 /// parseInt (https://tc39.es/ecma262/#sec-parseint-string-radix)
-pub fn parse_int(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: &[Handle<Value>],
-) -> EvalResult<Handle<Value>> {
-    let input_string_arg = get_argument(cx, arguments, 0);
+pub fn parse_int(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    let input_string_arg = arguments.get(cx, 0);
     let input_string = to_string(cx, input_string_arg)?;
 
-    let radix_arg = get_argument(cx, arguments, 1);
+    let radix_arg = arguments.get(cx, 1);
     let radix = to_int32(cx, radix_arg)?;
 
     let lexer = StringLexer::new(input_string)?;
@@ -377,9 +360,9 @@ fn parse_int_impl(mut lexer: StringLexer, radix: i32) -> Option<f64> {
 pub fn decode_uri(
     cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
-    let uri_arg = get_argument(cx, arguments, 0);
+    let uri_arg = arguments.get(cx, 0);
     let uri_string = to_string(cx, uri_arg)?;
 
     decode::<true>(cx, uri_string)
@@ -389,9 +372,9 @@ pub fn decode_uri(
 pub fn decode_uri_component(
     cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
-    let uri_component_arg = get_argument(cx, arguments, 0);
+    let uri_component_arg = arguments.get(cx, 0);
     let uri_component_string = to_string(cx, uri_component_arg)?;
 
     decode::<false>(cx, uri_component_string)
@@ -532,9 +515,9 @@ fn decode<const INCLUDE_URI_UNESCAPED: bool>(
 pub fn encode_uri(
     cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
-    let uri_arg = get_argument(cx, arguments, 0);
+    let uri_arg = arguments.get(cx, 0);
     let uri_string = to_string(cx, uri_arg)?;
 
     encode::<true>(cx, uri_string)
@@ -544,9 +527,9 @@ pub fn encode_uri(
 pub fn encode_uri_component(
     cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
-    let uri_component_arg = get_argument(cx, arguments, 0);
+    let uri_component_arg = arguments.get(cx, 0);
     let uri_component_string = to_string(cx, uri_component_arg)?;
 
     encode::<false>(cx, uri_component_string)
@@ -639,9 +622,9 @@ pub fn init_global_annex_b_methods(mut cx: Context, realm: Handle<Realm>) -> All
 pub fn escape(
     mut cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
-    let string_arg = get_argument(cx, arguments, 0);
+    let string_arg = arguments.get(cx, 0);
     let string = to_string(cx, string_arg)?;
 
     let mut escaped_string = Wtf8String::new();
@@ -672,9 +655,9 @@ pub fn escape(
 pub fn unescape(
     mut cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
-    let string_arg = get_argument(cx, arguments, 0);
+    let string_arg = arguments.get(cx, 0);
     let string = to_string(cx, string_arg)?;
     let length = string.len();
 

--- a/src/js/runtime/intrinsics/intrinsics.rs
+++ b/src/js/runtime/intrinsics/intrinsics.rs
@@ -1,7 +1,7 @@
 use crate::{
     handle_scope, handle_scope_guard, must_a,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Arguments, Context, Handle, HeapPtr, Value,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -580,11 +580,7 @@ impl Intrinsics {
     }
 }
 
-pub fn throw_type_error(
-    cx: Context,
-    _: Handle<Value>,
-    _: &[Handle<Value>],
-) -> EvalResult<Handle<Value>> {
+pub fn throw_type_error(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
     type_error(
         cx,
         "`caller`, `callee`, and `arguments` properties may not be accessed on strict mode functions or the arguments objects for calls to them",

--- a/src/js/runtime/intrinsics/iterator_constructor.rs
+++ b/src/js/runtime/intrinsics/iterator_constructor.rs
@@ -1,14 +1,13 @@
 use crate::{
     extend_object,
     runtime::{
-        Context, HeapPtr, Value,
+        Arguments, Context, HeapPtr, Value,
         abstract_operations::{call, call_object, get_method, ordinary_has_instance},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         collections::array::value_array_from_slice,
         error::type_error,
         eval_result::EvalResult,
-        function::get_argument,
         gc::{Handle, HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::{
@@ -62,11 +61,7 @@ impl IteratorConstructor {
     }
 
     /// Iterator (https://tc39.es/ecma262/#sec-iterator-constructor)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn construct(mut cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let new_target = cx.current_new_target();
         let throw_type_error = match new_target {
             None => true,
@@ -91,11 +86,11 @@ impl IteratorConstructor {
     pub fn concat(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let mut iterator_methods = vec![];
 
-        for argument in arguments {
+        for argument in arguments.iter() {
             if !argument.is_object() {
                 return type_error(cx, "Iterator.concat argument is not an object");
             }
@@ -107,7 +102,7 @@ impl IteratorConstructor {
             }
         }
 
-        let iterables_array = value_array_from_slice(cx, arguments)?.to_handle();
+        let iterables_array = value_array_from_slice(cx, arguments.as_slice())?.to_handle();
         let iterator_methods_array = value_array_from_slice(cx, &iterator_methods)?.to_handle();
 
         Ok(IteratorHelperObject::new_concat(cx, iterables_array, iterator_methods_array)?
@@ -115,12 +110,8 @@ impl IteratorConstructor {
     }
 
     /// Iterator.from (https://tc39.es/ecma262/#sec-iterator.from)
-    pub fn from(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let value = arguments.get(cx, 0);
         let iterator = get_iterator_flattenable(cx, value, /* reject_primitives */ false)?;
 
         let iterator_constructor = cx.get_intrinsic(Intrinsic::IteratorConstructor);
@@ -212,11 +203,7 @@ impl WrapForValidIteratorPrototype {
     }
 
     /// %WrapForValidIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.next)
-    pub fn next(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let wrapper = this_wrapped_valid_iterator_object(cx, this_value, "next")?;
 
         // Call the wrapped iterator's next method
@@ -228,7 +215,7 @@ impl WrapForValidIteratorPrototype {
     pub fn return_(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let wrapper = this_wrapped_valid_iterator_object(cx, this_value, "return")?;
 

--- a/src/js/runtime/intrinsics/iterator_helper_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_prototype.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    Context, EvalResult, Handle, Realm, Value,
+    Arguments, Context, EvalResult, Handle, Realm, Value,
     alloc_error::AllocResult,
     error::type_error,
     generator_object::GeneratorState,
@@ -48,11 +48,7 @@ impl IteratorHelperPrototype {
     }
 
     /// %IteratorHelperPrototype%.next (https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.next)
-    pub fn next(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         // GenerateResume adapted for Iterator Helper Objects
         let mut object = this_iterator_helper_object(cx, this_value, "next")?;
 
@@ -97,7 +93,7 @@ impl IteratorHelperPrototype {
     pub fn return_(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let mut object = this_iterator_helper_object(cx, this_value, "return")?;
 

--- a/src/js/runtime/intrinsics/iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_prototype.rs
@@ -1,12 +1,11 @@
 use crate::{
     eval_err, must,
     runtime::{
-        Context, EvalResult, Handle, Value,
+        Arguments, Context, EvalResult, Handle, Value,
         abstract_operations::{call_object, setter_that_ignores_prototype_properties},
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         error::{range_error_value, type_error, type_error_value},
-        function::get_argument,
         intrinsics::{
             intrinsics::Intrinsic, iterator_helper_object::IteratorHelperObject,
             rust_runtime::RuntimeFunction,
@@ -134,7 +133,7 @@ impl IteratorPrototype {
     pub fn get_constructor(
         cx: Context,
         _: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Ok(cx.get_intrinsic(Intrinsic::IteratorConstructor).as_value())
     }
@@ -143,9 +142,9 @@ impl IteratorPrototype {
     pub fn set_constructor(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
 
         setter_that_ignores_prototype_properties(
             cx,
@@ -162,11 +161,11 @@ impl IteratorPrototype {
     pub fn drop(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object(cx, this_value, "drop")?;
 
-        let limit_arg = get_argument(cx, arguments, 0);
+        let limit_arg = arguments.get(cx, 0);
         let integer_limit = validate_limit_argument(cx, this_object, limit_arg, "drop")?;
 
         // Get the underlying iterator and create a new iterator helper drop object
@@ -178,11 +177,11 @@ impl IteratorPrototype {
     pub fn every(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object(cx, this_value, "every")?;
 
-        let predicate_arg = get_argument(cx, arguments, 0);
+        let predicate_arg = arguments.get(cx, 0);
         let predicate =
             validate_callable_argument(cx, this_object, predicate_arg, "every", "predicate")?;
 
@@ -216,11 +215,11 @@ impl IteratorPrototype {
     pub fn filter(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object(cx, this_value, "filter")?;
 
-        let predicate_arg = get_argument(cx, arguments, 0);
+        let predicate_arg = arguments.get(cx, 0);
         let predicate =
             validate_callable_argument(cx, this_object, predicate_arg, "filter", "predicate")?;
 
@@ -233,11 +232,11 @@ impl IteratorPrototype {
     pub fn find(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object(cx, this_value, "find")?;
 
-        let predicate_arg = get_argument(cx, arguments, 0);
+        let predicate_arg = arguments.get(cx, 0);
         let predicate =
             validate_callable_argument(cx, this_object, predicate_arg, "find", "predicate")?;
 
@@ -271,11 +270,11 @@ impl IteratorPrototype {
     pub fn flat_map(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object(cx, this_value, "flatMap")?;
 
-        let mapper_arg = get_argument(cx, arguments, 0);
+        let mapper_arg = arguments.get(cx, 0);
         let mapper = validate_callable_argument(cx, this_object, mapper_arg, "flatMap", "mapper")?;
 
         // Get the underlying iterator and create a new iterator helper map object
@@ -287,11 +286,11 @@ impl IteratorPrototype {
     pub fn for_each(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object(cx, this_value, "forEach")?;
 
-        let callback_arg = get_argument(cx, arguments, 0);
+        let callback_arg = arguments.get(cx, 0);
         let callback =
             validate_callable_argument(cx, this_object, callback_arg, "forEach", "callback")?;
 
@@ -322,11 +321,11 @@ impl IteratorPrototype {
     pub fn map(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object(cx, this_value, "map")?;
 
-        let mapper_arg = get_argument(cx, arguments, 0);
+        let mapper_arg = arguments.get(cx, 0);
         let mapper = validate_callable_argument(cx, this_object, mapper_arg, "map", "mapper")?;
 
         // Get the underlying iterator and create a new iterator helper map object
@@ -338,11 +337,11 @@ impl IteratorPrototype {
     pub fn reduce(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object(cx, this_value, "reduce")?;
 
-        let callback_arg = get_argument(cx, arguments, 0);
+        let callback_arg = arguments.get(cx, 0);
         let callback =
             validate_callable_argument(cx, this_object, callback_arg, "reduce", "callback")?;
 
@@ -362,7 +361,7 @@ impl IteratorPrototype {
                 }
             }
         } else {
-            accumulator = get_argument(cx, arguments, 1);
+            accumulator = arguments.get(cx, 1);
             counter = 0;
         };
 
@@ -395,11 +394,11 @@ impl IteratorPrototype {
     pub fn some(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object(cx, this_value, "some")?;
 
-        let predicate_arg = get_argument(cx, arguments, 0);
+        let predicate_arg = arguments.get(cx, 0);
         let predicate =
             validate_callable_argument(cx, this_object, predicate_arg, "some", "predicate")?;
 
@@ -433,11 +432,11 @@ impl IteratorPrototype {
     pub fn take(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object(cx, this_value, "take")?;
 
-        let limit_arg = get_argument(cx, arguments, 0);
+        let limit_arg = arguments.get(cx, 0);
         let integer_limit = validate_limit_argument(cx, this_object, limit_arg, "take")?;
 
         // Get the underlying iterator and create a new iterator helper take object
@@ -449,7 +448,7 @@ impl IteratorPrototype {
     pub fn to_array(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object(cx, this_value, "toArray")?;
 
@@ -469,7 +468,7 @@ impl IteratorPrototype {
     pub fn iterator_prototype_get_to_string_tag(
         cx: Context,
         _: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Ok(cx.names.iterator().as_string().as_value())
     }
@@ -478,9 +477,9 @@ impl IteratorPrototype {
     pub fn set_to_string_tag(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
 
         setter_that_ignores_prototype_properties(
             cx,

--- a/src/js/runtime/intrinsics/json_object.rs
+++ b/src/js/runtime/intrinsics/json_object.rs
@@ -7,14 +7,13 @@ use crate::{
     },
     must,
     runtime::{
-        Context, EvalResult, Handle, PropertyKey, Realm, Value,
+        Arguments, Context, EvalResult, Handle, PropertyKey, Realm, Value,
         abstract_operations::{
             KeyOrValue, call_object, create_data_property, create_data_property_or_throw,
             enumerable_own_property_names, length_of_array_like,
         },
         alloc_error::AllocResult,
         error::syntax_error,
-        function::get_argument,
         get,
         intrinsics::{
             intrinsics::Intrinsic,
@@ -79,185 +78,29 @@ impl JSONObject {
     pub fn is_raw_json(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+        let argument = arguments.get(cx, 0);
         let is_raw_json = argument.is_object() && argument.as_object().is_raw_json_object();
 
         Ok(cx.bool(is_raw_json))
     }
 
     /// JSON.parse (https://tc39.es/ecma262/#sec-json.parse)
-    pub fn parse(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let text_arg = get_argument(cx, arguments, 0);
-        let text_string = to_string(cx, text_arg)?;
+    pub fn parse(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let text_arg = arguments.get(cx, 0);
+        let reviver_arg = arguments.get(cx, 1);
 
-        // Parse JSON into an AST, not yet allocated on heap
-        let json_value = if let Some(json_value) = parse_json(text_string)? {
-            json_value
-        } else {
-            return syntax_error(cx, "JSON.parse parsed invalid JSON");
-        };
-
-        // If reviver argument is provided then we must create a JSONParseRecord so that the
-        // initially parsed structure can be associated with the resulting values.
-        let reviver_arg = get_argument(cx, arguments, 1);
-        if is_callable(reviver_arg) {
-            let reviver = reviver_arg.as_object();
-
-            let parse_record = json_value.to_json_parse_record(cx)?;
-
-            let root = ordinary_object_create(cx)?;
-            let root_name = cx.names.empty_string();
-            must!(create_data_property_or_throw(cx, root, root_name, parse_record.value));
-
-            let flat_text_string = text_string.flatten()?;
-
-            return Self::internalize_json_property(
-                cx,
-                root,
-                root_name,
-                reviver,
-                flat_text_string,
-                Some(&parse_record),
-            );
-        }
-
-        // Otherwise reviver not needed so create JSON value on the heap
-        json_value.to_js_value(cx)
-    }
-
-    /// InternalizeJSONProperty (https://tc39.es/ecma262/#sec-internalizejsonproperty)
-    fn internalize_json_property(
-        cx: Context,
-        holder: Handle<ObjectValue>,
-        holder_key: Handle<PropertyKey>,
-        reviver: Handle<ObjectValue>,
-        source_text: Handle<FlatString>,
-        parse_record: Option<&JSONParseRecord>,
-    ) -> EvalResult<Handle<Value>> {
-        let value = get(cx, holder, holder_key)?;
-
-        let context = ordinary_object_create(cx)?;
-
-        // Literal values attach source text to the context object to be passed to the reviver
-        if let Some(parse_record) = &parse_record {
-            if !value.is_object() {
-                if same_value(value, parse_record.value)? {
-                    let loc = parse_record.loc;
-
-                    // Source text was stored as byte indices in the parse record
-                    let source_string = source_text
-                        .substring_by_byte_index(cx, loc.start, loc.end)?
-                        .to_handle();
-                    let source = source_string.as_string().as_value();
-
-                    must!(create_data_property_or_throw(cx, context, cx.names.source(), source));
-                }
-            }
-        }
-
-        if value.is_object() {
-            let mut value = value.as_object();
-
-            // Key is shared between iterations
-            let mut key = PropertyKey::uninit().to_handle(cx);
-
-            if is_array(cx, value.into())? {
-                // Find matching element records if present so they can be passed down
-                let mut element_records: &[JSONParseRecord] = &[];
-                if let Some(parse_record) = &parse_record {
-                    if let Some(JSONParseRecordChildren::Elements(elements)) =
-                        &parse_record.children
-                    {
-                        element_records = elements.as_slice();
-                    }
-                }
-
-                let length = length_of_array_like(cx, value)?;
-
-                for i in 0..length {
-                    key.replace(PropertyKey::from_u64(cx, i)?);
-
-                    // Find the matching element record for this index, if in bounds
-                    let element_record = element_records.get(i as usize);
-
-                    let new_element = Self::internalize_json_property(
-                        cx,
-                        value,
-                        key,
-                        reviver,
-                        source_text,
-                        element_record,
-                    )?;
-
-                    if new_element.is_undefined() {
-                        value.delete(cx, key)?;
-                    } else {
-                        create_data_property(cx, value, key, new_element)?;
-                    }
-                }
-            } else {
-                // Find matching property records if present so they can be passed down
-                let mut property_records: &[(Handle<PropertyKey>, JSONParseRecord)] = &[];
-                if let Some(parse_record) = &parse_record {
-                    if let Some(JSONParseRecordChildren::Properties(properties)) =
-                        &parse_record.children
-                    {
-                        property_records = properties.as_slice();
-                    }
-                }
-
-                let key_values = enumerable_own_property_names(cx, value, KeyOrValue::Key)?;
-                for key_value in key_values {
-                    key.replace(PropertyKey::from_value(cx, key_value)?);
-
-                    // Find the matching property record value for this key, if one exists
-                    let property_record =
-                        property_records
-                            .iter()
-                            .find_map(|(record_key, record_value)| {
-                                if *record_key == key {
-                                    Some(record_value)
-                                } else {
-                                    None
-                                }
-                            });
-
-                    let new_element = Self::internalize_json_property(
-                        cx,
-                        value,
-                        key,
-                        reviver,
-                        source_text,
-                        property_record,
-                    )?;
-
-                    if new_element.is_undefined() {
-                        value.delete(cx, key)?;
-                    } else {
-                        create_data_property(cx, value, key, new_element)?;
-                    }
-                }
-            }
-        }
-
-        let holder_key_value = holder_key.to_value(cx)?;
-
-        call_object(cx, reviver, holder.into(), &[holder_key_value, value, context.as_value()])
+        json_parse(cx, text_arg, reviver_arg)
     }
 
     /// JSON.rawJSON (https://tc39.es/ecma262/#sec-json.rawjson)
     pub fn raw_json(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let text_argument = get_argument(cx, arguments, 0);
+        let text_argument = arguments.get(cx, 0);
         let text_string = to_string(cx, text_argument)?;
 
         if text_string.is_empty() {
@@ -303,10 +146,10 @@ impl JSONObject {
     pub fn stringify(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         // Replacer arg may be a function or property list
-        let replacer_arg = get_argument(cx, arguments, 1);
+        let replacer_arg = arguments.get(cx, 1);
 
         let mut replacer_function = None;
         let mut property_list = None;
@@ -366,7 +209,7 @@ impl JSONObject {
         }
 
         // Convert number and string object to primitive values
-        let space_arg = get_argument(cx, arguments, 2);
+        let space_arg = arguments.get(cx, 2);
 
         let space_value = if space_arg.is_object() {
             let space_object = space_arg.as_object();
@@ -403,7 +246,7 @@ impl JSONObject {
 
         let wrapper = ordinary_object_create(cx)?;
 
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         must!(create_data_property_or_throw(cx, wrapper, cx.names.empty_string(), value));
 
         let mut serializer = JSONSerializer::new(replacer_function, property_list, gap);
@@ -413,4 +256,164 @@ impl JSONObject {
 
         Ok(serializer.build(cx)?.as_value())
     }
+}
+
+/// Implementation of JSON.parse with the given text and reviver argument, which may be undefined.
+pub fn json_parse(
+    cx: Context,
+    text: Handle<Value>,
+    reviver: Handle<Value>,
+) -> EvalResult<Handle<Value>> {
+    let text_string = to_string(cx, text)?;
+
+    // Parse JSON into an AST, not yet allocated on heap
+    let json_value = if let Some(json_value) = parse_json(text_string)? {
+        json_value
+    } else {
+        return syntax_error(cx, "JSON.parse parsed invalid JSON");
+    };
+
+    // If reviver argument is provided then we must create a JSONParseRecord so that the
+    // initially parsed structure can be associated with the resulting values.
+    if is_callable(reviver) {
+        let reviver = reviver.as_object();
+
+        let parse_record = json_value.to_json_parse_record(cx)?;
+
+        let root = ordinary_object_create(cx)?;
+        let root_name = cx.names.empty_string();
+        must!(create_data_property_or_throw(cx, root, root_name, parse_record.value));
+
+        let flat_text_string = text_string.flatten()?;
+
+        return internalize_json_property(
+            cx,
+            root,
+            root_name,
+            reviver,
+            flat_text_string,
+            Some(&parse_record),
+        );
+    }
+
+    // Otherwise reviver not needed so create JSON value on the heap
+    json_value.to_js_value(cx)
+}
+
+/// InternalizeJSONProperty (https://tc39.es/ecma262/#sec-internalizejsonproperty)
+fn internalize_json_property(
+    cx: Context,
+    holder: Handle<ObjectValue>,
+    holder_key: Handle<PropertyKey>,
+    reviver: Handle<ObjectValue>,
+    source_text: Handle<FlatString>,
+    parse_record: Option<&JSONParseRecord>,
+) -> EvalResult<Handle<Value>> {
+    let value = get(cx, holder, holder_key)?;
+
+    let context = ordinary_object_create(cx)?;
+
+    // Literal values attach source text to the context object to be passed to the reviver
+    if let Some(parse_record) = &parse_record {
+        if !value.is_object() {
+            if same_value(value, parse_record.value)? {
+                let loc = parse_record.loc;
+
+                // Source text was stored as byte indices in the parse record
+                let source_string = source_text
+                    .substring_by_byte_index(cx, loc.start, loc.end)?
+                    .to_handle();
+                let source = source_string.as_string().as_value();
+
+                must!(create_data_property_or_throw(cx, context, cx.names.source(), source));
+            }
+        }
+    }
+
+    if value.is_object() {
+        let mut value = value.as_object();
+
+        // Key is shared between iterations
+        let mut key = PropertyKey::uninit().to_handle(cx);
+
+        if is_array(cx, value.into())? {
+            // Find matching element records if present so they can be passed down
+            let mut element_records: &[JSONParseRecord] = &[];
+            if let Some(parse_record) = &parse_record {
+                if let Some(JSONParseRecordChildren::Elements(elements)) = &parse_record.children {
+                    element_records = elements.as_slice();
+                }
+            }
+
+            let length = length_of_array_like(cx, value)?;
+
+            for i in 0..length {
+                key.replace(PropertyKey::from_u64(cx, i)?);
+
+                // Find the matching element record for this index, if in bounds
+                let element_record = element_records.get(i as usize);
+
+                let new_element = internalize_json_property(
+                    cx,
+                    value,
+                    key,
+                    reviver,
+                    source_text,
+                    element_record,
+                )?;
+
+                if new_element.is_undefined() {
+                    value.delete(cx, key)?;
+                } else {
+                    create_data_property(cx, value, key, new_element)?;
+                }
+            }
+        } else {
+            // Find matching property records if present so they can be passed down
+            let mut property_records: &[(Handle<PropertyKey>, JSONParseRecord)] = &[];
+            if let Some(parse_record) = &parse_record {
+                if let Some(JSONParseRecordChildren::Properties(properties)) =
+                    &parse_record.children
+                {
+                    property_records = properties.as_slice();
+                }
+            }
+
+            let key_values = enumerable_own_property_names(cx, value, KeyOrValue::Key)?;
+            for key_value in key_values {
+                key.replace(PropertyKey::from_value(cx, key_value)?);
+
+                // Find the matching property record value for this key, if one exists
+                let property_record =
+                    property_records
+                        .iter()
+                        .find_map(|(record_key, record_value)| {
+                            if *record_key == key {
+                                Some(record_value)
+                            } else {
+                                None
+                            }
+                        });
+
+                let new_element = internalize_json_property(
+                    cx,
+                    value,
+                    key,
+                    reviver,
+                    source_text,
+                    property_record,
+                )?;
+
+                if new_element.is_undefined() {
+                    value.delete(cx, key)?;
+                } else {
+                    create_data_property(cx, value, key, new_element)?;
+                }
+            }
+        }
+    }
+
+    let holder_key_value = holder_key.to_value(cx)?;
+
+    call_object(cx, reviver, holder.into(), &[holder_key_value, value, context.as_value()])
 }

--- a/src/js/runtime/intrinsics/map_constructor.rs
+++ b/src/js/runtime/intrinsics/map_constructor.rs
@@ -1,14 +1,13 @@
 use crate::{
     must,
     runtime::{
-        Context, Handle,
+        Arguments, Context, Handle,
         abstract_operations::{GroupByKeyCoercion, call_object, construct, group_by},
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
-        function::get_argument,
         get,
         intrinsics::{intrinsics::Intrinsic, map_object::MapObject, rust_runtime::RuntimeFunction},
         iterator::iter_iterator_values,
@@ -59,7 +58,7 @@ impl MapConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
@@ -69,7 +68,7 @@ impl MapConstructor {
 
         let map_object = MapObject::new_from_constructor(cx, new_target)?.as_object();
 
-        let iterable = get_argument(cx, arguments, 0);
+        let iterable = arguments.get(cx, 0);
         if iterable.is_nullish() {
             return Ok(map_object.as_value());
         }
@@ -89,10 +88,10 @@ impl MapConstructor {
     pub fn group_by(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let items = get_argument(cx, arguments, 0);
-        let callback = get_argument(cx, arguments, 1);
+        let items = arguments.get(cx, 0);
+        let callback = arguments.get(cx, 1);
 
         let groups = group_by(cx, items, callback, GroupByKeyCoercion::Collection)?;
 

--- a/src/js/runtime/intrinsics/map_iterator.rs
+++ b/src/js/runtime/intrinsics/map_iterator.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object,
     runtime::{
-        Context, Handle, HeapPtr,
+        Arguments, Context, Handle, HeapPtr,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         collections::index_map::GcSafeEntriesIter,
@@ -109,11 +109,7 @@ impl MapIteratorPrototype {
 
     /// %MapIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%mapiteratorprototype%.next)
     /// Adapted from the abstract closure in CreateMapIterator (https://tc39.es/ecma262/#sec-createmapiterator)
-    pub fn next(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let mut map_iterator = MapIterator::cast_from_value(cx, this_value)?;
 
         // Check if iterator is already done

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -1,11 +1,10 @@
 use crate::runtime::{
-    Context, Handle,
+    Arguments, Context, Handle,
     abstract_operations::{call, call_object},
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic,
         map_iterator::{MapIterator, MapIteratorKind},
@@ -111,7 +110,7 @@ impl MapPrototype {
     pub fn clear(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let map = this_map_value(cx, this_value, "clear")?;
 
@@ -124,11 +123,11 @@ impl MapPrototype {
     pub fn delete(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let map = this_map_value(cx, this_value, "delete")?;
 
-        let key = get_argument(cx, arguments, 0);
+        let key = arguments.get(cx, 0);
 
         // May allocate
         let map_key = ValueCollectionKey::from(key)?;
@@ -142,7 +141,7 @@ impl MapPrototype {
     pub fn entries(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let map = this_map_value(cx, this_value, "entries")?;
 
@@ -153,17 +152,17 @@ impl MapPrototype {
     pub fn for_each(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let map = this_map_value(cx, this_value, "forEach")?;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "Map.prototype.forEach argument must be a function");
         }
 
         let callback_function = callback_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         // Share key and value handles during iteration
         let mut key_handle = Handle::<Value>::empty(cx);
@@ -186,11 +185,11 @@ impl MapPrototype {
     pub fn get(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let map = this_map_value(cx, this_value, "get")?;
 
-        let key = get_argument(cx, arguments, 0);
+        let key = arguments.get(cx, 0);
 
         // May allocate
         let map_key = ValueCollectionKey::from(key)?;
@@ -205,12 +204,12 @@ impl MapPrototype {
     pub fn get_or_insert(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let map = this_map_value(cx, this_value, "getOrInsert")?;
 
-        let key = get_argument(cx, arguments, 0);
-        let value = get_argument(cx, arguments, 1);
+        let key = arguments.get(cx, 0);
+        let value = arguments.get(cx, 1);
 
         // May allocate
         let map_key = ValueCollectionKey::from(key)?;
@@ -227,12 +226,12 @@ impl MapPrototype {
     pub fn get_or_insert_computed(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let map = this_map_value(cx, this_value, "getOrInsertComputed")?;
 
-        let key = get_argument(cx, arguments, 0);
-        let callback = get_argument(cx, arguments, 1);
+        let key = arguments.get(cx, 0);
+        let callback = arguments.get(cx, 1);
 
         if !is_callable(callback) {
             return type_error(
@@ -264,11 +263,11 @@ impl MapPrototype {
     pub fn has(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let map = this_map_value(cx, this_value, "has")?;
 
-        let key = get_argument(cx, arguments, 0);
+        let key = arguments.get(cx, 0);
 
         // May allocate
         let map_key = ValueCollectionKey::from(key)?;
@@ -277,11 +276,7 @@ impl MapPrototype {
     }
 
     /// Map.prototype.keys (https://tc39.es/ecma262/#sec-map.prototype.keys)
-    pub fn keys(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn keys(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let map = this_map_value(cx, this_value, "keys")?;
 
         Ok(MapIterator::new(cx, map, MapIteratorKind::Key)?.as_value())
@@ -291,12 +286,12 @@ impl MapPrototype {
     pub fn set(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let map = this_map_value(cx, this_value, "set")?;
 
-        let mut key = get_argument(cx, arguments, 0);
-        let value = get_argument(cx, arguments, 1);
+        let mut key = arguments.get(cx, 0);
+        let value = arguments.get(cx, 1);
 
         // Convert negative zero to positive zero for key in map
         if key.is_negative_zero() {
@@ -309,11 +304,7 @@ impl MapPrototype {
     }
 
     /// get Map.prototype.size (https://tc39.es/ecma262/#sec-get-map.prototype.size)
-    pub fn size(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn size(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let map = this_map_value(cx, this_value, "size")?;
 
         Ok(cx.number(map.map_data().num_entries_occupied()))
@@ -323,7 +314,7 @@ impl MapPrototype {
     pub fn values(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let map = this_map_value(cx, this_value, "values")?;
 

--- a/src/js/runtime/intrinsics/math_object.rs
+++ b/src/js/runtime/intrinsics/math_object.rs
@@ -7,11 +7,10 @@ use crate::{
         numeric::{MAX_I32_PLUS_ONE_AS_F64, MAX_SAFE_INTEGER_U64},
     },
     runtime::{
-        Context, Handle,
+        Arguments, Context, Handle,
         alloc_error::AllocResult,
         error::{range_error, type_error},
         eval_result::EvalResult,
-        function::get_argument,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         iterator::{IteratorHint, get_iterator, iterator_close, iterator_step_value},
         numeric_operations::number_exponentiate,
@@ -131,12 +130,8 @@ impl MathObject {
     }
 
     /// Math.abs (https://tc39.es/ecma262/#sec-math.abs)
-    pub fn abs(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn abs(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
 
         if n.is_smi() {
@@ -152,104 +147,68 @@ impl MathObject {
     }
 
     /// Math.acos (https://tc39.es/ecma262/#sec-math.acos)
-    pub fn acos(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn acos(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::acos(n.as_number())))
     }
 
     /// Math.acosh (https://tc39.es/ecma262/#sec-math.acosh)
-    pub fn acosh(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn acosh(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::acosh(n.as_number())))
     }
 
     /// Math.asin (https://tc39.es/ecma262/#sec-math.asin)
-    pub fn asin(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn asin(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::asin(n.as_number())))
     }
 
     /// Math.asinh (https://tc39.es/ecma262/#sec-math.asinh)
-    pub fn asinh(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn asinh(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::asinh(n.as_number())))
     }
 
     /// Math.atan (https://tc39.es/ecma262/#sec-math.atan)
-    pub fn atan(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn atan(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::atan(n.as_number())))
     }
 
     /// Math.atanh (https://tc39.es/ecma262/#sec-math.atanh)
-    pub fn atanh(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn atanh(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::atanh(n.as_number())))
     }
 
     /// Math.atan2 (https://tc39.es/ecma262/#sec-math.atan2)
-    pub fn atan2(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let y_arg = get_argument(cx, arguments, 0);
+    pub fn atan2(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let y_arg = arguments.get(cx, 0);
         let y = to_number(cx, y_arg)?;
 
-        let x_arg = get_argument(cx, arguments, 1);
+        let x_arg = arguments.get(cx, 1);
         let x = to_number(cx, x_arg)?;
 
         Ok(cx.number(y.as_number().atan2(x.as_number())))
     }
 
     /// Math.cbrt (https://tc39.es/ecma262/#sec-math.cbrt)
-    pub fn cbrt(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn cbrt(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::cbrt(n.as_number())))
     }
 
     /// Math.ceil (https://tc39.es/ecma262/#sec-math.ceil)
-    pub fn ceil(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn ceil(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
 
         if n.is_smi() {
@@ -260,56 +219,36 @@ impl MathObject {
     }
 
     /// Math.clz32 (https://tc39.es/ecma262/#sec-math.clz32)
-    pub fn clz32(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn clz32(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_uint32(cx, argument)?;
         Ok(cx.smi(n.leading_zeros() as u8))
     }
 
     /// Math.cos (https://tc39.es/ecma262/#sec-math.cos)
-    pub fn cos(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn cos(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::cos(n.as_number())))
     }
 
     /// Math.cosh (https://tc39.es/ecma262/#sec-math.cosh)
-    pub fn cosh(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn cosh(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::cosh(n.as_number())))
     }
 
     /// Math.exp (https://tc39.es/ecma262/#sec-math.exp)
-    pub fn exp(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn exp(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::exp(n.as_number())))
     }
 
     /// Math.expm1 (https://tc39.es/ecma262/#sec-math.expm1)
-    pub fn expm1(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn expm1(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::exp_m1(n.as_number())))
     }
@@ -318,9 +257,9 @@ impl MathObject {
     pub fn f16_round(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
 
         if n.is_nan() || n.is_zero() || n.is_infinity() {
@@ -333,12 +272,8 @@ impl MathObject {
     }
 
     /// Math.floor (https://tc39.es/ecma262/#sec-math.floor)
-    pub fn floor(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn floor(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
 
         if n.is_smi() {
@@ -352,24 +287,20 @@ impl MathObject {
     pub fn fround(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number((n.as_number() as f32) as f64))
     }
 
     /// Math.hypot (https://tc39.es/ecma262/#sec-math.hypot)
-    pub fn hypot(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn hypot(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
         let mut sum = Value::smi(0);
         let mut has_infinity: bool = false;
         let mut has_nan: bool = false;
 
-        for arg in arguments {
+        for arg in arguments.iter() {
             let n = *to_number(cx, *arg)?;
 
             if has_infinity {
@@ -404,15 +335,11 @@ impl MathObject {
     }
 
     /// Math.imul (https://tc39.es/ecma262/#sec-math.imul)
-    pub fn imul(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let x_arg = get_argument(cx, arguments, 0);
+    pub fn imul(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let x_arg = arguments.get(cx, 0);
         let x = to_uint32(cx, x_arg)?;
 
-        let y_arg = get_argument(cx, arguments, 1);
+        let y_arg = arguments.get(cx, 1);
         let y = to_uint32(cx, y_arg)?;
 
         let mod_mul = ((x as u64) * (y as u64)) as u32;
@@ -421,59 +348,39 @@ impl MathObject {
     }
 
     /// Math.log (https://tc39.es/ecma262/#sec-math.log)
-    pub fn log(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn log(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::ln(n.as_number())))
     }
 
     /// Math.log1p (https://tc39.es/ecma262/#sec-math.log1p)
-    pub fn log1p(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn log1p(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::ln_1p(n.as_number())))
     }
 
     /// Math.log10 (https://tc39.es/ecma262/#sec-math.log10)
-    pub fn log10(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn log10(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::log10(n.as_number())))
     }
 
     /// Math.log2 (https://tc39.es/ecma262/#sec-math.log2)
-    pub fn log2(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn log2(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::log2(n.as_number())))
     }
 
     /// Math.max (https://tc39.es/ecma262/#sec-math.max)
-    pub fn max(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn max(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
         let mut highest = Value::number(f64::NEG_INFINITY);
         let mut found_nan = false;
 
-        for arg in arguments {
+        for arg in arguments.iter() {
             let n = *to_number(cx, *arg)?;
 
             if found_nan || n.is_nan() {
@@ -498,15 +405,11 @@ impl MathObject {
     }
 
     /// Math.min (https://tc39.es/ecma262/#sec-math.min)
-    pub fn min(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn min(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
         let mut lowest = Value::number(f64::INFINITY);
         let mut found_nan = false;
 
-        for arg in arguments {
+        for arg in arguments.iter() {
             let n = *to_number(cx, *arg)?;
 
             if found_nan || n.is_nan() {
@@ -531,37 +434,25 @@ impl MathObject {
     }
 
     /// Math.pow (https://tc39.es/ecma262/#sec-math.pow)
-    pub fn pow(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let base_arg = get_argument(cx, arguments, 0);
+    pub fn pow(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let base_arg = arguments.get(cx, 0);
         let base = to_number(cx, base_arg)?;
 
-        let exponent_arg = get_argument(cx, arguments, 1);
+        let exponent_arg = arguments.get(cx, 1);
         let exponent = to_number(cx, exponent_arg)?;
 
         Ok(cx.number(number_exponentiate(base.as_number(), exponent.as_number())))
     }
 
     /// Math.random (https://tc39.es/ecma262/#sec-math.random)
-    pub fn random(
-        mut cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn random(mut cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let n = cx.rand.r#gen::<f64>();
         Ok(cx.number(n))
     }
 
     /// Math.round (https://tc39.es/ecma262/#sec-math.round)
-    pub fn round(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn round(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
 
         if n.is_smi() {
@@ -581,12 +472,8 @@ impl MathObject {
     }
 
     /// Math.sign (https://tc39.es/ecma262/#sec-math.sign)
-    pub fn sign(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn sign(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = *to_number(cx, argument)?;
 
         if n.is_smi() {
@@ -612,34 +499,22 @@ impl MathObject {
     }
 
     /// Math.sin (https://tc39.es/ecma262/#sec-math.sin)
-    pub fn sin(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn sin(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::sin(n.as_number())))
     }
 
     /// Math.sinh (https://tc39.es/ecma262/#sec-math.sinh)
-    pub fn sinh(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn sinh(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::sinh(n.as_number())))
     }
 
     /// Math.sqrt (https://tc39.es/ecma262/#sec-math.sqrt)
-    pub fn sqrt(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn sqrt(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::sqrt(n.as_number())))
     }
@@ -648,9 +523,9 @@ impl MathObject {
     pub fn sum_precise(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let items_arg = get_argument(cx, arguments, 0);
+        let items_arg = arguments.get(cx, 0);
 
         if !items_arg.is_object() {
             return type_error(cx, "Math.sumPrecise argument must be an object");
@@ -714,34 +589,22 @@ impl MathObject {
     }
 
     /// Math.tan (https://tc39.es/ecma262/#sec-math.tan)
-    pub fn tan(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn tan(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::tan(n.as_number())))
     }
 
     /// Math.tanh (https://tc39.es/ecma262/#sec-math.tanh)
-    pub fn tanh(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn tanh(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::tanh(n.as_number())))
     }
 
     /// Math.trunc (https://tc39.es/ecma262/#sec-math.trunc)
-    pub fn trunc(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn trunc(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
 
         if n.is_smi() {

--- a/src/js/runtime/intrinsics/native_error.rs
+++ b/src/js/runtime/intrinsics/native_error.rs
@@ -1,10 +1,9 @@
 use crate::runtime::{
-    Context, Handle, HeapPtr, Value,
+    Arguments, Context, Handle, HeapPtr, Value,
     abstract_operations::{construct, create_non_enumerable_data_property_or_throw},
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         error_constructor::{ErrorObject, install_error_cause},
         intrinsics::Intrinsic,
@@ -88,7 +87,7 @@ macro_rules! create_native_error {
             pub fn construct(
                 mut cx: Context,
                 _: Handle<Value>,
-                arguments: &[Handle<Value>],
+                arguments: Arguments,
             ) -> EvalResult<Handle<Value>> {
                 let new_target = if let Some(new_target) = cx.current_new_target() {
                     new_target
@@ -103,7 +102,7 @@ macro_rules! create_native_error {
                     /* skip_current_frame */ true,
                 )?;
 
-                let message = get_argument(cx, arguments, 0);
+                let message = arguments.get(cx, 0);
                 if !message.is_undefined() {
                     let message_string = to_string(cx, message)?;
                     create_non_enumerable_data_property_or_throw(
@@ -114,7 +113,7 @@ macro_rules! create_native_error {
                     )?;
                 }
 
-                let options_arg = get_argument(cx, arguments, 1);
+                let options_arg = arguments.get(cx, 1);
                 install_error_cause(cx, object, options_arg)?;
 
                 Ok(object.as_value())

--- a/src/js/runtime/intrinsics/number_constructor.rs
+++ b/src/js/runtime/intrinsics/number_constructor.rs
@@ -6,11 +6,10 @@ use crate::{
     common::numeric::{MAX_SAFE_INTEGER_F64, MIN_POSITIVE_SUBNORMAL_F64, MIN_SAFE_INTEGER_F64},
     extend_object,
     runtime::{
-        Context, HeapPtr,
+        Arguments, Context, HeapPtr,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         eval_result::EvalResult,
-        function::get_argument,
         gc::{Handle, HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
@@ -171,12 +170,12 @@ impl NumberConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let number_value = if arguments.is_empty() {
             0.0
         } else {
-            let argument = get_argument(cx, arguments, 0);
+            let argument = arguments.get(cx, 0);
             let numeric_value = to_numeric(cx, argument)?;
             if numeric_value.is_bigint() {
                 // Safe since BigInt::to_f64 never returns None
@@ -198,9 +197,9 @@ impl NumberConstructor {
     pub fn is_finite(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         if !value.is_number() {
             return Ok(cx.bool(false));
         }
@@ -212,9 +211,9 @@ impl NumberConstructor {
     pub fn is_integer(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         Ok(cx.bool(is_integral_number(*value)))
     }
 
@@ -222,9 +221,9 @@ impl NumberConstructor {
     pub fn is_nan(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         if !value.is_number() {
             return Ok(cx.bool(false));
         }
@@ -236,9 +235,9 @@ impl NumberConstructor {
     pub fn is_safe_integer(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         if !is_integral_number(*value) {
             return Ok(cx.bool(false));
         }

--- a/src/js/runtime/intrinsics/number_prototype.rs
+++ b/src/js/runtime/intrinsics/number_prototype.rs
@@ -1,9 +1,8 @@
 use crate::runtime::{
-    Context, Handle,
+    Arguments, Context, Handle,
     alloc_error::AllocResult,
     error::{range_error, type_error},
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic, number_constructor::NumberObject, rust_runtime::RuntimeFunction,
     },
@@ -74,12 +73,12 @@ impl NumberPrototype {
     pub fn to_exponential(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let number_value = this_number_value(cx, this_value, "toExponential")?;
         let mut number = number_value.as_number();
 
-        let fraction_digits_arg = get_argument(cx, arguments, 0);
+        let fraction_digits_arg = arguments.get(cx, 0);
         let num_fraction_digits = to_integer_or_infinity(cx, fraction_digits_arg)?;
 
         if !number.is_finite() {
@@ -156,12 +155,12 @@ impl NumberPrototype {
     pub fn to_fixed(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let number_value = this_number_value(cx, this_value, "toFixed")?;
         let mut number = number_value.as_number();
 
-        let fraction_digits_arg = get_argument(cx, arguments, 0);
+        let fraction_digits_arg = arguments.get(cx, 0);
         let num_fraction_digits = to_integer_or_infinity(cx, fraction_digits_arg)?;
         if !num_fraction_digits.is_finite() || !(0.0..=100.0).contains(&num_fraction_digits) {
             return range_error(
@@ -204,20 +203,20 @@ impl NumberPrototype {
     pub fn to_locale_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        Self::to_string_impl(cx, this_value, &[], "toLocaleString")
+        Self::to_string_impl(cx, this_value, cx.undefined(), "toLocaleString")
     }
 
     /// Number.prototype.toPrecision (https://tc39.es/ecma262/#sec-number.prototype.toprecision)
     pub fn to_precision(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let number_value = this_number_value(cx, this_value, "toPrecision")?;
 
-        let precision_arg = get_argument(cx, arguments, 0);
+        let precision_arg = arguments.get(cx, 0);
         if precision_arg.is_undefined() {
             return Ok(to_string(cx, number_value.to_handle(cx))?.as_value());
         }
@@ -297,20 +296,19 @@ impl NumberPrototype {
     pub fn to_string(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        Self::to_string_impl(cx, this_value, arguments, "toString")
+        let radix_arg = arguments.get(cx, 0);
+        Self::to_string_impl(cx, this_value, radix_arg, "toString")
     }
 
     fn to_string_impl(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        radix: Handle<Value>,
         method_name: &str,
     ) -> EvalResult<Handle<Value>> {
         let number_value = this_number_value(cx, this_value, method_name)?;
-
-        let radix = get_argument(cx, arguments, 0);
 
         let radix = if radix.is_undefined() {
             10
@@ -417,7 +415,7 @@ impl NumberPrototype {
     pub fn value_of(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let number_value = this_number_value(cx, this_value, "valueOf")?;
         Ok(number_value.to_handle(cx))

--- a/src/js/runtime/intrinsics/object_constructor.rs
+++ b/src/js/runtime/intrinsics/object_constructor.rs
@@ -1,7 +1,7 @@
 use crate::{
     must,
     runtime::{
-        Context, Handle, Value,
+        Arguments, Context, Handle, Value,
         abstract_operations::{
             GroupByKeyCoercion, IntegrityLevel, KeyOrValue, create_data_property_or_throw,
             define_property_or_throw, enumerable_own_property_names, get, group_by,
@@ -12,7 +12,6 @@ use crate::{
         builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
-        function::get_argument,
         heap_item_descriptor::HeapItemKind,
         intrinsics::{
             intrinsics::Intrinsic, map_constructor::add_entries_from_iterable,
@@ -213,7 +212,7 @@ impl ObjectConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if let Some(new_target) = cx.current_new_target() {
             if !cx.current_function().ptr_eq(&new_target) {
@@ -227,7 +226,7 @@ impl ObjectConstructor {
             }
         }
 
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         if value.is_nullish() {
             let new_value: Handle<Value> = ordinary_object_create(cx)?.into();
             return Ok(new_value);
@@ -240,9 +239,9 @@ impl ObjectConstructor {
     pub fn assign(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let to_arg = get_argument(cx, arguments, 0);
+        let to_arg = arguments.get(cx, 0);
         let to = to_object(cx, to_arg)?;
 
         if arguments.len() <= 1 {
@@ -277,9 +276,9 @@ impl ObjectConstructor {
     pub fn create(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let proto = get_argument(cx, arguments, 0);
+        let proto = arguments.get(cx, 0);
         let proto = if proto.is_object() {
             Some(proto.as_object())
         } else if proto.is_null() {
@@ -295,7 +294,7 @@ impl ObjectConstructor {
         )?
         .to_handle();
 
-        let properties = get_argument(cx, arguments, 1);
+        let properties = arguments.get(cx, 1);
         if properties.is_undefined() {
             Ok(object.as_value())
         } else {
@@ -307,14 +306,14 @@ impl ObjectConstructor {
     pub fn define_properties(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let object = get_argument(cx, arguments, 0);
+        let object = arguments.get(cx, 0);
         if !object.is_object() {
             return type_error(cx, "Object.defineProperties target must be an object");
         }
 
-        let properties_arg = get_argument(cx, arguments, 1);
+        let properties_arg = arguments.get(cx, 1);
         Self::object_define_properties(cx, object.as_object(), properties_arg)
     }
 
@@ -354,17 +353,17 @@ impl ObjectConstructor {
     pub fn define_property(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let object = get_argument(cx, arguments, 0);
+        let object = arguments.get(cx, 0);
         if !object.is_object() {
             return type_error(cx, "Object.defineProperty target must be an object");
         }
 
-        let property_arg = get_argument(cx, arguments, 1);
+        let property_arg = arguments.get(cx, 1);
         let property_key = to_property_key(cx, property_arg)?;
 
-        let desc_arg = get_argument(cx, arguments, 2);
+        let desc_arg = arguments.get(cx, 2);
         let desc = to_property_descriptor(cx, desc_arg)?;
 
         define_property_or_throw(cx, object.as_object(), property_key, desc)?;
@@ -376,9 +375,9 @@ impl ObjectConstructor {
     pub fn entries(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let object_arg = get_argument(cx, arguments, 0);
+        let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
         let name_list = enumerable_own_property_names(cx, object, KeyOrValue::KeyAndValue)?;
         Ok(create_array_from_list(cx, &name_list)?.as_value())
@@ -388,9 +387,9 @@ impl ObjectConstructor {
     pub fn freeze(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let object = get_argument(cx, arguments, 0);
+        let object = arguments.get(cx, 0);
         if !object.is_object() {
             return Ok(object);
         }
@@ -406,9 +405,9 @@ impl ObjectConstructor {
     pub fn from_entries(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let iterable_arg = get_argument(cx, arguments, 0);
+        let iterable_arg = arguments.get(cx, 0);
         let iterable = require_object_coercible(cx, iterable_arg)?;
 
         let object = ordinary_object_create(cx)?;
@@ -424,12 +423,12 @@ impl ObjectConstructor {
     pub fn get_own_property_descriptor(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let object_arg = get_argument(cx, arguments, 0);
+        let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
 
-        let property_arg = get_argument(cx, arguments, 1);
+        let property_arg = arguments.get(cx, 1);
         let property_key = to_property_key(cx, property_arg)?;
 
         match object.get_own_property(cx, property_key)? {
@@ -442,9 +441,9 @@ impl ObjectConstructor {
     pub fn get_own_property_descriptors(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let object_arg = get_argument(cx, arguments, 0);
+        let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
 
         let keys = object.own_property_keys(cx)?;
@@ -470,9 +469,9 @@ impl ObjectConstructor {
     pub fn get_own_property_names(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let object_arg = get_argument(cx, arguments, 0);
+        let object_arg = arguments.get(cx, 0);
         let symbol_keys = Self::get_own_property_keys(cx, object_arg, true)?;
         Ok(create_array_from_list(cx, &symbol_keys)?.as_value())
     }
@@ -481,9 +480,9 @@ impl ObjectConstructor {
     pub fn get_own_property_symbols(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let object_arg = get_argument(cx, arguments, 0);
+        let object_arg = arguments.get(cx, 0);
         let symbol_keys = Self::get_own_property_keys(cx, object_arg, false)?;
         Ok(create_array_from_list(cx, &symbol_keys)?.as_value())
     }
@@ -515,9 +514,9 @@ impl ObjectConstructor {
     pub fn get_prototype_of(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let object_arg = get_argument(cx, arguments, 0);
+        let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
         let prototype = object.get_prototype_of(cx)?;
 
@@ -531,10 +530,10 @@ impl ObjectConstructor {
     pub fn group_by(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let items = get_argument(cx, arguments, 0);
-        let callback = get_argument(cx, arguments, 1);
+        let items = arguments.get(cx, 0);
+        let callback = arguments.get(cx, 1);
 
         let groups = group_by(cx, items, callback, GroupByKeyCoercion::Property)?;
 
@@ -553,12 +552,12 @@ impl ObjectConstructor {
     pub fn has_own(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let object_arg = get_argument(cx, arguments, 0);
+        let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
 
-        let key_arg = get_argument(cx, arguments, 1);
+        let key_arg = arguments.get(cx, 1);
         let key = to_property_key(cx, key_arg)?;
 
         let has_own = has_own_property(cx, object, key)?;
@@ -566,12 +565,8 @@ impl ObjectConstructor {
     }
 
     /// Object.is (https://tc39.es/ecma262/#sec-object.is)
-    pub fn is(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let is_same = same_value(get_argument(cx, arguments, 0), get_argument(cx, arguments, 1))?;
+    pub fn is(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let is_same = same_value(arguments.get(cx, 0), arguments.get(cx, 1))?;
         Ok(cx.bool(is_same))
     }
 
@@ -579,9 +574,9 @@ impl ObjectConstructor {
     pub fn is_extensible(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(cx.bool(false));
         }
@@ -594,9 +589,9 @@ impl ObjectConstructor {
     pub fn is_frozen(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(cx.bool(true));
         }
@@ -609,9 +604,9 @@ impl ObjectConstructor {
     pub fn is_sealed(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(cx.bool(true));
         }
@@ -621,12 +616,8 @@ impl ObjectConstructor {
     }
 
     /// Object.keys (https://tc39.es/ecma262/#sec-object.keys)
-    pub fn keys(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let object_arg = get_argument(cx, arguments, 0);
+    pub fn keys(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
         let name_list = enumerable_own_property_names(cx, object, KeyOrValue::Key)?;
         Ok(create_array_from_list(cx, &name_list)?.as_value())
@@ -636,9 +627,9 @@ impl ObjectConstructor {
     pub fn prevent_extensions(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(value);
         }
@@ -654,12 +645,8 @@ impl ObjectConstructor {
     }
 
     /// Object.seal (https://tc39.es/ecma262/#sec-object.seal)
-    pub fn seal(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let object = get_argument(cx, arguments, 0);
+    pub fn seal(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let object = arguments.get(cx, 0);
         if !object.is_object() {
             return Ok(object);
         }
@@ -675,12 +662,12 @@ impl ObjectConstructor {
     pub fn set_prototype_of(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let object_arg = get_argument(cx, arguments, 0);
+        let object_arg = arguments.get(cx, 0);
         let object = require_object_coercible(cx, object_arg)?;
 
-        let proto = get_argument(cx, arguments, 1);
+        let proto = arguments.get(cx, 1);
         let proto = if proto.is_object() {
             Some(proto.as_object())
         } else if proto.is_null() {
@@ -705,9 +692,9 @@ impl ObjectConstructor {
     pub fn values(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let object_arg = get_argument(cx, arguments, 0);
+        let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
         let name_list = enumerable_own_property_names(cx, object, KeyOrValue::Value)?;
         Ok(create_array_from_list(cx, &name_list)?.as_value())

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -3,12 +3,11 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Arguments, Context, Handle, HeapPtr, Value,
         abstract_operations::{define_property_or_throw, get, has_own_property, invoke},
         alloc_error::AllocResult,
         error::type_error,
         eval_result::EvalResult,
-        function::get_argument,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::rust_runtime::RuntimeFunction,
@@ -135,9 +134,9 @@ impl ObjectPrototype {
     pub fn has_own_property(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let property_arg = get_argument(cx, arguments, 0);
+        let property_arg = arguments.get(cx, 0);
         let property_key = to_property_key(cx, property_arg)?;
         let this_object = to_object(cx, this_value)?;
 
@@ -149,9 +148,9 @@ impl ObjectPrototype {
     pub fn is_prototype_of(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(cx.bool(false));
         }
@@ -178,9 +177,9 @@ impl ObjectPrototype {
     pub fn property_is_enumerable(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let property_arg = get_argument(cx, arguments, 0);
+        let property_arg = arguments.get(cx, 0);
         let property_key = to_property_key(cx, property_arg)?;
         let this_object = to_object(cx, this_value)?;
 
@@ -194,7 +193,7 @@ impl ObjectPrototype {
     pub fn to_locale_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         invoke(cx, this_value, cx.names.to_string(), &[])
     }
@@ -203,7 +202,7 @@ impl ObjectPrototype {
     pub fn to_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if this_value.is_undefined() {
             return Ok(cx.alloc_static_string("[object Undefined]")?.as_value());
@@ -257,7 +256,7 @@ impl ObjectPrototype {
     pub fn value_of(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Ok(to_object(cx, this_value)?.as_value())
     }
@@ -266,7 +265,7 @@ impl ObjectPrototype {
     pub fn get_proto(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
         match object.get_prototype_of(cx)? {
@@ -279,11 +278,11 @@ impl ObjectPrototype {
     pub fn set_proto(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = require_object_coercible(cx, this_value)?;
 
-        let proto = get_argument(cx, arguments, 0);
+        let proto = arguments.get(cx, 0);
         let proto = if proto.is_object() {
             Some(proto.as_object())
         } else if proto.is_null() {
@@ -307,16 +306,16 @@ impl ObjectPrototype {
     pub fn define_getter(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
 
-        let getter = get_argument(cx, arguments, 1);
+        let getter = arguments.get(cx, 1);
         if !is_callable(getter) {
             return type_error(cx, "Object.prototype.__defineGetter__ getter must be a function");
         }
 
-        let key_arg = get_argument(cx, arguments, 0);
+        let key_arg = arguments.get(cx, 0);
         let key = to_property_key(cx, key_arg)?;
         let desc = PropertyDescriptor::get_only(Some(getter.as_object()), true, true);
 
@@ -329,16 +328,16 @@ impl ObjectPrototype {
     pub fn define_setter(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
 
-        let setter = get_argument(cx, arguments, 1);
+        let setter = arguments.get(cx, 1);
         if !is_callable(setter) {
             return type_error(cx, "Object.prototype.__defineSetter__ setter must be a function");
         }
 
-        let key_arg = get_argument(cx, arguments, 0);
+        let key_arg = arguments.get(cx, 0);
         let key = to_property_key(cx, key_arg)?;
         let desc = PropertyDescriptor::set_only(Some(setter.as_object()), true, true);
 
@@ -351,10 +350,10 @@ impl ObjectPrototype {
     pub fn lookup_getter(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
-        let key_arg = get_argument(cx, arguments, 0);
+        let key_arg = arguments.get(cx, 0);
         let key = to_property_key(cx, key_arg)?;
 
         let mut current_object = object;
@@ -383,10 +382,10 @@ impl ObjectPrototype {
     pub fn lookup_setter(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = to_object(cx, this_value)?;
-        let key_arg = get_argument(cx, arguments, 0);
+        let key_arg = arguments.get(cx, 0);
         let key = to_property_key(cx, key_arg)?;
 
         let mut current_object = object;

--- a/src/js/runtime/intrinsics/promise_constructor.rs
+++ b/src/js/runtime/intrinsics/promise_constructor.rs
@@ -1,14 +1,13 @@
 use crate::{
     completion_value, must,
     runtime::{
-        Context, Handle, PropertyKey, Value,
+        Arguments, Context, Handle, PropertyKey, Value,
         abstract_operations::{call, call_object, create_data_property_or_throw, invoke},
         alloc_error::AllocResult,
         array_object::{ArrayObject, array_create},
         builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
-        function::get_argument,
         get,
         intrinsics::{
             aggregate_error_constructor::AggregateErrorObject, boolean_constructor::BooleanObject,
@@ -116,7 +115,7 @@ impl PromiseConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = if let Some(target) = cx.current_new_target() {
             target
@@ -125,7 +124,7 @@ impl PromiseConstructor {
         };
 
         // Extract and check type of executor
-        let executor = get_argument(cx, arguments, 0);
+        let executor = arguments.get(cx, 0);
         if !is_callable(executor) {
             return type_error(cx, "Promise executor must be a function");
         }
@@ -270,9 +269,9 @@ impl PromiseConstructor {
     pub fn all(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let iterable = get_argument(cx, arguments, 0);
+        let iterable = arguments.get(cx, 0);
         Self::collect_iterable_promises(cx, this_value, iterable, "all", Self::perform_promise_all)
     }
 
@@ -340,7 +339,7 @@ impl PromiseConstructor {
     pub fn promise_all_resolve(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let function = cx.current_function();
 
@@ -352,7 +351,7 @@ impl PromiseConstructor {
         Self::set_already_called(cx, function, cx.bool(true))?;
 
         // Set the value at the index in the values array
-        let resolved_value = get_argument(cx, arguments, 0);
+        let resolved_value = arguments.get(cx, 0);
         let index = Self::get_index(cx, function);
         let values = Self::get_values(cx, function);
 
@@ -377,9 +376,9 @@ impl PromiseConstructor {
     pub fn all_settled(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let iterable = get_argument(cx, arguments, 0);
+        let iterable = arguments.get(cx, 0);
         Self::collect_iterable_promises(
             cx,
             this_value,
@@ -477,7 +476,7 @@ impl PromiseConstructor {
     pub fn promise_all_settled_resolve(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let function = cx.current_function();
 
@@ -490,7 +489,7 @@ impl PromiseConstructor {
         already_called.set_boolean_data(true);
 
         // Create the result object
-        let resolved_value = get_argument(cx, arguments, 0);
+        let resolved_value = arguments.get(cx, 0);
         let result_object = ordinary_object_create(cx)?;
         must!(create_data_property_or_throw(
             cx,
@@ -530,7 +529,7 @@ impl PromiseConstructor {
     pub fn promise_all_settled_reject(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let function = cx.current_function();
 
@@ -543,7 +542,7 @@ impl PromiseConstructor {
         already_called.set_boolean_data(true);
 
         // Create the result object
-        let rejected_value = get_argument(cx, arguments, 0);
+        let rejected_value = arguments.get(cx, 0);
         let result_object = ordinary_object_create(cx)?;
         must!(create_data_property_or_throw(
             cx,
@@ -583,9 +582,9 @@ impl PromiseConstructor {
     pub fn any(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let iterable = get_argument(cx, arguments, 0);
+        let iterable = arguments.get(cx, 0);
         Self::collect_iterable_promises(cx, this_value, iterable, "any", Self::perform_promise_any)
     }
 
@@ -655,7 +654,7 @@ impl PromiseConstructor {
     pub fn promise_any_reject(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let function = cx.current_function();
 
@@ -667,7 +666,7 @@ impl PromiseConstructor {
         Self::set_already_called(cx, function, cx.bool(true))?;
 
         // Set the rejected value at the index in the errors array
-        let rejected_value = get_argument(cx, arguments, 0);
+        let rejected_value = arguments.get(cx, 0);
         let index = Self::get_index(cx, function);
         let errors = Self::get_values(cx, function);
 
@@ -693,9 +692,9 @@ impl PromiseConstructor {
     pub fn race(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let iterable = get_argument(cx, arguments, 0);
+        let iterable = arguments.get(cx, 0);
         Self::collect_iterable_promises(
             cx,
             this_value,
@@ -731,9 +730,9 @@ impl PromiseConstructor {
     pub fn reject(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let result = get_argument(cx, arguments, 0);
+        let result = arguments.get(cx, 0);
 
         // Create a new promise and immediately reject it
         let capability = PromiseCapability::new(cx, this_value)?;
@@ -746,13 +745,13 @@ impl PromiseConstructor {
     pub fn resolve(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Promise.resolve must be called on an object");
         }
 
-        let result = get_argument(cx, arguments, 0);
+        let result = arguments.get(cx, 0);
         Ok(promise_resolve(cx, this_value, result)?.as_value())
     }
 
@@ -760,7 +759,7 @@ impl PromiseConstructor {
     pub fn try_(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Promise.try must be called on an object");
@@ -768,7 +767,7 @@ impl PromiseConstructor {
 
         let capability = PromiseCapability::new(cx, this_value)?;
 
-        let callback_arg = get_argument(cx, arguments, 0);
+        let callback_arg = arguments.get(cx, 0);
         let completion = call(cx, callback_arg, cx.undefined(), &arguments[1..]);
 
         match completion_value!(completion) {
@@ -783,7 +782,7 @@ impl PromiseConstructor {
     pub fn with_resolvers(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let capability = PromiseCapability::new(cx, this_value)?;
 
@@ -879,9 +878,9 @@ fn get_promise(cx: Context, settle_function: Handle<ObjectValue>) -> Handle<Prom
 pub fn resolve_builtin_function(
     mut cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
-    let resolution = get_argument(cx, arguments, 0);
+    let resolution = arguments.get(cx, 0);
 
     let function = cx.current_function();
     let promise = get_promise(cx, function);
@@ -895,9 +894,9 @@ pub fn resolve_builtin_function(
 pub fn reject_builtin_function(
     mut cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
-    let resolution = get_argument(cx, arguments, 0);
+    let resolution = arguments.get(cx, 0);
 
     let function = cx.current_function();
     let mut promise = get_promise(cx, function);

--- a/src/js/runtime/intrinsics/promise_prototype.rs
+++ b/src/js/runtime/intrinsics/promise_prototype.rs
@@ -1,12 +1,11 @@
 use crate::{
     eval_err,
     runtime::{
-        Context, EvalResult, Handle, Value,
+        Arguments, Context, EvalResult, Handle, Value,
         abstract_operations::{call_object, invoke, species_constructor},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::type_error,
-        function::get_argument,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         promise_object::{PromiseCapability, PromiseObject, is_promise, promise_resolve},
@@ -63,9 +62,9 @@ impl PromisePrototype {
     pub fn catch(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let on_rejected = get_argument(cx, arguments, 0);
+        let on_rejected = arguments.get(cx, 0);
         invoke(cx, this_value, cx.names.then(), &[cx.undefined(), on_rejected])
     }
 
@@ -73,14 +72,14 @@ impl PromisePrototype {
     pub fn finally(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return type_error(cx, "Promise.prototype.finally must be called on an object");
         }
         let promise = this_value.as_object();
 
-        let on_finally = get_argument(cx, arguments, 0);
+        let on_finally = arguments.get(cx, 0);
 
         let constructor = species_constructor(cx, promise, Intrinsic::PromiseConstructor)?;
 
@@ -175,7 +174,7 @@ impl PromisePrototype {
     pub fn finally_then(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let current_function = cx.current_function();
 
@@ -195,7 +194,7 @@ impl PromisePrototype {
             None,
         )?;
 
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         Self::set_value(cx, continue_function, value)?;
 
         invoke(cx, promise.into(), cx.names.then(), &[continue_function.into()])
@@ -204,7 +203,7 @@ impl PromisePrototype {
     pub fn finally_then_continue(
         mut cx: Context,
         _: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let current_function = cx.current_function();
         Ok(Self::get_value(cx, current_function))
@@ -213,7 +212,7 @@ impl PromisePrototype {
     pub fn finally_catch(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let current_function = cx.current_function();
 
@@ -233,7 +232,7 @@ impl PromisePrototype {
             None,
         )?;
 
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         Self::set_value(cx, continue_function, value)?;
 
         invoke(cx, promise.into(), cx.names.then(), &[continue_function.into()])
@@ -242,7 +241,7 @@ impl PromisePrototype {
     pub fn finally_catch_continue(
         mut cx: Context,
         _: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let current_function = cx.current_function();
         let value = Self::get_value(cx, current_function);
@@ -254,7 +253,7 @@ impl PromisePrototype {
     pub fn then(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if !is_promise(*this_value) {
             return type_error(cx, "Promise.prototype.then must be called on a Promise");
@@ -264,8 +263,8 @@ impl PromisePrototype {
         let constructor = species_constructor(cx, promise.into(), Intrinsic::PromiseConstructor)?;
         let capability = PromiseCapability::new(cx, constructor.into())?;
 
-        let on_fulfilled = get_argument(cx, arguments, 0);
-        let on_rejected = get_argument(cx, arguments, 1);
+        let on_fulfilled = arguments.get(cx, 0);
+        let on_rejected = arguments.get(cx, 1);
 
         Ok(perform_promise_then(cx, promise, on_fulfilled, on_rejected, Some(capability))?)
     }

--- a/src/js/runtime/intrinsics/proxy_constructor.rs
+++ b/src/js/runtime/intrinsics/proxy_constructor.rs
@@ -1,13 +1,12 @@
 use crate::{
     must,
     runtime::{
-        Context, Value,
+        Arguments, Context, Value,
         abstract_operations::create_data_property_or_throw,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
-        function::get_argument,
         gc::Handle,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
@@ -46,14 +45,14 @@ impl ProxyConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if cx.current_new_target().is_none() {
             return type_error(cx, "Proxy constructor must be called with new");
         }
 
-        let target = get_argument(cx, arguments, 0);
-        let handler = get_argument(cx, arguments, 1);
+        let target = arguments.get(cx, 0);
+        let handler = arguments.get(cx, 1);
 
         Ok(proxy_create(cx, target, handler)?.as_value())
     }
@@ -62,10 +61,10 @@ impl ProxyConstructor {
     pub fn revocable(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
-        let handler = get_argument(cx, arguments, 1);
+        let target = arguments.get(cx, 0);
+        let handler = arguments.get(cx, 1);
         let proxy = proxy_create(cx, target, handler)?;
 
         let realm = cx.current_realm();
@@ -94,7 +93,7 @@ impl ProxyConstructor {
     }
 }
 
-pub fn revoke(mut cx: Context, _: Handle<Value>, _: &[Handle<Value>]) -> EvalResult<Handle<Value>> {
+pub fn revoke(mut cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
     // Find the proxy object attached to this closure via a private property
     let mut revoke_function = cx.current_function();
     let proxy_object_property =

--- a/src/js/runtime/intrinsics/reflect_object.rs
+++ b/src/js/runtime/intrinsics/reflect_object.rs
@@ -1,11 +1,10 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     abstract_operations::{call_object, construct, create_list_from_array_like_arguments},
     alloc_error::AllocResult,
     array_object::create_array_from_list,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
     object_value::ObjectValue,
     property::Property,
@@ -109,18 +108,14 @@ impl ReflectObject {
     }
 
     /// Reflect.apply (https://tc39.es/ecma262/#sec-reflect.apply)
-    pub fn apply(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
+    pub fn apply(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let target = arguments.get(cx, 0);
         if !is_callable(target) {
             return type_error(cx, "Reflect.apply target must be a function");
         }
 
-        let this_argument = get_argument(cx, arguments, 1);
-        let arguments_arg = get_argument(cx, arguments, 2);
+        let this_argument = arguments.get(cx, 1);
+        let arguments_arg = arguments.get(cx, 2);
         let arguments_list =
             create_list_from_array_like_arguments(cx, arguments_arg, "Reflect.apply")?;
 
@@ -131,9 +126,9 @@ impl ReflectObject {
     pub fn construct(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
+        let target = arguments.get(cx, 0);
         if !is_constructor_value(target) {
             return type_error(cx, "Reflect.construct target must be a constructor");
         }
@@ -141,7 +136,7 @@ impl ReflectObject {
         let target = target.as_object();
 
         let new_target = if arguments.len() >= 3 {
-            let new_target = get_argument(cx, arguments, 2);
+            let new_target = arguments.get(cx, 2);
             if !is_constructor_value(new_target) {
                 return type_error(cx, "Reflect.construct newTarget must be a constructor");
             }
@@ -151,7 +146,7 @@ impl ReflectObject {
             target
         };
 
-        let arguments_arg = get_argument(cx, arguments, 1);
+        let arguments_arg = arguments.get(cx, 1);
         let arguments_list =
             create_list_from_array_like_arguments(cx, arguments_arg, "Reflect.construct")?;
 
@@ -162,19 +157,19 @@ impl ReflectObject {
     pub fn define_property(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
+        let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.defineProperty target must be an object");
         }
 
         let mut target = target.as_object();
 
-        let key_arg = get_argument(cx, arguments, 1);
+        let key_arg = arguments.get(cx, 1);
         let key = to_property_key(cx, key_arg)?;
 
-        let desc_arg = get_argument(cx, arguments, 2);
+        let desc_arg = arguments.get(cx, 2);
         let desc = to_property_descriptor(cx, desc_arg)?;
 
         let result = target.define_own_property(cx, key, desc)?;
@@ -185,15 +180,15 @@ impl ReflectObject {
     pub fn delete_property(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
+        let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.deleteProperty target must be an object");
         }
 
         let mut target = target.as_object();
-        let key_arg = get_argument(cx, arguments, 1);
+        let key_arg = arguments.get(cx, 1);
         let key = to_property_key(cx, key_arg)?;
 
         let result = target.delete(cx, key)?;
@@ -201,21 +196,17 @@ impl ReflectObject {
     }
 
     /// Reflect.get (https://tc39.es/ecma262/#sec-reflect.get)
-    pub fn get(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
+    pub fn get(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.get target must be an object");
         }
 
-        let key_arg = get_argument(cx, arguments, 1);
+        let key_arg = arguments.get(cx, 1);
         let key = to_property_key(cx, key_arg)?;
 
         let receiver = if arguments.len() >= 3 {
-            get_argument(cx, arguments, 2)
+            arguments.get(cx, 2)
         } else {
             target
         };
@@ -227,15 +218,15 @@ impl ReflectObject {
     pub fn get_own_property_descriptor(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
+        let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.getOwnPropertyDescriptor target must be an object");
         }
 
         let target = target.as_object();
-        let key_arg = get_argument(cx, arguments, 1);
+        let key_arg = arguments.get(cx, 1);
         let key = to_property_key(cx, key_arg)?;
 
         let desc = target.get_own_property(cx, key)?;
@@ -251,9 +242,9 @@ impl ReflectObject {
     pub fn get_prototype_of(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
+        let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.getPrototypeOf target must be an object");
         }
@@ -264,18 +255,14 @@ impl ReflectObject {
     }
 
     /// Reflect.has (https://tc39.es/ecma262/#sec-reflect.has)
-    pub fn has(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
+    pub fn has(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.has target must be an object");
         }
 
         let target = target.as_object();
-        let key_arg = get_argument(cx, arguments, 1);
+        let key_arg = arguments.get(cx, 1);
         let key = to_property_key(cx, key_arg)?;
 
         let has_property = target.has_property(cx, key)?;
@@ -286,9 +273,9 @@ impl ReflectObject {
     pub fn is_extensible(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
+        let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.isExtensible target must be an object");
         }
@@ -301,9 +288,9 @@ impl ReflectObject {
     pub fn own_keys(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
+        let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.ownKeys target must be an object");
         }
@@ -317,9 +304,9 @@ impl ReflectObject {
     pub fn prevent_extensions(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
+        let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.preventExtensions target must be an object");
         }
@@ -329,22 +316,18 @@ impl ReflectObject {
     }
 
     /// Reflect.set (https://tc39.es/ecma262/#sec-reflect.set)
-    pub fn set(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
+    pub fn set(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.set target must be an object");
         }
 
-        let key_arg = get_argument(cx, arguments, 1);
+        let key_arg = arguments.get(cx, 1);
         let key = to_property_key(cx, key_arg)?;
-        let value = get_argument(cx, arguments, 2);
+        let value = arguments.get(cx, 2);
 
         let receiver = if arguments.len() >= 4 {
-            get_argument(cx, arguments, 3)
+            arguments.get(cx, 3)
         } else {
             target
         };
@@ -357,14 +340,14 @@ impl ReflectObject {
     pub fn set_prototype_of(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let target = get_argument(cx, arguments, 0);
+        let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.setPrototypeOf target must be an object");
         }
 
-        let proto = get_argument(cx, arguments, 1);
+        let proto = arguments.get(cx, 1);
         let proto = if proto.is_object() {
             Some(proto.as_object())
         } else if proto.is_null() {

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -23,13 +23,12 @@ use crate::{
         regexp_parser::RegExpParser,
     },
     runtime::{
-        Context, HeapPtr, PropertyDescriptor, Value,
+        Arguments, Context, HeapPtr, PropertyDescriptor, Value,
         abstract_operations::{define_property_or_throw, set},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::{syntax_parse_error, type_error},
         eval_result::EvalResult,
-        function::get_argument,
         gc::{Handle, HeapItem, HeapVisitor},
         get,
         heap_item_descriptor::HeapItemKind,
@@ -170,10 +169,10 @@ impl RegExpConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let pattern_arg = get_argument(cx, arguments, 0);
-        let flags_arg = get_argument(cx, arguments, 1);
+        let pattern_arg = arguments.get(cx, 0);
+        let flags_arg = arguments.get(cx, 1);
 
         let pattern_is_regexp = is_regexp(cx, pattern_arg)?;
 
@@ -229,9 +228,9 @@ impl RegExpConstructor {
     pub fn escape(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let string_arg = get_argument(cx, arguments, 0);
+        let string_arg = arguments.get(cx, 0);
         if !string_arg.is_string() {
             return type_error(cx, "RegExp.escape argument must be a string");
         }

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -7,7 +7,7 @@ use crate::{
     must,
     parser::regexp::RegExpFlags,
     runtime::{
-        Context, Handle, PropertyKey, Value,
+        Arguments, Context, Handle, PropertyKey, Value,
         abstract_operations::{
             call, call_object, construct, create_data_property_or_throw, length_of_array_like, set,
             species_constructor,
@@ -16,7 +16,6 @@ use crate::{
         array_object::{array_create, create_array_from_list},
         error::type_error,
         eval_result::EvalResult,
-        function::get_argument,
         get,
         intrinsics::{
             intrinsics::Intrinsic,
@@ -190,11 +189,11 @@ impl RegExpPrototype {
     pub fn exec(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let regexp_object = this_regexp_object(cx, this_value, "RegExp.prototype.exec")?;
 
-        let string_arg = get_argument(cx, arguments, 0);
+        let string_arg = arguments.get(cx, 0);
         let string_value = to_string(cx, string_arg)?;
 
         regexp_builtin_exec(cx, regexp_object, string_value)
@@ -204,7 +203,7 @@ impl RegExpPrototype {
     pub fn dot_all(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::DOT_ALL, "RegExp.prototype.dotAll")
     }
@@ -213,7 +212,7 @@ impl RegExpPrototype {
     pub fn flags(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object(cx, this_value, "RegExp.prototype.flags")?;
 
@@ -272,7 +271,7 @@ impl RegExpPrototype {
     pub fn global(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::GLOBAL, "RegExp.prototype.global")
     }
@@ -281,7 +280,7 @@ impl RegExpPrototype {
     pub fn has_indices(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::HAS_INDICES, "RegExp.prototype.hasIndices")
     }
@@ -290,7 +289,7 @@ impl RegExpPrototype {
     pub fn ignore_case(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::IGNORE_CASE, "RegExp.prototype.ignoreCase")
     }
@@ -299,11 +298,11 @@ impl RegExpPrototype {
     pub fn match_(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@match]")?;
 
-        let string_arg = get_argument(cx, arguments, 0);
+        let string_arg = arguments.get(cx, 0);
         let string_value = to_string(cx, string_arg)?;
 
         let flags_string = get(cx, regexp_object, cx.names.flags())?;
@@ -366,11 +365,11 @@ impl RegExpPrototype {
     pub fn match_all(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@matchAll]")?;
 
-        let string_arg = get_argument(cx, arguments, 0);
+        let string_arg = arguments.get(cx, 0);
         let string_value = to_string(cx, string_arg)?;
 
         let constructor = species_constructor(cx, regexp_object, Intrinsic::RegExpConstructor)?;
@@ -398,7 +397,7 @@ impl RegExpPrototype {
     pub fn multiline(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::MULTILINE, "RegExp.prototype.multiline")
     }
@@ -407,14 +406,14 @@ impl RegExpPrototype {
     pub fn replace(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@replace]")?;
 
-        let target_string_arg = get_argument(cx, arguments, 0);
+        let target_string_arg = arguments.get(cx, 0);
         let target_string = to_string(cx, target_string_arg)?;
 
-        let replace_arg = get_argument(cx, arguments, 1);
+        let replace_arg = arguments.get(cx, 1);
         let replace_value = if is_callable(replace_arg) {
             ReplaceValue::Function(replace_arg.as_object())
         } else {
@@ -594,11 +593,11 @@ impl RegExpPrototype {
     pub fn search(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@search]")?;
 
-        let string_arg = get_argument(cx, arguments, 0);
+        let string_arg = arguments.get(cx, 0);
         let string_value = to_string(cx, string_arg)?;
 
         // Save original last index, resetting to zero for search
@@ -628,7 +627,7 @@ impl RegExpPrototype {
     pub fn source(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if this_value.is_object() {
             let this_object = this_value.as_object();
@@ -649,11 +648,11 @@ impl RegExpPrototype {
     pub fn split(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@split]")?;
 
-        let string_arg = get_argument(cx, arguments, 0);
+        let string_arg = arguments.get(cx, 0);
         let string_value = to_string(cx, string_arg)?;
 
         let constructor = species_constructor(cx, regexp_object, Intrinsic::RegExpConstructor)?;
@@ -684,7 +683,7 @@ impl RegExpPrototype {
         let result_array = array_create(cx, 0, None)?.as_object();
 
         // Calculate optional limit argument
-        let limit_arg = get_argument(cx, arguments, 1);
+        let limit_arg = arguments.get(cx, 1);
         let limit = if limit_arg.is_undefined() {
             u32::MAX
         } else {
@@ -786,7 +785,7 @@ impl RegExpPrototype {
     pub fn sticky(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::STICKY, "RegExp.prototype.sticky")
     }
@@ -795,11 +794,11 @@ impl RegExpPrototype {
     pub fn test(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let regexp_object = this_object(cx, this_value, "test")?;
 
-        let string_arg = get_argument(cx, arguments, 0);
+        let string_arg = arguments.get(cx, 0);
         let string_value = to_string(cx, string_arg)?;
 
         let exec_result = regexp_exec(cx, regexp_object, string_value, "RegExp.prototype.test")?;
@@ -811,7 +810,7 @@ impl RegExpPrototype {
     pub fn to_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object(cx, this_value, "toString")?;
 
@@ -835,7 +834,7 @@ impl RegExpPrototype {
     pub fn unicode(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::UNICODE_AWARE, "RegExp.prototype.unicode")
     }
@@ -844,7 +843,7 @@ impl RegExpPrototype {
     pub fn unicode_sets(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         regexp_has_flag(cx, this_value, RegExpFlags::UNICODE_SETS, "RegExp.prototype.unicodeSets")
     }
@@ -853,12 +852,12 @@ impl RegExpPrototype {
     pub fn compile(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let regexp_object = this_regexp_object(cx, this_value, "RegExp.prototype.compile")?;
 
-        let pattern_arg = get_argument(cx, arguments, 0);
-        let flags_arg = get_argument(cx, arguments, 1);
+        let pattern_arg = arguments.get(cx, 0);
+        let flags_arg = arguments.get(cx, 1);
 
         let pattern_source = if let Some(pattern_regexp_object) = as_regexp_object(pattern_arg) {
             if !flags_arg.is_undefined() {

--- a/src/js/runtime/intrinsics/regexp_string_iterator.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object,
     runtime::{
-        Context, Handle, HeapPtr, PropertyKey, Value,
+        Arguments, Context, Handle, HeapPtr, PropertyKey, Value,
         abstract_operations::set,
         alloc_error::AllocResult,
         error::type_error,
@@ -104,11 +104,7 @@ impl RegExpStringIteratorPrototype {
     }
 
     /// %RegExpStringIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%regexpstringiteratorprototype%.next)
-    pub fn next(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let mut regexp_iterator = RegExpStringIterator::cast_from_value(cx, this_value)?;
 
         let regexp_object = regexp_iterator.regexp_object();

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -117,11 +117,55 @@ pub type RuntimeFunctionId = u16;
 // Check that the number of runtime functions fits in the RustRuntimeFunctionId type.
 static_assert!(NUM_BUILTIN_RUST_RUNTIME_FUNCTIONS <= (1 << (RuntimeFunctionId::BITS as usize)));
 
-pub type RuntimeFunctionPtr = fn(
-    cx: Context,
-    this_value: Handle<Value>,
-    arguments: &[Handle<Value>],
-) -> EvalResult<Handle<Value>>;
+pub type RuntimeFunctionPtr =
+    fn(cx: Context, this_value: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>>;
+
+/// Arguments to a runtime function. Can be treated as a slice.
+#[derive(Clone, Copy)]
+pub struct Arguments<'a> {
+    arguments: &'a [Handle<Value>],
+}
+
+impl<'a> Arguments<'a> {
+    #[inline]
+    pub fn new(arguments: &'a [Handle<Value>]) -> Self {
+        Self { arguments }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.arguments.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.arguments.is_empty()
+    }
+
+    /// Return the value of a particular argument, or undefined if the argument was not provided.
+    #[inline]
+    pub fn get(&self, cx: Context, i: usize) -> Handle<Value> {
+        if i < self.arguments.len() {
+            self.arguments[i]
+        } else {
+            cx.undefined()
+        }
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &'a [Handle<Value>] {
+        self.arguments
+    }
+}
+
+impl std::ops::Deref for Arguments<'_> {
+    type Target = [Handle<Value>];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.arguments
+    }
+}
 
 impl RustRuntimeFunctionRegistry {
     #[inline]
@@ -1067,16 +1111,12 @@ impl RuntimeFunction {
 pub fn return_this(
     _: Context,
     this_value: Handle<Value>,
-    _: &[Handle<Value>],
+    _: Arguments,
 ) -> EvalResult<Handle<Value>> {
     Ok(this_value)
 }
 
 /// Rust runtime function that simply returns `undefined`.
-pub fn return_undefined(
-    cx: Context,
-    _: Handle<Value>,
-    _: &[Handle<Value>],
-) -> EvalResult<Handle<Value>> {
+pub fn return_undefined(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
     Ok(cx.undefined())
 }

--- a/src/js/runtime/intrinsics/set_constructor.rs
+++ b/src/js/runtime/intrinsics/set_constructor.rs
@@ -1,11 +1,10 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     abstract_operations::call_object,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     get,
     intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction, set_object::SetObject},
     iterator::iter_iterator_values,
@@ -45,7 +44,7 @@ impl SetConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
@@ -55,7 +54,7 @@ impl SetConstructor {
 
         let set_object = SetObject::new_from_constructor(cx, new_target)?.as_object();
 
-        let iterable = get_argument(cx, arguments, 0);
+        let iterable = arguments.get(cx, 0);
         if iterable.is_nullish() {
             return Ok(set_object.as_value());
         }

--- a/src/js/runtime/intrinsics/set_iterator.rs
+++ b/src/js/runtime/intrinsics/set_iterator.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Arguments, Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         collections::{BsIndexMap, index_map::GcSafeEntriesIter},
@@ -105,11 +105,7 @@ impl SetIteratorPrototype {
     /// %SetIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%setiteratorprototype%.next)
     ///
     /// Adapted from the abstract closure in CreateSetIterator (https://tc39.es/ecma262/#sec-createsetiterator)
-    pub fn next(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let mut set_iterator = SetIterator::cast_from_value(cx, this_value)?;
 
         // Check if iterator is already done

--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -1,14 +1,13 @@
 use crate::{
     must,
     runtime::{
-        Context, Handle,
+        Arguments, Context, Handle,
         abstract_operations::{call_object, canonicalize_keyed_collection_key},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         collections::BsIndexSetField,
         error::{range_error, type_error},
         eval_result::EvalResult,
-        function::get_argument,
         get,
         intrinsics::{
             intrinsics::Intrinsic,
@@ -154,12 +153,12 @@ impl SetPrototype {
     pub fn add(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let set = this_set_value(cx, this_value, "add")?;
 
         // Convert negative zero to positive zero in set
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         let value = canonicalize_keyed_collection_key(cx, value);
 
         set.insert(cx, value)?;
@@ -171,7 +170,7 @@ impl SetPrototype {
     pub fn clear(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let set = this_set_value(cx, this_value, "clear")?;
 
@@ -184,11 +183,11 @@ impl SetPrototype {
     pub fn delete(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let set = this_set_value(cx, this_value, "delete")?;
 
-        let key = get_argument(cx, arguments, 0);
+        let key = arguments.get(cx, 0);
 
         // May allocate
         let set_key = ValueCollectionKey::from(key)?;
@@ -202,11 +201,11 @@ impl SetPrototype {
     pub fn difference(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_set = this_set_value(cx, this_value, "difference")?;
 
-        let other = get_argument(cx, arguments, 0);
+        let other = arguments.get(cx, 0);
         let other_set_record = get_set_record(cx, other, "difference")?;
 
         // Create a copy of this set
@@ -267,7 +266,7 @@ impl SetPrototype {
     pub fn entries(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let set = this_set_value(cx, this_value, "entries")?;
 
@@ -278,17 +277,17 @@ impl SetPrototype {
     pub fn for_each(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let set = this_set_value(cx, this_value, "forEach")?;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "Set.prototype.forEach callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         // Share handle across iterations
         let mut value_handle = Handle::<Value>::empty(cx);
@@ -309,11 +308,11 @@ impl SetPrototype {
     pub fn has(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let set = this_set_value(cx, this_value, "has")?;
 
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
 
         // May allocate
         let set_value = ValueCollectionKey::from(value)?;
@@ -325,11 +324,11 @@ impl SetPrototype {
     pub fn intersection(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_set = this_set_value(cx, this_value, "intersection")?;
 
-        let other = get_argument(cx, arguments, 0);
+        let other = arguments.get(cx, 0);
         let other_set_record = get_set_record(cx, other, "intersection")?;
 
         // Create an empty set
@@ -393,11 +392,11 @@ impl SetPrototype {
     pub fn is_disjoint_from(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_set = this_set_value(cx, this_value, "isDisjointFrom")?;
 
-        let other = get_argument(cx, arguments, 0);
+        let other = arguments.get(cx, 0);
         let other_set_record = get_set_record(cx, other, "isDisjointFrom")?;
 
         if this_set.set_data_ptr().num_entries_occupied() as f64 <= other_set_record.size {
@@ -454,11 +453,11 @@ impl SetPrototype {
     pub fn is_subset_of(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_set = this_set_value(cx, this_value, "isSubsetOf")?;
 
-        let other = get_argument(cx, arguments, 0);
+        let other = arguments.get(cx, 0);
         let other_set_record = get_set_record(cx, other, "isSubsetOf")?;
 
         // We can return early if this set is larger than the other set
@@ -494,11 +493,11 @@ impl SetPrototype {
     pub fn is_superset_of(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_set = this_set_value(cx, this_value, "isSupersetOf")?;
 
-        let other = get_argument(cx, arguments, 0);
+        let other = arguments.get(cx, 0);
         let other_set_record = get_set_record(cx, other, "isSupersetOf")?;
 
         // We can return early if this set is smaller than the other set
@@ -533,11 +532,7 @@ impl SetPrototype {
     }
 
     /// get Set.prototype.size (https://tc39.es/ecma262/#sec-get-set.prototype.size)
-    pub fn size(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn size(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let set = this_set_value(cx, this_value, "size")?;
 
         Ok(cx.number(set.set_data_ptr().num_entries_occupied()))
@@ -547,11 +542,11 @@ impl SetPrototype {
     pub fn symmetric_difference(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_set = this_set_value(cx, this_value, "symmetricDifference")?;
 
-        let other = get_argument(cx, arguments, 0);
+        let other = arguments.get(cx, 0);
         let other_set_record = get_set_record(cx, other, "symmetricDifference")?;
 
         // Create a copy of this set
@@ -595,11 +590,11 @@ impl SetPrototype {
     pub fn union(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_set = this_set_value(cx, this_value, "union")?;
 
-        let other = get_argument(cx, arguments, 0);
+        let other = arguments.get(cx, 0);
         let other_set_record = get_set_record(cx, other, "union")?;
 
         // Create a copy of this set
@@ -629,7 +624,7 @@ impl SetPrototype {
     pub fn values(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let set = this_set_value(cx, this_value, "values")?;
 

--- a/src/js/runtime/intrinsics/string_constructor.rs
+++ b/src/js/runtime/intrinsics/string_constructor.rs
@@ -1,13 +1,12 @@
 use crate::{
     common::unicode::CodePoint,
     runtime::{
-        Context, Handle, PropertyKey, Value,
+        Arguments, Context, Handle, PropertyKey, Value,
         abstract_operations::length_of_array_like,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::range_error,
         eval_result::EvalResult,
-        function::get_argument,
         get,
         intrinsics::{
             intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
@@ -64,14 +63,14 @@ impl StringConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = cx.current_new_target();
 
         let string_value = if arguments.is_empty() {
             cx.names.empty_string().as_string()
         } else {
-            let value = get_argument(cx, arguments, 0);
+            let value = arguments.get(cx, 0);
             if new_target.is_none() && value.is_symbol() {
                 return Ok(symbol_descriptive_string(cx, value.as_symbol())?.as_value());
             }
@@ -93,7 +92,7 @@ impl StringConstructor {
     pub fn from_char_code(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         // Common case, return a single code unit string
         if arguments.len() == 1 {
@@ -102,7 +101,7 @@ impl StringConstructor {
         }
 
         let mut code_points = vec![];
-        for arg in arguments {
+        for arg in arguments.iter() {
             let code_unit = to_uint16(cx, *arg)?;
             code_points.push(code_unit as u32);
         }
@@ -114,7 +113,7 @@ impl StringConstructor {
     pub fn from_code_point(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         macro_rules! get_code_point {
             ($arg:expr) => {{
@@ -152,7 +151,7 @@ impl StringConstructor {
         }
 
         let mut code_points = vec![];
-        for arg in arguments {
+        for arg in arguments.iter() {
             code_points.push(get_code_point!(*arg));
         }
 
@@ -160,14 +159,10 @@ impl StringConstructor {
     }
 
     /// String.raw (https://tc39.es/ecma262/#sec-string.raw)
-    pub fn raw(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn raw(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
         let substitution_count = arguments.len().saturating_sub(1);
 
-        let template_arg = get_argument(cx, arguments, 0);
+        let template_arg = arguments.get(cx, 0);
         let cooked = to_object(cx, template_arg)?;
 
         let literals = get(cx, cooked, cx.names.raw())?;
@@ -197,7 +192,7 @@ impl StringConstructor {
             }
 
             if next_index < substitution_count as u64 {
-                let substitution_arg = get_argument(cx, arguments, next_index as usize + 1);
+                let substitution_arg = arguments.get(cx, next_index as usize + 1);
                 let next_substitution = to_string(cx, substitution_arg)?;
 
                 result = StringValue::concat(cx, result, next_substitution)?;

--- a/src/js/runtime/intrinsics/string_iterator.rs
+++ b/src/js/runtime/intrinsics/string_iterator.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Arguments, Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         error::type_error,
         eval_result::EvalResult,
@@ -72,11 +72,7 @@ impl StringIteratorPrototype {
     }
 
     /// %StringIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%stringiteratorprototype%.next)
-    pub fn next(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let mut string_iterator = StringIterator::cast_from_value(cx, this_value)?;
 
         match string_iterator.iter.next() {

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -11,13 +11,12 @@ use crate::{
     must, must_a,
     parser::regexp::RegExpFlags,
     runtime::{
-        Context, Handle, HeapPtr, PropertyKey,
+        Arguments, Context, Handle, HeapPtr, PropertyKey,
         abstract_operations::{call_object, get_method, invoke},
         alloc_error::AllocResult,
         array_object::{array_create, create_array_from_list},
         error::{range_error, type_error},
         eval_result::EvalResult,
-        function::get_argument,
         get,
         intrinsics::{
             intrinsics::Intrinsic,
@@ -360,14 +359,14 @@ impl StringPrototype {
     pub fn at(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "at")?;
         let string = to_string(cx, object)?;
 
         let length = string.len() as i64;
 
-        let index_arg = get_argument(cx, arguments, 0);
+        let index_arg = arguments.get(cx, 0);
         let relative_index = to_integer_or_infinity(cx, index_arg)?;
         if relative_index == f64::INFINITY {
             return Ok(cx.undefined());
@@ -392,12 +391,12 @@ impl StringPrototype {
     pub fn char_at(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "charAt")?;
         let string = to_string(cx, object)?;
 
-        let position_arg = get_argument(cx, arguments, 0);
+        let position_arg = arguments.get(cx, 0);
         let position = to_integer_or_infinity(cx, position_arg)?;
 
         if position < 0.0 || position >= string.len() as f64 {
@@ -413,12 +412,12 @@ impl StringPrototype {
     pub fn char_code_at(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "charCodeAt")?;
         let string = to_string(cx, object)?;
 
-        let position_arg = get_argument(cx, arguments, 0);
+        let position_arg = arguments.get(cx, 0);
         let position = to_integer_or_infinity(cx, position_arg)?;
 
         if position < 0.0 || position >= string.len() as f64 {
@@ -433,12 +432,12 @@ impl StringPrototype {
     pub fn code_point_at(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "codePointAt")?;
         let string = to_string(cx, object)?;
 
-        let position_arg = get_argument(cx, arguments, 0);
+        let position_arg = arguments.get(cx, 0);
         let position = to_integer_or_infinity(cx, position_arg)?;
 
         if position < 0.0 || position >= string.len() as f64 {
@@ -453,12 +452,12 @@ impl StringPrototype {
     pub fn concat(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "concat")?;
         let mut concat_string = to_string(cx, object)?;
 
-        for argument in arguments {
+        for argument in arguments.iter() {
             let string = to_string(cx, *argument)?;
             concat_string = StringValue::concat(cx, concat_string, string)?;
         }
@@ -470,20 +469,20 @@ impl StringPrototype {
     pub fn ends_with(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "endsWith")?;
         let string = to_string(cx, object)?;
         let length = string.len();
 
-        let search_value = get_argument(cx, arguments, 0);
+        let search_value = arguments.get(cx, 0);
         if is_regexp(cx, search_value)? {
             return type_error(cx, "String.prototype.endsWith first argument cannot be a RegExp");
         }
 
         let search_string = to_string(cx, search_value)?;
 
-        let end_index_argument = get_argument(cx, arguments, 1);
+        let end_index_argument = arguments.get(cx, 1);
         let end_index = if end_index_argument.is_undefined() {
             length
         } else {
@@ -510,19 +509,19 @@ impl StringPrototype {
     pub fn includes(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "includes")?;
         let string = to_string(cx, object)?;
 
-        let search_string = get_argument(cx, arguments, 0);
+        let search_string = arguments.get(cx, 0);
         if is_regexp(cx, search_string)? {
             return type_error(cx, "String.prototype.includes cannot take a RegExp");
         }
 
         let search_string = to_string(cx, search_string)?;
 
-        let pos_arg = get_argument(cx, arguments, 1);
+        let pos_arg = arguments.get(cx, 1);
         let pos = to_integer_or_infinity(cx, pos_arg)?;
         let pos = pos.clamp(0.0, string.len() as f64) as u32;
 
@@ -538,15 +537,15 @@ impl StringPrototype {
     pub fn index_of(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "indexOf")?;
         let string = to_string(cx, object)?;
 
-        let search_arg = get_argument(cx, arguments, 0);
+        let search_arg = arguments.get(cx, 0);
         let search_string = to_string(cx, search_arg)?;
 
-        let pos_arg = get_argument(cx, arguments, 1);
+        let pos_arg = arguments.get(cx, 1);
         let pos = to_integer_or_infinity(cx, pos_arg)?;
         let pos = pos.clamp(0.0, string.len() as f64) as u32;
 
@@ -564,7 +563,7 @@ impl StringPrototype {
     pub fn is_well_formed(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "isWellFormed")?;
         let string = to_string(cx, object)?;
@@ -576,15 +575,15 @@ impl StringPrototype {
     pub fn last_index_of(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "lastIndexOf")?;
         let string = to_string(cx, object)?;
 
-        let search_arg = get_argument(cx, arguments, 0);
+        let search_arg = arguments.get(cx, 0);
         let search_string = to_string(cx, search_arg)?;
 
-        let pos_arg = get_argument(cx, arguments, 1);
+        let pos_arg = arguments.get(cx, 1);
         let num_pos = to_number(cx, pos_arg)?;
 
         let pos = if num_pos.is_nan() {
@@ -605,12 +604,12 @@ impl StringPrototype {
     pub fn locale_compare(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "localeCompare")?;
         let string = to_string(cx, object)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other_string = to_string(cx, other_arg)?;
 
         let wtf8_string = string.to_wtf8_string()?;
@@ -627,11 +626,11 @@ impl StringPrototype {
     pub fn match_(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object_coercible_value(cx, this_value, "match")?;
 
-        let regexp_arg = get_argument(cx, arguments, 0);
+        let regexp_arg = arguments.get(cx, 0);
         if regexp_arg.is_object() {
             let matcher = get_method(cx, regexp_arg, cx.well_known_symbols.match_())?;
             if let Some(matcher) = matcher {
@@ -655,11 +654,11 @@ impl StringPrototype {
     pub fn match_all(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_object = this_object_coercible_value(cx, this_value, "matchAll")?;
 
-        let regexp_arg = get_argument(cx, arguments, 0);
+        let regexp_arg = arguments.get(cx, 0);
         if regexp_arg.is_object() {
             if is_regexp(cx, regexp_arg)? {
                 let regexp_object = regexp_arg.as_object();
@@ -706,12 +705,12 @@ impl StringPrototype {
     pub fn normalize(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "normalize")?;
         let string = to_string(cx, object)?;
 
-        let form_arg = get_argument(cx, arguments, 0);
+        let form_arg = arguments.get(cx, 0);
         let form = if form_arg.is_undefined() {
             NormalizationForm::NFC
         } else {
@@ -754,10 +753,10 @@ impl StringPrototype {
     pub fn pad_end(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let max_length_arg = get_argument(cx, arguments, 0);
-        let fill_string_arg = get_argument(cx, arguments, 1);
+        let max_length_arg = arguments.get(cx, 0);
+        let fill_string_arg = arguments.get(cx, 1);
 
         Self::pad_string(cx, this_value, max_length_arg, fill_string_arg, false, "padEnd")
     }
@@ -766,10 +765,10 @@ impl StringPrototype {
     pub fn pad_start(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let max_length_arg = get_argument(cx, arguments, 0);
-        let fill_string_arg = get_argument(cx, arguments, 1);
+        let max_length_arg = arguments.get(cx, 0);
+        let fill_string_arg = arguments.get(cx, 1);
 
         Self::pad_string(cx, this_value, max_length_arg, fill_string_arg, true, "padStart")
     }
@@ -840,12 +839,12 @@ impl StringPrototype {
     pub fn repeat(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "repeat")?;
         let string = to_string(cx, object)?;
 
-        let n_arg = get_argument(cx, arguments, 0);
+        let n_arg = arguments.get(cx, 0);
         let n = to_integer_or_infinity(cx, n_arg)?;
         if n.is_sign_negative() || n.is_infinite() {
             return range_error(
@@ -865,12 +864,12 @@ impl StringPrototype {
     pub fn replace(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "replace")?;
 
-        let search_arg = get_argument(cx, arguments, 0);
-        let replace_arg = get_argument(cx, arguments, 1);
+        let search_arg = arguments.get(cx, 0);
+        let replace_arg = arguments.get(cx, 1);
 
         // Use the @@replace method of the argument if one exists
         if search_arg.is_object() {
@@ -947,12 +946,12 @@ impl StringPrototype {
     pub fn replace_all(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "replaceAll")?;
 
-        let search_arg = get_argument(cx, arguments, 0);
-        let replace_arg = get_argument(cx, arguments, 1);
+        let search_arg = arguments.get(cx, 0);
+        let replace_arg = arguments.get(cx, 1);
 
         // Use the @@replace method of the argument if one exists
         if search_arg.is_object() {
@@ -1061,12 +1060,12 @@ impl StringPrototype {
     pub fn search(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "search")?;
 
         // Use the @@search method of the argument if one exists
-        let regexp_arg = get_argument(cx, arguments, 0);
+        let regexp_arg = arguments.get(cx, 0);
         if regexp_arg.is_object() {
             let searcher = get_method(cx, regexp_arg, cx.well_known_symbols.search())?;
             if let Some(searcher) = searcher {
@@ -1091,16 +1090,16 @@ impl StringPrototype {
     pub fn slice(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "slice")?;
         let string = to_string(cx, object)?;
         let length = string.len();
 
-        let start_arg = get_argument(cx, arguments, 0);
+        let start_arg = arguments.get(cx, 0);
         let start_index = resolve_relative_index_argument(cx, start_arg, length as u64)? as u32;
 
-        let end_argument = get_argument(cx, arguments, 1);
+        let end_argument = arguments.get(cx, 1);
         let end_index = if !end_argument.is_undefined() {
             resolve_relative_index_argument(cx, end_argument, length as u64)? as u32
         } else {
@@ -1118,12 +1117,12 @@ impl StringPrototype {
     pub fn split(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "split")?;
 
-        let separator_argument = get_argument(cx, arguments, 0);
-        let limit_argument = get_argument(cx, arguments, 1);
+        let separator_argument = arguments.get(cx, 0);
+        let limit_argument = arguments.get(cx, 1);
 
         // Use the @@split method of the separator if one exists
         if separator_argument.is_object() {
@@ -1212,20 +1211,20 @@ impl StringPrototype {
     pub fn starts_with(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "startsWith")?;
         let string = to_string(cx, object)?;
         let length = string.len();
 
-        let search_value = get_argument(cx, arguments, 0);
+        let search_value = arguments.get(cx, 0);
         if is_regexp(cx, search_value)? {
             return type_error(cx, "String.prototype.startsWith first argument cannot be a RegExp");
         }
 
         let search_string = to_string(cx, search_value)?;
 
-        let start_index_argument = get_argument(cx, arguments, 1);
+        let start_index_argument = arguments.get(cx, 1);
         let start_index = if start_index_argument.is_undefined() {
             0
         } else {
@@ -1259,17 +1258,17 @@ impl StringPrototype {
     pub fn substring(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "substring")?;
         let string = to_string(cx, object)?;
         let length = string.len();
 
-        let start_arg = get_argument(cx, arguments, 0);
+        let start_arg = arguments.get(cx, 0);
         let start = to_integer_or_infinity(cx, start_arg)?;
         let mut int_start = f64::max(0.0, f64::min(start, length as f64)) as u32;
 
-        let end_argument = get_argument(cx, arguments, 1);
+        let end_argument = arguments.get(cx, 1);
         let mut int_end = if end_argument.is_undefined() {
             length
         } else {
@@ -1288,7 +1287,7 @@ impl StringPrototype {
     pub fn to_lower_case(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "toLowerCase")?;
         let string = to_string(cx, object)?;
@@ -1300,7 +1299,7 @@ impl StringPrototype {
     pub fn to_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         this_string_value(cx, this_value, "toString")
     }
@@ -1309,7 +1308,7 @@ impl StringPrototype {
     pub fn to_upper_case(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "toUpperCase")?;
         let string = to_string(cx, object)?;
@@ -1321,7 +1320,7 @@ impl StringPrototype {
     pub fn to_well_formed(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "toWellFormed")?;
         let string = to_string(cx, object)?;
@@ -1330,11 +1329,7 @@ impl StringPrototype {
     }
 
     /// String.prototype.trim (https://tc39.es/ecma262/#sec-string.prototype.trim)
-    pub fn trim(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn trim(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "trim")?;
         let string = to_string(cx, object)?;
 
@@ -1345,7 +1340,7 @@ impl StringPrototype {
     pub fn trim_end(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "trimEnd")?;
         let string = to_string(cx, object)?;
@@ -1357,7 +1352,7 @@ impl StringPrototype {
     pub fn trim_start(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "trimStart")?;
         let string = to_string(cx, object)?;
@@ -1369,7 +1364,7 @@ impl StringPrototype {
     pub fn iterator(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "iterator")?;
         let string = to_string(cx, object)?;
@@ -1383,7 +1378,7 @@ impl StringPrototype {
     pub fn substr(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let object = this_object_coercible_value(cx, this_value, "substr")?;
         let string = to_string(cx, object)?;
@@ -1391,12 +1386,12 @@ impl StringPrototype {
         let string_length = string.len() as u32;
 
         // Convert the start argument to an integer
-        let start_arg = get_argument(cx, arguments, 0);
+        let start_arg = arguments.get(cx, 0);
         let start_index =
             resolve_relative_index_argument(cx, start_arg, string_length as u64)? as u32;
 
         // Second argument is the length
-        let length_arg = get_argument(cx, arguments, 1);
+        let length_arg = arguments.get(cx, 1);
         let length = if length_arg.is_undefined() {
             string_length
         } else {
@@ -1458,20 +1453,16 @@ impl StringPrototype {
     pub fn anchor(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let name_arg = get_argument(cx, arguments, 0);
+        let name_arg = arguments.get(cx, 0);
         let html_string =
             Self::create_html(cx, this_value, "a", "anchor", Some(("name", name_arg)))?;
         Ok(html_string.as_value())
     }
 
     /// String.prototype.big (https://tc39.es/ecma262/#sec-string.prototype.big)
-    pub fn big(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn big(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let html_string = Self::create_html(cx, this_value, "big", "big", None)?;
         Ok(html_string.as_value())
     }
@@ -1480,18 +1471,14 @@ impl StringPrototype {
     pub fn blink(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let html_string = Self::create_html(cx, this_value, "blink", "blink", None)?;
         Ok(html_string.as_value())
     }
 
     /// String.prototype.bold (https://tc39.es/ecma262/#sec-string.prototype.bold)
-    pub fn bold(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn bold(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let html_string = Self::create_html(cx, this_value, "b", "bold", None)?;
         Ok(html_string.as_value())
     }
@@ -1500,7 +1487,7 @@ impl StringPrototype {
     pub fn fixed(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let html_string = Self::create_html(cx, this_value, "tt", "fixed", None)?;
         Ok(html_string.as_value())
@@ -1510,9 +1497,9 @@ impl StringPrototype {
     pub fn font_color(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let color_arg = get_argument(cx, arguments, 0);
+        let color_arg = arguments.get(cx, 0);
         let html_string =
             Self::create_html(cx, this_value, "font", "fontcolor", Some(("color", color_arg)))?;
         Ok(html_string.as_value())
@@ -1522,9 +1509,9 @@ impl StringPrototype {
     pub fn font_size(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let size_arg = get_argument(cx, arguments, 0);
+        let size_arg = arguments.get(cx, 0);
         let html_string =
             Self::create_html(cx, this_value, "font", "fontsize", Some(("size", size_arg)))?;
         Ok(html_string.as_value())
@@ -1534,7 +1521,7 @@ impl StringPrototype {
     pub fn italics(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let html_string = Self::create_html(cx, this_value, "i", "italics", None)?;
         Ok(html_string.as_value())
@@ -1544,9 +1531,9 @@ impl StringPrototype {
     pub fn link(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let url_arg = get_argument(cx, arguments, 0);
+        let url_arg = arguments.get(cx, 0);
         let html_string = Self::create_html(cx, this_value, "a", "link", Some(("href", url_arg)))?;
         Ok(html_string.as_value())
     }
@@ -1555,7 +1542,7 @@ impl StringPrototype {
     pub fn small(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let html_string = Self::create_html(cx, this_value, "small", "small", None)?;
         Ok(html_string.as_value())
@@ -1565,28 +1552,20 @@ impl StringPrototype {
     pub fn strike(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let html_string = Self::create_html(cx, this_value, "strike", "strike", None)?;
         Ok(html_string.as_value())
     }
 
     /// String.prototype.sub (https://tc39.es/ecma262/#sec-string.prototype.sub)
-    pub fn sub(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn sub(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let html_string = Self::create_html(cx, this_value, "sub", "sub", None)?;
         Ok(html_string.as_value())
     }
 
     /// String.prototype.sup (https://tc39.es/ecma262/#sec-string.prototype.sup)
-    pub fn sup(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn sup(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let html_string = Self::create_html(cx, this_value, "sup", "sup", None)?;
         Ok(html_string.as_value())
     }

--- a/src/js/runtime/intrinsics/symbol_constructor.rs
+++ b/src/js/runtime/intrinsics/symbol_constructor.rs
@@ -3,13 +3,12 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Arguments, Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         collections::BsHashMapField,
         error::type_error,
         eval_result::EvalResult,
-        function::get_argument,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
@@ -137,13 +136,13 @@ impl SymbolConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if cx.current_new_target().is_some() {
             return type_error(cx, "Symbol constructor must be called with new");
         }
 
-        let description_arg = get_argument(cx, arguments, 0);
+        let description_arg = arguments.get(cx, 0);
         let description_value = if description_arg.is_undefined() {
             None
         } else {
@@ -157,9 +156,9 @@ impl SymbolConstructor {
     pub fn for_(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+        let argument = arguments.get(cx, 0);
         let string_key = to_string(cx, argument)?.flatten()?;
         if let Some(symbol_value) = cx.global_symbol_registry().get(&string_key) {
             return Ok(symbol_value.to_handle().into());
@@ -178,9 +177,9 @@ impl SymbolConstructor {
     pub fn key_for(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let symbol_value = get_argument(cx, arguments, 0);
+        let symbol_value = arguments.get(cx, 0);
         if !symbol_value.is_symbol() {
             return type_error(cx, "Symbol.keyFor argument must be a symbol");
         }

--- a/src/js/runtime/intrinsics/symbol_prototype.rs
+++ b/src/js/runtime/intrinsics/symbol_prototype.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
@@ -74,7 +74,7 @@ impl SymbolPrototype {
     pub fn get_description(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let symbol_value = this_symbol_value(cx, this_value, "description")?;
         match symbol_value.as_symbol().description() {
@@ -87,7 +87,7 @@ impl SymbolPrototype {
     pub fn to_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let symbol_value = this_symbol_value(cx, this_value, "toString")?;
         Ok(symbol_descriptive_string(cx, symbol_value.as_symbol())?.as_value())
@@ -97,7 +97,7 @@ impl SymbolPrototype {
     pub fn value_of(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         this_symbol_value(cx, this_value, "valueOf")
     }

--- a/src/js/runtime/intrinsics/temporal/duration_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_constructor.rs
@@ -1,12 +1,11 @@
 use temporal_rs::{Duration, partial::PartialDuration};
 
 use crate::runtime::{
-    Context, Handle, Realm, Value,
+    Arguments, Context, Handle, Realm, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     get,
     intrinsics::{
         intrinsics::Intrinsic,
@@ -64,7 +63,7 @@ impl DurationConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Temporal.Duration constructor";
 
@@ -72,16 +71,16 @@ impl DurationConstructor {
             return type_error(cx, "Temporal.Duration constructor must be called with new");
         };
 
-        let years_arg = get_argument(cx, arguments, 0);
-        let months_arg = get_argument(cx, arguments, 1);
-        let weeks_arg = get_argument(cx, arguments, 2);
-        let days_arg = get_argument(cx, arguments, 3);
-        let hours_arg = get_argument(cx, arguments, 4);
-        let minutes_arg = get_argument(cx, arguments, 5);
-        let seconds_arg = get_argument(cx, arguments, 6);
-        let millis_arg = get_argument(cx, arguments, 7);
-        let micros_arg = get_argument(cx, arguments, 8);
-        let nanos_arg = get_argument(cx, arguments, 9);
+        let years_arg = arguments.get(cx, 0);
+        let months_arg = arguments.get(cx, 1);
+        let weeks_arg = arguments.get(cx, 2);
+        let days_arg = arguments.get(cx, 3);
+        let hours_arg = arguments.get(cx, 4);
+        let minutes_arg = arguments.get(cx, 5);
+        let seconds_arg = arguments.get(cx, 6);
+        let millis_arg = arguments.get(cx, 7);
+        let micros_arg = arguments.get(cx, 8);
+        let nanos_arg = arguments.get(cx, 9);
 
         // Convert duration arguments into truncated integers
         let years = to_integer_if_integral(cx, years_arg, NAME)?;
@@ -105,12 +104,8 @@ impl DurationConstructor {
     }
 
     /// Temporal.Duration.from (https://tc39.es/proposal-temporal/#sec-temporal.duration.from)
-    pub fn from(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let item_arg = get_argument(cx, arguments, 0);
+    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let item_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, item_arg, "Duration.from")?;
 
         Ok(DurationObject::new(cx, duration)?.as_value())
@@ -120,13 +115,13 @@ impl DurationConstructor {
     pub fn compare(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Duration.compare";
 
-        let arg_1 = get_argument(cx, arguments, 0);
-        let arg_2 = get_argument(cx, arguments, 1);
-        let options_arg = get_argument(cx, arguments, 2);
+        let arg_1 = arguments.get(cx, 0);
+        let arg_2 = arguments.get(cx, 1);
+        let options_arg = arguments.get(cx, 2);
 
         let duration_1 = to_temporal_duration(cx, arg_1, NAME)?;
         let duration_2 = to_temporal_duration(cx, arg_2, NAME)?;

--- a/src/js/runtime/intrinsics/temporal/duration_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_prototype.rs
@@ -6,11 +6,10 @@ use temporal_rs::{
 use crate::{
     must,
     runtime::{
-        Context, EvalResult, Handle, Realm, Value,
+        Arguments, Context, EvalResult, Handle, Realm, Value,
         abstract_operations::create_data_property_or_throw,
         alloc_error::AllocResult,
         error::{range_error, type_error},
-        function::get_argument,
         intrinsics::{
             intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
@@ -208,7 +207,7 @@ impl DurationPrototype {
     pub fn years(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.years")?;
         let years = duration.duration().years();
@@ -220,7 +219,7 @@ impl DurationPrototype {
     pub fn months(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.months")?;
         let months = duration.duration().months();
@@ -232,7 +231,7 @@ impl DurationPrototype {
     pub fn weeks(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.weeks")?;
         let weeks = duration.duration().weeks();
@@ -241,11 +240,7 @@ impl DurationPrototype {
     }
 
     /// get Temporal.Duration.prototype.days (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.days)
-    pub fn days(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn days(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.days")?;
         let days = duration.duration().days();
 
@@ -256,7 +251,7 @@ impl DurationPrototype {
     pub fn hours(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.hours")?;
         let hours = duration.duration().hours();
@@ -268,7 +263,7 @@ impl DurationPrototype {
     pub fn minutes(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.minutes")?;
         let minutes = duration.duration().minutes();
@@ -280,7 +275,7 @@ impl DurationPrototype {
     pub fn seconds(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.seconds")?;
         let seconds = duration.duration().seconds();
@@ -292,7 +287,7 @@ impl DurationPrototype {
     pub fn milliseconds(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.milliseconds")?;
         let millis = duration.duration().milliseconds();
@@ -304,7 +299,7 @@ impl DurationPrototype {
     pub fn microseconds(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.microseconds")?;
         let micros = duration.duration().microseconds();
@@ -315,7 +310,7 @@ impl DurationPrototype {
     pub fn nanoseconds(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.nanoseconds")?;
         let nanos = duration.duration().nanoseconds();
@@ -323,11 +318,7 @@ impl DurationPrototype {
     }
 
     /// get Temporal.Duration.prototype.sign (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.sign)
-    pub fn sign(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn sign(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.sign")?;
         let sign = duration.duration().sign();
 
@@ -338,7 +329,7 @@ impl DurationPrototype {
     pub fn blank(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.blank")?;
         let is_zero = duration.duration().is_zero();
@@ -350,12 +341,12 @@ impl DurationPrototype {
     pub fn with(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Duration.prototype.with";
 
         let duration_object = this_duration(cx, this_value, NAME)?;
-        let duration_like_arg = get_argument(cx, arguments, 0);
+        let duration_like_arg = arguments.get(cx, 0);
 
         let partial = to_temporal_partial_duration_record(cx, duration_like_arg, NAME)?;
         let duration = duration_object.duration();
@@ -389,7 +380,7 @@ impl DurationPrototype {
     pub fn negated(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.negated")?;
         let negated_duration = duration.duration().negated();
@@ -398,11 +389,7 @@ impl DurationPrototype {
     }
 
     /// Temporal.Duration.prototype.abs (https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.abs)
-    pub fn abs(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn abs(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let duration = this_duration(cx, this_value, "Duration.prototype.abs")?;
         let abs_duration = duration.duration().abs();
 
@@ -413,12 +400,12 @@ impl DurationPrototype {
     pub fn add(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Duration.prototype.add";
 
         let duration = this_duration(cx, this_value, NAME)?;
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other = to_temporal_duration(cx, other_arg, NAME)?;
 
         let sum_result = duration.duration().add(&other);
@@ -431,12 +418,12 @@ impl DurationPrototype {
     pub fn subtract(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Duration.prototype.subtract";
 
         let duration = this_duration(cx, this_value, NAME)?;
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other = to_temporal_duration(cx, other_arg, NAME)?;
 
         let difference_result = duration.duration().subtract(&other);
@@ -449,13 +436,13 @@ impl DurationPrototype {
     pub fn round(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Duration.prototype.round";
 
         let duration = this_duration(cx, this_value, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options = parse_round_options_argument(cx, options_arg, NAME)?;
 
         // Parse rounding options from options object
@@ -485,12 +472,12 @@ impl DurationPrototype {
     pub fn total(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Duration.prototype.total";
 
         let duration = this_duration(cx, this_value, NAME)?;
-        let total_of_arg = get_argument(cx, arguments, 0);
+        let total_of_arg = arguments.get(cx, 0);
 
         // Options object. A string is shorthand for the `unit` option.
         let options = if total_of_arg.is_undefined() {
@@ -526,13 +513,13 @@ impl DurationPrototype {
     pub fn to_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Duration.prototype.toString";
 
         let duration = this_duration(cx, this_value, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options = validate_options_object(cx, options_arg, NAME)?;
 
         // Parse rounding options from options object
@@ -556,7 +543,7 @@ impl DurationPrototype {
     pub fn to_locale_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Duration.prototype.toLocaleString";
 
@@ -574,7 +561,7 @@ impl DurationPrototype {
     pub fn to_json(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Duration.prototype.toJSON";
 
@@ -589,11 +576,7 @@ impl DurationPrototype {
     }
 
     /// Temporal.Duration.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         type_error(cx, "Duration.prototype.valueOf must not be called")
     }
 }

--- a/src/js/runtime/intrinsics/temporal/instant_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_constructor.rs
@@ -4,12 +4,11 @@ use temporal_rs::Instant;
 use crate::{
     common::constants::NANOSECONDS_IN_ONE_MILLISECOND,
     runtime::{
-        Context, Handle, Realm, Value,
+        Arguments, Context, Handle, Realm, Value,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
-        function::get_argument,
         intrinsics::{
             bigint_constructor::number_to_bigint,
             intrinsics::Intrinsic,
@@ -80,13 +79,13 @@ impl InstantConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let Some(new_target) = cx.current_new_target() else {
             return type_error(cx, "Temporal.Instant constructor must be called with new");
         };
 
-        let epoch_nanos_arg = get_argument(cx, arguments, 0);
+        let epoch_nanos_arg = arguments.get(cx, 0);
         let epoch_nanos = to_bigint(cx, epoch_nanos_arg)?;
 
         let instant = create_temporal_instant(
@@ -100,12 +99,8 @@ impl InstantConstructor {
     }
 
     /// Temporal.Instant.from (https://tc39.es/proposal-temporal/#sec-temporal.instant.from)
-    pub fn from(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let item_arg = get_argument(cx, arguments, 0);
+    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let item_arg = arguments.get(cx, 0);
         let instant = to_temporal_instant(cx, item_arg, "Instant.from")?;
 
         Ok(InstantObject::new(cx, instant)?.as_value())
@@ -115,10 +110,10 @@ impl InstantConstructor {
     pub fn from_epoch_milliseconds(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Instant.fromEpochMilliseconds";
-        let epoch_millis_arg = get_argument(cx, arguments, 0);
+        let epoch_millis_arg = arguments.get(cx, 0);
         let epoch_millis_number = to_number(cx, epoch_millis_arg)?;
         let epoch_millis_bigint = number_to_bigint(cx, *epoch_millis_number, NAME)?;
 
@@ -131,9 +126,9 @@ impl InstantConstructor {
     pub fn from_epoch_nanoseconds(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let epoch_nanos_arg = get_argument(cx, arguments, 0);
+        let epoch_nanos_arg = arguments.get(cx, 0);
         let epoch_nanos = to_bigint(cx, epoch_nanos_arg)?;
 
         let instant = create_temporal_instant(
@@ -150,12 +145,12 @@ impl InstantConstructor {
     pub fn compare(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Instant.compare";
 
-        let arg_1 = get_argument(cx, arguments, 0);
-        let arg_2 = get_argument(cx, arguments, 1);
+        let arg_1 = arguments.get(cx, 0);
+        let arg_2 = arguments.get(cx, 1);
 
         let instant_1 = to_temporal_instant(cx, arg_1, NAME)?;
         let instant_2 = to_temporal_instant(cx, arg_2, NAME)?;

--- a/src/js/runtime/intrinsics/temporal/instant_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_prototype.rs
@@ -2,10 +2,9 @@ use num_bigint::BigInt;
 use temporal_rs::options::{RoundingMode, RoundingOptions, ToStringRoundingOptions};
 
 use crate::runtime::{
-    Context, EvalResult, Handle, Realm, Value,
+    Arguments, Context, EvalResult, Handle, Realm, Value,
     alloc_error::AllocResult,
     error::type_error,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -145,7 +144,7 @@ impl InstantPrototype {
     pub fn epoch_milliseconds(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let instant = this_instant(cx, this_value, "Instant.prototype.epochMilliseconds")?;
         let epoch_millis = instant.instant().epoch_milliseconds();
@@ -157,7 +156,7 @@ impl InstantPrototype {
     pub fn epoch_nanoseconds(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let instant = this_instant(cx, this_value, "Instant.prototype.epochNanoseconds")?;
         let epoch_nanos = instant.instant().epoch_nanoseconds().as_i128();
@@ -169,13 +168,13 @@ impl InstantPrototype {
     pub fn add(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Instant.prototype.add";
 
         let instant = this_instant(cx, this_value, NAME)?;
 
-        let duration_arg = get_argument(cx, arguments, 0);
+        let duration_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, duration_arg, NAME)?;
 
         let new_instant_result = instant.instant().add(&duration);
@@ -188,13 +187,13 @@ impl InstantPrototype {
     pub fn subtract(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Instant.prototype.subtract";
 
         let instant = this_instant(cx, this_value, NAME)?;
 
-        let duration_arg = get_argument(cx, arguments, 0);
+        let duration_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, duration_arg, NAME)?;
 
         let new_instant_result = instant.instant().subtract(&duration);
@@ -207,7 +206,7 @@ impl InstantPrototype {
     pub fn until(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Self::diff(cx, this_value, arguments, DiffOperation::Until, "Instant.prototype.until")
     }
@@ -216,7 +215,7 @@ impl InstantPrototype {
     pub fn since(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Self::diff(cx, this_value, arguments, DiffOperation::Since, "Instant.prototype.since")
     }
@@ -224,16 +223,16 @@ impl InstantPrototype {
     fn diff(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
         operation: DiffOperation,
         method_name: &str,
     ) -> EvalResult<Handle<Value>> {
         let instant = this_instant(cx, this_value, method_name)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other = to_temporal_instant(cx, other_arg, method_name)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, method_name)?;
         let difference_settings = get_difference_settings(cx, options, method_name)?;
 
@@ -251,13 +250,13 @@ impl InstantPrototype {
     pub fn round(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Instant.prototype.round";
 
         let instant = this_instant(cx, this_value, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options = parse_round_options_argument(cx, options_arg, NAME)?;
 
         // Parse rounding from options object
@@ -280,13 +279,13 @@ impl InstantPrototype {
     pub fn equals(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Instant.prototype.equals";
 
         let instant = this_instant(cx, this_value, NAME)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other_instant = to_temporal_instant(cx, other_arg, NAME)?;
 
         Ok(cx.bool(instant.instant() == other_instant))
@@ -296,13 +295,13 @@ impl InstantPrototype {
     pub fn to_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Instant.prototype.toString";
 
         let instant = this_instant(cx, this_value, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options = validate_options_object(cx, options_arg, NAME)?;
 
         // Parse rounding options from options object
@@ -331,7 +330,7 @@ impl InstantPrototype {
     pub fn to_locale_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Instant.prototype.toLocaleString";
 
@@ -351,7 +350,7 @@ impl InstantPrototype {
     pub fn to_json(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Instant.prototype.toJSON";
 
@@ -368,11 +367,7 @@ impl InstantPrototype {
     }
 
     /// Temporal.Instant.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         type_error(cx, "Instant.prototype.valueOf must not be called")
     }
 
@@ -380,13 +375,13 @@ impl InstantPrototype {
     pub fn to_zoned_date_time_iso(
         cx: Context,
         this_value: Handle<Value>,
-        argument: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Instant.prototype.toZonedDateTimeISO";
 
         let instant = this_instant(cx, this_value, NAME)?;
 
-        let time_zone_arg = get_argument(cx, argument, 0);
+        let time_zone_arg = arguments.get(cx, 0);
         let time_zone = to_time_zone_identifier(cx, time_zone_arg, NAME)?;
 
         let zoned_date_time_result = instant

--- a/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
@@ -3,12 +3,11 @@ use temporal_rs::{
 };
 
 use crate::runtime::{
-    Context, Handle, Realm, Value,
+    Arguments, Context, Handle, Realm, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -66,7 +65,7 @@ impl PlainDateConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Temporal.PlainDate constructor";
 
@@ -74,9 +73,9 @@ impl PlainDateConstructor {
             return type_error(cx, "Temporal.PlainDate constructor must be called with new");
         };
 
-        let year_arg = get_argument(cx, arguments, 0);
-        let month_arg = get_argument(cx, arguments, 1);
-        let day_arg = get_argument(cx, arguments, 2);
+        let year_arg = arguments.get(cx, 0);
+        let month_arg = arguments.get(cx, 1);
+        let day_arg = arguments.get(cx, 2);
 
         // Truncation for year, month, and day will trigger an error later in creation
         let year = to_integer_with_truncation(cx, year_arg, NAME)?;
@@ -84,7 +83,7 @@ impl PlainDateConstructor {
         let day = to_integer_with_truncation(cx, day_arg, NAME)?;
 
         // Validate calendar argument
-        let calendar_arg = get_argument(cx, arguments, 3);
+        let calendar_arg = arguments.get(cx, 3);
         let calendar = parse_calendar_argument(cx, calendar_arg, NAME)?;
 
         // Clamp year, month, and day into range for `temporal_rs`
@@ -98,12 +97,12 @@ impl PlainDateConstructor {
     pub fn compare(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDate.compare";
 
-        let arg_1 = get_argument(cx, arguments, 0);
-        let arg_2 = get_argument(cx, arguments, 1);
+        let arg_1 = arguments.get(cx, 0);
+        let arg_2 = arguments.get(cx, 1);
 
         let date_1 = to_temporal_date(cx, arg_1, NAME)?;
         let date_2 = to_temporal_date(cx, arg_2, NAME)?;
@@ -112,13 +111,9 @@ impl PlainDateConstructor {
     }
 
     /// Temporal.PlainDate.from (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.from)
-    pub fn from(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let item_arg = get_argument(cx, arguments, 0);
-        let options_arg = get_argument(cx, arguments, 1);
+    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let item_arg = arguments.get(cx, 0);
+        let options_arg = arguments.get(cx, 1);
 
         let plain_date =
             to_temporal_date_with_options(cx, item_arg, options_arg, "PlainDate.from")?;

--- a/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
@@ -1,10 +1,9 @@
 use temporal_rs::options::DisplayCalendar;
 
 use crate::runtime::{
-    Context, EvalResult, Handle, Realm, Value,
+    Arguments, Context, EvalResult, Handle, Realm, Value,
     alloc_error::AllocResult,
     error::type_error,
-    function::get_argument,
     get,
     intrinsics::{
         intrinsics::Intrinsic,
@@ -260,7 +259,7 @@ impl PlainDatePrototype {
     pub fn calendar_id(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.calendarId")?;
         let calendar_str = this_date.date().calendar().identifier();
@@ -272,7 +271,7 @@ impl PlainDatePrototype {
     pub fn era(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.era")?;
 
@@ -286,7 +285,7 @@ impl PlainDatePrototype {
     pub fn era_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.eraYear")?;
 
@@ -297,11 +296,7 @@ impl PlainDatePrototype {
     }
 
     /// get Temporal.PlainDate.prototype.year (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.year)
-    pub fn year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn year(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.year")?;
         let year_number = this_date.date().year();
 
@@ -312,7 +307,7 @@ impl PlainDatePrototype {
     pub fn month(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.month")?;
         let month_number = this_date.date().month();
@@ -324,7 +319,7 @@ impl PlainDatePrototype {
     pub fn month_code(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.monthCode")?;
         let month_code = this_date.date().month_code();
@@ -333,11 +328,7 @@ impl PlainDatePrototype {
     }
 
     /// get Temporal.PlainDate.prototype.day (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.day)
-    pub fn day(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn day(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.day")?;
         let day_number = this_date.date().day();
 
@@ -348,7 +339,7 @@ impl PlainDatePrototype {
     pub fn day_of_week(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.dayOfWeek")?;
         let day_of_week_number = this_date.date().day_of_week();
@@ -360,7 +351,7 @@ impl PlainDatePrototype {
     pub fn day_of_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.dayOfYear")?;
         let day_of_year_number = this_date.date().day_of_year();
@@ -372,7 +363,7 @@ impl PlainDatePrototype {
     pub fn week_of_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.weekOfYear")?;
 
@@ -386,7 +377,7 @@ impl PlainDatePrototype {
     pub fn year_of_week(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.yearOfWeek")?;
 
@@ -400,7 +391,7 @@ impl PlainDatePrototype {
     pub fn days_in_week(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.daysInWeek")?;
         let num_days_in_week = this_date.date().days_in_week();
@@ -412,7 +403,7 @@ impl PlainDatePrototype {
     pub fn days_in_month(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.daysInMonth")?;
         let num_days_in_month = this_date.date().days_in_month();
@@ -424,7 +415,7 @@ impl PlainDatePrototype {
     pub fn days_in_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.daysInYear")?;
         let num_days_in_year = this_date.date().days_in_year();
@@ -436,7 +427,7 @@ impl PlainDatePrototype {
     pub fn months_in_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.monthsInYear")?;
         let num_months_in_year = this_date.date().months_in_year();
@@ -448,7 +439,7 @@ impl PlainDatePrototype {
     pub fn in_leap_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.inLeapYear")?;
         let in_leap_year = this_date.date().in_leap_year();
@@ -460,16 +451,16 @@ impl PlainDatePrototype {
     pub fn add(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDate.prototype.add";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
 
-        let duration_arg = get_argument(cx, arguments, 0);
+        let duration_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, duration_arg, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
@@ -483,16 +474,16 @@ impl PlainDatePrototype {
     pub fn subtract(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDate.prototype.subtract";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
 
-        let duration_arg = get_argument(cx, arguments, 0);
+        let duration_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, duration_arg, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
@@ -506,7 +497,7 @@ impl PlainDatePrototype {
     pub fn until(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Self::diff(cx, this_value, arguments, DiffOperation::Until, "PlainDate.prototype.until")
     }
@@ -515,7 +506,7 @@ impl PlainDatePrototype {
     pub fn since(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Self::diff(cx, this_value, arguments, DiffOperation::Since, "PlainDate.prototype.since")
     }
@@ -523,16 +514,16 @@ impl PlainDatePrototype {
     fn diff(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
         operation: DiffOperation,
         method_name: &str,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, method_name)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other = to_temporal_date(cx, other_arg, method_name)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, method_name)?;
         let difference_settings = get_difference_settings(cx, options, method_name)?;
 
@@ -550,13 +541,13 @@ impl PlainDatePrototype {
     pub fn equals(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDate.prototype.equals";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other_date = to_temporal_date(cx, other_arg, NAME)?;
 
         Ok(cx.bool(this_date.date() == &other_date))
@@ -566,13 +557,13 @@ impl PlainDatePrototype {
     pub fn to_plain_date_time(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDate.prototype.toPlainDateTime";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
 
-        let time_arg = get_argument(cx, arguments, 0);
+        let time_arg = arguments.get(cx, 0);
         let time = if time_arg.is_undefined() {
             None
         } else {
@@ -589,7 +580,7 @@ impl PlainDatePrototype {
     pub fn to_plain_month_day(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDate.prototype.toPlainMonthDay";
 
@@ -605,7 +596,7 @@ impl PlainDatePrototype {
     pub fn to_plain_year_month(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDate.prototype.toPlainYearMonth";
 
@@ -621,13 +612,13 @@ impl PlainDatePrototype {
     pub fn to_zoned_date_time(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDate.prototype.toZonedDateTime";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
 
-        let item_arg = get_argument(cx, arguments, 0);
+        let item_arg = arguments.get(cx, 0);
 
         let plain_time_opt;
         let time_zone;
@@ -669,14 +660,14 @@ impl PlainDatePrototype {
     pub fn to_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDate.prototype.toString";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
 
         // Parse calendar format from options
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let display_name = get_show_calendar_name_option(cx, options, NAME)?;
 
@@ -689,7 +680,7 @@ impl PlainDatePrototype {
     pub fn to_locale_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.toLocaleString")?;
         let date_string = this_date.date().to_ixdtf_string(DisplayCalendar::Auto);
@@ -701,7 +692,7 @@ impl PlainDatePrototype {
     pub fn to_json(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.toJSON")?;
         let date_string = this_date.date().to_ixdtf_string(DisplayCalendar::Auto);
@@ -710,11 +701,7 @@ impl PlainDatePrototype {
     }
 
     /// Temporal.PlainDate.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         type_error(cx, "PlainDate.prototype.valueOf must not be called")
     }
 
@@ -722,13 +709,13 @@ impl PlainDatePrototype {
     pub fn with(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDate.prototype.with";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
 
-        let date_like_arg = get_argument(cx, arguments, 0);
+        let date_like_arg = arguments.get(cx, 0);
         if !is_partial_temporal_object(cx, date_like_arg)? {
             return type_error(cx, "PlainDate.prototype.with argument must be a date-like object");
         }
@@ -749,7 +736,7 @@ impl PlainDatePrototype {
             NAME,
         )?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
@@ -765,13 +752,13 @@ impl PlainDatePrototype {
     pub fn with_calendar(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDate.prototype.withCalendar";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
 
-        let calendar_arg = get_argument(cx, arguments, 0);
+        let calendar_arg = arguments.get(cx, 0);
         let calendar = to_temporal_calendar_identifier(cx, calendar_arg, NAME)?;
 
         let new_date = this_date.date().with_calendar(calendar);

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
@@ -1,12 +1,11 @@
 use temporal_rs::{PlainDateTime, parsed_intermediates::ParsedDateTime, partial::PartialDateTime};
 
 use crate::runtime::{
-    Context, Handle, Realm, Value,
+    Arguments, Context, Handle, Realm, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -68,7 +67,7 @@ impl PlainDateTimeConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Temporal.PlainDateTime constructor";
 
@@ -77,37 +76,37 @@ impl PlainDateTimeConstructor {
         };
 
         // Truncation for year, month, and day will trigger an error later in creation
-        let year_arg = get_argument(cx, arguments, 0);
+        let year_arg = arguments.get(cx, 0);
         let year = to_integer_with_truncation(cx, year_arg, NAME)?;
 
-        let month_arg = get_argument(cx, arguments, 1);
+        let month_arg = arguments.get(cx, 1);
         let month = to_integer_with_truncation(cx, month_arg, NAME)?;
 
-        let day_arg = get_argument(cx, arguments, 2);
+        let day_arg = arguments.get(cx, 2);
         let day = to_integer_with_truncation(cx, day_arg, NAME)?;
 
         // Truncate time arguments to signed ints. This effectively clamps the value on the upper
         // bound (since an error will be triggered later). But the lower bound must be checked
         // manually later. Signed width is enough to hold the maximum value of each time field.
-        let hour_arg = get_argument(cx, arguments, 3);
+        let hour_arg = arguments.get(cx, 3);
         let hour = to_integer_with_truncation_or_zero::<i8>(cx, hour_arg, NAME)?;
 
-        let minute_arg = get_argument(cx, arguments, 4);
+        let minute_arg = arguments.get(cx, 4);
         let minute = to_integer_with_truncation_or_zero::<i8>(cx, minute_arg, NAME)?;
 
-        let second_arg = get_argument(cx, arguments, 5);
+        let second_arg = arguments.get(cx, 5);
         let second = to_integer_with_truncation_or_zero::<i8>(cx, second_arg, NAME)?;
 
-        let millis_arg = get_argument(cx, arguments, 6);
+        let millis_arg = arguments.get(cx, 6);
         let millis = to_integer_with_truncation_or_zero::<i16>(cx, millis_arg, NAME)?;
 
-        let micros_arg = get_argument(cx, arguments, 7);
+        let micros_arg = arguments.get(cx, 7);
         let micros = to_integer_with_truncation_or_zero::<i16>(cx, micros_arg, NAME)?;
 
-        let nanos_arg = get_argument(cx, arguments, 8);
+        let nanos_arg = arguments.get(cx, 8);
         let nanos = to_integer_with_truncation_or_zero::<i16>(cx, nanos_arg, NAME)?;
 
-        let calendar_arg = get_argument(cx, arguments, 9);
+        let calendar_arg = arguments.get(cx, 9);
         let calendar = parse_calendar_argument(cx, calendar_arg, NAME)?;
 
         let (hour, minute, second, millis, micros, nanos) =
@@ -122,13 +121,9 @@ impl PlainDateTimeConstructor {
     }
 
     /// Temporal.PlainDateTime.from (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.from)
-    pub fn from(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let item_arg = get_argument(cx, arguments, 0);
-        let options_arg = get_argument(cx, arguments, 1);
+    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let item_arg = arguments.get(cx, 0);
+        let options_arg = arguments.get(cx, 1);
 
         let plain_date_time =
             to_temporal_date_time_with_options(cx, item_arg, options_arg, "PlainDateTime.from")?;
@@ -140,12 +135,12 @@ impl PlainDateTimeConstructor {
     pub fn compare(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDateTime.compare";
 
-        let arg_1 = get_argument(cx, arguments, 0);
-        let arg_2 = get_argument(cx, arguments, 1);
+        let arg_1 = arguments.get(cx, 0);
+        let arg_2 = arguments.get(cx, 1);
 
         let date_time_1 = to_temporal_date_time(cx, arg_1, NAME)?;
         let date_time_2 = to_temporal_date_time(cx, arg_2, NAME)?;

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
@@ -3,10 +3,9 @@ use temporal_rs::options::{
 };
 
 use crate::runtime::{
-    Context, EvalResult, Handle, Realm, Value,
+    Arguments, Context, EvalResult, Handle, Realm, Value,
     alloc_error::AllocResult,
     error::type_error,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -312,7 +311,7 @@ impl PlainDateTimePrototype {
     pub fn calendar_id(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.calendarId")?;
@@ -325,7 +324,7 @@ impl PlainDateTimePrototype {
     pub fn era(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.era")?;
 
@@ -339,7 +338,7 @@ impl PlainDateTimePrototype {
     pub fn era_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.eraYear")?;
@@ -351,11 +350,7 @@ impl PlainDateTimePrototype {
     }
 
     /// get Temporal.PlainDateTime.prototype.year (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.year)
-    pub fn year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn year(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let this_date_time = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.year")?;
         let year = this_date_time.date_time().year();
 
@@ -366,7 +361,7 @@ impl PlainDateTimePrototype {
     pub fn month(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.month")?;
         let month = this_date_time.date_time().month();
@@ -378,7 +373,7 @@ impl PlainDateTimePrototype {
     pub fn month_code(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.monthCode")?;
@@ -388,11 +383,7 @@ impl PlainDateTimePrototype {
     }
 
     /// get Temporal.PlainDateTime.prototype.day (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.day)
-    pub fn day(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn day(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let this_date_time = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.day")?;
         let day = this_date_time.date_time().day();
 
@@ -403,7 +394,7 @@ impl PlainDateTimePrototype {
     pub fn day_of_week(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.dayOfWeek")?;
@@ -416,7 +407,7 @@ impl PlainDateTimePrototype {
     pub fn day_of_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.dayOfYear")?;
@@ -429,7 +420,7 @@ impl PlainDateTimePrototype {
     pub fn week_of_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.weekOfYear")?;
@@ -444,7 +435,7 @@ impl PlainDateTimePrototype {
     pub fn year_of_week(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.yearOfWeek")?;
@@ -459,7 +450,7 @@ impl PlainDateTimePrototype {
     pub fn days_in_week(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.daysInWeek")?;
@@ -472,7 +463,7 @@ impl PlainDateTimePrototype {
     pub fn days_in_month(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.daysInMonth")?;
@@ -485,7 +476,7 @@ impl PlainDateTimePrototype {
     pub fn days_in_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.daysInYear")?;
@@ -498,7 +489,7 @@ impl PlainDateTimePrototype {
     pub fn months_in_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.monthsInYear")?;
@@ -511,7 +502,7 @@ impl PlainDateTimePrototype {
     pub fn in_leap_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.inLeapYear")?;
@@ -521,11 +512,7 @@ impl PlainDateTimePrototype {
     }
 
     /// get Temporal.PlainDateTime.prototype.hour (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.hour)
-    pub fn hour(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn hour(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let this_date_time = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.hour")?;
         let hour = this_date_time.date_time().hour();
 
@@ -536,7 +523,7 @@ impl PlainDateTimePrototype {
     pub fn minute(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.minute")?;
@@ -549,7 +536,7 @@ impl PlainDateTimePrototype {
     pub fn second(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.second")?;
@@ -562,7 +549,7 @@ impl PlainDateTimePrototype {
     pub fn millisecond(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.millisecond")?;
@@ -575,7 +562,7 @@ impl PlainDateTimePrototype {
     pub fn microsecond(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.microsecond")?;
@@ -588,7 +575,7 @@ impl PlainDateTimePrototype {
     pub fn nanosecond(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.nanosecond")?;
@@ -601,16 +588,16 @@ impl PlainDateTimePrototype {
     pub fn add(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDateTime.prototype.add";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
 
-        let duration_arg = get_argument(cx, arguments, 0);
+        let duration_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, duration_arg, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
@@ -624,16 +611,16 @@ impl PlainDateTimePrototype {
     pub fn subtract(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDateTime.prototype.subtract";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
 
-        let duration_arg = get_argument(cx, arguments, 0);
+        let duration_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, duration_arg, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
@@ -649,7 +636,7 @@ impl PlainDateTimePrototype {
     pub fn until(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Self::diff(cx, this_value, arguments, DiffOperation::Until, "PlainDateTime.prototype.until")
     }
@@ -658,7 +645,7 @@ impl PlainDateTimePrototype {
     pub fn since(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Self::diff(cx, this_value, arguments, DiffOperation::Since, "PlainDateTime.prototype.since")
     }
@@ -666,16 +653,16 @@ impl PlainDateTimePrototype {
     fn diff(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
         operation: DiffOperation,
         method_name: &str,
     ) -> EvalResult<Handle<Value>> {
         let plain_date_time = this_plain_date_time(cx, this_value, method_name)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other = to_temporal_date_time(cx, other_arg, method_name)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, method_name)?;
         let difference_settings = get_difference_settings(cx, options, method_name)?;
 
@@ -697,13 +684,13 @@ impl PlainDateTimePrototype {
     pub fn round(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDateTime.prototype.round";
 
         let plain_date_time = this_plain_date_time(cx, this_value, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options = parse_round_options_argument(cx, options_arg, NAME)?;
 
         // Parse rounding options from options object
@@ -726,13 +713,13 @@ impl PlainDateTimePrototype {
     pub fn equals(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDateTime.prototype.equals";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other_date_time = to_temporal_date_time(cx, other_arg, NAME)?;
 
         Ok(cx.bool(this_date_time.date_time() == &other_date_time))
@@ -742,7 +729,7 @@ impl PlainDateTimePrototype {
     pub fn to_plain_date(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.toPlainDate")?;
@@ -755,7 +742,7 @@ impl PlainDateTimePrototype {
     pub fn to_plain_time(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.toPlainTime")?;
@@ -768,16 +755,16 @@ impl PlainDateTimePrototype {
     pub fn to_zoned_date_time(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDateTime.prototype.toZonedDateTime";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
 
-        let time_zone_arg = get_argument(cx, arguments, 0);
+        let time_zone_arg = arguments.get(cx, 0);
         let time_zone = to_time_zone_identifier(cx, time_zone_arg, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let disambiguation = get_disambiguation_option(cx, options, NAME)?;
 
@@ -795,13 +782,13 @@ impl PlainDateTimePrototype {
     pub fn to_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDateTime.prototype.toString";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options = validate_options_object(cx, options_arg, NAME)?;
 
         // Parse rounding options from options object
@@ -828,7 +815,7 @@ impl PlainDateTimePrototype {
     pub fn to_locale_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDateTime.prototype.toLocaleString";
 
@@ -845,7 +832,7 @@ impl PlainDateTimePrototype {
     pub fn to_json(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDateTime.prototype.toJSON";
 
@@ -859,11 +846,7 @@ impl PlainDateTimePrototype {
     }
 
     /// Temporal.PlainDateTime.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         type_error(cx, "PlainDateTime.prototype.valueOf must not be called")
     }
 
@@ -871,13 +854,13 @@ impl PlainDateTimePrototype {
     pub fn with(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDateTime.prototype.with";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
 
-        let date_like_arg = get_argument(cx, arguments, 0);
+        let date_like_arg = arguments.get(cx, 0);
         if !is_partial_temporal_object(cx, date_like_arg)? {
             return type_error(
                 cx,
@@ -908,7 +891,7 @@ impl PlainDateTimePrototype {
             NAME,
         )?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
@@ -924,13 +907,13 @@ impl PlainDateTimePrototype {
     pub fn with_plain_time(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDateTime.prototype.withPlainTime";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
 
-        let time_arg = get_argument(cx, arguments, 0);
+        let time_arg = arguments.get(cx, 0);
         let time = if time_arg.is_undefined() {
             None
         } else {
@@ -947,13 +930,13 @@ impl PlainDateTimePrototype {
     pub fn with_calendar(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainDateTime.prototype.withCalendar";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
 
-        let calendar_arg = get_argument(cx, arguments, 0);
+        let calendar_arg = arguments.get(cx, 0);
         let calendar = to_temporal_calendar_identifier(cx, calendar_arg, NAME)?;
 
         let new_date_time = this_date_time.date_time().with_calendar(calendar);

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
@@ -3,12 +3,11 @@ use temporal_rs::{
 };
 
 use crate::runtime::{
-    Context, Handle, Realm, Value,
+    Arguments, Context, Handle, Realm, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -61,7 +60,7 @@ impl PlainMonthDayConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Temporal.PlainMonthDay constructor";
 
@@ -69,17 +68,17 @@ impl PlainMonthDayConstructor {
             return type_error(cx, "Temporal.PlainMonthDay constructor must be called with new");
         };
 
-        let month_arg = get_argument(cx, arguments, 0);
-        let day_arg = get_argument(cx, arguments, 1);
+        let month_arg = arguments.get(cx, 0);
+        let day_arg = arguments.get(cx, 1);
 
         // Truncation for year, month, and day will trigger an error later in creation
         let month = to_integer_with_truncation(cx, month_arg, NAME)?;
         let day = to_integer_with_truncation(cx, day_arg, NAME)?;
 
-        let calendar_arg = get_argument(cx, arguments, 2);
+        let calendar_arg = arguments.get(cx, 2);
         let calendar = parse_calendar_argument(cx, calendar_arg, NAME)?;
 
-        let reference_iso_year_arg = get_argument(cx, arguments, 3);
+        let reference_iso_year_arg = arguments.get(cx, 3);
         let reference_iso_year = if reference_iso_year_arg.is_undefined() {
             None
         } else {
@@ -99,13 +98,9 @@ impl PlainMonthDayConstructor {
     }
 
     /// Temporal.PlainMonthDay.from (https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.from)
-    pub fn from(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let item_arg = get_argument(cx, arguments, 0);
-        let options_arg = get_argument(cx, arguments, 1);
+    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let item_arg = arguments.get(cx, 0);
+        let options_arg = arguments.get(cx, 1);
 
         let plain_month_day =
             to_temporal_month_day(cx, item_arg, Some(options_arg), "PlainMonthDay.from")?;

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
@@ -1,10 +1,9 @@
 use temporal_rs::options::DisplayCalendar;
 
 use crate::runtime::{
-    Context, EvalResult, Handle, Realm, Value,
+    Arguments, Context, EvalResult, Handle, Realm, Value,
     alloc_error::AllocResult,
     error::type_error,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -123,7 +122,7 @@ impl PlainMonthDayPrototype {
     pub fn calendar_id(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_month_day =
             this_plain_month_day(cx, this_value, "PlainMonthDay.prototype.calendarId")?;
@@ -136,7 +135,7 @@ impl PlainMonthDayPrototype {
     pub fn month_code(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_month_day =
             this_plain_month_day(cx, this_value, "PlainMonthDay.prototype.monthCode")?;
@@ -146,11 +145,7 @@ impl PlainMonthDayPrototype {
     }
 
     /// get Temporal.PlainMonthDay.prototype.day (https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.day)
-    pub fn day(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn day(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let this_month_day = this_plain_month_day(cx, this_value, "PlainMonthDay.prototype.day")?;
         let day = this_month_day.month_day().day();
 
@@ -161,13 +156,13 @@ impl PlainMonthDayPrototype {
     pub fn equals(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainMonthDay.prototype.equals";
 
         let this_month_day = this_plain_month_day(cx, this_value, NAME)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other_month_day = to_temporal_month_day(cx, other_arg, None, NAME)?;
 
         Ok(cx.bool(this_month_day.month_day() == &other_month_day))
@@ -177,13 +172,13 @@ impl PlainMonthDayPrototype {
     pub fn to_plain_date(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainMonthDay.prototype.toPlainDate";
 
         let this_month_day = this_plain_month_day(cx, this_value, NAME)?;
 
-        let item_arg = get_argument(cx, arguments, 0);
+        let item_arg = arguments.get(cx, 0);
         if !item_arg.is_object() {
             return type_error(
                 cx,
@@ -212,13 +207,13 @@ impl PlainMonthDayPrototype {
     pub fn to_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainMonthDay.prototype.toString";
 
         let this_month_day = this_plain_month_day(cx, this_value, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let display_calendar = get_show_calendar_name_option(cx, options, NAME)?;
 
@@ -231,7 +226,7 @@ impl PlainMonthDayPrototype {
     pub fn to_locale_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_month_day =
             this_plain_month_day(cx, this_value, "PlainMonthDay.prototype.toLocaleString")?;
@@ -246,7 +241,7 @@ impl PlainMonthDayPrototype {
     pub fn to_json(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_month_day =
             this_plain_month_day(cx, this_value, "PlainMonthDay.prototype.toJSON")?;
@@ -258,11 +253,7 @@ impl PlainMonthDayPrototype {
     }
 
     /// Temporal.PlainMonthDay.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         type_error(cx, "PlainMonthDay.prototype.valueOf must not be called")
     }
 
@@ -270,13 +261,13 @@ impl PlainMonthDayPrototype {
     pub fn with(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainMonthDay.prototype.with";
 
         let this_month_day = this_plain_month_day(cx, this_value, NAME)?;
 
-        let date_like_arg = get_argument(cx, arguments, 0);
+        let date_like_arg = arguments.get(cx, 0);
         if !is_partial_temporal_object(cx, date_like_arg)? {
             return type_error(
                 cx,
@@ -300,7 +291,7 @@ impl PlainMonthDayPrototype {
             NAME,
         )?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 

--- a/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
@@ -1,12 +1,11 @@
 use temporal_rs::PlainTime;
 
 use crate::runtime::{
-    Context, Handle, Realm, Value,
+    Arguments, Context, Handle, Realm, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -63,7 +62,7 @@ impl PlainTimeConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Temporal.PlainTime constructor";
 
@@ -74,22 +73,22 @@ impl PlainTimeConstructor {
         // Truncate time arguments to signed ints. This effectively clamps the value on the upper
         // bound (since an error will be triggered later). But the lower bound must be checked
         // manually later. Signed width is enough to hold the maximum value of each time field.
-        let hour_arg = get_argument(cx, arguments, 0);
+        let hour_arg = arguments.get(cx, 0);
         let hour = to_integer_with_truncation_or_zero::<i8>(cx, hour_arg, NAME)?;
 
-        let minute_arg = get_argument(cx, arguments, 1);
+        let minute_arg = arguments.get(cx, 1);
         let minute = to_integer_with_truncation_or_zero::<i8>(cx, minute_arg, NAME)?;
 
-        let second_arg = get_argument(cx, arguments, 2);
+        let second_arg = arguments.get(cx, 2);
         let second = to_integer_with_truncation_or_zero::<i8>(cx, second_arg, NAME)?;
 
-        let millis_arg = get_argument(cx, arguments, 3);
+        let millis_arg = arguments.get(cx, 3);
         let millis = to_integer_with_truncation_or_zero::<i16>(cx, millis_arg, NAME)?;
 
-        let micros_arg = get_argument(cx, arguments, 4);
+        let micros_arg = arguments.get(cx, 4);
         let micros = to_integer_with_truncation_or_zero::<i16>(cx, micros_arg, NAME)?;
 
-        let nanos_arg = get_argument(cx, arguments, 5);
+        let nanos_arg = arguments.get(cx, 5);
         let nanos = to_integer_with_truncation_or_zero::<i16>(cx, nanos_arg, NAME)?;
 
         let (hour, minute, second, millis, micros, nanos) =
@@ -102,13 +101,9 @@ impl PlainTimeConstructor {
     }
 
     /// Temporal.PlainTime.from (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.from)
-    pub fn from(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let item_arg = get_argument(cx, arguments, 0);
-        let options_arg = get_argument(cx, arguments, 1);
+    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let item_arg = arguments.get(cx, 0);
+        let options_arg = arguments.get(cx, 1);
 
         let plain_time =
             to_temporal_time_with_options(cx, item_arg, options_arg, "PlainTime.from")?;
@@ -120,12 +115,12 @@ impl PlainTimeConstructor {
     pub fn compare(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainTime.compare";
 
-        let arg_1 = get_argument(cx, arguments, 0);
-        let arg_2 = get_argument(cx, arguments, 1);
+        let arg_1 = arguments.get(cx, 0);
+        let arg_2 = arguments.get(cx, 1);
 
         let time_1 = to_temporal_time(cx, arg_1, NAME)?;
         let time_2 = to_temporal_time(cx, arg_2, NAME)?;

--- a/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
@@ -1,10 +1,9 @@
 use temporal_rs::options::{RoundingMode, RoundingOptions, ToStringRoundingOptions};
 
 use crate::runtime::{
-    Context, EvalResult, Handle, Realm, Value,
+    Arguments, Context, EvalResult, Handle, Realm, Value,
     alloc_error::AllocResult,
     error::type_error,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -163,11 +162,7 @@ impl PlainTimePrototype {
     }
 
     /// get Temporal.PlainTime.prototype.hour (https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.hour)
-    pub fn hour(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn hour(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.hour")?;
         let hour = this_time.time().hour();
 
@@ -178,7 +173,7 @@ impl PlainTimePrototype {
     pub fn minute(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.minute")?;
         let minute = this_time.time().minute();
@@ -190,7 +185,7 @@ impl PlainTimePrototype {
     pub fn second(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.second")?;
         let second = this_time.time().second();
@@ -202,7 +197,7 @@ impl PlainTimePrototype {
     pub fn millisecond(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.millisecond")?;
         let millis = this_time.time().millisecond();
@@ -214,7 +209,7 @@ impl PlainTimePrototype {
     pub fn microsecond(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.microsecond")?;
         let micros = this_time.time().microsecond();
@@ -226,7 +221,7 @@ impl PlainTimePrototype {
     pub fn nanosecond(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.nanosecond")?;
         let nanos = this_time.time().nanosecond();
@@ -238,13 +233,13 @@ impl PlainTimePrototype {
     pub fn add(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainTime.prototype.add";
 
         let this_time = this_plain_time(cx, this_value, NAME)?;
 
-        let duration_arg = get_argument(cx, arguments, 0);
+        let duration_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, duration_arg, NAME)?;
 
         let new_time_result = this_time.time().add(&duration);
@@ -257,13 +252,13 @@ impl PlainTimePrototype {
     pub fn subtract(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainTime.prototype.subtract";
 
         let this_time = this_plain_time(cx, this_value, NAME)?;
 
-        let duration_arg = get_argument(cx, arguments, 0);
+        let duration_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, duration_arg, NAME)?;
 
         let new_time_result = this_time.time().subtract(&duration);
@@ -276,12 +271,12 @@ impl PlainTimePrototype {
     pub fn with(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainTime.prototype.with";
 
         let plain_time = this_plain_time(cx, this_value, NAME)?;
-        let time_like_arg = get_argument(cx, arguments, 0);
+        let time_like_arg = arguments.get(cx, 0);
 
         if !is_partial_temporal_object(cx, time_like_arg)? {
             return type_error(
@@ -292,7 +287,7 @@ impl PlainTimePrototype {
 
         let partial_record = to_partial_time_record(cx, time_like_arg, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
@@ -308,7 +303,7 @@ impl PlainTimePrototype {
     pub fn until(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Self::diff(cx, this_value, arguments, DiffOperation::Until, "PlainTime.prototype.until")
     }
@@ -317,7 +312,7 @@ impl PlainTimePrototype {
     pub fn since(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Self::diff(cx, this_value, arguments, DiffOperation::Since, "PlainTime.prototype.since")
     }
@@ -325,16 +320,16 @@ impl PlainTimePrototype {
     fn diff(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
         operation: DiffOperation,
         method_name: &str,
     ) -> EvalResult<Handle<Value>> {
         let plain_time = this_plain_time(cx, this_value, method_name)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other = to_temporal_time(cx, other_arg, method_name)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, method_name)?;
         let difference_settings = get_difference_settings(cx, options, method_name)?;
 
@@ -352,13 +347,13 @@ impl PlainTimePrototype {
     pub fn round(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainTime.prototype.round";
 
         let plain_time = this_plain_time(cx, this_value, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options = parse_round_options_argument(cx, options_arg, NAME)?;
 
         // Parse rounding from options object
@@ -381,13 +376,13 @@ impl PlainTimePrototype {
     pub fn equals(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainTime.prototype.equals";
 
         let this_time = this_plain_time(cx, this_value, NAME)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other_time = to_temporal_time(cx, other_arg, NAME)?;
 
         Ok(cx.bool(this_time.time() == other_time))
@@ -397,13 +392,13 @@ impl PlainTimePrototype {
     pub fn to_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainTime.prototype.toString";
 
         let this_time = this_plain_time(cx, this_value, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options = validate_options_object(cx, options_arg, NAME)?;
 
         // Parse rounding options from options object
@@ -427,7 +422,7 @@ impl PlainTimePrototype {
     pub fn to_locale_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainTime.prototype.toLocaleString";
 
@@ -444,7 +439,7 @@ impl PlainTimePrototype {
     pub fn to_json(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainTime.prototype.toJSON";
 
@@ -458,11 +453,7 @@ impl PlainTimePrototype {
     }
 
     /// Temporal.PlainTime.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         type_error(cx, "PlainTime.prototype.valueOf must not be called")
     }
 }

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
@@ -1,12 +1,11 @@
 use temporal_rs::{PlainYearMonth, parsed_intermediates::ParsedDate, partial::PartialYearMonth};
 
 use crate::runtime::{
-    Context, Handle, Realm, Value,
+    Arguments, Context, Handle, Realm, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -66,7 +65,7 @@ impl PlainYearMonthConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Temporal.PlainYearMonth constructor";
 
@@ -74,17 +73,17 @@ impl PlainYearMonthConstructor {
             return type_error(cx, "Temporal.PlainYearMonth constructor must be called with new");
         };
 
-        let year_arg = get_argument(cx, arguments, 0);
-        let month_arg = get_argument(cx, arguments, 1);
+        let year_arg = arguments.get(cx, 0);
+        let month_arg = arguments.get(cx, 1);
 
         // Truncation for year, month, and day will trigger an error later in creation
         let year = to_integer_with_truncation(cx, year_arg, NAME)?;
         let month = to_integer_with_truncation(cx, month_arg, NAME)?;
 
-        let calendar_arg = get_argument(cx, arguments, 2);
+        let calendar_arg = arguments.get(cx, 2);
         let calendar = parse_calendar_argument(cx, calendar_arg, NAME)?;
 
-        let reference_iso_day_arg = get_argument(cx, arguments, 3);
+        let reference_iso_day_arg = arguments.get(cx, 3);
         let reference_iso_day = if reference_iso_day_arg.is_undefined() {
             None
         } else {
@@ -102,13 +101,9 @@ impl PlainYearMonthConstructor {
     }
 
     /// Temporal.PlainYearMonth.from (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.from)
-    pub fn from(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let item_arg = get_argument(cx, arguments, 0);
-        let options_arg = get_argument(cx, arguments, 1);
+    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let item_arg = arguments.get(cx, 0);
+        let options_arg = arguments.get(cx, 1);
 
         let plain_year_month =
             to_temporal_year_month(cx, item_arg, Some(options_arg), "PlainYearMonth.from")?;
@@ -120,12 +115,12 @@ impl PlainYearMonthConstructor {
     pub fn compare(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainYearMonth.compare";
 
-        let arg_1 = get_argument(cx, arguments, 0);
-        let arg_2 = get_argument(cx, arguments, 1);
+        let arg_1 = arguments.get(cx, 0);
+        let arg_2 = arguments.get(cx, 1);
 
         let year_month_1 = to_temporal_year_month(cx, arg_1, None, NAME)?;
         let year_month_2 = to_temporal_year_month(cx, arg_2, None, NAME)?;

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
@@ -1,10 +1,9 @@
 use temporal_rs::options::DisplayCalendar;
 
 use crate::runtime::{
-    Context, EvalResult, Handle, Realm, Value,
+    Arguments, Context, EvalResult, Handle, Realm, Value,
     alloc_error::AllocResult,
     error::type_error,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -195,7 +194,7 @@ impl PlainYearMonthPrototype {
     pub fn calendar_id(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.calendarId")?;
@@ -208,7 +207,7 @@ impl PlainYearMonthPrototype {
     pub fn era(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.era")?;
@@ -223,7 +222,7 @@ impl PlainYearMonthPrototype {
     pub fn era_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.eraYear")?;
@@ -235,11 +234,7 @@ impl PlainYearMonthPrototype {
     }
 
     /// get Temporal.PlainYearMonth.prototype.year (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.year)
-    pub fn year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn year(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.year")?;
         let year = this_year_month.year_month().year();
@@ -251,7 +246,7 @@ impl PlainYearMonthPrototype {
     pub fn month(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.month")?;
@@ -264,7 +259,7 @@ impl PlainYearMonthPrototype {
     pub fn month_code(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.monthCode")?;
@@ -277,7 +272,7 @@ impl PlainYearMonthPrototype {
     pub fn days_in_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.daysInYear")?;
@@ -290,7 +285,7 @@ impl PlainYearMonthPrototype {
     pub fn days_in_month(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.daysInMonth")?;
@@ -303,7 +298,7 @@ impl PlainYearMonthPrototype {
     pub fn months_in_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.monthsInYear")?;
@@ -316,7 +311,7 @@ impl PlainYearMonthPrototype {
     pub fn in_leap_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.inLeapYear")?;
@@ -329,16 +324,16 @@ impl PlainYearMonthPrototype {
     pub fn add(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainYearMonth.prototype.add";
 
         let this_year_month = this_plain_year_month(cx, this_value, NAME)?;
 
-        let duration_arg = get_argument(cx, arguments, 0);
+        let duration_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, duration_arg, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
@@ -352,16 +347,16 @@ impl PlainYearMonthPrototype {
     pub fn subtract(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainYearMonth.prototype.subtract";
 
         let this_year_month = this_plain_year_month(cx, this_value, NAME)?;
 
-        let duration_arg = get_argument(cx, arguments, 0);
+        let duration_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, duration_arg, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
@@ -375,7 +370,7 @@ impl PlainYearMonthPrototype {
     pub fn until(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Self::diff(
             cx,
@@ -390,7 +385,7 @@ impl PlainYearMonthPrototype {
     pub fn since(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Self::diff(
             cx,
@@ -404,16 +399,16 @@ impl PlainYearMonthPrototype {
     fn diff(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
         operation: DiffOperation,
         method_name: &str,
     ) -> EvalResult<Handle<Value>> {
         let this_year_month = this_plain_year_month(cx, this_value, method_name)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other = to_temporal_year_month(cx, other_arg, None, method_name)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, method_name)?;
         let difference_settings = get_difference_settings(cx, options, method_name)?;
 
@@ -435,13 +430,13 @@ impl PlainYearMonthPrototype {
     pub fn equals(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainYearMonth.prototype.equals";
 
         let this_year_month = this_plain_year_month(cx, this_value, NAME)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other_year_month = to_temporal_year_month(cx, other_arg, None, NAME)?;
 
         Ok(cx.bool(this_year_month.year_month() == &other_year_month))
@@ -451,13 +446,13 @@ impl PlainYearMonthPrototype {
     pub fn to_plain_date(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainYearMonth.prototype.toPlainDate";
 
         let this_year_month = this_plain_year_month(cx, this_value, NAME)?;
 
-        let item_arg = get_argument(cx, arguments, 0);
+        let item_arg = arguments.get(cx, 0);
         if !item_arg.is_object() {
             return type_error(
                 cx,
@@ -486,13 +481,13 @@ impl PlainYearMonthPrototype {
     pub fn to_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainYearMonth.prototype.toString";
 
         let this_year_month = this_plain_year_month(cx, this_value, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let display_calendar = get_show_calendar_name_option(cx, options, NAME)?;
 
@@ -507,7 +502,7 @@ impl PlainYearMonthPrototype {
     pub fn to_locale_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.toLocaleString")?;
@@ -522,7 +517,7 @@ impl PlainYearMonthPrototype {
     pub fn to_json(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.toJSON")?;
@@ -534,11 +529,7 @@ impl PlainYearMonthPrototype {
     }
 
     /// Temporal.PlainYearMonth.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         type_error(cx, "PlainYearMonth.prototype.valueOf must not be called")
     }
 
@@ -546,13 +537,13 @@ impl PlainYearMonthPrototype {
     pub fn with(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "PlainYearMonth.prototype.with";
 
         let this_year_month = this_plain_year_month(cx, this_value, NAME)?;
 
-        let date_like_arg = get_argument(cx, arguments, 0);
+        let date_like_arg = arguments.get(cx, 0);
         if !is_partial_temporal_object(cx, date_like_arg)? {
             return type_error(
                 cx,
@@ -571,7 +562,7 @@ impl PlainYearMonthPrototype {
             NAME,
         )?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 

--- a/src/js/runtime/intrinsics/temporal/temporal_now_object.rs
+++ b/src/js/runtime/intrinsics/temporal/temporal_now_object.rs
@@ -7,9 +7,8 @@ use temporal_rs::{
 };
 
 use crate::runtime::{
-    Context, EvalResult, Handle, Realm, Value,
+    Arguments, Context, EvalResult, Handle, Realm, Value,
     alloc_error::AllocResult,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -97,7 +96,7 @@ impl TemporalNowObject {
     pub fn time_zone_id(
         mut cx: Context,
         _: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Now.timeZoneId";
 
@@ -111,11 +110,7 @@ impl TemporalNowObject {
     }
 
     /// Temporal.Now.instant (https://tc39.es/proposal-temporal/#sec-temporal.now.instant)
-    pub fn instant(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn instant(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let instant_result = Self::now(cx).instant();
         let instant = map_temporal_result(cx, instant_result, "Now.instant")?;
 
@@ -126,11 +121,11 @@ impl TemporalNowObject {
     pub fn plain_date_time_iso(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Now.plainDateTimeISO";
 
-        let time_zone_arg = get_argument(cx, arguments, 0);
+        let time_zone_arg = arguments.get(cx, 0);
         let time_zone = Self::parse_time_zone_argument(cx, time_zone_arg, NAME)?;
 
         let date_time_result =
@@ -144,11 +139,11 @@ impl TemporalNowObject {
     pub fn zoned_date_time_iso(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Now.zonedDateTimeISO";
 
-        let time_zone_arg = get_argument(cx, arguments, 0);
+        let time_zone_arg = arguments.get(cx, 0);
         let time_zone = Self::parse_time_zone_argument(cx, time_zone_arg, NAME)?;
 
         let zoned_date_time_result =
@@ -162,11 +157,11 @@ impl TemporalNowObject {
     pub fn plain_date_iso(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Now.plainDateISO";
 
-        let time_zone_arg = get_argument(cx, arguments, 0);
+        let time_zone_arg = arguments.get(cx, 0);
         let time_zone = Self::parse_time_zone_argument(cx, time_zone_arg, NAME)?;
 
         let date_result =
@@ -180,11 +175,11 @@ impl TemporalNowObject {
     pub fn plain_time_iso(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Now.plainTimeISO";
 
-        let time_zone_arg = get_argument(cx, arguments, 0);
+        let time_zone_arg = arguments.get(cx, 0);
         let time_zone = Self::parse_time_zone_argument(cx, time_zone_arg, NAME)?;
 
         let time_result =

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
@@ -6,12 +6,11 @@ use temporal_rs::{
 };
 
 use crate::runtime::{
-    Context, Handle, Realm, Value,
+    Arguments, Context, Handle, Realm, Value,
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic,
         rust_runtime::RuntimeFunction,
@@ -74,7 +73,7 @@ impl ZonedDateTimeConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "Temporal.ZonedDateTime constructor";
 
@@ -82,14 +81,14 @@ impl ZonedDateTimeConstructor {
             return type_error(cx, "Temporal.ZonedDateTime constructor must be called with new");
         };
 
-        let epoch_nanos_arg = get_argument(cx, arguments, 0);
+        let epoch_nanos_arg = arguments.get(cx, 0);
         let epoch_nanos_bigint = to_bigint(cx, epoch_nanos_arg)?;
         let epoch_nanos_i128 = clamp_epoch_nanos_to_i128(&epoch_nanos_bigint.bigint());
 
-        let time_zone_arg = get_argument(cx, arguments, 1);
+        let time_zone_arg = arguments.get(cx, 1);
         let time_zone = parse_time_zone_identifier_argument(cx, time_zone_arg, NAME)?;
 
-        let calendar_arg = get_argument(cx, arguments, 2);
+        let calendar_arg = arguments.get(cx, 2);
         let calendar = parse_calendar_argument(cx, calendar_arg, NAME)?;
 
         let zoned_date_time_result = ZonedDateTime::try_new_with_provider(
@@ -107,12 +106,12 @@ impl ZonedDateTimeConstructor {
     pub fn compare(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.compare";
 
-        let arg_1 = get_argument(cx, arguments, 0);
-        let arg_2 = get_argument(cx, arguments, 1);
+        let arg_1 = arguments.get(cx, 0);
+        let arg_2 = arguments.get(cx, 1);
 
         let zoned_date_time_1 = to_temporal_zoned_date_time(cx, arg_1, NAME)?;
         let zoned_date_time_2 = to_temporal_zoned_date_time(cx, arg_2, NAME)?;
@@ -121,13 +120,9 @@ impl ZonedDateTimeConstructor {
     }
 
     /// Temporal.ZonedDateTime.from (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.from)
-    pub fn from(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let item_arg = get_argument(cx, arguments, 0);
-        let options_arg = get_argument(cx, arguments, 1);
+    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let item_arg = arguments.get(cx, 0);
+        let options_arg = arguments.get(cx, 1);
 
         let zoned_date_time = to_temporal_zoned_date_time_with_options(
             cx,

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
@@ -7,11 +7,10 @@ use temporal_rs::options::{
 use crate::{
     must,
     runtime::{
-        Context, EvalResult, Handle, Realm, Value,
+        Arguments, Context, EvalResult, Handle, Realm, Value,
         abstract_operations::create_data_property_or_throw,
         alloc_error::AllocResult,
         error::type_error,
-        function::get_argument,
         intrinsics::{
             intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
@@ -387,7 +386,7 @@ impl ZonedDateTimePrototype {
     pub fn calendar_id(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.calendarId")?;
@@ -403,7 +402,7 @@ impl ZonedDateTimePrototype {
     pub fn time_zone_id(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.timeZoneId";
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -420,7 +419,7 @@ impl ZonedDateTimePrototype {
     pub fn epoch_milliseconds(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.epochMilliseconds")?;
@@ -433,7 +432,7 @@ impl ZonedDateTimePrototype {
     pub fn epoch_nanoseconds(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.epochNanoseconds")?;
@@ -449,7 +448,7 @@ impl ZonedDateTimePrototype {
     pub fn era(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.era")?;
@@ -464,7 +463,7 @@ impl ZonedDateTimePrototype {
     pub fn era_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.eraYear")?;
@@ -476,11 +475,7 @@ impl ZonedDateTimePrototype {
     }
 
     /// get Temporal.ZonedDateTime.prototype.year (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.year)
-    pub fn year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn year(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.year")?;
         let year = this_zoned_date_time.zoned_date_time().year();
@@ -492,7 +487,7 @@ impl ZonedDateTimePrototype {
     pub fn month(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.month")?;
@@ -505,7 +500,7 @@ impl ZonedDateTimePrototype {
     pub fn month_code(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.monthCode")?;
@@ -515,11 +510,7 @@ impl ZonedDateTimePrototype {
     }
 
     /// get Temporal.ZonedDateTime.prototype.day (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.day)
-    pub fn day(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn day(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.day")?;
         let day = this_zoned_date_time.zoned_date_time().day();
@@ -528,11 +519,7 @@ impl ZonedDateTimePrototype {
     }
 
     /// get Temporal.ZonedDateTime.prototype.hour (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.hour)
-    pub fn hour(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn hour(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.hour")?;
         let hour = this_zoned_date_time.zoned_date_time().hour();
@@ -544,7 +531,7 @@ impl ZonedDateTimePrototype {
     pub fn minute(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.minute")?;
@@ -557,7 +544,7 @@ impl ZonedDateTimePrototype {
     pub fn second(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.second")?;
@@ -570,7 +557,7 @@ impl ZonedDateTimePrototype {
     pub fn millisecond(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.millisecond")?;
@@ -583,7 +570,7 @@ impl ZonedDateTimePrototype {
     pub fn microsecond(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.microsecond")?;
@@ -596,7 +583,7 @@ impl ZonedDateTimePrototype {
     pub fn nanosecond(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.nanosecond")?;
@@ -609,7 +596,7 @@ impl ZonedDateTimePrototype {
     pub fn offset(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.offset")?;
@@ -622,7 +609,7 @@ impl ZonedDateTimePrototype {
     pub fn offset_nanoseconds(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.offsetNanoseconds")?;
@@ -635,7 +622,7 @@ impl ZonedDateTimePrototype {
     pub fn day_of_week(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.dayOfWeek")?;
@@ -648,7 +635,7 @@ impl ZonedDateTimePrototype {
     pub fn day_of_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.dayOfYear")?;
@@ -661,7 +648,7 @@ impl ZonedDateTimePrototype {
     pub fn week_of_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.weekOfYear")?;
@@ -676,7 +663,7 @@ impl ZonedDateTimePrototype {
     pub fn year_of_week(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.yearOfWeek")?;
@@ -691,7 +678,7 @@ impl ZonedDateTimePrototype {
     pub fn days_in_week(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.daysInWeek")?;
@@ -704,7 +691,7 @@ impl ZonedDateTimePrototype {
     pub fn days_in_month(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.daysInMonth")?;
@@ -717,7 +704,7 @@ impl ZonedDateTimePrototype {
     pub fn days_in_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.daysInYear")?;
@@ -730,7 +717,7 @@ impl ZonedDateTimePrototype {
     pub fn months_in_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.monthsInYear")?;
@@ -743,7 +730,7 @@ impl ZonedDateTimePrototype {
     pub fn in_leap_year(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.inLeapYear")?;
@@ -756,7 +743,7 @@ impl ZonedDateTimePrototype {
     pub fn hours_in_day(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.hoursInDay";
 
@@ -774,16 +761,16 @@ impl ZonedDateTimePrototype {
     pub fn add(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.add";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let duration_arg = get_argument(cx, arguments, 0);
+        let duration_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, duration_arg, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
@@ -801,16 +788,16 @@ impl ZonedDateTimePrototype {
     pub fn subtract(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.subtract";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let duration_arg = get_argument(cx, arguments, 0);
+        let duration_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, duration_arg, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let overflow = get_overflow_option(cx, options, NAME)?;
 
@@ -826,7 +813,7 @@ impl ZonedDateTimePrototype {
     pub fn until(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Self::diff(cx, this_value, arguments, DiffOperation::Until, "ZonedDateTime.prototype.until")
     }
@@ -835,7 +822,7 @@ impl ZonedDateTimePrototype {
     pub fn since(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         Self::diff(cx, this_value, arguments, DiffOperation::Since, "ZonedDateTime.prototype.since")
     }
@@ -843,16 +830,16 @@ impl ZonedDateTimePrototype {
     fn diff(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
         operation: DiffOperation,
         method_name: &str,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, method_name)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other = to_temporal_zoned_date_time(cx, other_arg, method_name)?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, method_name)?;
         let difference_settings = get_difference_settings(cx, options, method_name)?;
 
@@ -878,13 +865,13 @@ impl ZonedDateTimePrototype {
     pub fn round(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.round";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options = parse_round_options_argument(cx, options_arg, NAME)?;
 
         // Parse rounding options from options object
@@ -909,13 +896,13 @@ impl ZonedDateTimePrototype {
     pub fn equals(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.equals";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let other_arg = get_argument(cx, arguments, 0);
+        let other_arg = arguments.get(cx, 0);
         let other_zoned_date_time = to_temporal_zoned_date_time(cx, other_arg, NAME)?;
 
         let is_equal_result = this_zoned_date_time
@@ -930,7 +917,7 @@ impl ZonedDateTimePrototype {
     pub fn to_instant(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.toInstant")?;
@@ -943,7 +930,7 @@ impl ZonedDateTimePrototype {
     pub fn to_plain_date(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.toPlainDate")?;
@@ -956,7 +943,7 @@ impl ZonedDateTimePrototype {
     pub fn to_plain_time(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.toPlainTime")?;
@@ -969,7 +956,7 @@ impl ZonedDateTimePrototype {
     pub fn to_plain_date_time(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.toPlainDateTime")?;
@@ -982,13 +969,13 @@ impl ZonedDateTimePrototype {
     pub fn to_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.toString";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options = validate_options_object(cx, options_arg, NAME)?;
 
         // Parse display and rounding options from options object
@@ -1023,7 +1010,7 @@ impl ZonedDateTimePrototype {
     pub fn to_locale_string(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.toLocaleString";
 
@@ -1047,7 +1034,7 @@ impl ZonedDateTimePrototype {
     pub fn to_json(
         mut cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.toJSON";
 
@@ -1068,11 +1055,7 @@ impl ZonedDateTimePrototype {
     }
 
     /// Temporal.ZonedDateTime.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         type_error(cx, "ZonedDateTime.prototype.valueOf must not be called")
     }
 
@@ -1080,13 +1063,13 @@ impl ZonedDateTimePrototype {
     pub fn with(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.with";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let date_like_arg = get_argument(cx, arguments, 0);
+        let date_like_arg = arguments.get(cx, 0);
         if !is_partial_temporal_object(cx, date_like_arg)? {
             return type_error(
                 cx,
@@ -1118,7 +1101,7 @@ impl ZonedDateTimePrototype {
             NAME,
         )?;
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = validate_options_object(cx, options_arg, NAME)?;
         let disambiguation = get_disambiguation_option(cx, options, NAME)?;
         let offset = get_offset_option(cx, options, OffsetDisambiguation::Prefer, NAME)?;
@@ -1142,13 +1125,13 @@ impl ZonedDateTimePrototype {
     pub fn with_plain_time(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.withPlainTime";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let time_arg = get_argument(cx, arguments, 0);
+        let time_arg = arguments.get(cx, 0);
         let time = if time_arg.is_undefined() {
             None
         } else {
@@ -1167,13 +1150,13 @@ impl ZonedDateTimePrototype {
     pub fn with_time_zone(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.withTimeZone";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let time_zone_arg = get_argument(cx, arguments, 0);
+        let time_zone_arg = arguments.get(cx, 0);
         let time_zone = to_time_zone_identifier(cx, time_zone_arg, NAME)?;
 
         let new_zoned_date_time_result = this_zoned_date_time
@@ -1188,13 +1171,13 @@ impl ZonedDateTimePrototype {
     pub fn with_calendar(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.withCalendar";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let calendar_arg = get_argument(cx, arguments, 0);
+        let calendar_arg = arguments.get(cx, 0);
         let calendar = to_temporal_calendar_identifier(cx, calendar_arg, NAME)?;
 
         let new_zoned_date_time = this_zoned_date_time
@@ -1208,7 +1191,7 @@ impl ZonedDateTimePrototype {
     pub fn start_of_day(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.startOfDay";
 
@@ -1226,13 +1209,13 @@ impl ZonedDateTimePrototype {
     pub fn get_time_zone_transition(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         const NAME: &str = "ZonedDateTime.prototype.getTimeZoneTransition";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
 
-        let direction_arg = get_argument(cx, arguments, 0);
+        let direction_arg = arguments.get(cx, 0);
         if direction_arg.is_undefined() {
             return type_error(
                 cx,

--- a/src/js/runtime/intrinsics/typed_array.rs
+++ b/src/js/runtime/intrinsics/typed_array.rs
@@ -8,13 +8,12 @@ use crate::{
     common::math::f64_to_f16,
     create_typed_array_constructor, create_typed_array_prototype, extend_object, heap_trait_object,
     runtime::{
-        Context, Handle, HeapPtr,
+        Arguments, Context, Handle, HeapPtr,
         abstract_operations::{get, get_method, length_of_array_like, set},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::{range_error, type_error},
         eval_result::EvalResult,
-        function::get_argument,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::{

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -1,13 +1,12 @@
 use crate::{
     eval_err, must, must_a,
     runtime::{
-        Context, Handle, PropertyKey, Realm,
+        Arguments, Context, Handle, PropertyKey, Realm,
         abstract_operations::{call_object, get_method, length_of_array_like, set},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
-        function::get_argument,
         get,
         intrinsics::{
             encodings::{
@@ -96,11 +95,7 @@ impl TypedArrayConstructor {
     }
 
     /// %TypedArray% (https://tc39.es/ecma262/#sec-%typedarray%)
-    pub fn construct(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn construct(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         type_error(cx, "TypedArray constructor is abstract and cannot be called")
     }
 
@@ -108,7 +103,7 @@ impl TypedArrayConstructor {
     pub fn from(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if !is_constructor_value(this_value) {
             return type_error(cx, "TypedArray.from must be called on a constructor");
@@ -117,7 +112,7 @@ impl TypedArrayConstructor {
         let this_constructor = this_value.as_object();
 
         let map_function = {
-            let argument = get_argument(cx, arguments, 1);
+            let argument = arguments.get(cx, 1);
             if argument.is_undefined() {
                 None
             } else if !is_callable(argument) {
@@ -127,8 +122,8 @@ impl TypedArrayConstructor {
             }
         };
 
-        let source = get_argument(cx, arguments, 0);
-        let this_argument = get_argument(cx, arguments, 2);
+        let source = arguments.get(cx, 0);
+        let this_argument = arguments.get(cx, 2);
 
         let iterator_key = cx.well_known_symbols.iterator();
         let iterator = get_method(cx, source, iterator_key)?;
@@ -210,14 +205,14 @@ impl TypedArrayConstructor {
     pub fn from_base64(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let string_arg = get_argument(cx, arguments, 0);
+        let string_arg = arguments.get(cx, 0);
         if !string_arg.is_string() {
             return type_error(cx, "Uint8Array.fromBase64 argument must be a string");
         }
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options = get_base64_options_argument(cx, options_arg, "Uint8Array.fromBase64")?;
 
         let alphabet = get_base64_alphabet_option(cx, options, "Uint8Array.fromBase64")?;
@@ -243,9 +238,9 @@ impl TypedArrayConstructor {
     pub fn from_hex(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let string_arg = get_argument(cx, arguments, 0);
+        let string_arg = arguments.get(cx, 0);
         if !string_arg.is_string() {
             return type_error(cx, "Uint8Array.fromHex argument must be a string");
         }
@@ -281,7 +276,7 @@ impl TypedArrayConstructor {
     pub fn of(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if !is_constructor_value(this_value) {
             return type_error(cx, "TypedArray.of must be called on a constructor");
@@ -757,7 +752,7 @@ macro_rules! create_typed_array_constructor {
             pub fn construct(
                 mut cx: Context,
                 _: Handle<Value>,
-                arguments: &[Handle<Value>],
+                arguments: Arguments,
             ) -> EvalResult<Handle<Value>> {
                 let new_target = if let Some(new_target) = cx.current_new_target() {
                     new_target
@@ -775,7 +770,7 @@ macro_rules! create_typed_array_constructor {
                     return Self::allocate_with_length(cx, new_target, 0);
                 }
 
-                let argument = get_argument(cx, arguments, 0);
+                let argument = arguments.get(cx, 0);
                 if !argument.is_object() {
                     let length = to_index(cx, argument)?;
                     return Self::allocate_with_length(cx, new_target, length);
@@ -791,8 +786,8 @@ macro_rules! create_typed_array_constructor {
                         argument.as_typed_array(),
                     );
                 } else if let Some(argument) = argument.as_array_buffer() {
-                    let byte_offset = get_argument(cx, arguments, 1);
-                    let length = get_argument(cx, arguments, 2);
+                    let byte_offset = arguments.get(cx, 1);
+                    let length = arguments.get(cx, 2);
 
                     return Self::initialize_typed_array_from_array_buffer(
                         cx,

--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -5,7 +5,7 @@ use num_bigint::{BigUint, Sign};
 use crate::{
     eval_err, must,
     runtime::{
-        Context, EvalResult, Handle, PropertyKey, Realm, Value,
+        Arguments, Context, EvalResult, Handle, PropertyKey, Realm, Value,
         abstract_operations::{
             call_object, construct, create_data_property_or_throw, has_property, invoke,
             length_of_array_like, set, species_constructor,
@@ -13,7 +13,6 @@ use crate::{
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::{range_error, type_error},
-        function::get_argument,
         get,
         intrinsics::{
             array_buffer_constructor::clone_array_buffer,
@@ -358,7 +357,7 @@ impl TypedArrayPrototype {
     pub fn at(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "at")?;
         let typed_array = typed_array_record.typed_array;
@@ -366,7 +365,7 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record);
 
-        let index_arg = get_argument(cx, arguments, 0);
+        let index_arg = arguments.get(cx, 0);
         let relative_index = to_integer_or_infinity(cx, index_arg)?;
 
         let key = if relative_index >= 0.0 {
@@ -390,7 +389,7 @@ impl TypedArrayPrototype {
     pub fn buffer(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = this_typed_array(cx, this_value, "buffer")?;
         Ok(typed_array.viewed_array_buffer().as_value())
@@ -400,7 +399,7 @@ impl TypedArrayPrototype {
     pub fn byte_length(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = this_typed_array(cx, this_value, "byteLength")?;
 
@@ -418,7 +417,7 @@ impl TypedArrayPrototype {
     pub fn byte_offset(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = this_typed_array(cx, this_value, "byteOffset")?;
 
@@ -434,7 +433,7 @@ impl TypedArrayPrototype {
     pub fn copy_within(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "copyWithin")?;
         let typed_array = typed_array_record.typed_array;
@@ -442,13 +441,13 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let target_arg = get_argument(cx, arguments, 0);
+        let target_arg = arguments.get(cx, 0);
         let to_index = resolve_relative_index_argument(cx, target_arg, length)?;
 
-        let start_arg = get_argument(cx, arguments, 1);
+        let start_arg = arguments.get(cx, 1);
         let from_start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
-        let end_argument = get_argument(cx, arguments, 2);
+        let end_argument = arguments.get(cx, 2);
         let from_end_index = if !end_argument.is_undefined() {
             resolve_relative_index_argument(cx, end_argument, length)?
         } else {
@@ -541,7 +540,7 @@ impl TypedArrayPrototype {
     pub fn entries(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "entries")?;
         let typed_array_object = typed_array_record.typed_array.into_object_value();
@@ -553,7 +552,7 @@ impl TypedArrayPrototype {
     pub fn every(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "every")?;
         let typed_array = typed_array_record.typed_array;
@@ -561,13 +560,13 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "TypedArray.prototype.every callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         // Shared between iterations
         let mut index_key = PropertyKey::uninit().to_handle(cx);
@@ -593,7 +592,7 @@ impl TypedArrayPrototype {
     pub fn fill(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "fill")?;
         let typed_array = typed_array_record.typed_array;
@@ -601,16 +600,16 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let value_arg = get_argument(cx, arguments, 0);
+        let value_arg = arguments.get(cx, 0);
         let value = match typed_array.content_type() {
             ContentType::Number => to_number(cx, value_arg)?,
             ContentType::BigInt => to_bigint(cx, value_arg)?.into(),
         };
 
-        let start_arg = get_argument(cx, arguments, 1);
+        let start_arg = arguments.get(cx, 1);
         let start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
-        let end_argument = get_argument(cx, arguments, 2);
+        let end_argument = arguments.get(cx, 2);
         let end_index = if !end_argument.is_undefined() {
             resolve_relative_index_argument(cx, end_argument, length)?
         } else {
@@ -639,7 +638,7 @@ impl TypedArrayPrototype {
     pub fn filter(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "filter")?;
         let typed_array = typed_array_record.typed_array;
@@ -647,13 +646,13 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "TypedArray.prototype.filter callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         let mut kept_values = vec![];
 
@@ -697,7 +696,7 @@ impl TypedArrayPrototype {
     pub fn find(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "find")?;
         let typed_array = typed_array_record.typed_array;
@@ -705,13 +704,13 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let predicate_function = get_argument(cx, arguments, 0);
+        let predicate_function = arguments.get(cx, 0);
         if !is_callable(predicate_function) {
             return type_error(cx, "TypedArray.prototype.find callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         let find_result = find_via_predicate(cx, object, 0..length, predicate_function, this_arg)?;
 
@@ -725,7 +724,7 @@ impl TypedArrayPrototype {
     pub fn find_index(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "findIndex")?;
         let typed_array = typed_array_record.typed_array;
@@ -733,13 +732,13 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let predicate_function = get_argument(cx, arguments, 0);
+        let predicate_function = arguments.get(cx, 0);
         if !is_callable(predicate_function) {
             return type_error(cx, "TypedArray.prototype.findIndex callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         let find_result = find_via_predicate(cx, object, 0..length, predicate_function, this_arg)?;
 
@@ -753,7 +752,7 @@ impl TypedArrayPrototype {
     pub fn find_last(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "findLast")?;
         let typed_array = typed_array_record.typed_array;
@@ -761,13 +760,13 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let predicate_function = get_argument(cx, arguments, 0);
+        let predicate_function = arguments.get(cx, 0);
         if !is_callable(predicate_function) {
             return type_error(cx, "TypedArray.prototype.findLast callback must be a function");
         }
 
         let predicate_function = predicate_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         let find_result =
             find_via_predicate(cx, object, (0..length).rev(), predicate_function, this_arg)?;
@@ -782,7 +781,7 @@ impl TypedArrayPrototype {
     pub fn find_last_index(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "findLastIndex")?;
         let typed_array = typed_array_record.typed_array;
@@ -790,7 +789,7 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let predicate_function = get_argument(cx, arguments, 0);
+        let predicate_function = arguments.get(cx, 0);
         if !is_callable(predicate_function) {
             return type_error(
                 cx,
@@ -799,7 +798,7 @@ impl TypedArrayPrototype {
         }
 
         let predicate_function = predicate_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         let find_result =
             find_via_predicate(cx, object, (0..length).rev(), predicate_function, this_arg)?;
@@ -814,7 +813,7 @@ impl TypedArrayPrototype {
     pub fn for_each(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "forEach")?;
         let typed_array = typed_array_record.typed_array;
@@ -822,13 +821,13 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "TypedArray.prototype.forEach callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         // Shared between iterations
         let mut index_key = PropertyKey::uninit().to_handle(cx);
@@ -851,7 +850,7 @@ impl TypedArrayPrototype {
     pub fn includes(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "includes")?;
         let typed_array = typed_array_record.typed_array;
@@ -863,9 +862,9 @@ impl TypedArrayPrototype {
             return Ok(cx.bool(false));
         }
 
-        let search_element = get_argument(cx, arguments, 0);
+        let search_element = arguments.get(cx, 0);
 
-        let n_arg = get_argument(cx, arguments, 1);
+        let n_arg = arguments.get(cx, 1);
         let start_index = resolve_relative_index_argument(cx, n_arg, length)?;
 
         // Shared between iterations
@@ -887,7 +886,7 @@ impl TypedArrayPrototype {
     pub fn index_of(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "indexOf")?;
         let typed_array = typed_array_record.typed_array;
@@ -899,9 +898,9 @@ impl TypedArrayPrototype {
             return Ok(cx.negative_one());
         }
 
-        let search_element = get_argument(cx, arguments, 0);
+        let search_element = arguments.get(cx, 0);
 
-        let n_arg = get_argument(cx, arguments, 1);
+        let n_arg = arguments.get(cx, 1);
         let start_index = resolve_relative_index_argument(cx, n_arg, length)?;
 
         // Shared between iterations
@@ -924,7 +923,7 @@ impl TypedArrayPrototype {
     pub fn join(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "join")?;
         let typed_array = typed_array_record.typed_array;
@@ -932,7 +931,7 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record);
 
-        let separator = get_argument(cx, arguments, 0);
+        let separator = arguments.get(cx, 0);
         let separator = if separator.is_undefined() {
             cx.names.comma().as_string()
         } else {
@@ -962,11 +961,7 @@ impl TypedArrayPrototype {
     }
 
     /// %TypedArray%.prototype.keys (https://tc39.es/ecma262/#sec-%typedarray%.prototype.keys)
-    pub fn keys(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn keys(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "keys")?;
         let typed_array_object = typed_array_record.typed_array.into_object_value();
 
@@ -977,7 +972,7 @@ impl TypedArrayPrototype {
     pub fn last_index_of(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "lastIndexOf")?;
         let typed_array = typed_array_record.typed_array;
@@ -989,10 +984,10 @@ impl TypedArrayPrototype {
             return Ok(cx.negative_one());
         }
 
-        let search_element = get_argument(cx, arguments, 0);
+        let search_element = arguments.get(cx, 0);
 
         let start_index = if arguments.len() >= 2 {
-            let start_arg = get_argument(cx, arguments, 1);
+            let start_arg = arguments.get(cx, 1);
             let n = to_integer_or_infinity(cx, start_arg)?;
             if n == f64::NEG_INFINITY {
                 return Ok(cx.negative_one());
@@ -1033,7 +1028,7 @@ impl TypedArrayPrototype {
     pub fn length(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = this_typed_array(cx, this_value, "length")?;
 
@@ -1051,7 +1046,7 @@ impl TypedArrayPrototype {
     pub fn map(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "map")?;
         let typed_array = typed_array_record.typed_array;
@@ -1059,13 +1054,13 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record);
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "TypedArray.prototype.map mapper must be a function");
         }
 
         let callback_function = callback_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         let length_value = cx.number(length);
         let array = typed_array_species_create_object(cx, typed_array, &[length_value], "map")?;
@@ -1092,7 +1087,7 @@ impl TypedArrayPrototype {
     pub fn reduce(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "reduce")?;
         let typed_array = typed_array_record.typed_array;
@@ -1100,7 +1095,7 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "TypedArray.prototype.reduce callback must be a function");
         }
@@ -1109,7 +1104,7 @@ impl TypedArrayPrototype {
         let mut initial_index = 0;
 
         let mut accumulator = if arguments.len() >= 2 {
-            get_argument(cx, arguments, 1)
+            arguments.get(cx, 1)
         } else if length == 0 {
             return type_error(cx, "TypedArray.prototype.reduce does not have an initial value");
         } else {
@@ -1139,7 +1134,7 @@ impl TypedArrayPrototype {
     pub fn reduce_right(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "reduceRight")?;
         let typed_array = typed_array_record.typed_array;
@@ -1147,7 +1142,7 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "TypedArray.prototype.reduceRight callback must be a function");
         }
@@ -1156,7 +1151,7 @@ impl TypedArrayPrototype {
         let mut initial_index = length as i64 - 1;
 
         let mut accumulator = if arguments.len() >= 2 {
-            get_argument(cx, arguments, 1)
+            arguments.get(cx, 1)
         } else if length == 0 {
             return type_error(
                 cx,
@@ -1189,7 +1184,7 @@ impl TypedArrayPrototype {
     pub fn reverse(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "reverse")?;
         let typed_array = typed_array_record.typed_array;
@@ -1227,18 +1222,18 @@ impl TypedArrayPrototype {
     pub fn set(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "set")?;
         let typed_array = typed_array_record.typed_array;
 
-        let offset_arg = get_argument(cx, arguments, 1);
+        let offset_arg = arguments.get(cx, 1);
         let offset = to_integer_or_infinity(cx, offset_arg)?;
         if offset < 0.0 {
             return range_error(cx, "TypedArray.prototype.set offset is negative");
         }
 
-        let source_arg = get_argument(cx, arguments, 0);
+        let source_arg = arguments.get(cx, 0);
         if source_arg.is_object() && source_arg.as_object().is_typed_array() {
             Self::set_typed_array_from_typed_array(
                 cx,
@@ -1376,16 +1371,16 @@ impl TypedArrayPrototype {
     pub fn set_from_base64(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = validate_uint8_array(cx, this_value, "setFromBase64")?;
 
-        let string_arg = get_argument(cx, arguments, 0);
+        let string_arg = arguments.get(cx, 0);
         if !string_arg.is_string() {
             return type_error(cx, "Uint8Array.prototype.setFromBase64 argument must be a string");
         }
 
-        let options_arg = get_argument(cx, arguments, 1);
+        let options_arg = arguments.get(cx, 1);
         let options =
             get_base64_options_argument(cx, options_arg, "Uint8Array.prototype.setFromBase64")?;
 
@@ -1423,11 +1418,11 @@ impl TypedArrayPrototype {
     pub fn set_from_hex(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = validate_uint8_array(cx, this_value, "setFromHex")?;
 
-        let string_arg = get_argument(cx, arguments, 0);
+        let string_arg = arguments.get(cx, 0);
         if !string_arg.is_string() {
             return type_error(cx, "Uint8Array.prototype.setFromHex argument must be a string");
         }
@@ -1488,7 +1483,7 @@ impl TypedArrayPrototype {
     pub fn slice(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "slice")?;
         let typed_array = typed_array_record.typed_array;
@@ -1496,10 +1491,10 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record) as u64;
 
-        let start_arg = get_argument(cx, arguments, 0);
+        let start_arg = arguments.get(cx, 0);
         let start_index = resolve_relative_index_argument(cx, start_arg, length)?;
 
-        let end_argument = get_argument(cx, arguments, 1);
+        let end_argument = arguments.get(cx, 1);
         let end_index = if !end_argument.is_undefined() {
             resolve_relative_index_argument(cx, end_argument, length)?
         } else {
@@ -1570,7 +1565,7 @@ impl TypedArrayPrototype {
     pub fn some(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "some")?;
         let typed_array = typed_array_record.typed_array;
@@ -1578,13 +1573,13 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record);
 
-        let callback_function = get_argument(cx, arguments, 0);
+        let callback_function = arguments.get(cx, 0);
         if !is_callable(callback_function) {
             return type_error(cx, "TypedArray.prototype.some callback must be a function");
         }
 
         let callback_function = callback_function.as_object();
-        let this_arg = get_argument(cx, arguments, 1);
+        let this_arg = arguments.get(cx, 1);
 
         // Shared between iterations
         let mut index_key = PropertyKey::uninit().to_handle(cx);
@@ -1610,9 +1605,9 @@ impl TypedArrayPrototype {
     pub fn sort(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let compare_function_arg = get_argument(cx, arguments, 0);
+        let compare_function_arg = arguments.get(cx, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
             return type_error(cx, "TypedArray.prototype.sort comparator must be a function");
         };
@@ -1646,7 +1641,7 @@ impl TypedArrayPrototype {
     pub fn subarray(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = this_typed_array(cx, this_value, "subarray")?;
         let buffer = typed_array.viewed_array_buffer();
@@ -1658,10 +1653,10 @@ impl TypedArrayPrototype {
             typed_array_length(&source_record) as u64
         };
 
-        let start_arg = get_argument(cx, arguments, 0);
+        let start_arg = arguments.get(cx, 0);
         let start_index = resolve_relative_index_argument(cx, start_arg, source_length)?;
 
-        let end_argument = get_argument(cx, arguments, 1);
+        let end_argument = arguments.get(cx, 1);
         let end_index = if !end_argument.is_undefined() {
             resolve_relative_index_argument(cx, end_argument, source_length)?
         } else {
@@ -1699,11 +1694,11 @@ impl TypedArrayPrototype {
     pub fn to_base64(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = validate_uint8_array(cx, this_value, "toBase64")?;
 
-        let options_arg = get_argument(cx, arguments, 0);
+        let options_arg = arguments.get(cx, 0);
         let options =
             get_base64_options_argument(cx, options_arg, "Uint8Array.prototype.toBase64")?;
 
@@ -1730,7 +1725,7 @@ impl TypedArrayPrototype {
     pub fn to_hex(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array = validate_uint8_array(cx, this_value, "toHex")?;
 
@@ -1754,7 +1749,7 @@ impl TypedArrayPrototype {
     pub fn to_locale_string(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "toLocaleString")?;
         let typed_array = typed_array_record.typed_array;
@@ -1788,7 +1783,7 @@ impl TypedArrayPrototype {
     pub fn to_reversed(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "toReversed")?;
         let typed_array = typed_array_record.typed_array;
@@ -1817,9 +1812,9 @@ impl TypedArrayPrototype {
     pub fn to_sorted(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let compare_function_arg = get_argument(cx, arguments, 0);
+        let compare_function_arg = arguments.get(cx, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
             return type_error(cx, "TypedArray.prototype.toSorted comparator must be a function");
         };
@@ -1855,7 +1850,7 @@ impl TypedArrayPrototype {
     pub fn values(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "values")?;
         let typed_array_object = typed_array_record.typed_array.into_object_value();
@@ -1867,7 +1862,7 @@ impl TypedArrayPrototype {
     pub fn with(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let typed_array_record = this_typed_array_record(cx, this_value, "with")?;
         let typed_array = typed_array_record.typed_array;
@@ -1875,7 +1870,7 @@ impl TypedArrayPrototype {
         let object = typed_array.into_object_value();
         let length = typed_array_length(&typed_array_record);
 
-        let index_arg = get_argument(cx, arguments, 0);
+        let index_arg = arguments.get(cx, 0);
         let relative_index = to_integer_or_infinity(cx, index_arg)?;
 
         // Convert from relative to actual index, making sure index is in range
@@ -1886,7 +1881,7 @@ impl TypedArrayPrototype {
         };
 
         // Convert new value to correct typed
-        let new_value = get_argument(cx, arguments, 1);
+        let new_value = arguments.get(cx, 1);
         let new_value = match typed_array.content_type() {
             ContentType::BigInt => to_bigint(cx, new_value)?.into(),
             ContentType::Number => to_number(cx, new_value)?,
@@ -1939,7 +1934,7 @@ impl TypedArrayPrototype {
     pub fn get_to_string_tag(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if !this_value.is_object() {
             return Ok(cx.undefined());

--- a/src/js/runtime/intrinsics/weak_map_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_map_constructor.rs
@@ -1,11 +1,10 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     abstract_operations::{call_object, get},
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic, map_constructor::add_entries_from_iterable,
         rust_runtime::RuntimeFunction, weak_map_object::WeakMapObject,
@@ -42,7 +41,7 @@ impl WeakMapConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
@@ -52,7 +51,7 @@ impl WeakMapConstructor {
 
         let weak_map = WeakMapObject::new_from_constructor(cx, new_target)?;
 
-        let iterable = get_argument(cx, arguments, 0);
+        let iterable = arguments.get(cx, 0);
         if iterable.is_nullish() {
             return Ok(weak_map.as_value());
         }

--- a/src/js/runtime/intrinsics/weak_map_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_map_prototype.rs
@@ -1,10 +1,9 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     abstract_operations::call,
     alloc_error::AllocResult,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic, rust_runtime::RuntimeFunction, weak_map_object::WeakMapObject,
         weak_ref_constructor::can_be_held_weakly,
@@ -83,12 +82,12 @@ impl WeakMapPrototype {
     pub fn delete(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let weak_map_object = this_weak_map_object(cx, this_value, "delete")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value map
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
 
         // May allocate
         let map_key = ValueCollectionKey::from(value)?;
@@ -102,12 +101,12 @@ impl WeakMapPrototype {
     pub fn get(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let weak_map_object = this_weak_map_object(cx, this_value, "get")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value map
-        let key = get_argument(cx, arguments, 0);
+        let key = arguments.get(cx, 0);
 
         // May allocate
         let map_key = ValueCollectionKey::from(key)?;
@@ -125,12 +124,12 @@ impl WeakMapPrototype {
     pub fn get_or_insert(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let weak_map_object = this_weak_map_object(cx, this_value, "getOrInsert")?;
 
-        let key = get_argument(cx, arguments, 0);
-        let value = get_argument(cx, arguments, 1);
+        let key = arguments.get(cx, 0);
+        let value = arguments.get(cx, 1);
 
         validate_can_be_held_weakly(cx, key, "getOrInsert")?;
 
@@ -149,12 +148,12 @@ impl WeakMapPrototype {
     pub fn get_or_insert_computed(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let weak_map_object = this_weak_map_object(cx, this_value, "getOrInsertComputed")?;
 
-        let key = get_argument(cx, arguments, 0);
-        let callback = get_argument(cx, arguments, 1);
+        let key = arguments.get(cx, 0);
+        let callback = arguments.get(cx, 1);
 
         validate_can_be_held_weakly(cx, key, "getOrInsertComputed")?;
 
@@ -184,12 +183,12 @@ impl WeakMapPrototype {
     pub fn has(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let weak_map_object = this_weak_map_object(cx, this_value, "has")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value map
-        let key = get_argument(cx, arguments, 0);
+        let key = arguments.get(cx, 0);
 
         // May allocate
         let map_key = ValueCollectionKey::from(key)?;
@@ -203,12 +202,12 @@ impl WeakMapPrototype {
     pub fn set(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let weak_map_object = this_weak_map_object(cx, this_value, "set")?;
 
-        let key = get_argument(cx, arguments, 0);
-        let value = get_argument(cx, arguments, 1);
+        let key = arguments.get(cx, 0);
+        let value = arguments.get(cx, 1);
 
         validate_can_be_held_weakly(cx, key, "set")?;
 

--- a/src/js/runtime/intrinsics/weak_ref_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_ref_constructor.rs
@@ -3,12 +3,11 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Arguments, Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
-        function::get_argument,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
@@ -92,7 +91,7 @@ impl WeakRefConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
@@ -100,7 +99,7 @@ impl WeakRefConstructor {
             return type_error(cx, "WeakRef constructor must be called with new");
         };
 
-        let target_value = get_argument(cx, arguments, 0);
+        let target_value = arguments.get(cx, 0);
         if !can_be_held_weakly(cx, *target_value) {
             return type_error(
                 cx,

--- a/src/js/runtime/intrinsics/weak_ref_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_ref_prototype.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     alloc_error::AllocResult,
     error::type_error,
     eval_result::EvalResult,
@@ -43,7 +43,7 @@ impl WeakRefPrototype {
     pub fn deref(
         cx: Context,
         this_value: Handle<Value>,
-        _: &[Handle<Value>],
+        _: Arguments,
     ) -> EvalResult<Handle<Value>> {
         if let Some(weak_ref_object) = this_weak_ref_value(this_value) {
             Ok(weak_ref_object.weak_ref_target().to_handle(cx))

--- a/src/js/runtime/intrinsics/weak_set_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_set_constructor.rs
@@ -1,11 +1,10 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     abstract_operations::{call_object, get},
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic, rust_runtime::RuntimeFunction, weak_set_object::WeakSetObject,
     },
@@ -42,7 +41,7 @@ impl WeakSetConstructor {
     pub fn construct(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
@@ -52,7 +51,7 @@ impl WeakSetConstructor {
 
         let weak_set = WeakSetObject::new_from_constructor(cx, new_target)?;
 
-        let iterable = get_argument(cx, arguments, 0);
+        let iterable = arguments.get(cx, 0);
         if iterable.is_nullish() {
             return Ok(weak_set.as_value());
         }

--- a/src/js/runtime/intrinsics/weak_set_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_set_prototype.rs
@@ -1,9 +1,8 @@
 use crate::runtime::{
-    Context, Handle, Value,
+    Arguments, Context, Handle, Value,
     alloc_error::AllocResult,
     error::type_error,
     eval_result::EvalResult,
-    function::get_argument,
     intrinsics::{
         intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
         weak_ref_constructor::can_be_held_weakly, weak_set_object::WeakSetObject,
@@ -60,11 +59,11 @@ impl WeakSetPrototype {
     pub fn add(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let weak_set_object = this_weak_set_value(cx, this_value, "add")?;
 
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         if !can_be_held_weakly(cx, *value) {
             return type_error(
                 cx,
@@ -81,12 +80,12 @@ impl WeakSetPrototype {
     pub fn delete(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let weak_set_object = this_weak_set_value(cx, this_value, "delete")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value set
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
 
         // May allocate
         let set_key = ValueCollectionKey::from(value)?;
@@ -100,12 +99,12 @@ impl WeakSetPrototype {
     pub fn has(
         cx: Context,
         this_value: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         let weak_set_object = this_weak_set_value(cx, this_value, "has")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value set
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
 
         // May allocate
         let set_key = ValueCollectionKey::from(value)?;

--- a/src/js/runtime/mod.rs
+++ b/src/js/runtime/mod.rs
@@ -62,6 +62,7 @@ pub use context::{Context, ContextBuilder};
 pub use error::BsResult;
 pub use eval_result::EvalResult;
 pub use gc::{Handle, HeapPtr};
+pub use intrinsics::rust_runtime::Arguments;
 pub use property_descriptor::PropertyDescriptor;
 pub use property_key::PropertyKey;
 pub use realm::Realm;

--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -3,13 +3,12 @@ use std::{collections::HashMap, path::Path};
 use crate::{
     completion_value, eval_err, if_abrupt_reject_promise, must, must_a,
     runtime::{
-        Context, EvalResult, Handle, PropertyKey, Value,
+        Arguments, Context, EvalResult, Handle, PropertyKey, Value,
         abstract_operations::{KeyOrValue, call_object, enumerable_own_property_names},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         context::ModuleCacheKey,
         error::type_error_value,
-        function::get_argument,
         get,
         heap_item_descriptor::HeapItemKind,
         interned_strings::InternedStrings,
@@ -137,7 +136,7 @@ fn set_capability(
 pub fn load_requested_modules_static_resolve(
     mut cx: Context,
     _: Handle<Value>,
-    _: &[Handle<Value>],
+    _: Arguments,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the module and capbility passed from `execute_module`
     let current_function = cx.current_function();
@@ -167,13 +166,13 @@ pub fn load_requested_modules_static_resolve(
 pub fn load_requested_modules_reject(
     mut cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the capbility passed from `execute_module`
     let current_function = cx.current_function();
     let capability = get_capability(cx, current_function);
 
-    let error = get_argument(cx, arguments, 0);
+    let error = arguments.get(cx, 0);
     must!(call_object(cx, capability.reject(), cx.undefined(), &[error]));
 
     Ok(cx.undefined())
@@ -417,7 +416,7 @@ fn execute_async_module(mut cx: Context, module: Handle<SourceTextModule>) -> Al
 pub fn async_module_execution_fulfilled(
     mut cx: Context,
     _: Handle<Value>,
-    _: &[Handle<Value>],
+    _: Arguments,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the module passed from `execute_async_module`
     let current_function = cx.current_function();
@@ -559,13 +558,13 @@ fn async_module_execution_rejected(
 pub fn async_module_execution_rejected_runtime(
     mut cx: Context,
     _: Handle<Value>,
-    arguments: &[Handle<Value>],
+    arguments: Arguments,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the module passed from `execute_async_module`
     let current_function = cx.current_function();
     let module = get_module(cx, current_function);
 
-    let error = get_argument(cx, arguments, 0);
+    let error = arguments.get(cx, 0);
     async_module_execution_rejected(cx, module, error)?;
 
     Ok(cx.undefined())
@@ -690,7 +689,7 @@ fn continue_dynamic_import(
 pub fn load_requested_modules_dynamic_resolve(
     mut cx: Context,
     _: Handle<Value>,
-    _: &[Handle<Value>],
+    _: Arguments,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the module and capability passed from the caller
     let current_function = cx.current_function();
@@ -735,7 +734,7 @@ pub fn load_requested_modules_dynamic_resolve(
 pub fn module_evaluate_dynamic_resolve(
     mut cx: Context,
     _: Handle<Value>,
-    _: &[Handle<Value>],
+    _: Arguments,
 ) -> EvalResult<Handle<Value>> {
     // Fetch the module and capbility passed from the caller
     let current_function = cx.current_function();

--- a/src/js/runtime/module/loader.rs
+++ b/src/js/runtime/module/loader.rs
@@ -11,7 +11,7 @@ use crate::{
         context::ModuleCacheKey,
         error::{syntax_error, syntax_parse_error},
         eval_result::EvalResult,
-        intrinsics::{intrinsics::Intrinsic, json_object::JSONObject},
+        intrinsics::{intrinsics::Intrinsic, json_object::json_parse},
         module::{
             module::{DynModule, ModuleId},
             source_text_module::{ModuleRequest, ModuleState, SourceTextModule},
@@ -265,5 +265,5 @@ fn parse_json_file_at_path(mut cx: Context, path: &Path) -> EvalResult<Handle<Va
         Err(error) => return syntax_parse_error(cx, &error),
     };
 
-    JSONObject::parse(cx, cx.undefined(), &[file_contents.as_value()])
+    json_parse(cx, file_contents.as_value(), cx.undefined())
 }

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -3,12 +3,11 @@ use std::mem::size_of;
 use crate::{
     completion_value, extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr,
+        Arguments, Context, EvalResult, Handle, HeapPtr,
         abstract_operations::{call_object, construct, get_function_realm_no_error},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::{type_error, type_error_value},
-        function::get_argument,
         gc::{AnyHeapItem, HeapItem, HeapVisitor},
         get,
         heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
@@ -540,7 +539,7 @@ impl PromiseCapability {
     pub fn executor(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
         // Get the capability object that was attached to the executor function
         let current_function = cx.current_function();
@@ -558,8 +557,8 @@ impl PromiseCapability {
         }
 
         // If not, set them from the executor's arguments
-        let resolve = get_argument(cx, arguments, 0);
-        let reject = get_argument(cx, arguments, 1);
+        let resolve = arguments.get(cx, 0);
+        let reject = arguments.get(cx, 1);
 
         capability.resolve = *resolve;
         capability.reject = *reject;

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -4,12 +4,11 @@ use crate::{
     handle_scope, must_a,
     parser::source::Source,
     runtime::{
-        Context, EvalResult, Handle, PropertyKey, Realm, Value,
+        Arguments, Context, EvalResult, Handle, PropertyKey, Realm, Value,
         abstract_operations::set,
         alloc_error::AllocResult,
         error::{syntax_parse_error, type_error},
         eval::eval::evaluate_script,
-        function::get_argument,
         get,
         intrinsics::{
             array_buffer_constructor::ArrayBufferObject, intrinsics::Intrinsic,
@@ -128,12 +127,8 @@ impl Test262Object {
     }
 
     /// Adds strings to a running print log stored on the global object.
-    pub fn print(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let argument = get_argument(cx, arguments, 0);
+    pub fn print(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let argument = arguments.get(cx, 0);
         if !argument.is_string() {
             return type_error(cx, "print expects a string");
         }
@@ -147,11 +142,7 @@ impl Test262Object {
         Ok(cx.undefined())
     }
 
-    pub fn create_realm(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    pub fn create_realm(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         // Create a new realm that also has the test262 object installed
         let mut realm = Realm::new(cx)?;
         realm.install_optional_globals(cx)?;
@@ -162,9 +153,9 @@ impl Test262Object {
     pub fn eval_script(
         mut cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let script_text = get_argument(cx, arguments, 0);
+        let script_text = arguments.get(cx, 0);
         if !script_text.is_string() {
             return type_error(cx, "expected a string");
         }
@@ -187,9 +178,9 @@ impl Test262Object {
     pub fn detach_array_buffer(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let value = get_argument(cx, arguments, 0);
+        let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(cx.undefined());
         }

--- a/src/js/runtime/test_shell.rs
+++ b/src/js/runtime/test_shell.rs
@@ -8,7 +8,7 @@ use crate::{
     must_a,
     parser::source::Source,
     runtime::{
-        Context, EvalResult, Handle, PropertyDescriptor, PropertyKey, Realm, Value,
+        Arguments, Context, EvalResult, Handle, PropertyDescriptor, PropertyKey, Realm, Value,
         abstract_operations::{create_data_property_or_throw, define_property_or_throw},
         alloc_error::AllocResult,
         array_object::array_create_in_realm,
@@ -16,7 +16,6 @@ use crate::{
         console::ConsoleObject,
         error::syntax_parse_error,
         eval::eval::evaluate_script,
-        function::get_argument,
         gc_object::GcObject,
         intrinsics::{
             array_buffer_constructor::ArrayBufferObject, error_constructor::ErrorObject,
@@ -131,12 +130,8 @@ impl TestShell {
     }
 
     /// Read a file at the given path and evaluate it as a script in the current realm.
-    fn load(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let path_arg = get_argument(cx, arguments, 0);
+    fn load(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let path_arg = arguments.get(cx, 0);
         let path = resolve_path_arg(cx, path_arg)?;
 
         let source = match Source::new_from_file(&path.to_string_lossy()) {
@@ -151,9 +146,9 @@ impl TestShell {
     fn load_string(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let script_arg = get_argument(cx, arguments, 0);
+        let script_arg = arguments.get(cx, 0);
         let script_string = to_string(cx, script_arg)?.to_wtf8_string()?;
         let source = source_from_string(cx, script_string)?;
 
@@ -162,15 +157,11 @@ impl TestShell {
 
     /// Read a file to either a string or an ArrayBuffer depending on the value of the second
     /// argument.
-    fn read(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
-        let path_arg = get_argument(cx, arguments, 0);
+    fn read(mut cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+        let path_arg = arguments.get(cx, 0);
         let path = resolve_path_arg(cx, path_arg)?;
 
-        let mode_arg = get_argument(cx, arguments, 1);
+        let mode_arg = arguments.get(cx, 1);
         let is_binary = mode_arg.is_string() && mode_arg.as_string().flatten()?.eq_str("binary");
 
         if is_binary {
@@ -200,11 +191,7 @@ impl TestShell {
         }
     }
 
-    fn performance_now(
-        cx: Context,
-        _: Handle<Value>,
-        _: &[Handle<Value>],
-    ) -> EvalResult<Handle<Value>> {
+    fn performance_now(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
         let time_origin = cx.current_realm().time_origin();
         let duration_millis = time_origin.elapsed().as_secs_f64() * 1000.0;
 
@@ -215,9 +202,9 @@ impl TestShell {
     fn run_string(
         cx: Context,
         _: Handle<Value>,
-        arguments: &[Handle<Value>],
+        arguments: Arguments,
     ) -> EvalResult<Handle<Value>> {
-        let script_arg = get_argument(cx, arguments, 0);
+        let script_arg = arguments.get(cx, 0);
         let script_string = to_string(cx, script_arg)?.to_wtf8_string()?;
         let source = source_from_string(cx, script_string)?;
 

--- a/tests/fuzz/src/main.rs
+++ b/tests/fuzz/src/main.rs
@@ -13,9 +13,9 @@ use brimstone_core::{
     handle_scope, must_a,
     parser::source::Source,
     runtime::{
-        Context, ContextBuilder, EvalResult, Handle, PropertyDescriptor, PropertyKey, Value,
-        abstract_operations::define_property_or_throw, alloc_error::AllocResult,
-        builtin_function::BuiltinFunction, error::type_error, function::get_argument,
+        Arguments, Context, ContextBuilder, EvalResult, Handle, PropertyDescriptor, PropertyKey,
+        Value, abstract_operations::define_property_or_throw, alloc_error::AllocResult,
+        builtin_function::BuiltinFunction, error::type_error,
     },
 };
 
@@ -67,7 +67,7 @@ fn main() {
                 let options = Rc::new(OptionsBuilder::new().expose_gc(true).build().unwrap());
                 let cx = ContextBuilder::new().set_options(options).build()?;
 
-                cx.initial_realm().install_optional_globals(cx);
+                cx.initial_realm().install_optional_globals(cx).unwrap();
                 install_fuzzilli_function(cx)?;
 
                 // Execute test case
@@ -118,16 +118,12 @@ fn install_fuzzilli_function(mut cx: Context) -> AllocResult<()> {
     })
 }
 
-fn fuzzilli(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: &[Handle<Value>],
-) -> EvalResult<Handle<Value>> {
+fn fuzzilli(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
     if arguments.len() < 2 {
         return type_error(cx, "fuzzilli requires at least one argument");
     }
 
-    let command_arg = get_argument(cx, arguments, 0);
+    let command_arg = arguments.get(cx, 0);
     if !command_arg.is_string() {
         return type_error(cx, "fuzzilli argument must be a string");
     }
@@ -136,7 +132,7 @@ fn fuzzilli(
 
     match command.to_wtf8_string()?.as_bytes() {
         b"FUZZILLI_CRASH" => {
-            let kind = get_argument(cx, arguments, 1);
+            let kind = arguments.get(cx, 1);
             if !kind.is_smi() {
                 return type_error(cx, "fuzzilli crash argument must be an integer");
             }
@@ -150,7 +146,7 @@ fn fuzzilli(
             }
         }
         b"FUZZILLI_PRINT" => {
-            let printed = get_argument(cx, arguments, 1);
+            let printed = arguments.get(cx, 1);
             if !printed.is_string() {
                 return type_error(cx, "fuzzilli print argument must be a string");
             }


### PR DESCRIPTION
## Summary

Create a lightweight `Arguments` struct that holds runtime function arguments and provides a `get` accessor instead of using `get_argument`. This is cleaner and conciser.

## Tests

- CI