### PR TITLE
[runtime] Create all Rust runtime functions with a macro

### DIFF
--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -1,7 +1,7 @@
 use crate::{
     completion_value, eval_err, extend_object, field_offset, must_a,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         abstract_operations::call_object,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -25,7 +25,7 @@ use crate::{
         promise_object::{PromiseCapability, coerce_to_ordinary_promise},
         realm::Realm,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // An async generator object represents the state of an async generator function. It holds the
@@ -400,11 +400,8 @@ pub fn async_generator_await_return(
     Ok(())
 }
 
-pub fn await_return_resolve(
-    mut cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+runtime_fn! {
+fn await_return_resolve(cx, _, arguments) {
     let value = arguments.get(cx, 0);
 
     let current_function = cx.current_function();
@@ -416,13 +413,10 @@ pub fn await_return_resolve(
     async_generator_drain_queue(cx, async_generator)?;
 
     Ok(cx.undefined())
-}
+}}
 
-pub fn await_return_reject(
-    mut cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+runtime_fn! {
+fn await_return_reject(cx, _, arguments) {
     let value = arguments.get(cx, 0);
 
     let current_function = cx.current_function();
@@ -434,7 +428,7 @@ pub fn await_return_reject(
     async_generator_drain_queue(cx, async_generator)?;
 
     Ok(cx.undefined())
-}
+}}
 
 fn get_async_generator(cx: Context, function: Handle<ObjectValue>) -> Handle<AsyncGeneratorObject> {
     function

--- a/src/js/runtime/bound_function_object.rs
+++ b/src/js/runtime/bound_function_object.rs
@@ -1,17 +1,20 @@
-use crate::runtime::{
-    Arguments, Context, Handle,
-    abstract_operations::{call_object, construct, length_of_array_like},
-    alloc_error::AllocResult,
-    array_object::{ArrayObject, create_array_from_list},
-    builtin_function::BuiltinFunction,
-    eval_result::EvalResult,
-    gc::HeapPtr,
-    get,
-    intrinsics::rust_runtime::RuntimeFunction,
-    object_value::ObjectValue,
-    property_key::PropertyKey,
-    type_utilities::{is_constructor_object_value, same_object_value_handles},
-    value::Value,
+use crate::{
+    runtime::{
+        Context, Handle,
+        abstract_operations::{call_object, construct, length_of_array_like},
+        alloc_error::AllocResult,
+        array_object::{ArrayObject, create_array_from_list},
+        builtin_function::BuiltinFunction,
+        eval_result::EvalResult,
+        gc::HeapPtr,
+        get,
+        intrinsics::rust_runtime::RuntimeFunction,
+        object_value::ObjectValue,
+        property_key::PropertyKey,
+        type_utilities::{is_constructor_object_value, same_object_value_handles},
+        value::Value,
+    },
+    runtime_fn,
 };
 
 pub struct BoundFunctionObject;
@@ -138,16 +141,13 @@ impl BoundFunctionObject {
         )
     }
 
-    /// Call the bound function from the Rust runtime. This is called when the bound function has
-    /// been called (either normally or as a constructor).
+    runtime_fn! {
+    /// Call the bound function from the Rust runtime. This is called when the bound function
+    /// has been called (either normally or as a constructor).
     ///
     /// Combination of [[Call]] (https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist)
     /// and [[Construct]] (https://tc39.es/ecma262/#sec-bound-function-exotic-objects-construct-argumentslist-newtarget)
-    pub fn call(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn call(cx, _, arguments) {
         let bound_function = cx.current_function();
 
         let bound_target_function = Self::get_target_function(cx, bound_function);
@@ -184,5 +184,5 @@ impl BoundFunctionObject {
             // Otherwise call bound target normally
             call_object(cx, bound_target_function, bound_this, &all_arguments)
         }
-    }
+    }}
 }

--- a/src/js/runtime/console.rs
+++ b/src/js/runtime/console.rs
@@ -19,6 +19,7 @@ use crate::{
         type_utilities::number_to_string,
         value::{BOOL_TAG, NULL_TAG, UNDEFINED_TAG},
     },
+    runtime_fn,
 };
 
 enum ConsoleLogLevel {
@@ -69,25 +70,30 @@ impl ConsoleObject {
         Ok(object.to_handle())
     }
 
-    pub fn debug(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn debug(cx, _, arguments) {
         console_method_impl(cx, ConsoleLogLevel::Debug, arguments)
-    }
+    }}
 
-    pub fn error(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn error(cx, _, arguments) {
         console_method_impl(cx, ConsoleLogLevel::Error, arguments)
-    }
+    }}
 
-    pub fn info(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn info(cx, _, arguments) {
         console_method_impl(cx, ConsoleLogLevel::Info, arguments)
-    }
+    }}
 
-    pub fn log(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn log(cx, _, arguments) {
         console_method_impl(cx, ConsoleLogLevel::Log, arguments)
-    }
+    }}
 
-    pub fn warn(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn warn(cx, _, arguments) {
         console_method_impl(cx, ConsoleLogLevel::Warn, arguments)
-    }
+    }}
 }
 
 fn console_method_impl(

--- a/src/js/runtime/gc_object.rs
+++ b/src/js/runtime/gc_object.rs
@@ -1,15 +1,15 @@
 use crate::{
     handle_scope, must_a,
     runtime::{
-        Arguments, Context, Handle, PropertyDescriptor, Value,
+        Context, Handle, PropertyDescriptor,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
-        eval_result::EvalResult,
         gc::{GcType, Heap},
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         realm::Realm,
     },
+    runtime_fn,
 };
 
 pub struct GcObject;
@@ -35,8 +35,9 @@ impl GcObject {
         })
     }
 
-    pub fn run(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn run(cx, _, _) {
         Heap::run_gc(cx, GcType::Normal);
         Ok(cx.undefined())
-    }
+    }}
 }

--- a/src/js/runtime/global_names.rs
+++ b/src/js/runtime/global_names.rs
@@ -3,8 +3,7 @@ use std::collections::HashSet;
 use crate::{
     field_offset,
     runtime::{
-        Arguments, Context, EvalResult, Handle, HeapPtr, PropertyDescriptor, PropertyKey, Realm,
-        Value,
+        Context, EvalResult, Handle, HeapPtr, PropertyDescriptor, PropertyKey, Realm, Value,
         abstract_operations::{define_property_or_throw, has_own_property, is_extensible},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -17,7 +16,7 @@ use crate::{
         scope_names::ScopeNames,
         string_value::FlatString,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 #[repr(C)]
@@ -98,19 +97,16 @@ pub fn create_global_declaration_instantiation_intrinsic(
     .as_value())
 }
 
+runtime_fn! {
 /// GlobalDeclarationInstantiation in the Rust runtime, called from the script init function.
-pub fn global_declaration_instantiation_runtime(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+fn global_declaration_instantiation_runtime(cx, _, arguments) {
     let global_names = arguments.first().unwrap().cast::<GlobalNames>();
     let realm = cx.current_realm();
 
     global_declaration_instantiation(cx, realm, global_names)?;
 
     Ok(cx.undefined())
-}
+}}
 
 /// Initialize the global object with the provided var scoped names.
 ///

--- a/src/js/runtime/intrinsics/aggregate_error_constructor.rs
+++ b/src/js/runtime/intrinsics/aggregate_error_constructor.rs
@@ -1,7 +1,7 @@
 use crate::{
     must, must_a,
     runtime::{
-        Arguments, Context, Handle, Value,
+        Context, Handle, Value,
         abstract_operations::{
             create_data_property_or_throw, create_non_enumerable_data_property_or_throw,
             define_property_or_throw,
@@ -9,7 +9,6 @@ use crate::{
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         builtin_function::BuiltinFunction,
-        eval_result::EvalResult,
         intrinsics::{
             error_constructor::{ErrorObject, install_error_cause},
             intrinsics::Intrinsic,
@@ -21,6 +20,7 @@ use crate::{
         realm::Realm,
         type_utilities::to_string,
     },
+    runtime_fn,
 };
 
 /// AggregateError Objects (https://tc39.es/ecma262/#sec-aggregate-error-objects)
@@ -65,12 +65,9 @@ impl AggregateErrorConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// AggregateError (https://tc39.es/ecma262/#sec-aggregate-error)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
@@ -112,5 +109,5 @@ impl AggregateErrorConstructor {
         must!(define_property_or_throw(cx, object.into(), cx.names.errors(), errors_desc));
 
         Ok(object.as_value())
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/array_buffer_constructor.rs
+++ b/src/js/runtime/intrinsics/array_buffer_constructor.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         collections::{BsArray, array::ByteArray},
@@ -18,7 +18,7 @@ use crate::{
         realm::Realm,
         type_utilities::to_index,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // 4GB max array buffer size
@@ -187,12 +187,9 @@ impl ArrayBufferConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// ArrayBuffer (https://tc39.es/ecma262/#sec-arraybuffer-length)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
@@ -213,14 +210,11 @@ impl ArrayBufferConstructor {
             /* data */ None,
         )?
         .as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// ArrayBuffer.isView (https://tc39.es/ecma262/#sec-arraybuffer.isview)
-    pub fn is_view(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_view(cx, _, arguments) {
         let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(cx.bool(false));
@@ -230,7 +224,7 @@ impl ArrayBufferConstructor {
         let is_view = object.is_data_view() || object.is_typed_array();
 
         Ok(cx.bool(is_view))
-    }
+    }}
 }
 
 /// ArrayBufferCopyAndDetach (https://tc39.es/ecma262/#sec-arraybuffercopyanddetach)

--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -1,21 +1,24 @@
-use crate::runtime::{
-    Arguments, Context, EvalResult, Handle, Value,
-    abstract_operations::{construct, species_constructor},
-    alloc_error::AllocResult,
-    collections::BsArray,
-    error::{range_error, type_error},
-    heap_item_descriptor::HeapItemKind,
-    intrinsics::{
-        array_buffer_constructor::{
-            ArrayBufferObject, array_buffer_copy_and_detach, throw_if_detached,
+use crate::{
+    runtime::{
+        Context, EvalResult, Handle, Value,
+        abstract_operations::{construct, species_constructor},
+        alloc_error::AllocResult,
+        collections::BsArray,
+        error::{range_error, type_error},
+        heap_item_descriptor::HeapItemKind,
+        intrinsics::{
+            array_buffer_constructor::{
+                ArrayBufferObject, array_buffer_copy_and_detach, throw_if_detached,
+            },
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
         },
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
+        object_value::ObjectValue,
+        property::Property,
+        realm::Realm,
+        type_utilities::{resolve_relative_index_argument, to_index},
     },
-    object_value::ObjectValue,
-    property::Property,
-    realm::Realm,
-    type_utilities::{resolve_relative_index_argument, to_index},
+    runtime_fn,
 };
 
 pub struct ArrayBufferPrototype;
@@ -91,34 +94,25 @@ impl ArrayBufferPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// get ArrayBuffer.prototype.byteLength (https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength)
-    pub fn get_byte_length(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_byte_length(cx, this_value, _) {
         let array_buffer = require_array_buffer(cx, this_value, "byteLength")?;
 
         // Detached array buffers have byte length set to 0
         Ok(cx.number(array_buffer.byte_length()))
-    }
+    }}
 
+    runtime_fn! {
     /// get ArrayBuffer.prototype.detached (https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.detached)
-    pub fn get_detached(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_detached(cx, this_value, _) {
         let array_buffer = require_array_buffer(cx, this_value, "detached")?;
         Ok(cx.bool(array_buffer.is_detached()))
-    }
+    }}
 
+    runtime_fn! {
     /// get ArrayBuffer.prototype.maxByteLength (https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.maxbytelength)
-    pub fn get_max_byte_length(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_max_byte_length(cx, this_value, _) {
         let array_buffer = require_array_buffer(cx, this_value, "maxByteLength")?;
 
         // Detached array buffers have max byte length set to 0
@@ -127,24 +121,18 @@ impl ArrayBufferPrototype {
             .unwrap_or(array_buffer.byte_length());
 
         Ok(cx.number(max_byte_length))
-    }
+    }}
 
+    runtime_fn! {
     /// get ArrayBuffer.prototype.resizable (https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.resizable)
-    pub fn get_resizable(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_resizable(cx, this_value, _) {
         let array_buffer = require_array_buffer(cx, this_value, "resizable")?;
         Ok(cx.bool(!array_buffer.is_fixed_length()))
-    }
+    }}
 
+    runtime_fn! {
     /// ArrayBuffer.prototype.resize (https://tc39.es/ecma262/#sec-arraybuffer.prototype.resize)
-    pub fn resize(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn resize(cx, this_value, arguments) {
         let mut array_buffer = require_array_buffer(cx, this_value, "resize")?;
 
         let max_byte_length = if let Some(max_byte_length) = array_buffer.max_byte_length() {
@@ -195,14 +183,11 @@ impl ArrayBufferPrototype {
         array_buffer.set_byte_length(new_byte_length);
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// ArrayBuffer.prototype.slice (https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice)
-    pub fn slice(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn slice(cx, this_value, arguments) {
         let array_buffer = require_array_buffer(cx, this_value, "slice")?;
 
         throw_if_detached(cx, *array_buffer)?;
@@ -273,14 +258,11 @@ impl ArrayBufferPrototype {
         }
 
         Ok(new_array_buffer.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// ArrayBuffer.prototype.transfer (https://tc39.es/ecma262/#sec-arraybuffer.prototype.transfer)
-    pub fn transfer(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn transfer(cx, this_value, arguments) {
         let array_buffer = require_array_buffer(cx, this_value, "transfer")?;
         let new_length = arguments.get(cx, 0);
 
@@ -288,14 +270,11 @@ impl ArrayBufferPrototype {
             array_buffer_copy_and_detach(cx, array_buffer, new_length, /* to_fixed */ false)?;
 
         Ok(new_array_buffer.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// ArrayBuffer.prototype.transferToFixedLength (https://tc39.es/ecma262/#sec-arraybuffer.prototype.transfertofixedlength)
-    pub fn transfer_to_fixed_length(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn transfer_to_fixed_length(cx, this_value, arguments) {
         let array_buffer = require_array_buffer(cx, this_value, "transferToFixedLength")?;
         let new_length = arguments.get(cx, 0);
 
@@ -303,7 +282,7 @@ impl ArrayBufferPrototype {
             array_buffer_copy_and_detach(cx, array_buffer, new_length, /* to_fixed */ true)?;
 
         Ok(new_array_buffer.as_value())
-    }
+    }}
 }
 
 fn require_array_buffer(

--- a/src/js/runtime/intrinsics/array_constructor.rs
+++ b/src/js/runtime/intrinsics/array_constructor.rs
@@ -2,7 +2,7 @@ use crate::{
     common::numeric::MAX_SAFE_INTEGER_U64,
     must,
     runtime::{
-        Arguments, Context, EvalResult, Handle, Realm, Value,
+        Context, Handle, Realm, Value,
         abstract_operations::{
             call_object, construct, create_data_property_or_throw, get_method,
             length_of_array_like, set,
@@ -22,6 +22,7 @@ use crate::{
         property_key::PropertyKey,
         type_utilities::{is_array, is_callable, is_constructor_value, to_object, to_uint32},
     },
+    runtime_fn,
 };
 
 pub struct ArrayConstructor;
@@ -68,12 +69,9 @@ impl ArrayConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Array (https://tc39.es/ecma262/#sec-array)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = cx
             .current_new_target()
             .unwrap_or_else(|| cx.current_function());
@@ -118,14 +116,11 @@ impl ArrayConstructor {
 
             Ok(array.as_value())
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Array.from (https://tc39.es/ecma262/#sec-array.from)
-    pub fn from(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn from(cx, this_value, arguments) {
         // Determine if map function was provided and is callable
         let map_function_arg = arguments.get(cx, 1);
         let map_function = if map_function_arg.is_undefined() {
@@ -229,34 +224,25 @@ impl ArrayConstructor {
         set(cx, array, cx.names.length(), length_value, true)?;
 
         Ok(array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.fromAsync (https://tc39.es/proposal-array-from-async/#sec-array.fromasync)
-    pub fn from_async(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn from_async(cx, this_value, arguments) {
         ArrayFromAsyncGenerator::start(cx, this_value, arguments)
-    }
+    }}
 
+    runtime_fn! {
     /// Array.isArray (https://tc39.es/ecma262/#sec-array.isarray)
-    pub fn is_array(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_array(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let is_array = is_array(cx, argument)?;
         Ok(cx.bool(is_array))
-    }
+    }}
 
+    runtime_fn! {
     /// Array.of (https://tc39.es/ecma262/#sec-array.of)
-    pub fn of(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn of(cx, this_value, arguments) {
         let length = arguments.len();
         let length_value = cx.number(length);
 
@@ -278,5 +264,5 @@ impl ArrayConstructor {
         set(cx, array, cx.names.length(), length_value, true)?;
 
         Ok(array.as_value())
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/array_from_async_generator.rs
+++ b/src/js/runtime/intrinsics/array_from_async_generator.rs
@@ -21,6 +21,7 @@ use crate::{
         promise_object::{PromiseCapability, coerce_to_ordinary_promise},
         type_utilities::{is_callable, is_constructor_value, to_object},
     },
+    runtime_fn,
 };
 
 pub enum ArrayFromAsyncState {
@@ -66,18 +67,15 @@ pub enum ArrayFromAsyncState {
 pub struct ArrayFromAsyncGenerator;
 
 impl ArrayFromAsyncGenerator {
+    runtime_fn! {
     /// Start a new call to the Array.fromAsync generator function.
-    pub fn start(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn start(cx, this_value, arguments) {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
 
         let from_async_completion = Self::start_impl(cx, capability, this_value, arguments);
         BuiltinGenerator::handle_async_function_completion(cx, capability, from_async_completion)
-    }
+    }}
 
     /// Resume a paused Array.fromAsync generator function at a particular await point.
     ///

--- a/src/js/runtime/intrinsics/array_iterator.rs
+++ b/src/js/runtime/intrinsics/array_iterator.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object,
     runtime::{
-        Arguments, Context, Handle, HeapPtr,
+        Context, Handle, HeapPtr,
         abstract_operations::length_of_array_like,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
@@ -27,7 +27,7 @@ use crate::{
         realm::Realm,
         value::Value,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // Array Iterator Objects (https://tc39.es/ecma262/#sec-array-iterator-objects)
@@ -126,9 +126,10 @@ impl ArrayIteratorPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// %ArrayIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%arrayiteratorprototype%.next)
     /// Adapted from the abstract closure in CreateArrayIterator (https://tc39.es/ecma262/#sec-createarrayiterator)
-    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn next(cx, this_value, _) {
         let mut array_iterator = ArrayIterator::cast_from_value(cx, this_value)?;
         let array = array_iterator.array();
 
@@ -167,7 +168,7 @@ impl ArrayIteratorPrototype {
                 Ok(create_iter_result_object(cx, result_pair.into(), false)?)
             }
         }
-    }
+    }}
 }
 
 impl HeapItem for HeapPtr<ArrayIterator> {

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -4,7 +4,7 @@ use crate::{
     common::numeric::MAX_SAFE_INTEGER_U64,
     must, must_a,
     runtime::{
-        Arguments, Context, EvalResult, Handle, Value,
+        Context, EvalResult, Handle, Value,
         abstract_operations::{
             call, call_object, create_data_property_or_throw, delete_property_or_throw,
             has_property, invoke, length_of_array_like, set,
@@ -33,6 +33,7 @@ use crate::{
             to_number, to_object,
         },
     },
+    runtime_fn,
 };
 
 pub struct ArrayPrototype;
@@ -310,12 +311,9 @@ impl ArrayPrototype {
         Ok(array)
     }
 
+    runtime_fn! {
     /// Array.prototype.at (https://tc39.es/ecma262/#sec-array.prototype.at)
-    pub fn at(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn at(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -337,14 +335,11 @@ impl ArrayPrototype {
         };
 
         get(cx, object, key)
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.concat (https://tc39.es/ecma262/#sec-array.prototype.concat)
-    pub fn concat(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn concat(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let array = array_species_create(cx, object, 0)?;
 
@@ -360,7 +355,7 @@ impl ArrayPrototype {
         set(cx, array, cx.names.length(), new_length_value, true)?;
 
         Ok(array.as_value())
-    }
+    }}
 
     /// IsConcatSpreadable (https://tc39.es/ecma262/#sec-isconcatspreadable)
     pub fn is_concat_spreadable(cx: Context, object: Handle<Value>) -> EvalResult<bool> {
@@ -425,12 +420,9 @@ impl ArrayPrototype {
         Ok(())
     }
 
+    runtime_fn! {
     /// Array.prototype.copyWithin (https://tc39.es/ecma262/#sec-array.prototype.copywithin)
-    pub fn copy_within(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn copy_within(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -500,24 +492,18 @@ impl ArrayPrototype {
         }
 
         Ok(object.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.entries (https://tc39.es/ecma262/#sec-array.prototype.entries)
-    pub fn entries(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn entries(cx, this_value, _) {
         let object = to_object(cx, this_value)?;
         Ok(ArrayIterator::new(cx, object, ArrayIteratorKind::KeyAndValue)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.every (https://tc39.es/ecma262/#sec-array.prototype.every)
-    pub fn every(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn every(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -549,14 +535,11 @@ impl ArrayPrototype {
         }
 
         Ok(cx.bool(true))
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.fill (https://tc39.es/ecma262/#sec-array.prototype.fill)
-    pub fn fill(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn fill(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -581,14 +564,11 @@ impl ArrayPrototype {
         }
 
         Ok(object.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.filter (https://tc39.es/ecma262/#sec-array.prototype.filter)
-    pub fn filter(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn filter(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -631,14 +611,11 @@ impl ArrayPrototype {
         }
 
         Ok(array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.find (https://tc39.es/ecma262/#sec-array.prototype.find)
-    pub fn find(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn find(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -656,14 +633,11 @@ impl ArrayPrototype {
             Some((value, _)) => Ok(value),
             None => Ok(cx.undefined()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.findIndex (https://tc39.es/ecma262/#sec-array.prototype.findindex)
-    pub fn find_index(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn find_index(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -681,14 +655,11 @@ impl ArrayPrototype {
             Some((_, index_value)) => Ok(index_value),
             None => Ok(cx.negative_one()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.findLast (https://tc39.es/ecma262/#sec-array.prototype.findlast)
-    pub fn find_last(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn find_last(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -707,14 +678,11 @@ impl ArrayPrototype {
             Some((value, _)) => Ok(value),
             None => Ok(cx.undefined()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.findLastIndex (https://tc39.es/ecma262/#sec-array.prototype.findlastindex)
-    pub fn find_last_index(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn find_last_index(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -733,14 +701,11 @@ impl ArrayPrototype {
             Some((_, index_value)) => Ok(index_value),
             None => Ok(cx.negative_one()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.flat (https://tc39.es/ecma262/#sec-array.prototype.flat)
-    pub fn flat(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn flat(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -767,7 +732,7 @@ impl ArrayPrototype {
         )?;
 
         Ok(array.as_value())
-    }
+    }}
 
     /// FlattenIntoArray (https://tc39.es/ecma262/#sec-flattenintoarray)
     pub fn flatten_into_array(
@@ -844,12 +809,9 @@ impl ArrayPrototype {
         Ok(target_index)
     }
 
+    runtime_fn! {
     /// Array.prototype.flatMap (https://tc39.es/ecma262/#sec-array.prototype.flatmap)
-    pub fn flat_map(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn flat_map(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -875,14 +837,11 @@ impl ArrayPrototype {
         )?;
 
         Ok(array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.forEach (https://tc39.es/ecma262/#sec-array.prototype.foreach)
-    pub fn for_each(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn for_each(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -911,14 +870,11 @@ impl ArrayPrototype {
         }
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.includes (https://tc39.es/ecma262/#sec-array.prototype.includes)
-    pub fn includes(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn includes(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -944,14 +900,11 @@ impl ArrayPrototype {
         }
 
         Ok(cx.bool(false))
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.indexOf (https://tc39.es/ecma262/#sec-array.prototype.indexof)
-    pub fn index_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn index_of(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -978,14 +931,11 @@ impl ArrayPrototype {
         }
 
         Ok(cx.negative_one())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.join (https://tc39.es/ecma262/#sec-array.prototype.join)
-    pub fn join(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn join(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1016,20 +966,18 @@ impl ArrayPrototype {
         }
 
         Ok(joined.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.keys (https://tc39.es/ecma262/#sec-array.prototype.keys)
-    pub fn keys(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn keys(cx, this_value, _) {
         let object = to_object(cx, this_value)?;
         Ok(ArrayIterator::new(cx, object, ArrayIteratorKind::Key)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.lastIndexOf (https://tc39.es/ecma262/#sec-array.prototype.lastindexof)
-    pub fn last_index_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn last_index_of(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1075,14 +1023,11 @@ impl ArrayPrototype {
         }
 
         Ok(cx.negative_one())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.map (https://tc39.es/ecma262/#sec-array.prototype.map)
-    pub fn map(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn map(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1114,10 +1059,11 @@ impl ArrayPrototype {
         }
 
         Ok(array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.pop (https://tc39.es/ecma262/#sec-array.prototype.pop)
-    pub fn pop(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn pop(cx, this_value, _) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1137,14 +1083,11 @@ impl ArrayPrototype {
         set(cx, object, cx.names.length(), new_length_value, true)?;
 
         Ok(element)
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.push (https://tc39.es/ecma262/#sec-array.prototype.push)
-    pub fn push(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn push(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1165,14 +1108,11 @@ impl ArrayPrototype {
         set(cx, object, cx.names.length(), new_length_value, true)?;
 
         Ok(new_length_value)
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.reduce (https://tc39.es/ecma262/#sec-array.prototype.reduce)
-    pub fn reduce(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn reduce(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1227,14 +1167,11 @@ impl ArrayPrototype {
         }
 
         Ok(accumulator)
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.reduceRight (https://tc39.es/ecma262/#sec-array.prototype.reduceright)
-    pub fn reduce_right(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn reduce_right(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1288,14 +1225,11 @@ impl ArrayPrototype {
         }
 
         Ok(accumulator)
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.reverse (https://tc39.es/ecma262/#sec-array.prototype.reverse)
-    pub fn reverse(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn reverse(cx, this_value, _) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1345,14 +1279,11 @@ impl ArrayPrototype {
         }
 
         Ok(object.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.shift (https://tc39.es/ecma262/#sec-array.prototype.shift)
-    pub fn shift(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn shift(cx, this_value, _) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1388,14 +1319,11 @@ impl ArrayPrototype {
         set(cx, object, cx.names.length(), new_length_value, true)?;
 
         Ok(first)
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.slice (https://tc39.es/ecma262/#sec-array.prototype.slice)
-    pub fn slice(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn slice(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1436,14 +1364,11 @@ impl ArrayPrototype {
         set(cx, array, cx.names.length(), to_index_value, true)?;
 
         Ok(array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.some (https://tc39.es/ecma262/#sec-array.prototype.some)
-    pub fn some(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn some(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1475,14 +1400,11 @@ impl ArrayPrototype {
         }
 
         Ok(cx.bool(false))
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.sort (https://tc39.es/ecma262/#sec-array.prototype.sort)
-    pub fn sort(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn sort(cx, this_value, arguments) {
         let compare_function_arg = arguments.get(cx, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
             return type_error(cx, "Array.prototype.sort expects a function");
@@ -1514,14 +1436,11 @@ impl ArrayPrototype {
         }
 
         Ok(object.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.splice (https://tc39.es/ecma262/#sec-array.prototype.splice)
-    pub fn splice(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn splice(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1606,14 +1525,11 @@ impl ArrayPrototype {
         set(cx, object, cx.names.length(), new_length_value, true)?;
 
         Ok(array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.toLocaleString (https://tc39.es/ecma262/#sec-array.prototype.tolocalestring)
-    pub fn to_locale_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_string(cx, this_value, _) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1640,14 +1556,11 @@ impl ArrayPrototype {
         }
 
         Ok(result.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.toReversed (https://tc39.es/ecma262/#sec-array.prototype.toreversed)
-    pub fn to_reversed(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_reversed(cx, this_value, _) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1666,14 +1579,11 @@ impl ArrayPrototype {
         }
 
         Ok(array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.toSorted (https://tc39.es/ecma262/#sec-array.prototype.tosorted)
-    pub fn to_sorted(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_sorted(cx, this_value, arguments) {
         let compare_function_arg = arguments.get(cx, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
             return type_error(cx, "Array.prototype.toSorted expects a function");
@@ -1701,14 +1611,11 @@ impl ArrayPrototype {
         }
 
         Ok(sorted_array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.toSpliced (https://tc39.es/ecma262/#sec-array.prototype.tospliced)
-    pub fn to_spliced(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_spliced(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1764,14 +1671,11 @@ impl ArrayPrototype {
         }
 
         Ok(array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.toString (https://tc39.es/ecma262/#sec-array.prototype.tostring)
-    pub fn to_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, _) {
         let array = to_object(cx, this_value)?;
         let func = get(cx, array, cx.names.join())?;
 
@@ -1782,14 +1686,11 @@ impl ArrayPrototype {
         };
 
         call_object(cx, func, array.into(), &[])
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.unshift (https://tc39.es/ecma262/#sec-array.prototype.unshift)
-    pub fn unshift(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn unshift(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1825,24 +1726,18 @@ impl ArrayPrototype {
         set(cx, object, cx.names.length(), new_length, true)?;
 
         Ok(new_length)
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.values (https://tc39.es/ecma262/#sec-array.prototype.values)
-    pub fn values(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn values(cx, this_value, _) {
         let object = to_object(cx, this_value)?;
         Ok(ArrayIterator::new(cx, object, ArrayIteratorKind::Value)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Array.prototype.with (https://tc39.es/ecma262/#sec-array.prototype.with)
-    pub fn with(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let length = length_of_array_like(cx, object)?;
 
@@ -1885,7 +1780,7 @@ impl ArrayPrototype {
         }
 
         Ok(array.as_value())
-    }
+    }}
 
     /// Array.prototype [ @@unscopables ] (https://tc39.es/ecma262/#sec-array.prototype-%symbol.unscopables%)
     fn create_unscopables(cx: Context) -> AllocResult<Handle<ObjectValue>> {

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     eval_err, extend_object, if_abrupt_reject_promise, must,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         abstract_operations::{call_object, get_method},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -22,7 +22,7 @@ use crate::{
         promise_object::{PromiseCapability, coerce_to_ordinary_promise},
         realm::Realm,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // Async-from-Sync Iterator Objects (https://tc39.es/ecma262/#sec-async-from-sync-iterator-objects)
@@ -105,12 +105,9 @@ impl AsyncFromSyncIteratorPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// %AsyncFromSyncIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.next)
-    pub fn next(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn next(cx, this_value, arguments) {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
 
@@ -135,14 +132,11 @@ impl AsyncFromSyncIteratorPrototype {
             sync_iterator,
             /* close_on_rejection */ true,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// %AsyncFromSyncIteratorPrototype%.return (https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.return)
-    pub fn return_(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn return_(cx, this_value, arguments) {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
 
@@ -189,14 +183,11 @@ impl AsyncFromSyncIteratorPrototype {
             sync_iterator,
             /* close_on_rejection */ false,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// %AsyncFromSyncIteratorPrototype%.throw (https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.throw)
-    pub fn throw(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn throw(cx, this_value, arguments) {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
 
@@ -250,7 +241,7 @@ impl AsyncFromSyncIteratorPrototype {
             sync_iterator,
             /* close_on_rejection */ true,
         )
-    }
+    }}
 }
 
 /// AsyncFromSyncIteratorContinuation (https://tc39.es/ecma262/#sec-asyncfromsynciteratorcontinuation)
@@ -317,29 +308,20 @@ fn async_from_sync_iterator_continuation(
     Ok(capability.promise().as_value())
 }
 
-pub fn create_continuing_iter_result_object(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+runtime_fn! {
+fn create_continuing_iter_result_object(cx, _, arguments) {
     let value = arguments.get(cx, 0);
     Ok(create_iter_result_object(cx, value, /* is_done */ false)?)
-}
+}}
 
-pub fn create_done_iter_result_object(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+runtime_fn! {
+fn create_done_iter_result_object(cx, _, arguments) {
     let value = arguments.get(cx, 0);
     Ok(create_iter_result_object(cx, value, /* is_done */ true)?)
-}
+}}
 
-pub fn async_from_sync_iterator_continuation_on_reject(
-    mut cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+runtime_fn! {
+fn async_from_sync_iterator_continuation_on_reject(cx, _, arguments) {
     // Fetch the iterator passed from the caller
     let current_function = cx.current_function();
     let sync_iterator = get_sync_iterator(cx, current_function);
@@ -347,7 +329,7 @@ pub fn async_from_sync_iterator_continuation_on_reject(
     let error = arguments.get(cx, 0);
 
     iterator_close(cx, sync_iterator, eval_err!(error))
-}
+}}
 
 fn get_sync_iterator(cx: Context, function: Handle<ObjectValue>) -> Handle<ObjectValue> {
     function

--- a/src/js/runtime/intrinsics/async_function_constructor.rs
+++ b/src/js/runtime/intrinsics/async_function_constructor.rs
@@ -1,12 +1,14 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    eval::create_dynamic_function::create_dynamic_function,
-    eval_result::EvalResult,
-    intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
-    object_value::ObjectValue,
-    realm::Realm,
+use crate::{
+    runtime::{
+        Context, Handle,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        eval::create_dynamic_function::create_dynamic_function,
+        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        object_value::ObjectValue,
+        realm::Realm,
+    },
+    runtime_fn,
 };
 
 pub struct AsyncFunctionConstructor;
@@ -34,12 +36,9 @@ impl AsyncFunctionConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// AsyncFunction (https://tc39.es/ecma262/#sec-async-function-constructor-arguments)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let constructor = cx.current_function();
         Ok(create_dynamic_function(
             cx,
@@ -50,5 +49,5 @@ impl AsyncFunctionConstructor {
             /* is_generator */ false,
         )?
         .as_value())
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/async_generator_function_constructor.rs
+++ b/src/js/runtime/intrinsics/async_generator_function_constructor.rs
@@ -1,12 +1,14 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    eval::create_dynamic_function::create_dynamic_function,
-    eval_result::EvalResult,
-    intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
-    object_value::ObjectValue,
-    realm::Realm,
+use crate::{
+    runtime::{
+        Context, Handle,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        eval::create_dynamic_function::create_dynamic_function,
+        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        object_value::ObjectValue,
+        realm::Realm,
+    },
+    runtime_fn,
 };
 
 pub struct AsyncGeneratorFunctionConstructor;
@@ -34,12 +36,9 @@ impl AsyncGeneratorFunctionConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// AsyncGeneratorFunction (https://tc39.es/ecma262/#sec-asyncgeneratorfunction)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let constructor = cx.current_function();
         Ok(create_dynamic_function(
             cx,
@@ -50,5 +49,5 @@ impl AsyncGeneratorFunctionConstructor {
             /* is_generator */ true,
         )?
         .as_value())
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/async_generator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_generator_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     if_abrupt_reject_promise, must,
     runtime::{
-        Arguments, Context, Handle, Value,
+        Context, Handle,
         abstract_operations::{call_object, define_property_or_throw},
         alloc_error::AllocResult,
         async_generator_object::{
@@ -21,6 +21,7 @@ use crate::{
         property_descriptor::PropertyDescriptor,
         realm::Realm,
     },
+    runtime_fn,
 };
 
 pub struct AsyncGeneratorPrototype;
@@ -69,12 +70,9 @@ impl AsyncGeneratorPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// %AsyncGeneratorPrototype%.next (https://tc39.es/ecma262/#sec-asyncgenerator-prototype-next)
-    pub fn next(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn next(cx, this_value, arguments) {
         let value = arguments.get(cx, 0);
 
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
@@ -104,14 +102,11 @@ impl AsyncGeneratorPrototype {
         }
 
         Ok(capability.promise().as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %AsyncGeneratorPrototype%.return (https://tc39.es/ecma262/#sec-asyncgenerator-prototype-return)
-    pub fn return_(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn return_(cx, this_value, arguments) {
         let value = arguments.get(cx, 0);
 
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
@@ -133,14 +128,11 @@ impl AsyncGeneratorPrototype {
         }
 
         Ok(capability.promise().as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %AsyncGeneratorPrototype%.throw (https://tc39.es/ecma262/#sec-asyncgenerator-prototype-throw)
-    pub fn throw(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn throw(cx, this_value, arguments) {
         let error = arguments.get(cx, 0);
 
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
@@ -172,7 +164,7 @@ impl AsyncGeneratorPrototype {
         }
 
         Ok(capability.promise().as_value())
-    }
+    }}
 
     /// Every async generator function has a prototype property referencing an instance of the
     /// async generator prototype. Install this property on an async generator function.

--- a/src/js/runtime/intrinsics/bigint_constructor.rs
+++ b/src/js/runtime/intrinsics/bigint_constructor.rs
@@ -6,7 +6,7 @@ use num_traits::FromPrimitive;
 use crate::{
     extend_object,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::{range_error, type_error},
@@ -22,7 +22,7 @@ use crate::{
         },
         value::BigIntValue,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // BigInt Objects (https://tc39.es/ecma262/#sec-bigint-objects)
@@ -92,12 +92,9 @@ impl BigIntConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// BigInt (https://tc39.es/ecma262/#sec-bigint-constructor-number-value)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         if cx.current_new_target().is_some() {
             return type_error(cx, "BigInt constructor cannot be used with new");
         }
@@ -110,14 +107,11 @@ impl BigIntConstructor {
         } else {
             Ok(to_bigint(cx, primitive)?.into())
         }
-    }
+    }}
 
+    runtime_fn! {
     /// BigInt.asIntN (https://tc39.es/ecma262/#sec-bigint.asintn)
-    pub fn as_int_n(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn as_int_n(cx, _, arguments) {
         let bits_arg = arguments.get(cx, 0);
         let bits = to_index(cx, bits_arg)?;
 
@@ -137,14 +131,11 @@ impl BigIntConstructor {
         };
 
         Ok(BigIntValue::new(cx, signed_bigint)?.into())
-    }
+    }}
 
+    runtime_fn! {
     /// BigInt.asUintN (https://tc39.es/ecma262/#sec-bigint.asuintn)
-    pub fn as_uint_n(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn as_uint_n(cx, _, arguments) {
         let bits_arg = arguments.get(cx, 0);
         let bits = to_index(cx, bits_arg)?;
 
@@ -156,7 +147,7 @@ impl BigIntConstructor {
         let new_bigint = bigint.bigint() & &mask;
 
         Ok(BigIntValue::new(cx, new_bigint)?.into())
-    }
+    }}
 }
 
 /// NumberToBigInt (https://tc39.es/ecma262/#sec-numbertobigint)

--- a/src/js/runtime/intrinsics/bigint_prototype.rs
+++ b/src/js/runtime/intrinsics/bigint_prototype.rs
@@ -1,16 +1,19 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    alloc_error::AllocResult,
-    error::{range_error, type_error},
-    eval_result::EvalResult,
-    intrinsics::{
-        bigint_constructor::BigIntObject, intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
+use crate::{
+    runtime::{
+        Context, Handle, Value,
+        alloc_error::AllocResult,
+        error::{range_error, type_error},
+        eval_result::EvalResult,
+        intrinsics::{
+            bigint_constructor::BigIntObject, intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
+        },
+        object_value::ObjectValue,
+        property::Property,
+        realm::Realm,
+        type_utilities::to_integer_or_infinity,
+        value::BigIntValue,
     },
-    object_value::ObjectValue,
-    property::Property,
-    realm::Realm,
-    type_utilities::to_integer_or_infinity,
-    value::BigIntValue,
+    runtime_fn,
 };
 
 pub struct BigIntPrototype;
@@ -48,12 +51,9 @@ impl BigIntPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// BigInt.prototype.toString (https://tc39.es/ecma262/#sec-bigint.prototype.tostring)
-    pub fn to_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, arguments) {
         let bigint_value = this_bigint_value(cx, this_value, "toString")?;
 
         let radix = arguments.get(cx, 0);
@@ -74,16 +74,13 @@ impl BigIntPrototype {
         Ok(cx
             .alloc_string(&bigint_value.bigint().to_str_radix(radix))?
             .as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// BigInt.prototype.valueOf (https://tc39.es/ecma262/#sec-bigint.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, this_value, _) {
         Ok(this_bigint_value(cx, this_value, "valueOf")?.into())
-    }
+    }}
 }
 
 fn this_bigint_value(

--- a/src/js/runtime/intrinsics/boolean_constructor.rs
+++ b/src/js/runtime/intrinsics/boolean_constructor.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Arguments, Context, HeapPtr, Value,
+        Context, HeapPtr,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         eval_result::EvalResult,
@@ -17,7 +17,7 @@ use crate::{
         realm::Realm,
         type_utilities::to_boolean,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // Boolean Objects (https://tc39.es/ecma262/#sec-boolean-objects)
@@ -103,12 +103,9 @@ impl BooleanConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Boolean (https://tc39.es/ecma262/#sec-boolean-constructor-boolean-value)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let bool_value = to_boolean(*arguments.get(cx, 0));
 
         match cx.current_new_target() {
@@ -117,7 +114,7 @@ impl BooleanConstructor {
                 Ok(BooleanObject::new_from_constructor(cx, new_target, bool_value)?.as_value())
             }
         }
-    }
+    }}
 }
 
 impl HeapItem for HeapPtr<BooleanObject> {

--- a/src/js/runtime/intrinsics/boolean_prototype.rs
+++ b/src/js/runtime/intrinsics/boolean_prototype.rs
@@ -1,13 +1,17 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    alloc_error::AllocResult,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        boolean_constructor::BooleanObject, intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
+use crate::{
+    runtime::{
+        Context, Handle, Value,
+        alloc_error::AllocResult,
+        error::type_error,
+        eval_result::EvalResult,
+        intrinsics::{
+            boolean_constructor::BooleanObject, intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+        },
+        object_value::ObjectValue,
+        realm::Realm,
     },
-    object_value::ObjectValue,
-    realm::Realm,
+    runtime_fn,
 };
 
 pub struct BooleanPrototype;
@@ -37,27 +41,21 @@ impl BooleanPrototype {
         Ok(object.into())
     }
 
+    runtime_fn! {
     /// Boolean.prototype.toString (https://tc39.es/ecma262/#sec-boolean.prototype.tostring)
-    pub fn to_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, _) {
         let bool_value = this_boolean_value(cx, this_value, "toString")?;
         let string_value = if bool_value { "true" } else { "false" };
 
         Ok(cx.alloc_string(string_value)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Boolean.prototype.valueOf (https://tc39.es/ecma262/#sec-boolean.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, this_value, _) {
         let bool_value = this_boolean_value(cx, this_value, "valueOf")?;
         Ok(cx.bool(bool_value))
-    }
+    }}
 }
 
 fn this_boolean_value(cx: Context, value: Handle<Value>, method_name: &str) -> EvalResult<bool> {

--- a/src/js/runtime/intrinsics/data_view_constructor.rs
+++ b/src/js/runtime/intrinsics/data_view_constructor.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::{range_error, type_error},
@@ -20,6 +20,7 @@ use crate::{
         realm::Realm,
         type_utilities::to_index,
     },
+    runtime_fn,
 };
 
 // DataView Objects (https://tc39.es/ecma262/#sec-dataview-objects)
@@ -96,12 +97,9 @@ impl DataViewConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// DataView (https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
@@ -182,7 +180,7 @@ impl DataViewConstructor {
         }
 
         Ok(data_view.as_value())
-    }
+    }}
 }
 
 impl HeapItem for HeapPtr<DataViewObject> {

--- a/src/js/runtime/intrinsics/data_view_prototype.rs
+++ b/src/js/runtime/intrinsics/data_view_prototype.rs
@@ -1,26 +1,29 @@
 use half::f16;
 
-use crate::runtime::{
-    Arguments, Context, EvalResult, Handle, Value,
-    alloc_error::AllocResult,
-    error::{range_error, type_error},
-    intrinsics::{
-        data_view_constructor::DataViewObject,
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        typed_array::{
-            ContentType, from_big_int64_element, from_big_uint64_element, from_float16_element,
-            from_float32_element, from_float64_element, from_int8_element, from_int16_element,
-            from_int32_element, from_uint8_element, from_uint16_element, from_uint32_element,
-            to_big_int64_element, to_big_uint64_element, to_float16_element, to_float32_element,
-            to_float64_element, to_int8_element, to_int16_element, to_int32_element,
-            to_uint8_element, to_uint16_element, to_uint32_element,
+use crate::{
+    runtime::{
+        Arguments, Context, EvalResult, Handle, Value,
+        alloc_error::AllocResult,
+        error::{range_error, type_error},
+        intrinsics::{
+            data_view_constructor::DataViewObject,
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            typed_array::{
+                ContentType, from_big_int64_element, from_big_uint64_element, from_float16_element,
+                from_float32_element, from_float64_element, from_int8_element, from_int16_element,
+                from_int32_element, from_uint8_element, from_uint16_element, from_uint32_element,
+                to_big_int64_element, to_big_uint64_element, to_float16_element,
+                to_float32_element, to_float64_element, to_int8_element, to_int16_element,
+                to_int32_element, to_uint8_element, to_uint16_element, to_uint32_element,
+            },
         },
+        object_value::ObjectValue,
+        property::Property,
+        realm::Realm,
+        type_utilities::{to_bigint, to_boolean, to_index, to_number},
     },
-    object_value::ObjectValue,
-    property::Property,
-    realm::Realm,
-    type_utilities::{to_bigint, to_boolean, to_index, to_number},
+    runtime_fn,
 };
 
 pub struct DataViewPrototype;
@@ -216,22 +219,16 @@ impl DataViewPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// get DataView.prototype.buffer (https://tc39.es/ecma262/#sec-get-dataview.prototype.buffer)
-    pub fn get_buffer(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_buffer(cx, this_value, _) {
         let data_view = this_data_view(cx, this_value, "buffer")?;
         Ok(data_view.viewed_array_buffer().as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get DataView.prototype.byteLength (https://tc39.es/ecma262/#sec-get-dataview.prototype.bytelength)
-    pub fn get_byte_length(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_byte_length(cx, this_value, _) {
         let data_view = this_data_view(cx, this_value, "byteLength")?;
         let data_view_record = make_data_view_with_buffer_witness_record(data_view);
 
@@ -242,14 +239,11 @@ impl DataViewPrototype {
         let byte_length = get_view_byte_length(&data_view_record);
 
         Ok(cx.number(byte_length))
-    }
+    }}
 
+    runtime_fn! {
     /// get DataView.prototype.byteOffset (https://tc39.es/ecma262/#sec-get-dataview.prototype.byteoffset)
-    pub fn get_byte_offset(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_byte_offset(cx, this_value, _) {
         let data_view = this_data_view(cx, this_value, "byteOffset")?;
         let data_view_record = make_data_view_with_buffer_witness_record(data_view);
 
@@ -258,14 +252,11 @@ impl DataViewPrototype {
         }
 
         Ok(cx.number(data_view.byte_offset()))
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.getBigInt64 (https://tc39.es/ecma262/#sec-dataview.prototype.getbigint64)
-    pub fn get_big_int64(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_big_int64(cx, this_value, arguments) {
         get_view_value(
             cx,
             this_value,
@@ -274,14 +265,11 @@ impl DataViewPrototype {
             from_big_int64_element,
             i64::swap_bytes,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.getBigUint64 (https://tc39.es/ecma262/#sec-dataview.prototype.getbiguint64)
-    pub fn get_big_uint64(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_big_uint64(cx, this_value, arguments) {
         get_view_value(
             cx,
             this_value,
@@ -290,14 +278,11 @@ impl DataViewPrototype {
             from_big_uint64_element,
             u64::swap_bytes,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.getFloat16 (https://tc39.es/ecma262/#sec-dataview.prototype.getfloat16)
-    pub fn get_float16(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_float16(cx, this_value, arguments) {
         get_view_value(
             cx,
             this_value,
@@ -306,14 +291,11 @@ impl DataViewPrototype {
             from_float16_element,
             f16_swap_bytes,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.getFloat32 (https://tc39.es/ecma262/#sec-dataview.prototype.getfloat32)
-    pub fn get_float32(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_float32(cx, this_value, arguments) {
         get_view_value(
             cx,
             this_value,
@@ -322,14 +304,11 @@ impl DataViewPrototype {
             from_float32_element,
             f32_swap_bytes,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.getFloat64 (https://tc39.es/ecma262/#sec-dataview.prototype.getfloat64)
-    pub fn get_float64(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_float64(cx, this_value, arguments) {
         get_view_value(
             cx,
             this_value,
@@ -338,68 +317,47 @@ impl DataViewPrototype {
             from_float64_element,
             f64_swap_bytes,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.getInt8 (https://tc39.es/ecma262/#sec-dataview.prototype.getint8)
-    pub fn get_int8(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_int8(cx, this_value, arguments) {
         get_view_value(cx, this_value, arguments, "getInt8", from_int8_element, |element| element)
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.getInt16 (https://tc39.es/ecma262/#sec-dataview.prototype.getint16)
-    pub fn get_int16(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_int16(cx, this_value, arguments) {
         get_view_value(cx, this_value, arguments, "getInt16", from_int16_element, i16::swap_bytes)
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.getInt32 (https://tc39.es/ecma262/#sec-dataview.prototype.getint32)
-    pub fn get_int32(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_int32(cx, this_value, arguments) {
         get_view_value(cx, this_value, arguments, "getInt32", from_int32_element, i32::swap_bytes)
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.getUint8 (https://tc39.es/ecma262/#sec-dataview.prototype.getuint8)
-    pub fn get_uint8(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_uint8(cx, this_value, arguments) {
         get_view_value(cx, this_value, arguments, "getUint8", from_uint8_element, |element| element)
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.getUint16 (https://tc39.es/ecma262/#sec-dataview.prototype.getuint16)
-    pub fn get_uint16(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_uint16(cx, this_value, arguments) {
         get_view_value(cx, this_value, arguments, "getUint16", from_uint16_element, u16::swap_bytes)
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.getUint32 (https://tc39.es/ecma262/#sec-dataview.prototype.getuint32)
-    pub fn get_uint32(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_uint32(cx, this_value, arguments) {
         get_view_value(cx, this_value, arguments, "getUint32", from_uint32_element, u32::swap_bytes)
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.setBigInt64 (https://tc39.es/ecma262/#sec-dataview.prototype.setbigint64)
-    pub fn set_big_int64(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_big_int64(cx, this_value, arguments) {
         set_view_value(
             cx,
             this_value,
@@ -409,14 +367,11 @@ impl DataViewPrototype {
             to_big_int64_element,
             i64::swap_bytes,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.setBigUint64 (https://tc39.es/ecma262/#sec-dataview.prototype.setbiguint64)
-    pub fn set_big_uint64(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_big_uint64(cx, this_value, arguments) {
         set_view_value(
             cx,
             this_value,
@@ -426,14 +381,11 @@ impl DataViewPrototype {
             to_big_uint64_element,
             u64::swap_bytes,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.setFloat16 (https://tc39.es/ecma262/#sec-dataview.prototype.setfloat16)
-    pub fn set_float16(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_float16(cx, this_value, arguments) {
         set_view_value(
             cx,
             this_value,
@@ -443,14 +395,11 @@ impl DataViewPrototype {
             to_float16_element,
             f16_swap_bytes,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.setFloat32 (https://tc39.es/ecma262/#sec-dataview.prototype.setfloat32)
-    pub fn set_float32(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_float32(cx, this_value, arguments) {
         set_view_value(
             cx,
             this_value,
@@ -460,14 +409,11 @@ impl DataViewPrototype {
             to_float32_element,
             f32_swap_bytes,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.setFloat64 (https://tc39.es/ecma262/#sec-dataview.prototype.setfloat64)
-    pub fn set_float64(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_float64(cx, this_value, arguments) {
         set_view_value(
             cx,
             this_value,
@@ -477,14 +423,11 @@ impl DataViewPrototype {
             to_float64_element,
             f64_swap_bytes,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.setInt8 (https://tc39.es/ecma262/#sec-dataview.prototype.setint8)
-    pub fn set_int8(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_int8(cx, this_value, arguments) {
         set_view_value(
             cx,
             this_value,
@@ -494,14 +437,11 @@ impl DataViewPrototype {
             to_int8_element,
             |element| element,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.setInt16 (https://tc39.es/ecma262/#sec-dataview.prototype.setint16)
-    pub fn set_int16(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_int16(cx, this_value, arguments) {
         set_view_value(
             cx,
             this_value,
@@ -511,14 +451,11 @@ impl DataViewPrototype {
             to_int16_element,
             i16::swap_bytes,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.setInt32 (https://tc39.es/ecma262/#sec-dataview.prototype.setint32)
-    pub fn set_int32(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_int32(cx, this_value, arguments) {
         set_view_value(
             cx,
             this_value,
@@ -528,14 +465,11 @@ impl DataViewPrototype {
             to_int32_element,
             i32::swap_bytes,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.setUint8 (https://tc39.es/ecma262/#sec-dataview.prototype.setuint8)
-    pub fn set_uint8(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_uint8(cx, this_value, arguments) {
         set_view_value(
             cx,
             this_value,
@@ -545,14 +479,11 @@ impl DataViewPrototype {
             to_uint8_element,
             |element| element,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.setUint16 (https://tc39.es/ecma262/#sec-dataview.prototype.setuint16)
-    pub fn set_uint16(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_uint16(cx, this_value, arguments) {
         set_view_value(
             cx,
             this_value,
@@ -562,14 +493,11 @@ impl DataViewPrototype {
             to_uint16_element,
             u16::swap_bytes,
         )
-    }
+    }}
 
+    runtime_fn! {
     /// DataView.prototype.setUint32 (https://tc39.es/ecma262/#sec-dataview.prototype.setuint32)
-    pub fn set_uint32(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_uint32(cx, this_value, arguments) {
         set_view_value(
             cx,
             this_value,
@@ -579,7 +507,7 @@ impl DataViewPrototype {
             to_uint32_element,
             u32::swap_bytes,
         )
-    }
+    }}
 }
 
 #[inline]

--- a/src/js/runtime/intrinsics/date_constructor.rs
+++ b/src/js/runtime/intrinsics/date_constructor.rs
@@ -1,20 +1,24 @@
-use crate::runtime::{
-    Arguments, Context, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    eval_result::EvalResult,
-    gc::Handle,
-    intrinsics::{
-        date_object::{DateObject, make_date, make_day, make_full_year, make_time, time_clip, utc},
-        date_prototype::{to_date_string, validate_date_value},
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
+use crate::{
+    runtime::{
+        Context,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        gc::Handle,
+        intrinsics::{
+            date_object::{
+                DateObject, make_date, make_day, make_full_year, make_time, time_clip, utc,
+            },
+            date_prototype::{to_date_string, validate_date_value},
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+        },
+        object_value::ObjectValue,
+        realm::Realm,
+        string_parsing::parse_string_to_date,
+        to_string,
+        type_utilities::{ToPrimitivePreferredType, to_number, to_primitive},
     },
-    object_value::ObjectValue,
-    realm::Realm,
-    string_parsing::parse_string_to_date,
-    to_string,
-    type_utilities::{ToPrimitivePreferredType, to_number, to_primitive},
+    runtime_fn,
 };
 
 pub struct DateConstructor;
@@ -50,12 +54,9 @@ impl DateConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Date (https://tc39.es/ecma262/#sec-date)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
@@ -137,15 +138,17 @@ impl DateConstructor {
         Ok(DateObject::new_from_constructor(cx, new_target, date_value)?
             .to_handle()
             .into())
-    }
+    }}
 
+    runtime_fn! {
     /// Date.now (https://tc39.es/ecma262/#sec-date.now)
-    pub fn now(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn now(cx, _, _) {
         Ok(cx.number(cx.current_unix_time_millis() as f64))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.parse (https://tc39.es/ecma262/#sec-date.parse)
-    pub fn parse(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn parse(cx, _, arguments) {
         let string_arg = arguments.get(cx, 0);
         let string = to_string(cx, string_arg)?;
 
@@ -154,10 +157,11 @@ impl DateConstructor {
         } else {
             Ok(cx.nan())
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Date.UTC (https://tc39.es/ecma262/#sec-date.utc)
-    pub fn utc(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn utc(cx, _, arguments) {
         let number_of_args = arguments.len();
 
         let year_arg = arguments.get(cx, 0);
@@ -212,5 +216,5 @@ impl DateConstructor {
         let final_date = make_date(final_day, final_time);
 
         Ok(cx.number(time_clip(final_date)))
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -2,7 +2,7 @@ use crate::{
     common::constants::NANOSECONDS_IN_ONE_MILLISECOND,
     must_a,
     runtime::{
-        Arguments, Context, EvalResult, Handle, PropertyKey, Realm, Value,
+        Context, EvalResult, Handle, PropertyKey, Realm, Value,
         abstract_operations::invoke,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -27,6 +27,7 @@ use crate::{
             ToPrimitivePreferredType, ordinary_to_primitive, to_number, to_object, to_primitive,
         },
     },
+    runtime_fn,
 };
 
 pub struct DatePrototype;
@@ -403,12 +404,9 @@ impl DatePrototype {
         Ok(())
     }
 
+    runtime_fn! {
     /// Date.prototype.getDate (https://tc39.es/ecma262/#sec-date.prototype.getdate)
-    pub fn get_date(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_date(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getDate")?;
 
         if date_value.is_nan() {
@@ -418,14 +416,11 @@ impl DatePrototype {
         let date = date_from_time(local_time(date_value));
 
         Ok(cx.number(date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getDay (https://tc39.es/ecma262/#sec-date.prototype.getday)
-    pub fn get_day(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_day(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getDay")?;
 
         if date_value.is_nan() {
@@ -435,14 +430,11 @@ impl DatePrototype {
         let day = week_day(local_time(date_value));
 
         Ok(cx.number(day))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getFullYear (https://tc39.es/ecma262/#sec-date.prototype.getfullyear)
-    pub fn get_full_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_full_year(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getFullYear")?;
 
         if date_value.is_nan() {
@@ -452,14 +444,11 @@ impl DatePrototype {
         let year = year_from_time(local_time(date_value));
 
         Ok(cx.number(year))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getHours (https://tc39.es/ecma262/#sec-date.prototype.gethours)
-    pub fn get_hours(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_hours(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getHours")?;
 
         if date_value.is_nan() {
@@ -469,14 +458,11 @@ impl DatePrototype {
         let hour = hour_from_time(local_time(date_value));
 
         Ok(cx.number(hour))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getMilliseconds (https://tc39.es/ecma262/#sec-date.prototype.getmilliseconds)
-    pub fn get_milliseconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_milliseconds(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getMilliseconds")?;
 
         if date_value.is_nan() {
@@ -486,14 +472,11 @@ impl DatePrototype {
         let millisecond = millisecond_from_time(local_time(date_value));
 
         Ok(cx.number(millisecond))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getMinutes (https://tc39.es/ecma262/#sec-date.prototype.getminutes)
-    pub fn get_minutes(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_minutes(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getMinutes")?;
 
         if date_value.is_nan() {
@@ -503,14 +486,11 @@ impl DatePrototype {
         let minute = minute_from_time(local_time(date_value));
 
         Ok(cx.number(minute))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getMonth (https://tc39.es/ecma262/#sec-date.prototype.getmonth)
-    pub fn get_month(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_month(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getMonth")?;
 
         if date_value.is_nan() {
@@ -520,14 +500,11 @@ impl DatePrototype {
         let month = month_from_time(local_time(date_value));
 
         Ok(cx.number(month))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getSeconds (https://tc39.es/ecma262/#sec-date.prototype.getseconds)
-    pub fn get_seconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_seconds(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getSeconds")?;
 
         if date_value.is_nan() {
@@ -537,25 +514,19 @@ impl DatePrototype {
         let second = second_from_time(local_time(date_value));
 
         Ok(cx.number(second))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getTime (https://tc39.es/ecma262/#sec-date.prototype.gettime)
-    pub fn get_time(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_time(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getTime")?;
 
         Ok(cx.number(date_value))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getTimezoneOffset (https://tc39.es/ecma262/#sec-date.prototype.gettimezoneoffset)
-    pub fn get_timezone_offset(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_timezone_offset(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getTimezoneOffset")?;
 
         if date_value.is_nan() {
@@ -565,14 +536,11 @@ impl DatePrototype {
         let timezone_offset = (date_value - local_time(date_value)) / MS_PER_MINUTE;
 
         Ok(cx.number(timezone_offset))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getUTCDate (https://tc39.es/ecma262/#sec-date.prototype.getutcdate)
-    pub fn get_utc_date(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_utc_date(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getUTCDate")?;
 
         if date_value.is_nan() {
@@ -582,14 +550,11 @@ impl DatePrototype {
         let date = date_from_time(date_value);
 
         Ok(cx.number(date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getUTCDay (https://tc39.es/ecma262/#sec-date.prototype.getutcday)
-    pub fn get_utc_day(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_utc_day(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getUTCDay")?;
 
         if date_value.is_nan() {
@@ -599,14 +564,11 @@ impl DatePrototype {
         let hour = week_day(date_value);
 
         Ok(cx.number(hour))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getUTCFullYear (https://tc39.es/ecma262/#sec-date.prototype.getutcfullyear)
-    pub fn get_utc_full_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_utc_full_year(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getUTCFullYear")?;
 
         if date_value.is_nan() {
@@ -616,14 +578,11 @@ impl DatePrototype {
         let year = year_from_time(date_value);
 
         Ok(cx.number(year))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getUTCHours (https://tc39.es/ecma262/#sec-date.prototype.getutchours)
-    pub fn get_utc_hours(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_utc_hours(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getUTCHours")?;
 
         if date_value.is_nan() {
@@ -633,14 +592,11 @@ impl DatePrototype {
         let hour = hour_from_time(date_value);
 
         Ok(cx.number(hour))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getUTCMilliseconds (https://tc39.es/ecma262/#sec-date.prototype.getutcmilliseconds)
-    pub fn get_utc_milliseconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_utc_milliseconds(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getUTCMilliseconds")?;
 
         if date_value.is_nan() {
@@ -650,14 +606,11 @@ impl DatePrototype {
         let millisecond = millisecond_from_time(date_value);
 
         Ok(cx.number(millisecond))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getUTCMinutes (https://tc39.es/ecma262/#sec-date.prototype.getutcminutes)
-    pub fn get_utc_minutes(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_utc_minutes(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getUTCMinutes")?;
 
         if date_value.is_nan() {
@@ -667,14 +620,11 @@ impl DatePrototype {
         let minute = minute_from_time(date_value);
 
         Ok(cx.number(minute))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getUTCMonth (https://tc39.es/ecma262/#sec-date.prototype.getutcmonth)
-    pub fn get_utc_month(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_utc_month(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getUTCMonth")?;
 
         if date_value.is_nan() {
@@ -684,14 +634,11 @@ impl DatePrototype {
         let month = month_from_time(date_value);
 
         Ok(cx.number(month))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getUTCSeconds (https://tc39.es/ecma262/#sec-date.prototype.getutcseconds)
-    pub fn get_utc_seconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_utc_seconds(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getUTCSeconds")?;
 
         if date_value.is_nan() {
@@ -701,14 +648,11 @@ impl DatePrototype {
         let second = second_from_time(date_value);
 
         Ok(cx.number(second))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setDate (https://tc39.es/ecma262/#sec-date.prototype.setdate)
-    pub fn set_date(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_date(cx, this_value, arguments) {
         let date_value = this_date_value(cx, this_value, "setDate")?;
 
         let date_arg = arguments.get(cx, 0);
@@ -728,14 +672,11 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setFullYear (https://tc39.es/ecma262/#sec-date.prototype.setfullyear)
-    pub fn set_full_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_full_year(cx, this_value, arguments) {
         let mut date_value = this_date_value(cx, this_value, "setFullYear")?;
 
         let year_arg = arguments.get(cx, 0);
@@ -767,14 +708,11 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setHours (https://tc39.es/ecma262/#sec-date.prototype.sethours)
-    pub fn set_hours(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_hours(cx, this_value, arguments) {
         let date_value = this_date_value(cx, this_value, "setHours")?;
 
         let hours_arg = arguments.get(cx, 0);
@@ -830,14 +768,11 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setMilliseconds (https://tc39.es/ecma262/#sec-date.prototype.setmilliseconds)
-    pub fn set_milliseconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_milliseconds(cx, this_value, arguments) {
         let date_value = this_date_value(cx, this_value, "setMilliseconds")?;
 
         let milliseconds_arg = arguments.get(cx, 0);
@@ -862,14 +797,11 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setMinutes (https://tc39.es/ecma262/#sec-date.prototype.setminutes)
-    pub fn set_minutes(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_minutes(cx, this_value, arguments) {
         let date_value = this_date_value(cx, this_value, "setMinutes")?;
 
         let minutes_arg = arguments.get(cx, 0);
@@ -913,14 +845,11 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setMonth (https://tc39.es/ecma262/#sec-date.prototype.setmonth)
-    pub fn set_month(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_month(cx, this_value, arguments) {
         let date_value = this_date_value(cx, this_value, "setMonth")?;
 
         let month_arg = arguments.get(cx, 0);
@@ -952,14 +881,11 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setSeconds (https://tc39.es/ecma262/#sec-date.prototype.setseconds)
-    pub fn set_seconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_seconds(cx, this_value, arguments) {
         let date_value = this_date_value(cx, this_value, "setSeconds")?;
 
         let seconds_arg = arguments.get(cx, 0);
@@ -996,14 +922,11 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setTime (https://tc39.es/ecma262/#sec-date.prototype.settime)
-    pub fn set_time(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_time(cx, this_value, arguments) {
         let _ = this_date_value(cx, this_value, "setTime")?;
 
         let time_arg = arguments.get(cx, 0);
@@ -1012,14 +935,11 @@ impl DatePrototype {
         set_date_value(this_value, time_num);
 
         Ok(cx.number(time_num))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setUTCDate (https://tc39.es/ecma262/#sec-date.prototype.setutcdate)
-    pub fn set_utc_date(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_utc_date(cx, this_value, arguments) {
         let date_value = this_date_value(cx, this_value, "setUTCDate")?;
 
         let date_arg = arguments.get(cx, 0);
@@ -1037,14 +957,11 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setUTCFullYear (https://tc39.es/ecma262/#sec-date.prototype.setutcfullyear)
-    pub fn set_utc_full_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_utc_full_year(cx, this_value, arguments) {
         let mut date_value = this_date_value(cx, this_value, "setUTCFullYear")?;
 
         if date_value.is_nan() {
@@ -1074,14 +991,11 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setUTCHours (https://tc39.es/ecma262/#sec-date.prototype.setutchours)
-    pub fn set_utc_hours(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_utc_hours(cx, this_value, arguments) {
         let date_value = this_date_value(cx, this_value, "setUTCHours")?;
 
         let hours_arg = arguments.get(cx, 0);
@@ -1133,14 +1047,11 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setUTCMilliseconds (https://tc39.es/ecma262/#sec-date.prototype.setutcmilliseconds)
-    pub fn set_utc_milliseconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_utc_milliseconds(cx, this_value, arguments) {
         let date_value = this_date_value(cx, this_value, "setUTCMilliseconds")?;
 
         let milliseconds_arg = arguments.get(cx, 0);
@@ -1163,14 +1074,11 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setUTCMinutes (https://tc39.es/ecma262/#sec-date.prototype.setutcminutes)
-    pub fn set_utc_minutes(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_utc_minutes(cx, this_value, arguments) {
         let date_value = this_date_value(cx, this_value, "setUTCMinutes")?;
 
         let minutes_arg = arguments.get(cx, 0);
@@ -1212,14 +1120,11 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setUTCMonth (https://tc39.es/ecma262/#sec-date.prototype.setutcmonth)
-    pub fn set_utc_month(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_utc_month(cx, this_value, arguments) {
         let date_value = this_date_value(cx, this_value, "setUTCMonth")?;
 
         let month_arg = arguments.get(cx, 0);
@@ -1249,14 +1154,11 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setUTCSeconds (https://tc39.es/ecma262/#sec-date.prototype.setutcseconds)
-    pub fn set_utc_seconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_utc_seconds(cx, this_value, arguments) {
         let date_value = this_date_value(cx, this_value, "setUTCSeconds")?;
 
         let seconds_arg = arguments.get(cx, 0);
@@ -1291,18 +1193,15 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.toDateString (https://tc39.es/ecma262/#sec-date.prototype.todatestring)
-    pub fn to_date_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_date_string(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "toDateString")?;
 
         Self::to_date_string_shared(cx, date_value)
-    }
+    }}
 
     fn to_date_string_shared(mut cx: Context, date_value: f64) -> EvalResult<Handle<Value>> {
         if date_value.is_nan() {
@@ -1317,12 +1216,9 @@ impl DatePrototype {
         Ok(cx.alloc_string(&string)?.as_value())
     }
 
+    runtime_fn! {
     /// Date.prototype.toISOString (https://tc39.es/ecma262/#sec-date.prototype.toisostring)
-    pub fn to_iso_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_iso_string(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "toISOString")?;
 
         if !date_value.is_finite() {
@@ -1350,14 +1246,11 @@ impl DatePrototype {
         );
 
         Ok(cx.alloc_string(&string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.toJSON (https://tc39.es/ecma262/#sec-date.prototype.tojson)
-    pub fn to_json(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_json(cx, this_value, _) {
         let object = to_object(cx, this_value)?;
 
         let time_value = to_primitive(cx, object.into(), ToPrimitivePreferredType::Number)?;
@@ -1367,58 +1260,43 @@ impl DatePrototype {
         }
 
         invoke(cx, object.into(), cx.names.to_iso_string(), &[])
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.toLocaleDateString (https://tc39.es/ecma262/#sec-date.prototype.tolocaledatestring)
-    pub fn to_locale_date_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_date_string(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "toLocaleDateString")?;
 
         Self::to_date_string_shared(cx, date_value)
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.toLocaleString (https://tc39.es/ecma262/#sec-date.prototype.tolocalestring)
-    pub fn to_locale_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_string(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "toLocaleString")?;
 
         Ok(to_date_string(cx, date_value)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.toLocaleTimeString (https://tc39.es/ecma262/#sec-date.prototype.tolocaletimestring)
-    pub fn to_locale_time_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_time_string(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "toLocaleTimeString")?;
 
         Self::to_time_string_shared(cx, date_value)
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.toString (https://tc39.es/ecma262/#sec-date.prototype.tostring)
-    pub fn to_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "toString")?;
 
         Ok(to_date_string(cx, date_value)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.toTemporalInstant (https://tc39.es/proposal-temporal/#sec-date.prototype.totemporalinstant)
-    pub fn to_temporal_instant(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_temporal_instant(cx, this_value, _) {
         const NAME: &str = "Date.prototype.toTemporalInstant";
 
         let date_value = this_date_value(cx, this_value, "toTemporalInstant")?;
@@ -1429,18 +1307,15 @@ impl DatePrototype {
         let instant_object = create_temporal_instant(cx, &nanos, None, NAME)?;
 
         Ok(instant_object.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.toTimeString (https://tc39.es/ecma262/#sec-date.prototype.totimestring)
-    pub fn to_time_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_time_string(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "toTimeString")?;
 
         Self::to_time_string_shared(cx, date_value)
-    }
+    }}
 
     fn to_time_string_shared(mut cx: Context, date_value: f64) -> EvalResult<Handle<Value>> {
         if date_value.is_nan() {
@@ -1457,12 +1332,9 @@ impl DatePrototype {
         Ok(cx.alloc_string(&string)?.as_value())
     }
 
+    runtime_fn! {
     /// Date.prototype.toUTCString (https://tc39.es/ecma262/#sec-date.prototype.toutcstring)
-    pub fn to_utc_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_utc_string(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "toUTCString")?;
 
         if date_value.is_nan() {
@@ -1484,25 +1356,19 @@ impl DatePrototype {
         time_string(&mut string, date_value);
 
         Ok(cx.alloc_string(&string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.valueOf (https://tc39.es/ecma262/#sec-date.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "valueOf")?;
 
         Ok(cx.number(date_value))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype [ @@toPrimitive ] (https://tc39.es/ecma262/#sec-date.prototype-%symbol.toprimitive%)
-    pub fn to_primitive(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_primitive(cx, this_value, arguments) {
         if !this_value.is_object() {
             return type_error(cx, "Date.prototype[@@toPrimitive] must be called on an object");
         }
@@ -1531,14 +1397,11 @@ impl DatePrototype {
             cx,
             "Date.prototype[@@toPrimitive] hint argument must be `default`, `string`, or `number`",
         )
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.getYear (https://tc39.es/ecma262/#sec-date.prototype.getyear)
-    pub fn get_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_year(cx, this_value, _) {
         let date_value = this_date_value(cx, this_value, "getYear")?;
 
         if date_value.is_nan() {
@@ -1548,14 +1411,11 @@ impl DatePrototype {
         let short_year = year_from_time(local_time(date_value)) - 1900.0;
 
         Ok(cx.number(short_year))
-    }
+    }}
 
+    runtime_fn! {
     /// Date.prototype.setYear (https://tc39.es/ecma262/#sec-date.prototype.setyear)
-    pub fn set_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_year(cx, this_value, arguments) {
         let date_value = this_date_value(cx, this_value, "setYear")?;
 
         let year_arg = arguments.get(cx, 0);
@@ -1576,7 +1436,7 @@ impl DatePrototype {
         set_date_value(this_value, new_date);
 
         Ok(cx.number(new_date))
-    }
+    }}
 }
 
 /// TimeString (https://tc39.es/ecma262/#sec-timestring)

--- a/src/js/runtime/intrinsics/error_constructor.rs
+++ b/src/js/runtime/intrinsics/error_constructor.rs
@@ -4,7 +4,7 @@ use crate::{
     common::error::SourceInfo,
     extend_object,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         abstract_operations::{create_non_enumerable_data_property_or_throw, get, has_property},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -20,7 +20,7 @@ use crate::{
         string_value::FlatString,
         type_utilities::to_string,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 extend_object! {
@@ -177,12 +177,9 @@ impl ErrorConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Error (https://tc39.es/ecma262/#sec-error-message)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
@@ -211,14 +208,11 @@ impl ErrorConstructor {
         install_error_cause(cx, object, options_arg)?;
 
         Ok(object.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Error.isError (https://tc39.es/ecma262/#sec-error.iserror)
-    pub fn is_error(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_error(cx, _, arguments) {
         let arg = arguments.get(cx, 0);
 
         if !arg.is_object() {
@@ -226,7 +220,7 @@ impl ErrorConstructor {
         }
 
         Ok(cx.bool(arg.as_object().is_error()))
-    }
+    }}
 }
 
 /// InstallErrorCause (https://tc39.es/ecma262/#sec-installerrorcause)

--- a/src/js/runtime/intrinsics/error_prototype.rs
+++ b/src/js/runtime/intrinsics/error_prototype.rs
@@ -1,11 +1,10 @@
 use crate::{
     common::error::FormatOptions,
     runtime::{
-        Arguments, Context, Handle, Value,
+        Context, Handle,
         abstract_operations::get,
         alloc_error::AllocResult,
         error::type_error,
-        eval_result::EvalResult,
         intrinsics::{
             error_constructor::ErrorObject, intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
         },
@@ -15,6 +14,7 @@ use crate::{
         to_console_string,
         type_utilities::to_string,
     },
+    runtime_fn,
 };
 
 pub struct ErrorPrototype;
@@ -49,12 +49,9 @@ impl ErrorPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// Error.prototype.toString (https://tc39.es/ecma262/#sec-error.prototype.tostring)
-    pub fn to_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, _) {
         if !this_value.is_object() {
             return type_error(cx, "Error.prototype.toString must be called on an object");
         }
@@ -83,13 +80,10 @@ impl ErrorPrototype {
             let separator = cx.alloc_static_string(": ")?;
             Ok(StringValue::concat_all(cx, &[name_string, separator, message_string])?.as_value())
         }
-    }
+    }}
 
-    pub fn get_stack(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn get_stack(cx, this_value, _) {
         // Check that `stack` getter was called on an error object
         if !this_value.is_object() || !this_value.as_object().is_error() {
             return Ok(cx.undefined());
@@ -105,7 +99,7 @@ impl ErrorPrototype {
         stack_trace.push_str(&error.get_stack_trace(cx)?.frames.to_string());
 
         Ok(cx.alloc_string(&stack_trace)?.as_value())
-    }
+    }}
 }
 
 /// Format an error object into a one line string containing name and message

--- a/src/js/runtime/intrinsics/finalization_registry_constructor.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_constructor.rs
@@ -1,16 +1,18 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        finalization_registry_object::FinalizationRegistryObject, intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
+use crate::{
+    runtime::{
+        Context, Handle,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        error::type_error,
+        intrinsics::{
+            finalization_registry_object::FinalizationRegistryObject, intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+        },
+        object_value::ObjectValue,
+        realm::Realm,
+        type_utilities::is_callable,
     },
-    object_value::ObjectValue,
-    realm::Realm,
-    type_utilities::is_callable,
+    runtime_fn,
 };
 
 pub struct FinalizationRegistryConstructor;
@@ -38,12 +40,9 @@ impl FinalizationRegistryConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// FinalizationRegistry (https://tc39.es/ecma262/#sec-finalization-registry-cleanup-callback)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
@@ -61,5 +60,5 @@ impl FinalizationRegistryConstructor {
             cleanup_callback.as_object(),
         )?
         .as_value())
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/finalization_registry_prototype.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_prototype.rs
@@ -1,20 +1,23 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    alloc_error::AllocResult,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        finalization_registry_object::{
-            FinalizationRegistryCell, FinalizationRegistryCells, FinalizationRegistryObject,
+use crate::{
+    runtime::{
+        Context, Handle, Value,
+        alloc_error::AllocResult,
+        error::type_error,
+        eval_result::EvalResult,
+        intrinsics::{
+            finalization_registry_object::{
+                FinalizationRegistryCell, FinalizationRegistryCells, FinalizationRegistryObject,
+            },
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            weak_ref_constructor::can_be_held_weakly,
         },
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        weak_ref_constructor::can_be_held_weakly,
+        object_value::ObjectValue,
+        property::Property,
+        realm::Realm,
+        type_utilities::same_value,
     },
-    object_value::ObjectValue,
-    property::Property,
-    realm::Realm,
-    type_utilities::same_value,
+    runtime_fn,
 };
 
 pub struct FinalizationRegistryPrototype;
@@ -52,12 +55,9 @@ impl FinalizationRegistryPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// FinalizationRegistry.prototype.register (https://tc39.es/ecma262/#sec-finalization-registry.prototype.register)
-    pub fn register(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn register(cx, this_value, arguments) {
         let registry_object = this_finalization_registry_value(cx, this_value, "register")?;
 
         let target = arguments.get(cx, 0);
@@ -97,14 +97,11 @@ impl FinalizationRegistryPrototype {
             });
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// FinalizationRegistry.prototype.unregister (https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister)
-    pub fn unregister(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn unregister(cx, this_value, arguments) {
         let registry_object = this_finalization_registry_value(cx, this_value, "unregister")?;
 
         let unregister_token = arguments.get(cx, 0);
@@ -119,7 +116,7 @@ impl FinalizationRegistryPrototype {
         let did_remove = registry_object.cells().remove(*unregister_token);
 
         Ok(cx.bool(did_remove))
-    }
+    }}
 }
 
 fn this_finalization_registry_value(

--- a/src/js/runtime/intrinsics/function_constructor.rs
+++ b/src/js/runtime/intrinsics/function_constructor.rs
@@ -1,12 +1,14 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    eval::create_dynamic_function::create_dynamic_function,
-    eval_result::EvalResult,
-    intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
-    object_value::ObjectValue,
-    realm::Realm,
+use crate::{
+    runtime::{
+        Context, Handle,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        eval::create_dynamic_function::create_dynamic_function,
+        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        object_value::ObjectValue,
+        realm::Realm,
+    },
+    runtime_fn,
 };
 
 pub struct FunctionConstructor;
@@ -32,12 +34,9 @@ impl FunctionConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Function (https://tc39.es/ecma262/#sec-function-p1-p2-pn-body)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let constructor = cx.current_function();
         Ok(create_dynamic_function(
             cx,
@@ -48,5 +47,5 @@ impl FunctionConstructor {
             /* is_generator */ false,
         )?
         .as_value())
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     must,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         abstract_operations::{
             call_object, create_list_from_array_like_arguments, has_own_property,
             ordinary_has_instance,
@@ -23,6 +23,7 @@ use crate::{
         string_value::{FlatString, StringValue},
         type_utilities::{is_callable, is_callable_object, to_integer_or_infinity},
     },
+    runtime_fn,
 };
 
 pub struct FunctionPrototype {}
@@ -119,12 +120,9 @@ impl FunctionPrototype {
         Ok(())
     }
 
+    runtime_fn! {
     /// Function.prototype.apply (https://tc39.es/ecma262/#sec-function.prototype.apply)
-    pub fn apply(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn apply(cx, this_value, arguments) {
         let this_function = this_function_value(cx, this_value, "apply")?;
 
         let this_arg = arguments.get(cx, 0);
@@ -137,14 +135,11 @@ impl FunctionPrototype {
                 create_list_from_array_like_arguments(cx, arg_array, "Function.prototype.apply")?;
             call_object(cx, this_function, this_arg, &arg_list)
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Function.prototype.bind (https://tc39.es/ecma262/#sec-function.prototype.bind)
-    pub fn bind(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn bind(cx, this_value, arguments) {
         let target = this_function_value(cx, this_value, "bind")?;
 
         let this_arg = arguments.get(cx, 0);
@@ -189,14 +184,11 @@ impl FunctionPrototype {
         set_function_name(cx, bound_func, name_key, Some("bound"))?;
 
         Ok(bound_func.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Function.prototype.call (https://tc39.es/ecma262/#sec-function.prototype.call)
-    pub fn call_intrinsic(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn call_intrinsic(cx, this_value, arguments) {
         let this_function = this_function_value(cx, this_value, "call")?;
 
         if arguments.is_empty() {
@@ -205,14 +197,11 @@ impl FunctionPrototype {
             let argument = arguments.get(cx, 0);
             call_object(cx, this_function, argument, &arguments[1..])
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Function.prototype.toString (https://tc39.es/ecma262/#sec-function.prototype.tostring)
-    pub fn to_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, _) {
         if !this_value.is_object() {
             return type_error(cx, "Function.prototype.toString must be called on a function");
         }
@@ -262,18 +251,15 @@ impl FunctionPrototype {
         }
 
         type_error(cx, "Function.prototype.toString must be called on a function")
-    }
+    }}
 
+    runtime_fn! {
     /// Function.prototype [ @@hasInstance ] (https://tc39.es/ecma262/#sec-function.prototype-%symbol.hasinstance%)
-    pub fn has_instance(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn has_instance(cx, this_value, arguments) {
         let argument = arguments.get(cx, 0);
         let has_instance = ordinary_has_instance(cx, this_value, argument)?;
         Ok(cx.bool(has_instance))
-    }
+    }}
 }
 
 fn this_function_value(

--- a/src/js/runtime/intrinsics/generator_function_constructor.rs
+++ b/src/js/runtime/intrinsics/generator_function_constructor.rs
@@ -1,12 +1,14 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    eval::create_dynamic_function::create_dynamic_function,
-    eval_result::EvalResult,
-    intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
-    object_value::ObjectValue,
-    realm::Realm,
+use crate::{
+    runtime::{
+        Context, Handle,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        eval::create_dynamic_function::create_dynamic_function,
+        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        object_value::ObjectValue,
+        realm::Realm,
+    },
+    runtime_fn,
 };
 
 pub struct GeneratorFunctionConstructor;
@@ -34,12 +36,9 @@ impl GeneratorFunctionConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// GeneratorFunction (https://tc39.es/ecma262/#sec-generatorfunction)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let constructor = cx.current_function();
         Ok(create_dynamic_function(
             cx,
@@ -50,5 +49,5 @@ impl GeneratorFunctionConstructor {
             /* is_generator */ true,
         )?
         .as_value())
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/generator_prototype.rs
+++ b/src/js/runtime/intrinsics/generator_prototype.rs
@@ -1,17 +1,19 @@
-use crate::runtime::{
-    Arguments, Context, Handle, PropertyDescriptor,
-    abstract_operations::define_property_or_throw,
-    alloc_error::AllocResult,
-    bytecode::function::Closure,
-    eval_result::EvalResult,
-    generator_object::{GeneratorCompletionType, generator_resume, generator_resume_abrupt},
-    heap_item_descriptor::HeapItemKind,
-    intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
-    object_value::ObjectValue,
-    ordinary_object::object_create,
-    property::Property,
-    realm::Realm,
-    value::Value,
+use crate::{
+    runtime::{
+        Context, Handle, PropertyDescriptor,
+        abstract_operations::define_property_or_throw,
+        alloc_error::AllocResult,
+        bytecode::function::Closure,
+        eval_result::EvalResult,
+        generator_object::{GeneratorCompletionType, generator_resume, generator_resume_abrupt},
+        heap_item_descriptor::HeapItemKind,
+        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        object_value::ObjectValue,
+        ordinary_object::object_create,
+        property::Property,
+        realm::Realm,
+    },
+    runtime_fn,
 };
 
 pub struct GeneratorPrototype;
@@ -57,35 +59,26 @@ impl GeneratorPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// %GeneratorPrototype%.next (https://tc39.es/ecma262/#sec-generator.prototype.next)
-    pub fn next(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn next(cx, this_value, arguments) {
         let value = arguments.get(cx, 0);
         generator_resume(cx, this_value, value)
-    }
+    }}
 
+    runtime_fn! {
     /// %GeneratorPrototype%.return (https://tc39.es/ecma262/#sec-generator.prototype.return)
-    pub fn return_(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn return_(cx, this_value, arguments) {
         let value = arguments.get(cx, 0);
         generator_resume_abrupt(cx, this_value, value, GeneratorCompletionType::Return)
-    }
+    }}
 
+    runtime_fn! {
     /// %GeneratorPrototype%.throw (https://tc39.es/ecma262/#sec-generator.prototype.throw)
-    pub fn throw(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn throw(cx, this_value, arguments) {
         let error = arguments.get(cx, 0);
         generator_resume_abrupt(cx, this_value, error, GeneratorCompletionType::Throw)
-    }
+    }}
 
     /// Every generator function has a prototype property referencing an instance of the generator
     /// prototype. Install this property on a generator function.

--- a/src/js/runtime/intrinsics/global_object.rs
+++ b/src/js/runtime/intrinsics/global_object.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     handle_scope, handle_scope_guard,
     runtime::{
-        Arguments, Context, EvalResult, Handle, PropertyKey, Realm, Value,
+        Context, EvalResult, Handle, PropertyKey, Realm, Value,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -27,6 +27,7 @@ use crate::{
         to_string,
         type_utilities::{to_int32, to_number},
     },
+    runtime_fn,
 };
 
 /// SetDefaultGlobalBindings (https://tc39.es/ecma262/#sec-setdefaultglobalbindings)
@@ -205,33 +206,33 @@ pub fn create_parse_int(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle
     .into())
 }
 
+runtime_fn! {
 /// eval (https://tc39.es/ecma262/#sec-eval-x)
-pub fn eval(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+fn eval(cx, _, arguments) {
     let code_arg = arguments.get(cx, 0);
 
     perform_eval(cx, code_arg, /* is_strict_caller */ false, None, EvalFlags::empty())
-}
+}}
 
+runtime_fn! {
 /// isFinite (https://tc39.es/ecma262/#sec-isfinite-number)
-pub fn is_finite(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+fn is_finite(cx, _, arguments) {
     let argument = arguments.get(cx, 0);
     let num = to_number(cx, argument)?;
     Ok(cx.bool(!num.is_nan() && !num.is_infinity()))
-}
+}}
 
+runtime_fn! {
 /// isNaN (https://tc39.es/ecma262/#sec-isnan-number)
-pub fn is_nan(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+fn is_nan(cx, _, arguments) {
     let argument = arguments.get(cx, 0);
     let num = to_number(cx, argument)?;
     Ok(cx.bool(num.is_nan()))
-}
+}}
 
+runtime_fn! {
 /// parseFloat (https://tc39.es/ecma262/#sec-parsefloat-string)
-pub fn parse_float(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+fn parse_float(cx, _, arguments) {
     let input_string_arg = arguments.get(cx, 0);
     let input_string = to_string(cx, input_string_arg)?;
 
@@ -239,7 +240,7 @@ pub fn parse_float(
         Some(float) => Ok(cx.number(float)),
         None => Ok(cx.nan()),
     }
-}
+}}
 
 fn parse_float_with_string_lexer(string: Handle<StringValue>) -> AllocResult<Option<f64>> {
     let mut lexer = StringLexer::new(string)?;
@@ -248,8 +249,9 @@ fn parse_float_with_string_lexer(string: Handle<StringValue>) -> AllocResult<Opt
     Ok(parse_signed_decimal_literal(&mut lexer))
 }
 
+runtime_fn! {
 /// parseInt (https://tc39.es/ecma262/#sec-parseint-string-radix)
-pub fn parse_int(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+fn parse_int(cx, _, arguments) {
     let input_string_arg = arguments.get(cx, 0);
     let input_string = to_string(cx, input_string_arg)?;
 
@@ -261,7 +263,7 @@ pub fn parse_int(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalRes
         Some(number) => Ok(cx.number(number)),
         None => Ok(cx.nan()),
     }
-}
+}}
 
 #[inline]
 fn parse_int_impl(mut lexer: StringLexer, radix: i32) -> Option<f64> {
@@ -356,29 +358,23 @@ fn parse_int_impl(mut lexer: StringLexer, radix: i32) -> Option<f64> {
     }
 }
 
+runtime_fn! {
 /// decodeURI (https://tc39.es/ecma262/#sec-decodeuri-encodeduri)
-pub fn decode_uri(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+fn decode_uri(cx, _, arguments) {
     let uri_arg = arguments.get(cx, 0);
     let uri_string = to_string(cx, uri_arg)?;
 
     decode::<true>(cx, uri_string)
-}
+}}
 
+runtime_fn! {
 /// decodeURIComponent (https://tc39.es/ecma262/#sec-decodeuricomponent-encodeduricomponent)
-pub fn decode_uri_component(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+fn decode_uri_component(cx, _, arguments) {
     let uri_component_arg = arguments.get(cx, 0);
     let uri_component_string = to_string(cx, uri_component_arg)?;
 
     decode::<false>(cx, uri_component_string)
-}
+}}
 
 /// Decode (https://tc39.es/ecma262/#sec-decode)
 fn decode<const INCLUDE_URI_UNESCAPED: bool>(
@@ -511,29 +507,23 @@ fn decode<const INCLUDE_URI_UNESCAPED: bool>(
         .as_value())
 }
 
+runtime_fn! {
 /// encodeURI (https://tc39.es/ecma262/#sec-encodeuri-uri)
-pub fn encode_uri(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+fn encode_uri(cx, _, arguments) {
     let uri_arg = arguments.get(cx, 0);
     let uri_string = to_string(cx, uri_arg)?;
 
     encode::<true>(cx, uri_string)
-}
+}}
 
+runtime_fn! {
 /// encodeURIComponent (https://tc39.es/ecma262/#sec-encodeuricomponent-uricomponent)
-pub fn encode_uri_component(
-    cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+fn encode_uri_component(cx, _, arguments) {
     let uri_component_arg = arguments.get(cx, 0);
     let uri_component_string = to_string(cx, uri_component_arg)?;
 
     encode::<false>(cx, uri_component_string)
-}
+}}
 
 /// Encode (https://tc39.es/ecma262/#sec-encode)
 fn encode<const INCLUDE_URI_UNESCAPED: bool>(
@@ -618,12 +608,9 @@ pub fn init_global_annex_b_methods(mut cx: Context, realm: Handle<Realm>) -> All
     Ok(())
 }
 
+runtime_fn! {
 /// escape (https://tc39.es/ecma262/#sec-escape-string)
-pub fn escape(
-    mut cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+fn escape(cx, _, arguments) {
     let string_arg = arguments.get(cx, 0);
     let string = to_string(cx, string_arg)?;
 
@@ -649,14 +636,11 @@ pub fn escape(
     }
 
     Ok(cx.alloc_wtf8_string(&escaped_string)?.as_value())
-}
+}}
 
+runtime_fn! {
 /// unescape (https://tc39.es/ecma262/#sec-unescape-string)
-pub fn unescape(
-    mut cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+fn unescape(cx, _, arguments) {
     let string_arg = arguments.get(cx, 0);
     let string = to_string(cx, string_arg)?;
     let length = string.len();
@@ -698,7 +682,7 @@ pub fn unescape(
     }
 
     Ok(cx.alloc_wtf8_string(&unescaped_string)?.as_value())
-}
+}}
 
 fn parse_hex_code_units(
     string: Handle<StringValue>,

--- a/src/js/runtime/intrinsics/intrinsics.rs
+++ b/src/js/runtime/intrinsics/intrinsics.rs
@@ -1,13 +1,12 @@
 use crate::{
     handle_scope, handle_scope_guard, must_a,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         collections::InlineArray,
         error::type_error,
-        eval_result::EvalResult,
         gc::HeapVisitor,
         get,
         global_names::create_global_declaration_instantiation_intrinsic,
@@ -115,6 +114,7 @@ use crate::{
         property_descriptor::PropertyDescriptor,
         realm::Realm,
     },
+    runtime_fn,
 };
 
 #[repr(u8)]
@@ -580,12 +580,13 @@ impl Intrinsics {
     }
 }
 
-pub fn throw_type_error(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+runtime_fn! {
+fn throw_type_error(cx, _, _) {
     type_error(
         cx,
         "`caller`, `callee`, and `arguments` properties may not be accessed on strict mode functions or the arguments objects for calls to them",
     )
-}
+}}
 
 /// %ThrowTypeError% (https://tc39.es/ecma262/#sec-%throwtypeerror%)
 fn create_throw_type_error_intrinsic(

--- a/src/js/runtime/intrinsics/iterator_constructor.rs
+++ b/src/js/runtime/intrinsics/iterator_constructor.rs
@@ -1,7 +1,7 @@
 use crate::{
     extend_object,
     runtime::{
-        Arguments, Context, HeapPtr, Value,
+        Context, HeapPtr, Value,
         abstract_operations::{call, call_object, get_method, ordinary_has_instance},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -19,7 +19,7 @@ use crate::{
         ordinary_object::{object_create_from_constructor, object_create_with_proto},
         realm::Realm,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 pub struct IteratorConstructor;
@@ -60,8 +60,9 @@ impl IteratorConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Iterator (https://tc39.es/ecma262/#sec-iterator-constructor)
-    pub fn construct(mut cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, _) {
         let new_target = cx.current_new_target();
         let throw_type_error = match new_target {
             None => true,
@@ -80,14 +81,11 @@ impl IteratorConstructor {
         )?;
 
         Ok(object.to_handle().as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Iterator.concat (https://tc39.es/ecma262/#sec-iterator.concat)
-    pub fn concat(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn concat(cx, _, arguments) {
         let mut iterator_methods = vec![];
 
         for argument in arguments.iter() {
@@ -107,10 +105,11 @@ impl IteratorConstructor {
 
         Ok(IteratorHelperObject::new_concat(cx, iterables_array, iterator_methods_array)?
             .as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Iterator.from (https://tc39.es/ecma262/#sec-iterator.from)
-    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn from(cx, _, arguments) {
         let value = arguments.get(cx, 0);
         let iterator = get_iterator_flattenable(cx, value, /* reject_primitives */ false)?;
 
@@ -121,7 +120,7 @@ impl IteratorConstructor {
         }
 
         Ok(WrappedValidIterator::new(cx, iterator.iterator, iterator.next_method)?.as_value())
-    }
+    }}
 }
 
 // A WrappedValidIterator wraps an iterator object and its next method.
@@ -202,21 +201,19 @@ impl WrapForValidIteratorPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// %WrapForValidIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.next)
-    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn next(cx, this_value, _) {
         let wrapper = this_wrapped_valid_iterator_object(cx, this_value, "next")?;
 
         // Call the wrapped iterator's next method
         let iterator = wrapper.iterator().as_value();
         call(cx, wrapper.next_method(cx), iterator, &[])
-    }
+    }}
 
+    runtime_fn! {
     /// %WrapForValidIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.next)
-    pub fn return_(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn return_(cx, this_value, _) {
         let wrapper = this_wrapped_valid_iterator_object(cx, this_value, "return")?;
 
         // Call the wrapped iterator's return method if one exists
@@ -226,7 +223,7 @@ impl WrapForValidIteratorPrototype {
             None => Ok(create_iter_result_object(cx, cx.undefined(), true)?),
             Some(return_) => call_object(cx, return_, iterator, &[]),
         }
-    }
+    }}
 }
 
 fn this_wrapped_valid_iterator_object(

--- a/src/js/runtime/intrinsics/iterator_helper_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_prototype.rs
@@ -1,15 +1,18 @@
-use crate::runtime::{
-    Arguments, Context, EvalResult, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    error::type_error,
-    generator_object::GeneratorState,
-    intrinsics::{
-        intrinsics::Intrinsic, iterator_helper_object::IteratorHelperObject,
-        rust_runtime::RuntimeFunction,
+use crate::{
+    runtime::{
+        Context, EvalResult, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        error::type_error,
+        generator_object::GeneratorState,
+        intrinsics::{
+            intrinsics::Intrinsic, iterator_helper_object::IteratorHelperObject,
+            rust_runtime::RuntimeFunction,
+        },
+        iterator::{create_iter_result_object, iterator_close},
+        object_value::ObjectValue,
+        property::Property,
     },
-    iterator::{create_iter_result_object, iterator_close},
-    object_value::ObjectValue,
-    property::Property,
+    runtime_fn,
 };
 
 /// The Iterator Helper Prototype Object (https://tc39.es/ecma262/#sec-%iteratorhelperprototype%-object)
@@ -47,8 +50,9 @@ impl IteratorHelperPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// %IteratorHelperPrototype%.next (https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.next)
-    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn next(cx, this_value, _) {
         // GenerateResume adapted for Iterator Helper Objects
         let mut object = this_iterator_helper_object(cx, this_value, "next")?;
 
@@ -87,14 +91,11 @@ impl IteratorHelperPrototype {
                 Ok(result.as_value())
             }
         }
-    }
+    }}
 
+    runtime_fn! {
     /// %IteratorHelperPrototype%.return (https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.return)
-    pub fn return_(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn return_(cx, this_value, _) {
         let mut object = this_iterator_helper_object(cx, this_value, "return")?;
 
         match object.generator_state() {
@@ -130,7 +131,7 @@ impl IteratorHelperPrototype {
         object.set_generator_state(GeneratorState::Completed);
 
         return_result
-    }
+    }}
 }
 
 fn this_iterator_helper_object(

--- a/src/js/runtime/intrinsics/iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     eval_err, must,
     runtime::{
-        Arguments, Context, EvalResult, Handle, Value,
+        Context, EvalResult, Handle, Value,
         abstract_operations::{call_object, setter_that_ignores_prototype_properties},
         alloc_error::AllocResult,
         array_object::create_array_from_list,
@@ -15,6 +15,7 @@ use crate::{
         realm::Realm,
         type_utilities::{is_callable, to_boolean, to_integer_or_infinity, to_number},
     },
+    runtime_fn,
 };
 
 /// The %IteratorPrototype% Object (https://tc39.es/ecma262/#sec-%iteratorprototype%-object)
@@ -129,21 +130,15 @@ impl IteratorPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// get Iterator.prototype.constructor (https://tc39.es/ecma262/#sec-get-iterator.prototype.constructor)
-    pub fn get_constructor(
-        cx: Context,
-        _: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_constructor(cx, _, _) {
         Ok(cx.get_intrinsic(Intrinsic::IteratorConstructor).as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// set Iterator.prototype.constructor (https://tc39.es/ecma262/#sec-set-iterator.prototype.constructor)
-    pub fn set_constructor(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_constructor(cx, this_value, arguments) {
         let value = arguments.get(cx, 0);
 
         setter_that_ignores_prototype_properties(
@@ -155,14 +150,11 @@ impl IteratorPrototype {
         )?;
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// Iterator.prototype.drop (https://tc39.es/ecma262/#sec-iterator.prototype.drop)
-    pub fn drop(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn drop(cx, this_value, arguments) {
         let this_object = this_object(cx, this_value, "drop")?;
 
         let limit_arg = arguments.get(cx, 0);
@@ -171,14 +163,11 @@ impl IteratorPrototype {
         // Get the underlying iterator and create a new iterator helper drop object
         let iterated = get_iterator_direct(cx, this_object)?;
         Ok(IteratorHelperObject::new_drop(cx, &iterated, integer_limit)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Iterator.prototype.every (https://tc39.es/ecma262/#sec-iterator.prototype.every)
-    pub fn every(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn every(cx, this_value, arguments) {
         let this_object = this_object(cx, this_value, "every")?;
 
         let predicate_arg = arguments.get(cx, 0);
@@ -209,14 +198,11 @@ impl IteratorPrototype {
                 Ok(_) => counter += 1,
             }
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Iterator.prototype.filter (https://tc39.es/ecma262/#sec-iterator.prototype.filter)
-    pub fn filter(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn filter(cx, this_value, arguments) {
         let this_object = this_object(cx, this_value, "filter")?;
 
         let predicate_arg = arguments.get(cx, 0);
@@ -226,14 +212,11 @@ impl IteratorPrototype {
         // Get the underlying iterator and create a new iterator helper map object
         let iterated = get_iterator_direct(cx, this_object)?;
         Ok(IteratorHelperObject::new_filter(cx, &iterated, predicate)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Iterator.prototype.find (https://tc39.es/ecma262/#sec-iterator.prototype.find)
-    pub fn find(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn find(cx, this_value, arguments) {
         let this_object = this_object(cx, this_value, "find")?;
 
         let predicate_arg = arguments.get(cx, 0);
@@ -264,14 +247,11 @@ impl IteratorPrototype {
                 Ok(_) => counter += 1,
             }
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Iterator.prototype.flatMap (https://tc39.es/ecma262/#sec-iterator.prototype.flatmap)
-    pub fn flat_map(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn flat_map(cx, this_value, arguments) {
         let this_object = this_object(cx, this_value, "flatMap")?;
 
         let mapper_arg = arguments.get(cx, 0);
@@ -280,14 +260,11 @@ impl IteratorPrototype {
         // Get the underlying iterator and create a new iterator helper map object
         let iterated = get_iterator_direct(cx, this_object)?;
         Ok(IteratorHelperObject::new_flat_map(cx, &iterated, mapper)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Iterator.prototype.forEach (https://tc39.es/ecma262/#sec-iterator.prototype.foreach)
-    pub fn for_each(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn for_each(cx, this_value, arguments) {
         let this_object = this_object(cx, this_value, "forEach")?;
 
         let callback_arg = arguments.get(cx, 0);
@@ -315,14 +292,11 @@ impl IteratorPrototype {
                 Ok(_) => counter += 1,
             }
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Iterator.prototype.map (https://tc39.es/ecma262/#sec-iterator.prototype.map)
-    pub fn map(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn map(cx, this_value, arguments) {
         let this_object = this_object(cx, this_value, "map")?;
 
         let mapper_arg = arguments.get(cx, 0);
@@ -331,14 +305,11 @@ impl IteratorPrototype {
         // Get the underlying iterator and create a new iterator helper map object
         let iterated = get_iterator_direct(cx, this_object)?;
         Ok(IteratorHelperObject::new_map(cx, &iterated, mapper)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Iterator.prototype.reduce (https://tc39.es/ecma262/#sec-iterator.prototype.reduce)
-    pub fn reduce(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn reduce(cx, this_value, arguments) {
         let this_object = this_object(cx, this_value, "reduce")?;
 
         let callback_arg = arguments.get(cx, 0);
@@ -388,14 +359,11 @@ impl IteratorPrototype {
                 }
             }
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Iterator.prototype.some (https://tc39.es/ecma262/#sec-iterator.prototype.some)
-    pub fn some(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn some(cx, this_value, arguments) {
         let this_object = this_object(cx, this_value, "some")?;
 
         let predicate_arg = arguments.get(cx, 0);
@@ -426,14 +394,11 @@ impl IteratorPrototype {
                 Ok(_) => counter += 1,
             }
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Iterator.prototype.take (https://tc39.es/ecma262/#sec-iterator.prototype.take)
-    pub fn take(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn take(cx, this_value, arguments) {
         let this_object = this_object(cx, this_value, "take")?;
 
         let limit_arg = arguments.get(cx, 0);
@@ -442,14 +407,11 @@ impl IteratorPrototype {
         // Get the underlying iterator and create a new iterator helper take object
         let iterated = get_iterator_direct(cx, this_object)?;
         Ok(IteratorHelperObject::new_take(cx, &iterated, integer_limit)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Iterator.prototype.toArray (https://tc39.es/ecma262/#sec-iterator.prototype.toarray)
-    pub fn to_array(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_array(cx, this_value, _) {
         let this_object = this_object(cx, this_value, "toArray")?;
 
         let mut iterated = get_iterator_direct(cx, this_object)?;
@@ -462,23 +424,17 @@ impl IteratorPrototype {
                 Some(value) => items.push(value),
             }
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Iterator.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-get-iterator.prototype-%symbol.tostringtag%)
-    pub fn iterator_prototype_get_to_string_tag(
-        cx: Context,
-        _: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn iterator_prototype_get_to_string_tag(cx, _, _) {
         Ok(cx.names.iterator().as_string().as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// set Iterator.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-set-iterator.prototype-%symbol.tostringtag%)
-    pub fn set_to_string_tag(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_to_string_tag(cx, this_value, arguments) {
         let value = arguments.get(cx, 0);
 
         setter_that_ignores_prototype_properties(
@@ -490,7 +446,7 @@ impl IteratorPrototype {
         )?;
 
         Ok(cx.undefined())
-    }
+    }}
 }
 
 fn this_object(

--- a/src/js/runtime/intrinsics/json_object.rs
+++ b/src/js/runtime/intrinsics/json_object.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     must,
     runtime::{
-        Arguments, Context, EvalResult, Handle, PropertyKey, Realm, Value,
+        Context, EvalResult, Handle, PropertyKey, Realm, Value,
         abstract_operations::{
             KeyOrValue, call_object, create_data_property, create_data_property_or_throw,
             enumerable_own_property_names, length_of_array_like,
@@ -29,6 +29,7 @@ use crate::{
         to_string,
         type_utilities::{is_array, is_callable, same_value, to_integer_or_infinity, to_number},
     },
+    runtime_fn,
 };
 
 /// The JSON Object (https://tc39.es/ecma262/#sec-json-object)
@@ -74,32 +75,27 @@ impl JSONObject {
         Ok(object)
     }
 
+    runtime_fn! {
     /// JSON.isRawJSON (https://tc39.es/ecma262/#sec-json.israwjson)
-    pub fn is_raw_json(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_raw_json(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let is_raw_json = argument.is_object() && argument.as_object().is_raw_json_object();
 
         Ok(cx.bool(is_raw_json))
-    }
+    }}
 
+    runtime_fn! {
     /// JSON.parse (https://tc39.es/ecma262/#sec-json.parse)
-    pub fn parse(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn parse(cx, _, arguments) {
         let text_arg = arguments.get(cx, 0);
         let reviver_arg = arguments.get(cx, 1);
 
         json_parse(cx, text_arg, reviver_arg)
-    }
+    }}
 
+    runtime_fn! {
     /// JSON.rawJSON (https://tc39.es/ecma262/#sec-json.rawjson)
-    pub fn raw_json(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn raw_json(cx, _, arguments) {
         let text_argument = arguments.get(cx, 0);
         let text_string = to_string(cx, text_argument)?;
 
@@ -127,7 +123,7 @@ impl JSONObject {
         let raw_json_object = RawJSONObject::new(cx, text_string)?;
 
         Ok(raw_json_object.as_value())
-    }
+    }}
 
     fn is_raw_json_start_code_unit(code_unit: CodeUnit) -> bool {
         is_ascii_lowercase_alphabetic(code_unit as CodePoint)
@@ -142,12 +138,9 @@ impl JSONObject {
             || code_unit == '\"' as CodeUnit
     }
 
+    runtime_fn! {
     /// JSON.stringify (https://tc39.es/ecma262/#sec-json.stringify)
-    pub fn stringify(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn stringify(cx, _, arguments) {
         // Replacer arg may be a function or property list
         let replacer_arg = arguments.get(cx, 1);
 
@@ -255,7 +248,7 @@ impl JSONObject {
         }
 
         Ok(serializer.build(cx)?.as_value())
-    }
+    }}
 }
 
 /// Implementation of JSON.parse with the given text and reviver argument, which may be undefined.

--- a/src/js/runtime/intrinsics/map_constructor.rs
+++ b/src/js/runtime/intrinsics/map_constructor.rs
@@ -1,7 +1,7 @@
 use crate::{
     must,
     runtime::{
-        Arguments, Context, Handle,
+        Context, Handle,
         abstract_operations::{GroupByKeyCoercion, call_object, construct, group_by},
         alloc_error::AllocResult,
         array_object::create_array_from_list,
@@ -17,6 +17,7 @@ use crate::{
         type_utilities::is_callable,
         value::Value,
     },
+    runtime_fn,
 };
 
 pub struct MapConstructor;
@@ -54,12 +55,9 @@ impl MapConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Map (https://tc39.es/ecma262/#sec-map-iterable)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
@@ -82,14 +80,11 @@ impl MapConstructor {
             call_object(cx, adder.as_object(), map_object.into(), &[key, value])?;
             Ok(())
         })
-    }
+    }}
 
+    runtime_fn! {
     /// Map.groupBy (https://tc39.es/ecma262/#sec-map.groupby)
-    pub fn group_by(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn group_by(cx, _, arguments) {
         let items = arguments.get(cx, 0);
         let callback = arguments.get(cx, 1);
 
@@ -105,7 +100,7 @@ impl MapConstructor {
         }
 
         Ok(map.as_value())
-    }
+    }}
 }
 
 /// AddEntriesFromIterable (https://tc39.es/ecma262/#sec-add-entries-from-iterable)

--- a/src/js/runtime/intrinsics/map_iterator.rs
+++ b/src/js/runtime/intrinsics/map_iterator.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object,
     runtime::{
-        Arguments, Context, Handle, HeapPtr,
+        Context, Handle, HeapPtr,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         collections::index_map::GcSafeEntriesIter,
@@ -23,7 +23,7 @@ use crate::{
         realm::Realm,
         value::{Value, ValueCollectionKey},
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // Map Iterator Objects (https://tc39.es/ecma262/#sec-map-iterator-objects)
@@ -107,9 +107,10 @@ impl MapIteratorPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// %MapIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%mapiteratorprototype%.next)
     /// Adapted from the abstract closure in CreateMapIterator (https://tc39.es/ecma262/#sec-createmapiterator)
-    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn next(cx, this_value, _) {
         let mut map_iterator = MapIterator::cast_from_value(cx, this_value)?;
 
         // Check if iterator is already done
@@ -158,7 +159,7 @@ impl MapIteratorPrototype {
                 }
             },
         }
-    }
+    }}
 }
 
 impl HeapItem for HeapPtr<MapIterator> {

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -1,21 +1,24 @@
-use crate::runtime::{
-    Arguments, Context, Handle,
-    abstract_operations::{call, call_object},
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        map_iterator::{MapIterator, MapIteratorKind},
-        map_object::MapObject,
-        rust_runtime::RuntimeFunction,
+use crate::{
+    runtime::{
+        Context, Handle,
+        abstract_operations::{call, call_object},
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        error::type_error,
+        eval_result::EvalResult,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            map_iterator::{MapIterator, MapIteratorKind},
+            map_object::MapObject,
+            rust_runtime::RuntimeFunction,
+        },
+        object_value::ObjectValue,
+        property::Property,
+        realm::Realm,
+        type_utilities::is_callable,
+        value::{Value, ValueCollectionKey},
     },
-    object_value::ObjectValue,
-    property::Property,
-    realm::Realm,
-    type_utilities::is_callable,
-    value::{Value, ValueCollectionKey},
+    runtime_fn,
 };
 
 pub struct MapPrototype;
@@ -106,25 +109,19 @@ impl MapPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// Map.prototype.clear (https://tc39.es/ecma262/#sec-map.prototype.clear)
-    pub fn clear(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn clear(cx, this_value, _) {
         let map = this_map_value(cx, this_value, "clear")?;
 
         map.map_data().clear();
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// Map.prototype.delete (https://tc39.es/ecma262/#sec-map.prototype.delete)
-    pub fn delete(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn delete(cx, this_value, arguments) {
         let map = this_map_value(cx, this_value, "delete")?;
 
         let key = arguments.get(cx, 0);
@@ -135,25 +132,19 @@ impl MapPrototype {
         let existed = map.map_data().remove(&map_key);
 
         Ok(cx.bool(existed))
-    }
+    }}
 
+    runtime_fn! {
     /// Map.prototype.entries (https://tc39.es/ecma262/#sec-map.prototype.entries)
-    pub fn entries(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn entries(cx, this_value, _) {
         let map = this_map_value(cx, this_value, "entries")?;
 
         Ok(MapIterator::new(cx, map, MapIteratorKind::KeyAndValue)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Map.prototype.forEach (https://tc39.es/ecma262/#sec-map.prototype.foreach)
-    pub fn for_each(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn for_each(cx, this_value, arguments) {
         let map = this_map_value(cx, this_value, "forEach")?;
 
         let callback_function = arguments.get(cx, 0);
@@ -179,14 +170,11 @@ impl MapPrototype {
         }
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// Map.prototype.get (https://tc39.es/ecma262/#sec-map.prototype.get)
-    pub fn get(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get(cx, this_value, arguments) {
         let map = this_map_value(cx, this_value, "get")?;
 
         let key = arguments.get(cx, 0);
@@ -198,14 +186,11 @@ impl MapPrototype {
             Some(value) => Ok(value.to_handle(cx)),
             None => Ok(cx.undefined()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Map.prototype.getOrInsert (https://tc39.es/ecma262/#sec-map.prototype.getorinsert)
-    pub fn get_or_insert(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_or_insert(cx, this_value, arguments) {
         let map = this_map_value(cx, this_value, "getOrInsert")?;
 
         let key = arguments.get(cx, 0);
@@ -220,14 +205,11 @@ impl MapPrototype {
             map.insert(cx, key, value)?;
             Ok(value)
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Map.prototype.getOrInsertComputed (https://tc39.es/ecma262/#sec-map.prototype.getorinsertcomputed)
-    pub fn get_or_insert_computed(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_or_insert_computed(cx, this_value, arguments) {
         let map = this_map_value(cx, this_value, "getOrInsertComputed")?;
 
         let key = arguments.get(cx, 0);
@@ -257,14 +239,11 @@ impl MapPrototype {
         map.insert(cx, key, value)?;
 
         Ok(value.to_handle(cx))
-    }
+    }}
 
+    runtime_fn! {
     /// Map.prototype.has (https://tc39.es/ecma262/#sec-map.prototype.has)
-    pub fn has(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn has(cx, this_value, arguments) {
         let map = this_map_value(cx, this_value, "has")?;
 
         let key = arguments.get(cx, 0);
@@ -273,21 +252,19 @@ impl MapPrototype {
         let map_key = ValueCollectionKey::from(key)?;
 
         Ok(cx.bool(map.map_data().contains_key(&map_key)))
-    }
+    }}
 
+    runtime_fn! {
     /// Map.prototype.keys (https://tc39.es/ecma262/#sec-map.prototype.keys)
-    pub fn keys(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn keys(cx, this_value, _) {
         let map = this_map_value(cx, this_value, "keys")?;
 
         Ok(MapIterator::new(cx, map, MapIteratorKind::Key)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Map.prototype.set (https://tc39.es/ecma262/#sec-map.prototype.set)
-    pub fn set(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set(cx, this_value, arguments) {
         let map = this_map_value(cx, this_value, "set")?;
 
         let mut key = arguments.get(cx, 0);
@@ -301,25 +278,23 @@ impl MapPrototype {
         map.insert(cx, key, value)?;
 
         Ok(this_value)
-    }
+    }}
 
+    runtime_fn! {
     /// get Map.prototype.size (https://tc39.es/ecma262/#sec-get-map.prototype.size)
-    pub fn size(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn size(cx, this_value, _) {
         let map = this_map_value(cx, this_value, "size")?;
 
         Ok(cx.number(map.map_data().num_entries_occupied()))
-    }
+    }}
 
+    runtime_fn! {
     /// Map.prototype.values (https://tc39.es/ecma262/#sec-map.prototype.values)
-    pub fn values(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn values(cx, this_value, _) {
         let map = this_map_value(cx, this_value, "values")?;
 
         Ok(MapIterator::new(cx, map, MapIteratorKind::Value)?.as_value())
-    }
+    }}
 }
 
 fn this_map_value(

--- a/src/js/runtime/intrinsics/math_object.rs
+++ b/src/js/runtime/intrinsics/math_object.rs
@@ -7,10 +7,9 @@ use crate::{
         numeric::{MAX_I32_PLUS_ONE_AS_F64, MAX_SAFE_INTEGER_U64},
     },
     runtime::{
-        Arguments, Context, Handle,
+        Context, Handle,
         alloc_error::AllocResult,
         error::{range_error, type_error},
-        eval_result::EvalResult,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         iterator::{IteratorHint, get_iterator, iterator_close, iterator_step_value},
         numeric_operations::number_exponentiate,
@@ -20,6 +19,7 @@ use crate::{
         type_utilities::{to_number, to_uint32},
         value::Value,
     },
+    runtime_fn,
 };
 
 /// The Math Object (https://tc39.es/ecma262/#sec-math-object)
@@ -129,8 +129,9 @@ impl MathObject {
         Ok(object)
     }
 
+    runtime_fn! {
     /// Math.abs (https://tc39.es/ecma262/#sec-math.abs)
-    pub fn abs(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn abs(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
 
@@ -144,52 +145,59 @@ impl MathObject {
         }
 
         Ok(cx.number(f64::abs(n.as_double())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.acos (https://tc39.es/ecma262/#sec-math.acos)
-    pub fn acos(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn acos(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::acos(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.acosh (https://tc39.es/ecma262/#sec-math.acosh)
-    pub fn acosh(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn acosh(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::acosh(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.asin (https://tc39.es/ecma262/#sec-math.asin)
-    pub fn asin(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn asin(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::asin(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.asinh (https://tc39.es/ecma262/#sec-math.asinh)
-    pub fn asinh(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn asinh(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::asinh(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.atan (https://tc39.es/ecma262/#sec-math.atan)
-    pub fn atan(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn atan(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::atan(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.atanh (https://tc39.es/ecma262/#sec-math.atanh)
-    pub fn atanh(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn atanh(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::atanh(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.atan2 (https://tc39.es/ecma262/#sec-math.atan2)
-    pub fn atan2(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn atan2(cx, _, arguments) {
         let y_arg = arguments.get(cx, 0);
         let y = to_number(cx, y_arg)?;
 
@@ -197,17 +205,19 @@ impl MathObject {
         let x = to_number(cx, x_arg)?;
 
         Ok(cx.number(y.as_number().atan2(x.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.cbrt (https://tc39.es/ecma262/#sec-math.cbrt)
-    pub fn cbrt(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn cbrt(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::cbrt(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.ceil (https://tc39.es/ecma262/#sec-math.ceil)
-    pub fn ceil(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn ceil(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
 
@@ -216,49 +226,51 @@ impl MathObject {
         } else {
             Ok(cx.number(f64::ceil(n.as_double())))
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Math.clz32 (https://tc39.es/ecma262/#sec-math.clz32)
-    pub fn clz32(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn clz32(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_uint32(cx, argument)?;
         Ok(cx.smi(n.leading_zeros() as u8))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.cos (https://tc39.es/ecma262/#sec-math.cos)
-    pub fn cos(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn cos(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::cos(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.cosh (https://tc39.es/ecma262/#sec-math.cosh)
-    pub fn cosh(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn cosh(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::cosh(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.exp (https://tc39.es/ecma262/#sec-math.exp)
-    pub fn exp(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn exp(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::exp(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.expm1 (https://tc39.es/ecma262/#sec-math.expm1)
-    pub fn expm1(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn expm1(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::exp_m1(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.f16Round (https://tc39.es/ecma262/#sec-math.f16round)
-    pub fn f16_round(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn f16_round(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
 
@@ -269,10 +281,11 @@ impl MathObject {
         let rounded_f16 = f64_to_f16(n.as_number());
 
         Ok(cx.number(rounded_f16.to_f64()))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.floor (https://tc39.es/ecma262/#sec-math.floor)
-    pub fn floor(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn floor(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
 
@@ -281,21 +294,19 @@ impl MathObject {
         } else {
             Ok(cx.number(f64::floor(n.as_double())))
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Math.fround (https://tc39.es/ecma262/#sec-math.fround)
-    pub fn fround(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn fround(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number((n.as_number() as f32) as f64))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.hypot (https://tc39.es/ecma262/#sec-math.hypot)
-    pub fn hypot(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn hypot(cx, _, arguments) {
         let mut sum = Value::smi(0);
         let mut has_infinity: bool = false;
         let mut has_nan: bool = false;
@@ -332,10 +343,11 @@ impl MathObject {
         }
 
         Ok(cx.number(f64::sqrt(sum.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.imul (https://tc39.es/ecma262/#sec-math.imul)
-    pub fn imul(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn imul(cx, _, arguments) {
         let x_arg = arguments.get(cx, 0);
         let x = to_uint32(cx, x_arg)?;
 
@@ -345,38 +357,43 @@ impl MathObject {
         let mod_mul = ((x as u64) * (y as u64)) as u32;
 
         Ok(cx.smi(mod_mul as i32))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.log (https://tc39.es/ecma262/#sec-math.log)
-    pub fn log(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn log(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::ln(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.log1p (https://tc39.es/ecma262/#sec-math.log1p)
-    pub fn log1p(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn log1p(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::ln_1p(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.log10 (https://tc39.es/ecma262/#sec-math.log10)
-    pub fn log10(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn log10(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::log10(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.log2 (https://tc39.es/ecma262/#sec-math.log2)
-    pub fn log2(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn log2(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::log2(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.max (https://tc39.es/ecma262/#sec-math.max)
-    pub fn max(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn max(cx, _, arguments) {
         let mut highest = Value::number(f64::NEG_INFINITY);
         let mut found_nan = false;
 
@@ -402,10 +419,11 @@ impl MathObject {
         }
 
         Ok(highest.to_handle(cx))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.min (https://tc39.es/ecma262/#sec-math.min)
-    pub fn min(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn min(cx, _, arguments) {
         let mut lowest = Value::number(f64::INFINITY);
         let mut found_nan = false;
 
@@ -431,10 +449,11 @@ impl MathObject {
         }
 
         Ok(lowest.to_handle(cx))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.pow (https://tc39.es/ecma262/#sec-math.pow)
-    pub fn pow(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn pow(cx, _, arguments) {
         let base_arg = arguments.get(cx, 0);
         let base = to_number(cx, base_arg)?;
 
@@ -442,16 +461,18 @@ impl MathObject {
         let exponent = to_number(cx, exponent_arg)?;
 
         Ok(cx.number(number_exponentiate(base.as_number(), exponent.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.random (https://tc39.es/ecma262/#sec-math.random)
-    pub fn random(mut cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn random(cx, _, _) {
         let n = cx.rand.r#gen::<f64>();
         Ok(cx.number(n))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.round (https://tc39.es/ecma262/#sec-math.round)
-    pub fn round(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn round(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
 
@@ -469,10 +490,11 @@ impl MathObject {
 
             Ok(cx.number(rounded))
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Math.sign (https://tc39.es/ecma262/#sec-math.sign)
-    pub fn sign(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn sign(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = *to_number(cx, argument)?;
 
@@ -496,35 +518,35 @@ impl MathObject {
                 Ok(cx.negative_one())
             }
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Math.sin (https://tc39.es/ecma262/#sec-math.sin)
-    pub fn sin(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn sin(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::sin(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.sinh (https://tc39.es/ecma262/#sec-math.sinh)
-    pub fn sinh(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn sinh(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::sinh(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.sqrt (https://tc39.es/ecma262/#sec-math.sqrt)
-    pub fn sqrt(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn sqrt(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::sqrt(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.sumPrecise (https://tc39.es/proposal-math-sum/)
-    pub fn sum_precise(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn sum_precise(cx, _, arguments) {
         let items_arg = arguments.get(cx, 0);
 
         if !items_arg.is_object() {
@@ -586,24 +608,27 @@ impl MathObject {
             SumPreciseState::NegativeZero => Ok(cx.number(-0.0)),
             SumPreciseState::NaN => Ok(cx.nan()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Math.tan (https://tc39.es/ecma262/#sec-math.tan)
-    pub fn tan(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn tan(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::tan(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.tanh (https://tc39.es/ecma262/#sec-math.tanh)
-    pub fn tanh(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn tanh(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
         Ok(cx.number(f64::tanh(n.as_number())))
-    }
+    }}
 
+    runtime_fn! {
     /// Math.trunc (https://tc39.es/ecma262/#sec-math.trunc)
-    pub fn trunc(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn trunc(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let n = to_number(cx, argument)?;
 
@@ -612,7 +637,7 @@ impl MathObject {
         } else {
             Ok(cx.number(f64::trunc(n.as_double())))
         }
-    }
+    }}
 }
 
 #[derive(PartialEq)]

--- a/src/js/runtime/intrinsics/native_error.rs
+++ b/src/js/runtime/intrinsics/native_error.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    Arguments, Context, Handle, HeapPtr, Value,
+    Context, Handle, HeapPtr,
     abstract_operations::{construct, create_non_enumerable_data_property_or_throw},
     alloc_error::AllocResult,
     builtin_function::BuiltinFunction,
@@ -83,12 +83,9 @@ macro_rules! create_native_error {
                 Ok(func)
             }
 
+            $crate::runtime_fn! {
             /// NativeError (https://tc39.es/ecma262/#sec-nativeerror)
-            pub fn construct(
-                mut cx: Context,
-                _: Handle<Value>,
-                arguments: Arguments,
-            ) -> EvalResult<Handle<Value>> {
+            fn construct(cx, _, arguments) {
                 let new_target = if let Some(new_target) = cx.current_new_target() {
                     new_target
                 } else {
@@ -117,7 +114,7 @@ macro_rules! create_native_error {
                 install_error_cause(cx, object, options_arg)?;
 
                 Ok(object.as_value())
-            }
+            }}
         }
 
         pub struct $prototype;

--- a/src/js/runtime/intrinsics/number_constructor.rs
+++ b/src/js/runtime/intrinsics/number_constructor.rs
@@ -6,7 +6,7 @@ use crate::{
     common::numeric::{MAX_SAFE_INTEGER_F64, MIN_POSITIVE_SUBNORMAL_F64, MIN_SAFE_INTEGER_F64},
     extend_object,
     runtime::{
-        Arguments, Context, HeapPtr,
+        Context, HeapPtr,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         eval_result::EvalResult,
@@ -19,9 +19,8 @@ use crate::{
         },
         realm::Realm,
         type_utilities::{is_integral_number, to_numeric},
-        value::Value,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // Number Objects (https://tc39.es/ecma262/#sec-number-objects)
@@ -166,12 +165,9 @@ impl NumberConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Number (https://tc39.es/ecma262/#sec-number-constructor-number-value)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let number_value = if arguments.is_empty() {
             0.0
         } else {
@@ -191,59 +187,47 @@ impl NumberConstructor {
                 Ok(NumberObject::new_from_constructor(cx, new_target, number_value)?.as_value())
             }
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Number.isFinite (https://tc39.es/ecma262/#sec-number.isfinite)
-    pub fn is_finite(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_finite(cx, _, arguments) {
         let value = arguments.get(cx, 0);
         if !value.is_number() {
             return Ok(cx.bool(false));
         }
 
         Ok(cx.bool(!value.is_nan() && !value.is_infinity()))
-    }
+    }}
 
+    runtime_fn! {
     /// Number.isInteger (https://tc39.es/ecma262/#sec-number.isinteger)
-    pub fn is_integer(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_integer(cx, _, arguments) {
         let value = arguments.get(cx, 0);
         Ok(cx.bool(is_integral_number(*value)))
-    }
+    }}
 
+    runtime_fn! {
     /// Number.isNaN (https://tc39.es/ecma262/#sec-number.isnan)
-    pub fn is_nan(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_nan(cx, _, arguments) {
         let value = arguments.get(cx, 0);
         if !value.is_number() {
             return Ok(cx.bool(false));
         }
 
         Ok(cx.bool(value.is_nan()))
-    }
+    }}
 
+    runtime_fn! {
     /// Number.isSafeInteger (https://tc39.es/ecma262/#sec-number.issafeinteger)
-    pub fn is_safe_integer(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_safe_integer(cx, _, arguments) {
         let value = arguments.get(cx, 0);
         if !is_integral_number(*value) {
             return Ok(cx.bool(false));
         }
 
         Ok(cx.bool(value.as_number().abs() <= MAX_SAFE_INTEGER_F64))
-    }
+    }}
 }
 
 impl HeapItem for HeapPtr<NumberObject> {

--- a/src/js/runtime/intrinsics/number_prototype.rs
+++ b/src/js/runtime/intrinsics/number_prototype.rs
@@ -1,17 +1,20 @@
-use crate::runtime::{
-    Arguments, Context, Handle,
-    alloc_error::AllocResult,
-    error::{range_error, type_error},
-    eval_result::EvalResult,
-    intrinsics::{
-        intrinsics::Intrinsic, number_constructor::NumberObject, rust_runtime::RuntimeFunction,
+use crate::{
+    runtime::{
+        Context, Handle,
+        alloc_error::AllocResult,
+        error::{range_error, type_error},
+        eval_result::EvalResult,
+        intrinsics::{
+            intrinsics::Intrinsic, number_constructor::NumberObject, rust_runtime::RuntimeFunction,
+        },
+        object_value::ObjectValue,
+        realm::Realm,
+        string_value::FlatString,
+        to_string,
+        type_utilities::{number_to_string, to_integer_or_infinity},
+        value::Value,
     },
-    object_value::ObjectValue,
-    realm::Realm,
-    string_value::FlatString,
-    to_string,
-    type_utilities::{number_to_string, to_integer_or_infinity},
-    value::Value,
+    runtime_fn,
 };
 
 pub struct NumberPrototype;
@@ -69,12 +72,9 @@ impl NumberPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// Number.prototype.toExponential (https://tc39.es/ecma262/#sec-number.prototype.toexponential)
-    pub fn to_exponential(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_exponential(cx, this_value, arguments) {
         let number_value = this_number_value(cx, this_value, "toExponential")?;
         let mut number = number_value.as_number();
 
@@ -149,14 +149,11 @@ impl NumberPrototype {
         result.push_str(&exponent.to_string());
 
         Ok(cx.alloc_string(&result)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Number.prototype.toFixed (https://tc39.es/ecma262/#sec-number.prototype.tofixed)
-    pub fn to_fixed(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_fixed(cx, this_value, arguments) {
         let number_value = this_number_value(cx, this_value, "toFixed")?;
         let mut number = number_value.as_number();
 
@@ -197,23 +194,17 @@ impl NumberPrototype {
         }
 
         Ok(cx.alloc_string(&m)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Number.prototype.toLocaleString (https://tc39.es/ecma262/#sec-number.prototype.tolocalestring)
-    pub fn to_locale_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_string(cx, this_value, _) {
         Self::to_string_impl(cx, this_value, cx.undefined(), "toLocaleString")
-    }
+    }}
 
+    runtime_fn! {
     /// Number.prototype.toPrecision (https://tc39.es/ecma262/#sec-number.prototype.toprecision)
-    pub fn to_precision(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_precision(cx, this_value, arguments) {
         let number_value = this_number_value(cx, this_value, "toPrecision")?;
 
         let precision_arg = arguments.get(cx, 0);
@@ -290,17 +281,14 @@ impl NumberPrototype {
         }
 
         Ok(cx.alloc_string(&result)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Number.prototype.toString (https://tc39.es/ecma262/#sec-number.prototype.tostring)
-    pub fn to_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, arguments) {
         let radix_arg = arguments.get(cx, 0);
         Self::to_string_impl(cx, this_value, radix_arg, "toString")
-    }
+    }}
 
     fn to_string_impl(
         mut cx: Context,
@@ -411,15 +399,12 @@ impl NumberPrototype {
             .as_value())
     }
 
+    runtime_fn! {
     /// Number.prototype.valueOf (https://tc39.es/ecma262/#sec-number.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, this_value, _) {
         let number_value = this_number_value(cx, this_value, "valueOf")?;
         Ok(number_value.to_handle(cx))
-    }
+    }}
 }
 
 /// Character values that are used for each digit. May be a digit or letter e.g. `1` or `a`.

--- a/src/js/runtime/intrinsics/object_constructor.rs
+++ b/src/js/runtime/intrinsics/object_constructor.rs
@@ -1,7 +1,7 @@
 use crate::{
     must,
     runtime::{
-        Arguments, Context, Handle, Value,
+        Context, Handle, Value,
         abstract_operations::{
             GroupByKeyCoercion, IntegrityLevel, KeyOrValue, create_data_property_or_throw,
             define_property_or_throw, enumerable_own_property_names, get, group_by,
@@ -27,6 +27,7 @@ use crate::{
         realm::Realm,
         type_utilities::{require_object_coercible, same_value, to_object, to_property_key},
     },
+    runtime_fn,
 };
 
 pub struct ObjectConstructor;
@@ -208,12 +209,9 @@ impl ObjectConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Object (https://tc39.es/ecma262/#sec-object-value)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         if let Some(new_target) = cx.current_new_target() {
             if !cx.current_function().ptr_eq(&new_target) {
                 let new_object = object_create_from_constructor::<ObjectValue>(
@@ -233,14 +231,11 @@ impl ObjectConstructor {
         }
 
         Ok(must!(to_object(cx, value)).as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Object.assign (https://tc39.es/ecma262/#sec-object.assign)
-    pub fn assign(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn assign(cx, _, arguments) {
         let to_arg = arguments.get(cx, 0);
         let to = to_object(cx, to_arg)?;
 
@@ -270,14 +265,11 @@ impl ObjectConstructor {
         }
 
         Ok(to.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Object.create (https://tc39.es/ecma262/#sec-object.create)
-    pub fn create(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn create(cx, _, arguments) {
         let proto = arguments.get(cx, 0);
         let proto = if proto.is_object() {
             Some(proto.as_object())
@@ -300,14 +292,11 @@ impl ObjectConstructor {
         } else {
             Self::object_define_properties(cx, object, properties)
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Object.defineProperties (https://tc39.es/ecma262/#sec-object.defineproperties)
-    pub fn define_properties(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn define_properties(cx, _, arguments) {
         let object = arguments.get(cx, 0);
         if !object.is_object() {
             return type_error(cx, "Object.defineProperties target must be an object");
@@ -315,7 +304,7 @@ impl ObjectConstructor {
 
         let properties_arg = arguments.get(cx, 1);
         Self::object_define_properties(cx, object.as_object(), properties_arg)
-    }
+    }}
 
     /// ObjectDefineProperties (https://tc39.es/ecma262/#sec-objectdefineproperties)
     pub fn object_define_properties(
@@ -349,12 +338,9 @@ impl ObjectConstructor {
         Ok(object.as_value())
     }
 
+    runtime_fn! {
     /// Object.defineProperty (https://tc39.es/ecma262/#sec-object.defineproperty)
-    pub fn define_property(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn define_property(cx, _, arguments) {
         let object = arguments.get(cx, 0);
         if !object.is_object() {
             return type_error(cx, "Object.defineProperty target must be an object");
@@ -369,26 +355,20 @@ impl ObjectConstructor {
         define_property_or_throw(cx, object.as_object(), property_key, desc)?;
 
         Ok(object)
-    }
+    }}
 
+    runtime_fn! {
     /// Object.entries (https://tc39.es/ecma262/#sec-object.defineproperty)
-    pub fn entries(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn entries(cx, _, arguments) {
         let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
         let name_list = enumerable_own_property_names(cx, object, KeyOrValue::KeyAndValue)?;
         Ok(create_array_from_list(cx, &name_list)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Object.freeze (https://tc39.es/ecma262/#sec-object.freeze)
-    pub fn freeze(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn freeze(cx, _, arguments) {
         let object = arguments.get(cx, 0);
         if !object.is_object() {
             return Ok(object);
@@ -399,14 +379,11 @@ impl ObjectConstructor {
         }
 
         Ok(object)
-    }
+    }}
 
+    runtime_fn! {
     /// Object.fromEntries (https://tc39.es/ecma262/#sec-object.fromentries)
-    pub fn from_entries(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn from_entries(cx, _, arguments) {
         let iterable_arg = arguments.get(cx, 0);
         let iterable = require_object_coercible(cx, iterable_arg)?;
 
@@ -417,14 +394,11 @@ impl ObjectConstructor {
             must!(create_data_property_or_throw(cx, object, property_key, value));
             Ok(())
         })
-    }
+    }}
 
+    runtime_fn! {
     /// Object.getOwnPropertyDescriptor (https://tc39.es/ecma262/#sec-object.getownpropertydescriptor)
-    pub fn get_own_property_descriptor(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_own_property_descriptor(cx, _, arguments) {
         let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
 
@@ -435,14 +409,11 @@ impl ObjectConstructor {
             None => Ok(cx.undefined()),
             Some(desc) => Ok(from_property_descriptor(cx, desc)?.as_value()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Object.getOwnPropertyDescriptors (https://tc39.es/ecma262/#sec-object.getownpropertydescriptors)
-    pub fn get_own_property_descriptors(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_own_property_descriptors(cx, _, arguments) {
         let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
 
@@ -463,29 +434,23 @@ impl ObjectConstructor {
         }
 
         Ok(descriptors.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Object.getOwnPropertyNames (https://tc39.es/ecma262/#sec-object.getownpropertynames)
-    pub fn get_own_property_names(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_own_property_names(cx, _, arguments) {
         let object_arg = arguments.get(cx, 0);
         let symbol_keys = Self::get_own_property_keys(cx, object_arg, true)?;
         Ok(create_array_from_list(cx, &symbol_keys)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Object.getOwnPropertySymbols (https://tc39.es/ecma262/#sec-object.getownpropertysymbols)
-    pub fn get_own_property_symbols(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_own_property_symbols(cx, _, arguments) {
         let object_arg = arguments.get(cx, 0);
         let symbol_keys = Self::get_own_property_keys(cx, object_arg, false)?;
         Ok(create_array_from_list(cx, &symbol_keys)?.as_value())
-    }
+    }}
 
     /// GetOwnPropertyKeys (https://tc39.es/ecma262/#sec-getownpropertykeys)
     pub fn get_own_property_keys(
@@ -510,12 +475,9 @@ impl ObjectConstructor {
         Ok(keys_of_type)
     }
 
+    runtime_fn! {
     /// Object.getPrototypeOf (https://tc39.es/ecma262/#sec-object.getprototypeof)
-    pub fn get_prototype_of(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_prototype_of(cx, _, arguments) {
         let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
         let prototype = object.get_prototype_of(cx)?;
@@ -524,14 +486,11 @@ impl ObjectConstructor {
             None => Ok(cx.null()),
             Some(prototype) => Ok(prototype.as_value()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Object.groupBy (https://tc39.es/ecma262/#sec-object.groupby)
-    pub fn group_by(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn group_by(cx, _, arguments) {
         let items = arguments.get(cx, 0);
         let callback = arguments.get(cx, 1);
 
@@ -546,14 +505,11 @@ impl ObjectConstructor {
         }
 
         Ok(object.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Object.hasOwn (https://tc39.es/ecma262/#sec-object.hasown)
-    pub fn has_own(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn has_own(cx, _, arguments) {
         let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
 
@@ -562,20 +518,18 @@ impl ObjectConstructor {
 
         let has_own = has_own_property(cx, object, key)?;
         Ok(cx.bool(has_own))
-    }
+    }}
 
+    runtime_fn! {
     /// Object.is (https://tc39.es/ecma262/#sec-object.is)
-    pub fn is(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn is(cx, _, arguments) {
         let is_same = same_value(arguments.get(cx, 0), arguments.get(cx, 1))?;
         Ok(cx.bool(is_same))
-    }
+    }}
 
+    runtime_fn! {
     /// Object.isExtensible (https://tc39.es/ecma262/#sec-object.isextensible)
-    pub fn is_extensible(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_extensible(cx, _, arguments) {
         let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(cx.bool(false));
@@ -583,14 +537,11 @@ impl ObjectConstructor {
 
         let is_extensible = is_extensible(cx, value.as_object())?;
         Ok(cx.bool(is_extensible))
-    }
+    }}
 
+    runtime_fn! {
     /// Object.isFrozen (https://tc39.es/ecma262/#sec-object.isfrozen)
-    pub fn is_frozen(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_frozen(cx, _, arguments) {
         let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(cx.bool(true));
@@ -598,14 +549,11 @@ impl ObjectConstructor {
 
         let is_frozen = test_integrity_level(cx, value.as_object(), IntegrityLevel::Frozen)?;
         Ok(cx.bool(is_frozen))
-    }
+    }}
 
+    runtime_fn! {
     /// Object.isSealed (https://tc39.es/ecma262/#sec-object.issealed)
-    pub fn is_sealed(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_sealed(cx, _, arguments) {
         let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(cx.bool(true));
@@ -613,22 +561,20 @@ impl ObjectConstructor {
 
         let is_sealed = test_integrity_level(cx, value.as_object(), IntegrityLevel::Sealed)?;
         Ok(cx.bool(is_sealed))
-    }
+    }}
 
+    runtime_fn! {
     /// Object.keys (https://tc39.es/ecma262/#sec-object.keys)
-    pub fn keys(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn keys(cx, _, arguments) {
         let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
         let name_list = enumerable_own_property_names(cx, object, KeyOrValue::Key)?;
         Ok(create_array_from_list(cx, &name_list)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Object.preventExtensions (https://tc39.es/ecma262/#sec-object.preventextensions)
-    pub fn prevent_extensions(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn prevent_extensions(cx, _, arguments) {
         let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(value);
@@ -642,10 +588,11 @@ impl ObjectConstructor {
         }
 
         Ok(value)
-    }
+    }}
 
+    runtime_fn! {
     /// Object.seal (https://tc39.es/ecma262/#sec-object.seal)
-    pub fn seal(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn seal(cx, _, arguments) {
         let object = arguments.get(cx, 0);
         if !object.is_object() {
             return Ok(object);
@@ -656,14 +603,11 @@ impl ObjectConstructor {
         }
 
         Ok(object)
-    }
+    }}
 
+    runtime_fn! {
     /// Object.setPrototypeOf (https://tc39.es/ecma262/#sec-object.setprototypeof)
-    pub fn set_prototype_of(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_prototype_of(cx, _, arguments) {
         let object_arg = arguments.get(cx, 0);
         let object = require_object_coercible(cx, object_arg)?;
 
@@ -686,17 +630,14 @@ impl ObjectConstructor {
         }
 
         Ok(object.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Object.values (https://tc39.es/ecma262/#sec-object.values)
-    pub fn values(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn values(cx, _, arguments) {
         let object_arg = arguments.get(cx, 0);
         let object = to_object(cx, object_arg)?;
         let name_list = enumerable_own_property_names(cx, object, KeyOrValue::Value)?;
         Ok(create_array_from_list(cx, &name_list)?.as_value())
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -3,11 +3,10 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr,
         abstract_operations::{define_property_or_throw, get, has_own_property, invoke},
         alloc_error::AllocResult,
         error::type_error,
-        eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::rust_runtime::RuntimeFunction,
@@ -21,6 +20,7 @@ use crate::{
             to_property_key,
         },
     },
+    runtime_fn,
 };
 
 extend_object! {
@@ -130,26 +130,20 @@ impl ObjectPrototype {
         Ok(())
     }
 
+    runtime_fn! {
     /// Object.prototype.hasOwnProperty (https://tc39.es/ecma262/#sec-object.prototype.hasownproperty)
-    pub fn has_own_property(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn has_own_property(cx, this_value, arguments) {
         let property_arg = arguments.get(cx, 0);
         let property_key = to_property_key(cx, property_arg)?;
         let this_object = to_object(cx, this_value)?;
 
         let has_own_property = has_own_property(cx, this_object, property_key)?;
         Ok(cx.bool(has_own_property))
-    }
+    }}
 
+    runtime_fn! {
     /// Object.prototype.isPrototypeOf (https://tc39.es/ecma262/#sec-object.prototype.isprototypeof)
-    pub fn is_prototype_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_prototype_of(cx, this_value, arguments) {
         let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(cx.bool(false));
@@ -171,14 +165,11 @@ impl ObjectPrototype {
                 }
             }
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Object.prototype.propertyIsEnumerable (https://tc39.es/ecma262/#sec-object.prototype.propertyisenumerable)
-    pub fn property_is_enumerable(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn property_is_enumerable(cx, this_value, arguments) {
         let property_arg = arguments.get(cx, 0);
         let property_key = to_property_key(cx, property_arg)?;
         let this_object = to_object(cx, this_value)?;
@@ -187,23 +178,17 @@ impl ObjectPrototype {
             None => Ok(cx.bool(false)),
             Some(desc) => Ok(cx.bool(desc.is_enumerable())),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Object.prototype.toLocaleString (https://tc39.es/ecma262/#sec-object.prototype.tolocalestring)
-    pub fn to_locale_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_string(cx, this_value, _) {
         invoke(cx, this_value, cx.names.to_string(), &[])
-    }
+    }}
 
+    runtime_fn! {
     /// Object.prototype.toString (https://tc39.es/ecma262/#sec-object.prototype.tostring)
-    pub fn to_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, _) {
         if this_value.is_undefined() {
             return Ok(cx.alloc_static_string("[object Undefined]")?.as_value());
         } else if this_value.is_null() {
@@ -250,36 +235,27 @@ impl ObjectPrototype {
         Ok(cx
             .alloc_string(&format!("[object {tag_string}]"))?
             .as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Object.prototype.valueOf (https://tc39.es/ecma262/#sec-object.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, this_value, _) {
         Ok(to_object(cx, this_value)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get Object.prototype.__proto__ (https://tc39.es/ecma262/#sec-get-object.prototype.__proto__)
-    pub fn get_proto(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_proto(cx, this_value, _) {
         let object = to_object(cx, this_value)?;
         match object.get_prototype_of(cx)? {
             None => Ok(cx.null()),
             Some(prototype) => Ok(prototype.as_value()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// set Object.prototype.__proto__ (https://tc39.es/ecma262/#sec-set-object.prototype.__proto__)
-    pub fn set_proto(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_proto(cx, this_value, arguments) {
         let object = require_object_coercible(cx, this_value)?;
 
         let proto = arguments.get(cx, 0);
@@ -300,14 +276,11 @@ impl ObjectPrototype {
         }
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// Object.prototype.__defineGetter__ (https://tc39.es/ecma262/#sec-object.prototype.__defineGetter__)
-    pub fn define_getter(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn define_getter(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
 
         let getter = arguments.get(cx, 1);
@@ -322,14 +295,11 @@ impl ObjectPrototype {
         define_property_or_throw(cx, object, key, desc)?;
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// Object.prototype.__defineSetter__ (https://tc39.es/ecma262/#sec-object.prototype.__defineSetter__)
-    pub fn define_setter(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn define_setter(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
 
         let setter = arguments.get(cx, 1);
@@ -344,14 +314,11 @@ impl ObjectPrototype {
         define_property_or_throw(cx, object, key, desc)?;
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// Object.prototype.__lookupGetter__ (https://tc39.es/ecma262/#sec-object.prototype.__lookupGetter__)
-    pub fn lookup_getter(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn lookup_getter(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let key_arg = arguments.get(cx, 0);
         let key = to_property_key(cx, key_arg)?;
@@ -376,14 +343,11 @@ impl ObjectPrototype {
                 },
             }
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Object.prototype.__lookupSetter__ (https://tc39.es/ecma262/#sec-object.prototype.__lookupSetter__)
-    pub fn lookup_setter(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn lookup_setter(cx, this_value, arguments) {
         let object = to_object(cx, this_value)?;
         let key_arg = arguments.get(cx, 0);
         let key = to_property_key(cx, key_arg)?;
@@ -408,7 +372,7 @@ impl ObjectPrototype {
                 },
             }
         }
-    }
+    }}
 }
 
 impl HeapItem for HeapPtr<ObjectPrototype> {

--- a/src/js/runtime/intrinsics/promise_constructor.rs
+++ b/src/js/runtime/intrinsics/promise_constructor.rs
@@ -1,7 +1,7 @@
 use crate::{
     completion_value, must,
     runtime::{
-        Arguments, Context, Handle, PropertyKey, Value,
+        Context, Handle, PropertyKey, Value,
         abstract_operations::{call, call_object, create_data_property_or_throw, invoke},
         alloc_error::AllocResult,
         array_object::{ArrayObject, array_create},
@@ -20,6 +20,7 @@ use crate::{
         realm::Realm,
         type_utilities::is_callable,
     },
+    runtime_fn,
 };
 
 /// IfAbruptRejectPromise (https://tc39.es/ecma262/#sec-ifabruptrejectpromise)
@@ -111,12 +112,9 @@ impl PromiseConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     //// Promise (https://tc39.es/ecma262/#sec-promise-executor)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = if let Some(target) = cx.current_new_target() {
             target
         } else {
@@ -133,7 +131,7 @@ impl PromiseConstructor {
         let promise = PromiseObject::new_from_constructor(cx, new_target)?;
 
         execute_then(cx, executor, cx.undefined(), promise)
-    }
+    }}
 
     fn collect_iterable_promises(
         cx: Context,
@@ -265,15 +263,12 @@ impl PromiseConstructor {
         )
     }
 
+    runtime_fn! {
     /// Promise.all (https://tc39.es/ecma262/#sec-promise.all)
-    pub fn all(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn all(cx, this_value, arguments) {
         let iterable = arguments.get(cx, 0);
         Self::collect_iterable_promises(cx, this_value, iterable, "all", Self::perform_promise_all)
-    }
+    }}
 
     /// PerformPromiseAll (https://tc39.es/ecma262/#sec-performpromiseall)
     fn perform_promise_all(
@@ -335,12 +330,9 @@ impl PromiseConstructor {
         }
     }
 
+    runtime_fn! {
     /// Promise.all Resolve (https://tc39.es/ecma262/#sec-promise.all-resolve-element-functions)
-    pub fn promise_all_resolve(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn promise_all_resolve(cx, _, arguments) {
         let function = cx.current_function();
 
         // Check if already called and mark as called
@@ -370,14 +362,11 @@ impl PromiseConstructor {
         }
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// Promise.allSettled (https://tc39.es/ecma262/#sec-promise.allsettled)
-    pub fn all_settled(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn all_settled(cx, this_value, arguments) {
         let iterable = arguments.get(cx, 0);
         Self::collect_iterable_promises(
             cx,
@@ -386,7 +375,7 @@ impl PromiseConstructor {
             "allSettled",
             Self::perform_promise_all_settled,
         )
-    }
+    }}
 
     /// Promise.allSettled (https://tc39.es/ecma262/#sec-performpromiseallsettled)
     fn perform_promise_all_settled(
@@ -472,12 +461,9 @@ impl PromiseConstructor {
         }
     }
 
+    runtime_fn! {
     /// Promise.allSettled Resolve (https://tc39.es/ecma262/#sec-promise.allsettled-resolve-element-functions)
-    pub fn promise_all_settled_resolve(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn promise_all_settled_resolve(cx, _, arguments) {
         let function = cx.current_function();
 
         // Check if already called and mark as called
@@ -523,14 +509,11 @@ impl PromiseConstructor {
         }
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// Promise.allSettled Reject (https://tc39.es/ecma262/#sec-promise.allsettled-reject-element-functions)
-    pub fn promise_all_settled_reject(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn promise_all_settled_reject(cx, _, arguments) {
         let function = cx.current_function();
 
         // Check if already called and mark as called
@@ -576,17 +559,14 @@ impl PromiseConstructor {
         }
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// Promise.any (https://tc39.es/ecma262/#sec-promise.any)
-    pub fn any(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn any(cx, this_value, arguments) {
         let iterable = arguments.get(cx, 0);
         Self::collect_iterable_promises(cx, this_value, iterable, "any", Self::perform_promise_any)
-    }
+    }}
 
     /// PerformPromiseAny (https://tc39.es/ecma262/#sec-performpromiseany)
     fn perform_promise_any(
@@ -650,12 +630,9 @@ impl PromiseConstructor {
         }
     }
 
+    runtime_fn! {
     /// Promise.any Reject (https://tc39.es/ecma262/#sec-promise.any-reject-element-functions)
-    pub fn promise_any_reject(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn promise_any_reject(cx, _, arguments) {
         let function = cx.current_function();
 
         // Check if already called and mark as called
@@ -686,14 +663,11 @@ impl PromiseConstructor {
         }
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// Promise.race (https://tc39.es/ecma262/#sec-promise.race)
-    pub fn race(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn race(cx, this_value, arguments) {
         let iterable = arguments.get(cx, 0);
         Self::collect_iterable_promises(
             cx,
@@ -702,7 +676,7 @@ impl PromiseConstructor {
             "race",
             Self::perform_promise_race,
         )
-    }
+    }}
 
     /// PerformPromiseRace (https://tc39.es/ecma262/#sec-performpromiserace)
     fn perform_promise_race(
@@ -726,12 +700,9 @@ impl PromiseConstructor {
         }
     }
 
+    runtime_fn! {
     /// Promise.reject (https://tc39.es/ecma262/#sec-promise.reject)
-    pub fn reject(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn reject(cx, this_value, arguments) {
         let result = arguments.get(cx, 0);
 
         // Create a new promise and immediately reject it
@@ -739,28 +710,22 @@ impl PromiseConstructor {
         call_object(cx, capability.reject(), cx.undefined(), &[result])?;
 
         Ok(capability.promise().as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Promise.resolve (https://tc39.es/ecma262/#sec-promise.resolve)
-    pub fn resolve(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn resolve(cx, this_value, arguments) {
         if !this_value.is_object() {
             return type_error(cx, "Promise.resolve must be called on an object");
         }
 
         let result = arguments.get(cx, 0);
         Ok(promise_resolve(cx, this_value, result)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Promise.try (https://tc39.es/ecma262/#sec-promise.try)
-    pub fn try_(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn try_(cx, this_value, arguments) {
         if !this_value.is_object() {
             return type_error(cx, "Promise.try must be called on an object");
         }
@@ -776,14 +741,11 @@ impl PromiseConstructor {
         };
 
         Ok(capability.promise().as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Promise.withResolvers (https://tc39.es/ecma262/#sec-promise.withResolvers)
-    pub fn with_resolvers(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with_resolvers(cx, this_value, _) {
         let capability = PromiseCapability::new(cx, this_value)?;
 
         let object = ordinary_object_create(cx)?;
@@ -808,7 +770,7 @@ impl PromiseConstructor {
         ));
 
         Ok(object.as_value())
-    }
+    }}
 }
 
 pub fn execute_then(
@@ -874,12 +836,9 @@ fn get_promise(cx: Context, settle_function: Handle<ObjectValue>) -> Handle<Prom
         .cast::<PromiseObject>()
 }
 
+runtime_fn! {
 /// Promise Resolve Functions (https://tc39.es/ecma262/#sec-promise-resolve-functions)
-pub fn resolve_builtin_function(
-    mut cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+fn resolve_builtin_function(cx, _, arguments) {
     let resolution = arguments.get(cx, 0);
 
     let function = cx.current_function();
@@ -888,14 +847,11 @@ pub fn resolve_builtin_function(
     resolve(cx, promise, resolution)?;
 
     Ok(cx.undefined())
-}
+}}
 
+runtime_fn! {
 /// Promise Reject Functions (https://tc39.es/ecma262/#sec-promise-reject-functions)
-pub fn reject_builtin_function(
-    mut cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+fn reject_builtin_function(cx, _, arguments) {
     let resolution = arguments.get(cx, 0);
 
     let function = cx.current_function();
@@ -907,7 +863,7 @@ pub fn reject_builtin_function(
     }
 
     Ok(cx.undefined())
-}
+}}
 
 /// GetPromiseResolve (https://tc39.es/ecma262/#sec-getpromiseresolve)
 fn get_promise_resolve(

--- a/src/js/runtime/intrinsics/promise_prototype.rs
+++ b/src/js/runtime/intrinsics/promise_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     eval_err,
     runtime::{
-        Arguments, Context, EvalResult, Handle, Value,
+        Context, Handle, Value,
         abstract_operations::{call_object, invoke, species_constructor},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -13,6 +13,7 @@ use crate::{
         realm::Realm,
         type_utilities::is_callable,
     },
+    runtime_fn,
 };
 
 pub struct PromisePrototype;
@@ -58,22 +59,16 @@ impl PromisePrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// Promise.prototype.catch (https://tc39.es/ecma262/#sec-promise.prototype.catch)
-    pub fn catch(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn catch(cx, this_value, arguments) {
         let on_rejected = arguments.get(cx, 0);
         invoke(cx, this_value, cx.names.then(), &[cx.undefined(), on_rejected])
-    }
+    }}
 
+    runtime_fn! {
     /// Promise.prototype.finally (https://tc39.es/ecma262/#sec-promise.prototype.finally)
-    pub fn finally(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn finally(cx, this_value, arguments) {
         if !this_value.is_object() {
             return type_error(cx, "Promise.prototype.finally must be called on an object");
         }
@@ -122,7 +117,7 @@ impl PromisePrototype {
         }
 
         invoke(cx, promise.into(), cx.names.then(), &[then_finally, catch_finally])
-    }
+    }}
 
     fn get_constructor(cx: Context, function: Handle<ObjectValue>) -> Handle<ObjectValue> {
         function
@@ -171,11 +166,8 @@ impl PromisePrototype {
         function.private_element_set(cx, cx.well_known_symbols.values().cast(), value)
     }
 
-    pub fn finally_then(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn finally_then(cx, _, arguments) {
         let current_function = cx.current_function();
 
         let constructor = Self::get_constructor(cx, current_function);
@@ -198,22 +190,16 @@ impl PromisePrototype {
         Self::set_value(cx, continue_function, value)?;
 
         invoke(cx, promise.into(), cx.names.then(), &[continue_function.into()])
-    }
+    }}
 
-    pub fn finally_then_continue(
-        mut cx: Context,
-        _: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn finally_then_continue(cx, _, _) {
         let current_function = cx.current_function();
         Ok(Self::get_value(cx, current_function))
-    }
+    }}
 
-    pub fn finally_catch(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn finally_catch(cx, _, arguments) {
         let current_function = cx.current_function();
 
         let constructor = Self::get_constructor(cx, current_function);
@@ -236,25 +222,19 @@ impl PromisePrototype {
         Self::set_value(cx, continue_function, value)?;
 
         invoke(cx, promise.into(), cx.names.then(), &[continue_function.into()])
-    }
+    }}
 
-    pub fn finally_catch_continue(
-        mut cx: Context,
-        _: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn finally_catch_continue(cx, _, _) {
         let current_function = cx.current_function();
         let value = Self::get_value(cx, current_function);
 
         eval_err!(value)
-    }
+    }}
 
+    runtime_fn! {
     /// Promise.prototype.then (https://tc39.es/ecma262/#sec-promise.prototype.then)
-    pub fn then(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn then(cx, this_value, arguments) {
         if !is_promise(*this_value) {
             return type_error(cx, "Promise.prototype.then must be called on a Promise");
         }
@@ -267,7 +247,7 @@ impl PromisePrototype {
         let on_rejected = arguments.get(cx, 1);
 
         Ok(perform_promise_then(cx, promise, on_fulfilled, on_rejected, Some(capability))?)
-    }
+    }}
 }
 
 /// PerformPromiseThen (https://tc39.es/ecma262/#sec-performpromisethen) with a capability provided.

--- a/src/js/runtime/intrinsics/proxy_constructor.rs
+++ b/src/js/runtime/intrinsics/proxy_constructor.rs
@@ -1,12 +1,11 @@
 use crate::{
     must,
     runtime::{
-        Arguments, Context, Value,
+        Context,
         abstract_operations::create_data_property_or_throw,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::type_error,
-        eval_result::EvalResult,
         gc::Handle,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
@@ -14,6 +13,7 @@ use crate::{
         proxy_object::{ProxyObject, proxy_create},
         realm::Realm,
     },
+    runtime_fn,
 };
 
 pub struct ProxyConstructor;
@@ -41,12 +41,9 @@ impl ProxyConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Proxy (https://tc39.es/ecma262/#sec-proxy-target-handler)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         if cx.current_new_target().is_none() {
             return type_error(cx, "Proxy constructor must be called with new");
         }
@@ -55,14 +52,11 @@ impl ProxyConstructor {
         let handler = arguments.get(cx, 1);
 
         Ok(proxy_create(cx, target, handler)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Proxy.revocable (https://tc39.es/ecma262/#sec-proxy.revocable)
-    pub fn revocable(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn revocable(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         let handler = arguments.get(cx, 1);
         let proxy = proxy_create(cx, target, handler)?;
@@ -90,10 +84,11 @@ impl ProxyConstructor {
         must!(create_data_property_or_throw(cx, result, cx.names.revoke(), revoker.into()));
 
         Ok(result.as_value())
-    }
+    }}
 }
 
-pub fn revoke(mut cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+runtime_fn! {
+fn revoke(cx, _, _) {
     // Find the proxy object attached to this closure via a private property
     let mut revoke_function = cx.current_function();
     let proxy_object_property =
@@ -108,4 +103,4 @@ pub fn revoke(mut cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Han
     }
 
     Ok(cx.undefined())
-}
+}}

--- a/src/js/runtime/intrinsics/reflect_object.rs
+++ b/src/js/runtime/intrinsics/reflect_object.rs
@@ -1,16 +1,18 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    abstract_operations::{call_object, construct, create_list_from_array_like_arguments},
-    alloc_error::AllocResult,
-    array_object::create_array_from_list,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
-    object_value::ObjectValue,
-    property::Property,
-    property_descriptor::{from_property_descriptor, to_property_descriptor},
-    realm::Realm,
-    type_utilities::{is_callable, is_constructor_value, to_property_key},
+use crate::{
+    runtime::{
+        Context, Handle,
+        abstract_operations::{call_object, construct, create_list_from_array_like_arguments},
+        alloc_error::AllocResult,
+        array_object::create_array_from_list,
+        error::type_error,
+        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        object_value::ObjectValue,
+        property::Property,
+        property_descriptor::{from_property_descriptor, to_property_descriptor},
+        realm::Realm,
+        type_utilities::{is_callable, is_constructor_value, to_property_key},
+    },
+    runtime_fn,
 };
 
 /// The Reflect Object (https://tc39.es/ecma262/#sec-reflect-object)
@@ -107,8 +109,9 @@ impl ReflectObject {
         Ok(object)
     }
 
+    runtime_fn! {
     /// Reflect.apply (https://tc39.es/ecma262/#sec-reflect.apply)
-    pub fn apply(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn apply(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         if !is_callable(target) {
             return type_error(cx, "Reflect.apply target must be a function");
@@ -120,14 +123,11 @@ impl ReflectObject {
             create_list_from_array_like_arguments(cx, arguments_arg, "Reflect.apply")?;
 
         call_object(cx, target.as_object(), this_argument, &arguments_list)
-    }
+    }}
 
+    runtime_fn! {
     /// Reflect.construct (https://tc39.es/ecma262/#sec-reflect.construct)
-    pub fn construct(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         if !is_constructor_value(target) {
             return type_error(cx, "Reflect.construct target must be a constructor");
@@ -151,14 +151,11 @@ impl ReflectObject {
             create_list_from_array_like_arguments(cx, arguments_arg, "Reflect.construct")?;
 
         Ok(construct(cx, target, &arguments_list, Some(new_target))?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Reflect.defineProperty (https://tc39.es/ecma262/#sec-reflect.defineproperty)
-    pub fn define_property(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn define_property(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.defineProperty target must be an object");
@@ -174,14 +171,11 @@ impl ReflectObject {
 
         let result = target.define_own_property(cx, key, desc)?;
         Ok(cx.bool(result))
-    }
+    }}
 
+    runtime_fn! {
     /// Reflect.deleteProperty (https://tc39.es/ecma262/#sec-reflect.deleteproperty)
-    pub fn delete_property(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn delete_property(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.deleteProperty target must be an object");
@@ -193,10 +187,11 @@ impl ReflectObject {
 
         let result = target.delete(cx, key)?;
         Ok(cx.bool(result))
-    }
+    }}
 
+    runtime_fn! {
     /// Reflect.get (https://tc39.es/ecma262/#sec-reflect.get)
-    pub fn get(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn get(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.get target must be an object");
@@ -212,14 +207,11 @@ impl ReflectObject {
         };
 
         target.as_object().get(cx, key, receiver)
-    }
+    }}
 
+    runtime_fn! {
     /// Reflect.getOwnPropertyDescriptor (https://tc39.es/ecma262/#sec-reflect.getownpropertydescriptor)
-    pub fn get_own_property_descriptor(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_own_property_descriptor(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.getOwnPropertyDescriptor target must be an object");
@@ -236,14 +228,11 @@ impl ReflectObject {
             .transpose()?
             .map(|desc_object| desc_object.as_value())
             .unwrap_or(cx.undefined()))
-    }
+    }}
 
+    runtime_fn! {
     /// Reflect.getPrototypeOf (https://tc39.es/ecma262/#sec-reflect.getprototypeof)
-    pub fn get_prototype_of(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_prototype_of(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.getPrototypeOf target must be an object");
@@ -252,10 +241,11 @@ impl ReflectObject {
         let prototype = target.as_object().get_prototype_of(cx)?;
 
         Ok(prototype.map(|proto| proto.into()).unwrap_or(cx.null()))
-    }
+    }}
 
+    runtime_fn! {
     /// Reflect.has (https://tc39.es/ecma262/#sec-reflect.has)
-    pub fn has(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn has(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.has target must be an object");
@@ -267,14 +257,11 @@ impl ReflectObject {
 
         let has_property = target.has_property(cx, key)?;
         Ok(cx.bool(has_property))
-    }
+    }}
 
+    runtime_fn! {
     /// Reflect.isExtensible (https://tc39.es/ecma262/#sec-reflect.isextensible)
-    pub fn is_extensible(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_extensible(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.isExtensible target must be an object");
@@ -282,14 +269,11 @@ impl ReflectObject {
 
         let is_extensible = target.as_object().is_extensible(cx)?;
         Ok(cx.bool(is_extensible))
-    }
+    }}
 
+    runtime_fn! {
     /// Reflect.ownKeys (https://tc39.es/ecma262/#sec-reflect.ownkeys)
-    pub fn own_keys(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn own_keys(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.ownKeys target must be an object");
@@ -298,14 +282,11 @@ impl ReflectObject {
         let own_keys = target.as_object().own_property_keys(cx)?;
 
         Ok(create_array_from_list(cx, &own_keys)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Reflect.preventExtensions (https://tc39.es/ecma262/#sec-reflect.preventextensions)
-    pub fn prevent_extensions(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn prevent_extensions(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.preventExtensions target must be an object");
@@ -313,10 +294,11 @@ impl ReflectObject {
 
         let result = target.as_object().prevent_extensions(cx)?;
         Ok(cx.bool(result))
-    }
+    }}
 
+    runtime_fn! {
     /// Reflect.set (https://tc39.es/ecma262/#sec-reflect.set)
-    pub fn set(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn set(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.set target must be an object");
@@ -334,14 +316,11 @@ impl ReflectObject {
 
         let result = target.as_object().set(cx, key, value, receiver)?;
         Ok(cx.bool(result))
-    }
+    }}
 
+    runtime_fn! {
     /// Reflect.setPrototypeOf (https://tc39.es/ecma262/#sec-reflect.setprototypeof)
-    pub fn set_prototype_of(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_prototype_of(cx, _, arguments) {
         let target = arguments.get(cx, 0);
         if !target.is_object() {
             return type_error(cx, "Reflect.setPrototypeOf target must be an object");
@@ -358,5 +337,5 @@ impl ReflectObject {
 
         let result = target.as_object().set_prototype_of(cx, proto)?;
         Ok(cx.bool(result))
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -23,7 +23,7 @@ use crate::{
         regexp_parser::RegExpParser,
     },
     runtime::{
-        Arguments, Context, HeapPtr, PropertyDescriptor, Value,
+        Context, HeapPtr, PropertyDescriptor, Value,
         abstract_operations::{define_property_or_throw, set},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -41,7 +41,7 @@ use crate::{
         to_string,
         type_utilities::{is_regexp, same_value},
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // RegExp (Regular Expression) Objects (https://tc39.es/ecma262/#sec-regexp-regular-expression-objects)
@@ -165,12 +165,9 @@ impl RegExpConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// RegExp (https://tc39.es/ecma262/#sec-regexp-pattern-flags)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let pattern_arg = arguments.get(cx, 0);
         let flags_arg = arguments.get(cx, 1);
 
@@ -222,14 +219,11 @@ impl RegExpConstructor {
         };
 
         regexp_create(cx, regexp_source, new_target)
-    }
+    }}
 
+    runtime_fn! {
     /// RegExp.escape (https://tc39.es/ecma262/#sec-regexp.escape)
-    pub fn escape(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn escape(cx, _, arguments) {
         let string_arg = arguments.get(cx, 0);
         if !string_arg.is_string() {
             return type_error(cx, "RegExp.escape argument must be a string");
@@ -286,7 +280,7 @@ impl RegExpConstructor {
         }
 
         Ok(cx.alloc_wtf8_string(&escaped)?.as_value())
-    }
+    }}
 }
 
 #[inline]

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -7,7 +7,7 @@ use crate::{
     must,
     parser::regexp::RegExpFlags,
     runtime::{
-        Arguments, Context, Handle, PropertyKey, Value,
+        Context, Handle, PropertyKey, Value,
         abstract_operations::{
             call, call_object, construct, create_data_property_or_throw, length_of_array_like, set,
             species_constructor,
@@ -37,6 +37,7 @@ use crate::{
             to_length, to_object, to_uint32,
         },
     },
+    runtime_fn,
 };
 
 pub struct RegExpPrototype;
@@ -185,35 +186,26 @@ impl RegExpPrototype {
         )
     }
 
+    runtime_fn! {
     /// RegExp.prototype.exec (https://tc39.es/ecma262/#sec-regexp.prototype.exec)
-    pub fn exec(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn exec(cx, this_value, arguments) {
         let regexp_object = this_regexp_object(cx, this_value, "RegExp.prototype.exec")?;
 
         let string_arg = arguments.get(cx, 0);
         let string_value = to_string(cx, string_arg)?;
 
         regexp_builtin_exec(cx, regexp_object, string_value)
-    }
+    }}
 
+    runtime_fn! {
     /// get RegExp.prototype.dotAll (https://tc39.es/ecma262/#sec-get-regexp.prototype.dotAll)
-    pub fn dot_all(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn dot_all(cx, this_value, _) {
         regexp_has_flag(cx, this_value, RegExpFlags::DOT_ALL, "RegExp.prototype.dotAll")
-    }
+    }}
 
+    runtime_fn! {
     /// get RegExp.prototype.flags (https://tc39.es/ecma262/#sec-get-regexp.prototype.flags)
-    pub fn flags(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn flags(cx, this_value, _) {
         let this_object = this_object(cx, this_value, "RegExp.prototype.flags")?;
 
         let mut flags_string = String::new();
@@ -265,41 +257,29 @@ impl RegExpPrototype {
         };
 
         Ok(flags_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get RegExp.prototype.global (https://tc39.es/ecma262/#sec-get-regexp.prototype.global)
-    pub fn global(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn global(cx, this_value, _) {
         regexp_has_flag(cx, this_value, RegExpFlags::GLOBAL, "RegExp.prototype.global")
-    }
+    }}
 
+    runtime_fn! {
     /// get RegExp.prototype.hasIndices (https://tc39.es/ecma262/#sec-get-regexp.prototype.hasIndices)
-    pub fn has_indices(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn has_indices(cx, this_value, _) {
         regexp_has_flag(cx, this_value, RegExpFlags::HAS_INDICES, "RegExp.prototype.hasIndices")
-    }
+    }}
 
+    runtime_fn! {
     /// get RegExp.prototype.ignoreCase (https://tc39.es/ecma262/#sec-get-regexp.prototype.ignorecase)
-    pub fn ignore_case(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn ignore_case(cx, this_value, _) {
         regexp_has_flag(cx, this_value, RegExpFlags::IGNORE_CASE, "RegExp.prototype.ignoreCase")
-    }
+    }}
 
+    runtime_fn! {
     /// RegExp.prototype [ @@match ] (https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.match%)
-    pub fn match_(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn match_(cx, this_value, arguments) {
         let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@match]")?;
 
         let string_arg = arguments.get(cx, 0);
@@ -359,14 +339,11 @@ impl RegExpPrototype {
 
             n += 1;
         }
-    }
+    }}
 
+    runtime_fn! {
     /// RegExp.prototype [ @@matchAll ] (https://tc39.es/ecma262/#sec-regexp-prototype-%symbol.matchall%)
-    pub fn match_all(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn match_all(cx, this_value, arguments) {
         let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@matchAll]")?;
 
         let string_arg = arguments.get(cx, 0);
@@ -391,23 +368,17 @@ impl RegExpPrototype {
             || flags_string_contains(flags_string, 'v' as u32)?;
 
         Ok(RegExpStringIterator::new(cx, matcher, string_value, is_global, is_unicode)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get RegExp.prototype.multiline (https://tc39.es/ecma262/#sec-get-regexp.prototype.multiline)
-    pub fn multiline(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn multiline(cx, this_value, _) {
         regexp_has_flag(cx, this_value, RegExpFlags::MULTILINE, "RegExp.prototype.multiline")
-    }
+    }}
 
+    runtime_fn! {
     /// RegExp.prototype [ @@replace ] (https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.replace%)
-    pub fn replace(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn replace(cx, this_value, arguments) {
         let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@replace]")?;
 
         let target_string_arg = arguments.get(cx, 0);
@@ -587,14 +558,11 @@ impl RegExpPrototype {
         }
 
         Ok(StringValue::concat_all(cx, &string_parts)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// RegExp.prototype [ @@search ] (https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.search%)
-    pub fn search(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn search(cx, this_value, arguments) {
         let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@search]")?;
 
         let string_arg = arguments.get(cx, 0);
@@ -621,14 +589,11 @@ impl RegExpPrototype {
         } else {
             get(cx, result.as_object(), cx.names.index())
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get RegExp.prototype.source (https://tc39.es/ecma262/#sec-get-regexp.prototype.source)
-    pub fn source(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn source(cx, this_value, _) {
         if this_value.is_object() {
             let this_object = this_value.as_object();
             if let Some(regexp_object) = this_object.as_regexp_object() {
@@ -642,14 +607,11 @@ impl RegExpPrototype {
         }
 
         type_error(cx, "RegExp.prototype.source must be called on a RegExp")
-    }
+    }}
 
+    runtime_fn! {
     /// RegExp.prototype [ @@split ] (https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.split%)
-    pub fn split(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn split(cx, this_value, arguments) {
         let regexp_object = this_object(cx, this_value, "RegExp.prototype[@@split]")?;
 
         let string_arg = arguments.get(cx, 0);
@@ -779,23 +741,17 @@ impl RegExpPrototype {
         create_data_property_or_throw(cx, result_array, key, remaining_string.into())?;
 
         Ok(result_array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get RegExp.prototype.sticky (https://tc39.es/ecma262/#sec-get-regexp.prototype.sticky)
-    pub fn sticky(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn sticky(cx, this_value, _) {
         regexp_has_flag(cx, this_value, RegExpFlags::STICKY, "RegExp.prototype.sticky")
-    }
+    }}
 
+    runtime_fn! {
     /// RegExp.prototype.test (https://tc39.es/ecma262/#sec-regexp.prototype.test)
-    pub fn test(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn test(cx, this_value, arguments) {
         let regexp_object = this_object(cx, this_value, "test")?;
 
         let string_arg = arguments.get(cx, 0);
@@ -804,14 +760,11 @@ impl RegExpPrototype {
         let exec_result = regexp_exec(cx, regexp_object, string_value, "RegExp.prototype.test")?;
 
         Ok(cx.bool(!exec_result.is_null()))
-    }
+    }}
 
+    runtime_fn! {
     /// RegExp.prototype.toString (https://tc39.es/ecma262/#sec-regexp.prototype.tostring)
-    pub fn to_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, _) {
         let this_object = this_object(cx, this_value, "toString")?;
 
         let pattern_value = get(cx, this_object, cx.names.source())?;
@@ -828,32 +781,23 @@ impl RegExpPrototype {
         )?;
 
         Ok(full_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get RegExp.prototype.unicode (https://tc39.es/ecma262/#sec-get-regexp.prototype.unicode)
-    pub fn unicode(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn unicode(cx, this_value, _) {
         regexp_has_flag(cx, this_value, RegExpFlags::UNICODE_AWARE, "RegExp.prototype.unicode")
-    }
+    }}
 
+    runtime_fn! {
     /// get RegExp.prototype.unicodeSets (https://tc39.es/ecma262/#sec-get-regexp.prototype.unicodesets)
-    pub fn unicode_sets(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn unicode_sets(cx, this_value, _) {
         regexp_has_flag(cx, this_value, RegExpFlags::UNICODE_SETS, "RegExp.prototype.unicodeSets")
-    }
+    }}
 
+    runtime_fn! {
     /// RegExp.prototype.compile (https://tc39.es/ecma262/#sec-regexp.prototype.compile)
-    pub fn compile(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn compile(cx, this_value, arguments) {
         let regexp_object = this_regexp_object(cx, this_value, "RegExp.prototype.compile")?;
 
         let pattern_arg = arguments.get(cx, 0);
@@ -873,7 +817,7 @@ impl RegExpPrototype {
         };
 
         regexp_init(cx, regexp_object, pattern_source)
-    }
+    }}
 }
 
 fn this_object(

--- a/src/js/runtime/intrinsics/regexp_string_iterator.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, PropertyKey, Value,
+        Context, Handle, HeapPtr, PropertyKey, Value,
         abstract_operations::set,
         alloc_error::AllocResult,
         error::type_error,
@@ -25,7 +25,7 @@ use crate::{
         to_string,
         type_utilities::to_length,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // RegExp String Iterator Objects (https://tc39.es/ecma262/#sec-regexp-string-iterator-objects)
@@ -103,8 +103,9 @@ impl RegExpStringIteratorPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// %RegExpStringIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%regexpstringiteratorprototype%.next)
-    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn next(cx, this_value, _) {
         let mut regexp_iterator = RegExpStringIterator::cast_from_value(cx, this_value)?;
 
         let regexp_object = regexp_iterator.regexp_object();
@@ -149,7 +150,7 @@ impl RegExpStringIteratorPrototype {
         }
 
         Ok(create_iter_result_object(cx, match_result, false)?)
-    }
+    }}
 }
 
 impl HeapItem for HeapPtr<RegExpStringIterator> {

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -120,6 +120,21 @@ static_assert!(NUM_BUILTIN_RUST_RUNTIME_FUNCTIONS <= (1 << (RuntimeFunctionId::B
 pub type RuntimeFunctionPtr =
     fn(cx: Context, this_value: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>>;
 
+// Write a macro which generates a runtime function, given the name and body of the function.
+#[macro_export]
+macro_rules! runtime_fn {
+    ($(#[$attr:meta])* fn $name:ident($cx:tt, $this_value:tt, $arguments:tt) $body:block) => {
+        $(#[$attr])*
+        pub fn $name(
+            #[allow(unused_mut)] mut $cx: $crate::runtime::Context,
+            $this_value: $crate::runtime::Handle<$crate::runtime::Value>,
+            $arguments: $crate::runtime::Arguments,
+        ) -> $crate::runtime::EvalResult<$crate::runtime::Handle<$crate::runtime::Value>> {
+            $body
+        }
+    };
+}
+
 /// Arguments to a runtime function. Can be treated as a slice.
 #[derive(Clone, Copy)]
 pub struct Arguments<'a> {
@@ -1107,16 +1122,14 @@ impl RuntimeFunction {
     }
 }
 
+runtime_fn! {
 /// Rust runtime function that simply returns the `this` argument.
-pub fn return_this(
-    _: Context,
-    this_value: Handle<Value>,
-    _: Arguments,
-) -> EvalResult<Handle<Value>> {
+fn return_this(_cx, this_value, _) {
     Ok(this_value)
-}
+}}
 
+runtime_fn! {
 /// Rust runtime function that simply returns `undefined`.
-pub fn return_undefined(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+fn return_undefined(cx, _, _) {
     Ok(cx.undefined())
-}
+}}

--- a/src/js/runtime/intrinsics/set_constructor.rs
+++ b/src/js/runtime/intrinsics/set_constructor.rs
@@ -1,16 +1,18 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    abstract_operations::call_object,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    error::type_error,
-    eval_result::EvalResult,
-    get,
-    intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction, set_object::SetObject},
-    iterator::iter_iterator_values,
-    object_value::ObjectValue,
-    realm::Realm,
-    type_utilities::is_callable,
+use crate::{
+    runtime::{
+        Context, Handle,
+        abstract_operations::call_object,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        error::type_error,
+        get,
+        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction, set_object::SetObject},
+        iterator::iter_iterator_values,
+        object_value::ObjectValue,
+        realm::Realm,
+        type_utilities::is_callable,
+    },
+    runtime_fn,
 };
 
 pub struct SetConstructor;
@@ -40,12 +42,9 @@ impl SetConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Set (https://tc39.es/ecma262/#sec-set-iterable)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
@@ -76,5 +75,5 @@ impl SetConstructor {
         })?;
 
         Ok(set_value)
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/set_iterator.rs
+++ b/src/js/runtime/intrinsics/set_iterator.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         collections::{BsIndexMap, index_map::GcSafeEntriesIter},
@@ -19,7 +19,7 @@ use crate::{
         realm::Realm,
         value::ValueCollectionKey,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // Set Iterator Objects (https://tc39.es/ecma262/#sec-set-iterator-objects)
@@ -102,10 +102,11 @@ impl SetIteratorPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// %SetIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%setiteratorprototype%.next)
     ///
     /// Adapted from the abstract closure in CreateSetIterator (https://tc39.es/ecma262/#sec-createsetiterator)
-    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn next(cx, this_value, _) {
         let mut set_iterator = SetIterator::cast_from_value(cx, this_value)?;
 
         // Check if iterator is already done
@@ -148,7 +149,7 @@ impl SetIteratorPrototype {
                 }
             }
         }
-    }
+    }}
 }
 
 impl HeapItem for HeapPtr<SetIterator> {

--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     must,
     runtime::{
-        Arguments, Context, Handle,
+        Context, Handle,
         abstract_operations::{call_object, canonicalize_keyed_collection_key},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -25,6 +25,7 @@ use crate::{
         type_utilities::{is_callable, to_integer_or_infinity, to_number},
         value::{Value, ValueCollectionKey},
     },
+    runtime_fn,
 };
 
 pub struct SetPrototype;
@@ -149,12 +150,9 @@ impl SetPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// Set.prototype.add (https://tc39.es/ecma262/#sec-set.prototype.add)
-    pub fn add(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn add(cx, this_value, arguments) {
         let set = this_set_value(cx, this_value, "add")?;
 
         // Convert negative zero to positive zero in set
@@ -164,27 +162,21 @@ impl SetPrototype {
         set.insert(cx, value)?;
 
         Ok(this_value)
-    }
+    }}
 
+    runtime_fn! {
     /// Set.prototype.clear (https://tc39.es/ecma262/#sec-set.prototype.clear)
-    pub fn clear(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn clear(cx, this_value, _) {
         let set = this_set_value(cx, this_value, "clear")?;
 
         set.set_data_ptr().clear();
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// Set.prototype.delete (https://tc39.es/ecma262/#sec-set.prototype.delete)
-    pub fn delete(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn delete(cx, this_value, arguments) {
         let set = this_set_value(cx, this_value, "delete")?;
 
         let key = arguments.get(cx, 0);
@@ -195,14 +187,11 @@ impl SetPrototype {
         let existed = set.set_data_ptr().remove(&set_key);
 
         Ok(cx.bool(existed))
-    }
+    }}
 
+    runtime_fn! {
     /// Set.prototype.difference (https://tc39.es/ecma262/#sec-set.prototype.difference)
-    pub fn difference(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn difference(cx, this_value, arguments) {
         let this_set = this_set_value(cx, this_value, "difference")?;
 
         let other = arguments.get(cx, 0);
@@ -260,25 +249,19 @@ impl SetPrototype {
         }
 
         Ok(new_set.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Set.prototype.entries (https://tc39.es/ecma262/#sec-set.prototype.entries)
-    pub fn entries(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn entries(cx, this_value, _) {
         let set = this_set_value(cx, this_value, "entries")?;
 
         Ok(SetIterator::new(cx, set, SetIteratorKind::KeyAndValue)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Set.prototype.forEach (https://tc39.es/ecma262/#sec-set.prototype.foreach)
-    pub fn for_each(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn for_each(cx, this_value, arguments) {
         let set = this_set_value(cx, this_value, "forEach")?;
 
         let callback_function = arguments.get(cx, 0);
@@ -302,14 +285,11 @@ impl SetPrototype {
         }
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// Set.prototype.has (https://tc39.es/ecma262/#sec-set.prototype.has)
-    pub fn has(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn has(cx, this_value, arguments) {
         let set = this_set_value(cx, this_value, "has")?;
 
         let value = arguments.get(cx, 0);
@@ -318,14 +298,11 @@ impl SetPrototype {
         let set_value = ValueCollectionKey::from(value)?;
 
         Ok(cx.bool(set.set_data_ptr().contains(&set_value)))
-    }
+    }}
 
+    runtime_fn! {
     /// Set.prototype.intersection (https://tc39.es/ecma262/#sec-set.prototype.intersection)
-    pub fn intersection(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn intersection(cx, this_value, arguments) {
         let this_set = this_set_value(cx, this_value, "intersection")?;
 
         let other = arguments.get(cx, 0);
@@ -386,14 +363,11 @@ impl SetPrototype {
         }
 
         Ok(new_set.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Set.prototype.isDisjointFrom (https://tc39.es/ecma262/#sec-set.prototype.isdisjointfrom)
-    pub fn is_disjoint_from(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_disjoint_from(cx, this_value, arguments) {
         let this_set = this_set_value(cx, this_value, "isDisjointFrom")?;
 
         let other = arguments.get(cx, 0);
@@ -447,14 +421,11 @@ impl SetPrototype {
         }
 
         Ok(cx.bool(true))
-    }
+    }}
 
+    runtime_fn! {
     /// Set.prototype.isSubsetOf (https://tc39.es/ecma262/#sec-set.prototype.issubsetof)
-    pub fn is_subset_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_subset_of(cx, this_value, arguments) {
         let this_set = this_set_value(cx, this_value, "isSubsetOf")?;
 
         let other = arguments.get(cx, 0);
@@ -487,14 +458,11 @@ impl SetPrototype {
         }
 
         Ok(cx.bool(true))
-    }
+    }}
 
+    runtime_fn! {
     /// Set.prototype.isSupersetOf (https://tc39.es/ecma262/#sec-set.prototype.issupersetof)
-    pub fn is_superset_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_superset_of(cx, this_value, arguments) {
         let this_set = this_set_value(cx, this_value, "isSupersetOf")?;
 
         let other = arguments.get(cx, 0);
@@ -529,21 +497,19 @@ impl SetPrototype {
         }
 
         Ok(cx.bool(true))
-    }
+    }}
 
+    runtime_fn! {
     /// get Set.prototype.size (https://tc39.es/ecma262/#sec-get-set.prototype.size)
-    pub fn size(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn size(cx, this_value, _) {
         let set = this_set_value(cx, this_value, "size")?;
 
         Ok(cx.number(set.set_data_ptr().num_entries_occupied()))
-    }
+    }}
 
+    runtime_fn! {
     /// Set.prototype.symmetricDifference (https://tc39.es/ecma262/#sec-set.prototype.symmetricdifference)
-    pub fn symmetric_difference(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn symmetric_difference(cx, this_value, arguments) {
         let this_set = this_set_value(cx, this_value, "symmetricDifference")?;
 
         let other = arguments.get(cx, 0);
@@ -584,14 +550,11 @@ impl SetPrototype {
         )?;
 
         Ok(new_set.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Set.prototype.union (https://tc39.es/ecma262/#sec-set.prototype.union)
-    pub fn union(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn union(cx, this_value, arguments) {
         let this_set = this_set_value(cx, this_value, "union")?;
 
         let other = arguments.get(cx, 0);
@@ -618,18 +581,15 @@ impl SetPrototype {
         )?;
 
         Ok(new_set.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Set.prototype.values (https://tc39.es/ecma262/#sec-set.prototype.values)
-    pub fn values(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn values(cx, this_value, _) {
         let set = this_set_value(cx, this_value, "values")?;
 
         Ok(SetIterator::new(cx, set, SetIteratorKind::Value)?.as_value())
-    }
+    }}
 }
 
 fn this_set_value(

--- a/src/js/runtime/intrinsics/string_constructor.rs
+++ b/src/js/runtime/intrinsics/string_constructor.rs
@@ -1,12 +1,11 @@
 use crate::{
     common::unicode::CodePoint,
     runtime::{
-        Arguments, Context, Handle, PropertyKey, Value,
+        Context, Handle, PropertyKey,
         abstract_operations::length_of_array_like,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::range_error,
-        eval_result::EvalResult,
         get,
         intrinsics::{
             intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
@@ -18,6 +17,7 @@ use crate::{
         string_value::{FlatString, StringValue},
         type_utilities::{to_number, to_object, to_string, to_uint16},
     },
+    runtime_fn,
 };
 
 pub struct StringConstructor;
@@ -59,12 +59,9 @@ impl StringConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// String (https://tc39.es/ecma262/#sec-string-constructor-string-value)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = cx.current_new_target();
 
         let string_value = if arguments.is_empty() {
@@ -86,14 +83,11 @@ impl StringConstructor {
                 Ok(string_object.as_value())
             }
         }
-    }
+    }}
 
+    runtime_fn! {
     /// String.fromCharCode (https://tc39.es/ecma262/#sec-string.fromcharcode)
-    pub fn from_char_code(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn from_char_code(cx, _, arguments) {
         // Common case, return a single code unit string
         if arguments.len() == 1 {
             let code_unit = to_uint16(cx, arguments[0])?;
@@ -107,14 +101,11 @@ impl StringConstructor {
         }
 
         Ok(FlatString::from_code_points(cx, &code_points)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.fromCodePoint (https://tc39.es/ecma262/#sec-string.fromcodepoint)
-    pub fn from_code_point(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn from_code_point(cx, _, arguments) {
         macro_rules! get_code_point {
             ($arg:expr) => {{
                 let arg = $arg;
@@ -156,10 +147,11 @@ impl StringConstructor {
         }
 
         Ok(FlatString::from_code_points(cx, &code_points)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.raw (https://tc39.es/ecma262/#sec-string.raw)
-    pub fn raw(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn raw(cx, _, arguments) {
         let substitution_count = arguments.len().saturating_sub(1);
 
         let template_arg = arguments.get(cx, 0);
@@ -200,5 +192,5 @@ impl StringConstructor {
 
             next_index += 1;
         }
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/string_iterator.rs
+++ b/src/js/runtime/intrinsics/string_iterator.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         error::type_error,
         eval_result::EvalResult,
@@ -17,7 +17,7 @@ use crate::{
         realm::Realm,
         string_value::{FlatString, SafeCodePointIterator},
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // String Iterator Objects (https://tc39.es/ecma262/#sec-string-iterator-objects)
@@ -71,8 +71,9 @@ impl StringIteratorPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// %StringIteratorPrototype%.next (https://tc39.es/ecma262/#sec-%stringiteratorprototype%.next)
-    pub fn next(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn next(cx, this_value, _) {
         let mut string_iterator = StringIterator::cast_from_value(cx, this_value)?;
 
         match string_iterator.iter.next() {
@@ -83,7 +84,7 @@ impl StringIteratorPrototype {
                 Ok(create_iter_result_object(cx, code_point_string.into(), false)?)
             }
         }
-    }
+    }}
 }
 
 impl HeapItem for HeapPtr<StringIterator> {

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -11,7 +11,7 @@ use crate::{
     must, must_a,
     parser::regexp::RegExpFlags,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, PropertyKey,
+        Context, Handle, HeapPtr, PropertyKey,
         abstract_operations::{call_object, get_method, invoke},
         alloc_error::AllocResult,
         array_object::{array_create, create_array_from_list},
@@ -38,6 +38,7 @@ use crate::{
         },
         value::Value,
     },
+    runtime_fn,
 };
 
 pub struct StringPrototype;
@@ -355,12 +356,9 @@ impl StringPrototype {
         Ok(())
     }
 
+    runtime_fn! {
     /// String.prototype.at (https://tc39.es/ecma262/#sec-string.prototype.at)
-    pub fn at(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn at(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "at")?;
         let string = to_string(cx, object)?;
 
@@ -385,14 +383,11 @@ impl StringPrototype {
         let code_unit_string = FlatString::from_code_unit(cx, string.code_unit_at(index as u32)?)?;
 
         Ok(code_unit_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.charAt (https://tc39.es/ecma262/#sec-string.prototype.charat)
-    pub fn char_at(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn char_at(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "charAt")?;
         let string = to_string(cx, object)?;
 
@@ -406,14 +401,11 @@ impl StringPrototype {
         let char_string = FlatString::from_code_unit(cx, string.code_unit_at(position as u32)?)?;
 
         Ok(char_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.charCodeAt (https://tc39.es/ecma262/#sec-string.prototype.charcodeat)
-    pub fn char_code_at(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn char_code_at(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "charCodeAt")?;
         let string = to_string(cx, object)?;
 
@@ -426,14 +418,11 @@ impl StringPrototype {
 
         let code_unit = string.code_unit_at(position as u32)?;
         Ok(cx.smi(code_unit))
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.codePointAt (https://tc39.es/ecma262/#sec-string.prototype.codepointat)
-    pub fn code_point_at(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn code_point_at(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "codePointAt")?;
         let string = to_string(cx, object)?;
 
@@ -446,14 +435,11 @@ impl StringPrototype {
 
         let code_point = string.code_point_at(position as u32)?;
         Ok(cx.smi(code_point as i32))
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.concat (https://tc39.es/ecma262/#sec-string.prototype.concat)
-    pub fn concat(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn concat(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "concat")?;
         let mut concat_string = to_string(cx, object)?;
 
@@ -463,14 +449,11 @@ impl StringPrototype {
         }
 
         Ok(concat_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.endsWith (https://tc39.es/ecma262/#sec-string.prototype.endswith)
-    pub fn ends_with(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn ends_with(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "endsWith")?;
         let string = to_string(cx, object)?;
         let length = string.len();
@@ -503,14 +486,11 @@ impl StringPrototype {
         let ends_with_string = string.substring_equals(search_string, start_index)?;
 
         Ok(cx.bool(ends_with_string))
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.includes (https://tc39.es/ecma262/#sec-string.prototype.includes)
-    pub fn includes(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn includes(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "includes")?;
         let string = to_string(cx, object)?;
 
@@ -531,14 +511,11 @@ impl StringPrototype {
 
         let found_search_string = string.find(search_string, pos)?.is_some();
         Ok(cx.bool(found_search_string))
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.indexOf (https://tc39.es/ecma262/#sec-string.prototype.indexof)
-    pub fn index_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn index_of(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "indexOf")?;
         let string = to_string(cx, object)?;
 
@@ -557,26 +534,20 @@ impl StringPrototype {
             None => Ok(cx.negative_one()),
             Some(index) => Ok(cx.number(index)),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.isWellFormed (https://tc39.es/ecma262/#sec-string.prototype.iswellformed)
-    pub fn is_well_formed(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn is_well_formed(cx, this_value, _) {
         let object = this_object_coercible_value(cx, this_value, "isWellFormed")?;
         let string = to_string(cx, object)?;
 
         Ok(cx.bool(string.is_well_formed()?))
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.lastIndexOf (https://tc39.es/ecma262/#sec-string.prototype.lastindexof)
-    pub fn last_index_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn last_index_of(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "lastIndexOf")?;
         let string = to_string(cx, object)?;
 
@@ -598,14 +569,11 @@ impl StringPrototype {
             None => Ok(cx.negative_one()),
             Some(index) => Ok(cx.number(index)),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.localeCompare (https://tc39.es/ecma262/#sec-string.prototype.localecompare)
-    pub fn locale_compare(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn locale_compare(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "localeCompare")?;
         let string = to_string(cx, object)?;
 
@@ -620,14 +588,11 @@ impl StringPrototype {
             .compare_utf8(wtf8_string.as_bytes(), wtf8_other_string.as_bytes());
 
         Ok(cx.smi(comparison as i8))
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.match (https://tc39.es/ecma262/#sec-string.prototype.match)
-    pub fn match_(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn match_(cx, this_value, arguments) {
         let this_object = this_object_coercible_value(cx, this_value, "match")?;
 
         let regexp_arg = arguments.get(cx, 0);
@@ -648,14 +613,11 @@ impl StringPrototype {
         let regexp_object = regexp_create(cx, regexp_source, regexp_constructor)?;
 
         invoke(cx, regexp_object, cx.well_known_symbols.match_(), &[this_string.into()])
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.matchAll (https://tc39.es/ecma262/#sec-string.prototype.matchall)
-    pub fn match_all(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn match_all(cx, this_value, arguments) {
         let this_object = this_object_coercible_value(cx, this_value, "matchAll")?;
 
         let regexp_arg = arguments.get(cx, 0);
@@ -699,14 +661,11 @@ impl StringPrototype {
         let regexp_object = regexp_create(cx, regexp_source, regexp_constructor)?;
 
         invoke(cx, regexp_object, cx.well_known_symbols.match_all(), &[this_string.into()])
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.normalize (https://tc39.es/ecma262/#sec-string.prototype.normalize)
-    pub fn normalize(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn normalize(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "normalize")?;
         let string = to_string(cx, object)?;
 
@@ -747,31 +706,25 @@ impl StringPrototype {
         };
 
         Ok(normalized_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.padEnd (https://tc39.es/ecma262/#sec-string.prototype.padend)
-    pub fn pad_end(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn pad_end(cx, this_value, arguments) {
         let max_length_arg = arguments.get(cx, 0);
         let fill_string_arg = arguments.get(cx, 1);
 
         Self::pad_string(cx, this_value, max_length_arg, fill_string_arg, false, "padEnd")
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.padStart (https://tc39.es/ecma262/#sec-string.prototype.padstart)
-    pub fn pad_start(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn pad_start(cx, this_value, arguments) {
         let max_length_arg = arguments.get(cx, 0);
         let fill_string_arg = arguments.get(cx, 1);
 
         Self::pad_string(cx, this_value, max_length_arg, fill_string_arg, true, "padStart")
-    }
+    }}
 
     pub fn pad_string(
         cx: Context,
@@ -835,12 +788,9 @@ impl StringPrototype {
         }
     }
 
+    runtime_fn! {
     /// String.prototype.repeat (https://tc39.es/ecma262/#sec-string.prototype.repeat)
-    pub fn repeat(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn repeat(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "repeat")?;
         let string = to_string(cx, object)?;
 
@@ -858,14 +808,11 @@ impl StringPrototype {
         }
 
         Ok(string.repeat(cx, n as u32)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.replace (https://tc39.es/ecma262/#sec-string.prototype.replace)
-    pub fn replace(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn replace(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "replace")?;
 
         let search_arg = arguments.get(cx, 0);
@@ -940,14 +887,11 @@ impl StringPrototype {
             StringValue::concat_all(cx, &[preceding_string, replacement_string, following_string])?;
 
         Ok(result_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.replaceAll (https://tc39.es/ecma262/#sec-string.prototype.replaceall)
-    pub fn replace_all(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn replace_all(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "replaceAll")?;
 
         let search_arg = arguments.get(cx, 0);
@@ -1054,14 +998,11 @@ impl StringPrototype {
         }
 
         Ok(StringValue::concat_all(cx, &string_parts)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.search (https://tc39.es/ecma262/#sec-string.prototype.search)
-    pub fn search(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn search(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "search")?;
 
         // Use the @@search method of the argument if one exists
@@ -1084,14 +1025,11 @@ impl StringPrototype {
         let regexp_object = regexp_create(cx, regexp_source, regexp_constructor)?;
 
         invoke(cx, regexp_object, cx.well_known_symbols.search(), &[string.into()])
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.slice (https://tc39.es/ecma262/#sec-string.prototype.slice)
-    pub fn slice(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn slice(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "slice")?;
         let string = to_string(cx, object)?;
         let length = string.len();
@@ -1111,14 +1049,11 @@ impl StringPrototype {
         }
 
         Ok(string.substring(cx, start_index, end_index)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.split (https://tc39.es/ecma262/#sec-string.prototype.split)
-    pub fn split(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn split(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "split")?;
 
         let separator_argument = arguments.get(cx, 0);
@@ -1205,14 +1140,11 @@ impl StringPrototype {
         substrings.push(last_substring.into());
 
         Ok(create_array_from_list(cx, &substrings)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.startsWith (https://tc39.es/ecma262/#sec-string.prototype.startswith)
-    pub fn starts_with(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn starts_with(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "startsWith")?;
         let string = to_string(cx, object)?;
         let length = string.len();
@@ -1252,14 +1184,11 @@ impl StringPrototype {
         let starts_with_string = string.substring_equals(search_string, start_index)?;
 
         Ok(cx.bool(starts_with_string))
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.substring (https://tc39.es/ecma262/#sec-string.prototype.substring)
-    pub fn substring(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn substring(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "substring")?;
         let string = to_string(cx, object)?;
         let length = string.len();
@@ -1281,105 +1210,82 @@ impl StringPrototype {
         }
 
         Ok(string.substring(cx, int_start, int_end)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.toLowerCase (https://tc39.es/ecma262/#sec-string.prototype.tolowercase)
-    pub fn to_lower_case(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_lower_case(cx, this_value, _) {
         let object = this_object_coercible_value(cx, this_value, "toLowerCase")?;
         let string = to_string(cx, object)?;
 
         Ok(string.to_lower_case(cx)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.toString (https://tc39.es/ecma262/#sec-string.prototype.tostring)
-    pub fn to_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, _) {
         this_string_value(cx, this_value, "toString")
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.toUpperCase (https://tc39.es/ecma262/#sec-string.prototype.touppercase)
-    pub fn to_upper_case(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_upper_case(cx, this_value, _) {
         let object = this_object_coercible_value(cx, this_value, "toUpperCase")?;
         let string = to_string(cx, object)?;
 
         Ok(string.to_upper_case(cx)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.toWellFormed (https://tc39.es/ecma262/#sec-string.prototype.towellformed)
-    pub fn to_well_formed(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_well_formed(cx, this_value, _) {
         let object = this_object_coercible_value(cx, this_value, "toWellFormed")?;
         let string = to_string(cx, object)?;
 
         Ok(string.to_well_formed(cx)?.to_handle().as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.trim (https://tc39.es/ecma262/#sec-string.prototype.trim)
-    pub fn trim(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn trim(cx, this_value, _) {
         let object = this_object_coercible_value(cx, this_value, "trim")?;
         let string = to_string(cx, object)?;
 
         Ok(string.trim(cx, true, true)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.trimEnd (https://tc39.es/ecma262/#sec-string.prototype.trimend)
-    pub fn trim_end(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn trim_end(cx, this_value, _) {
         let object = this_object_coercible_value(cx, this_value, "trimEnd")?;
         let string = to_string(cx, object)?;
 
         Ok(string.trim(cx, false, true)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.trimStart (https://tc39.es/ecma262/#sec-string.prototype.trimstart)
-    pub fn trim_start(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn trim_start(cx, this_value, _) {
         let object = this_object_coercible_value(cx, this_value, "trimStart")?;
         let string = to_string(cx, object)?;
 
         Ok(string.trim(cx, true, false)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype [ @@iterator ] (https://tc39.es/ecma262/#sec-string.prototype-%symbol.iterator%)
-    pub fn iterator(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn iterator(cx, this_value, _) {
         let object = this_object_coercible_value(cx, this_value, "iterator")?;
         let string = to_string(cx, object)?;
 
         let flat_string = string.flatten()?;
 
         Ok(StringIterator::new(cx, flat_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.substr (https://tc39.es/ecma262/#sec-string.prototype.substr)
-    pub fn substr(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn substr(cx, this_value, arguments) {
         let object = this_object_coercible_value(cx, this_value, "substr")?;
         let string = to_string(cx, object)?;
 
@@ -1403,7 +1309,7 @@ impl StringPrototype {
         let end_index = u32::min(start_index + length, string_length);
 
         Ok(string.substring(cx, start_index, end_index)?.as_value())
-    }
+    }}
 
     /// CreateHTML (https://tc39.es/ecma262/#sec-createhtml)
     fn create_html(
@@ -1449,126 +1355,103 @@ impl StringPrototype {
         Ok(cx.alloc_wtf8_string(&html)?.as_string())
     }
 
+    runtime_fn! {
     /// String.prototype.anchor (https://tc39.es/ecma262/#sec-string.prototype.anchor)
-    pub fn anchor(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn anchor(cx, this_value, arguments) {
         let name_arg = arguments.get(cx, 0);
         let html_string =
             Self::create_html(cx, this_value, "a", "anchor", Some(("name", name_arg)))?;
         Ok(html_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.big (https://tc39.es/ecma262/#sec-string.prototype.big)
-    pub fn big(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn big(cx, this_value, _) {
         let html_string = Self::create_html(cx, this_value, "big", "big", None)?;
         Ok(html_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.blink (https://tc39.es/ecma262/#sec-string.prototype.blink)
-    pub fn blink(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn blink(cx, this_value, _) {
         let html_string = Self::create_html(cx, this_value, "blink", "blink", None)?;
         Ok(html_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.bold (https://tc39.es/ecma262/#sec-string.prototype.bold)
-    pub fn bold(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn bold(cx, this_value, _) {
         let html_string = Self::create_html(cx, this_value, "b", "bold", None)?;
         Ok(html_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.fixed (https://tc39.es/ecma262/#sec-string.prototype.fixed)
-    pub fn fixed(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn fixed(cx, this_value, _) {
         let html_string = Self::create_html(cx, this_value, "tt", "fixed", None)?;
         Ok(html_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.fontcolor (https://tc39.es/ecma262/#sec-string.prototype.fontcolor)
-    pub fn font_color(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn font_color(cx, this_value, arguments) {
         let color_arg = arguments.get(cx, 0);
         let html_string =
             Self::create_html(cx, this_value, "font", "fontcolor", Some(("color", color_arg)))?;
         Ok(html_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.fontsize (https://tc39.es/ecma262/#sec-string.prototype.fontsize)
-    pub fn font_size(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn font_size(cx, this_value, arguments) {
         let size_arg = arguments.get(cx, 0);
         let html_string =
             Self::create_html(cx, this_value, "font", "fontsize", Some(("size", size_arg)))?;
         Ok(html_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.italics (https://tc39.es/ecma262/#sec-string.prototype.italics)
-    pub fn italics(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn italics(cx, this_value, _) {
         let html_string = Self::create_html(cx, this_value, "i", "italics", None)?;
         Ok(html_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.link (https://tc39.es/ecma262/#sec-string.prototype.link)
-    pub fn link(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn link(cx, this_value, arguments) {
         let url_arg = arguments.get(cx, 0);
         let html_string = Self::create_html(cx, this_value, "a", "link", Some(("href", url_arg)))?;
         Ok(html_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.small (https://tc39.es/ecma262/#sec-string.prototype.small)
-    pub fn small(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn small(cx, this_value, _) {
         let html_string = Self::create_html(cx, this_value, "small", "small", None)?;
         Ok(html_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.strike (https://tc39.es/ecma262/#sec-string.prototype.strike)
-    pub fn strike(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn strike(cx, this_value, _) {
         let html_string = Self::create_html(cx, this_value, "strike", "strike", None)?;
         Ok(html_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.sub (https://tc39.es/ecma262/#sec-string.prototype.sub)
-    pub fn sub(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn sub(cx, this_value, _) {
         let html_string = Self::create_html(cx, this_value, "sub", "sub", None)?;
         Ok(html_string.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// String.prototype.sup (https://tc39.es/ecma262/#sec-string.prototype.sup)
-    pub fn sup(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn sup(cx, this_value, _) {
         let html_string = Self::create_html(cx, this_value, "sup", "sup", None)?;
         Ok(html_string.as_value())
-    }
+    }}
 }
 
 fn this_object_coercible_value(

--- a/src/js/runtime/intrinsics/symbol_constructor.rs
+++ b/src/js/runtime/intrinsics/symbol_constructor.rs
@@ -3,12 +3,11 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         collections::BsHashMapField,
         error::type_error,
-        eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
@@ -18,7 +17,7 @@ use crate::{
         type_utilities::to_string,
         value::SymbolValue,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // Symbol Objects (https://tc39.es/ecma262/#sec-symbol-objects)
@@ -132,12 +131,9 @@ impl SymbolConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Symbol (https://tc39.es/ecma262/#sec-symbol-description)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         if cx.current_new_target().is_some() {
             return type_error(cx, "Symbol constructor must be called with new");
         }
@@ -150,14 +146,11 @@ impl SymbolConstructor {
         };
 
         Ok(SymbolValue::new(cx, description_value, /* is_private */ false)?.into())
-    }
+    }}
 
+    runtime_fn! {
     /// Symbol.for (https://tc39.es/ecma262/#sec-symbol.for)
-    pub fn for_(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn for_(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         let string_key = to_string(cx, argument)?.flatten()?;
         if let Some(symbol_value) = cx.global_symbol_registry().get(&string_key) {
@@ -171,14 +164,11 @@ impl SymbolConstructor {
             .insert_without_growing(*string_key, *new_symbol);
 
         Ok(new_symbol.into())
-    }
+    }}
 
+    runtime_fn! {
     /// Symbol.keyFor (https://tc39.es/ecma262/#sec-symbol.keyfor)
-    pub fn key_for(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn key_for(cx, _, arguments) {
         let symbol_value = arguments.get(cx, 0);
         if !symbol_value.is_symbol() {
             return type_error(cx, "Symbol.keyFor argument must be a symbol");
@@ -192,7 +182,7 @@ impl SymbolConstructor {
         }
 
         Ok(cx.undefined())
-    }
+    }}
 }
 
 impl HeapItem for HeapPtr<SymbolObject> {

--- a/src/js/runtime/intrinsics/symbol_prototype.rs
+++ b/src/js/runtime/intrinsics/symbol_prototype.rs
@@ -1,15 +1,18 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
-    object_value::ObjectValue,
-    property::Property,
-    realm::Realm,
-    string_value::StringValue,
-    value::SymbolValue,
+use crate::{
+    runtime::{
+        Context, Handle, Value,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        error::type_error,
+        eval_result::EvalResult,
+        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        object_value::ObjectValue,
+        property::Property,
+        realm::Realm,
+        string_value::StringValue,
+        value::SymbolValue,
+    },
+    runtime_fn,
 };
 
 pub struct SymbolPrototype;
@@ -70,37 +73,28 @@ impl SymbolPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// get Symbol.prototype.description (https://tc39.es/ecma262/#sec-symbol.prototype.description)
-    pub fn get_description(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_description(cx, this_value, _) {
         let symbol_value = this_symbol_value(cx, this_value, "description")?;
         match symbol_value.as_symbol().description() {
             None => Ok(cx.undefined()),
             Some(desc) => Ok(desc.as_value()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// Symbol.prototype.toString (https://tc39.es/ecma262/#sec-symbol.prototype.tostring)
-    pub fn to_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, _) {
         let symbol_value = this_symbol_value(cx, this_value, "toString")?;
         Ok(symbol_descriptive_string(cx, symbol_value.as_symbol())?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Symbol.prototype.valueOf (https://tc39.es/ecma262/#sec-symbol.prototype.valueof)
-    pub fn value_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, this_value, _) {
         this_symbol_value(cx, this_value, "valueOf")
-    }
+    }}
 }
 
 fn this_symbol_value(

--- a/src/js/runtime/intrinsics/temporal/duration_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_constructor.rs
@@ -1,24 +1,27 @@
 use temporal_rs::{Duration, partial::PartialDuration};
 
-use crate::runtime::{
-    Arguments, Context, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    error::type_error,
-    eval_result::EvalResult,
-    get,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            duration_object::DurationObject,
-            utils::{
-                get_relative_to_option, map_temporal_result, to_integer_if_integral,
-                validate_options_object,
+use crate::{
+    runtime::{
+        Context, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        error::type_error,
+        eval_result::EvalResult,
+        get,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                duration_object::DurationObject,
+                utils::{
+                    get_relative_to_option, map_temporal_result, to_integer_if_integral,
+                    validate_options_object,
+                },
             },
         },
+        object_value::ObjectValue,
     },
-    object_value::ObjectValue,
+    runtime_fn,
 };
 
 pub struct DurationConstructor;
@@ -59,12 +62,9 @@ impl DurationConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Temporal.Duration (https://tc39.es/proposal-temporal/#sec-temporal-duration)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         const NAME: &str = "Temporal.Duration constructor";
 
         let Some(new_target) = cx.current_new_target() else {
@@ -101,22 +101,20 @@ impl DurationConstructor {
         let duration = map_temporal_result(cx, duration_result, NAME)?;
 
         Ok(DurationObject::new_from_constructor(cx, new_target, duration)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Duration.from (https://tc39.es/proposal-temporal/#sec-temporal.duration.from)
-    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn from(cx, _, arguments) {
         let item_arg = arguments.get(cx, 0);
         let duration = to_temporal_duration(cx, item_arg, "Duration.from")?;
 
         Ok(DurationObject::new(cx, duration)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Duration.compare (https://tc39.es/proposal-temporal/#sec-temporal.duration.compare)
-    pub fn compare(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn compare(cx, _, arguments) {
         const NAME: &str = "Duration.compare";
 
         let arg_1 = arguments.get(cx, 0);
@@ -134,7 +132,7 @@ impl DurationConstructor {
         let ordering = map_temporal_result(cx, ordering_result, NAME)?;
 
         Ok(cx.smi(ordering as i8))
-    }
+    }}
 }
 
 /// ToTemporalDuration (https://tc39.es/proposal-temporal/#sec-temporal-totemporalduration)

--- a/src/js/runtime/intrinsics/temporal/duration_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_prototype.rs
@@ -6,7 +6,7 @@ use temporal_rs::{
 use crate::{
     must,
     runtime::{
-        Arguments, Context, EvalResult, Handle, Realm, Value,
+        Context, EvalResult, Handle, Realm, Value,
         abstract_operations::create_data_property_or_throw,
         alloc_error::AllocResult,
         error::{range_error, type_error},
@@ -28,6 +28,7 @@ use crate::{
         ordinary_object::ordinary_object_create_without_proto,
         property::Property,
     },
+    runtime_fn,
 };
 
 pub struct DurationPrototype;
@@ -203,146 +204,115 @@ impl DurationPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// get Temporal.Duration.prototype.years (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.years)
-    pub fn years(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn years(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.years")?;
         let years = duration.duration().years();
 
         Ok(cx.number(years))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.Duration.prototype.months (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.months)
-    pub fn months(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn months(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.months")?;
         let months = duration.duration().months();
 
         Ok(cx.number(months))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.Duration.prototype.weeks (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.weeks)
-    pub fn weeks(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn weeks(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.weeks")?;
         let weeks = duration.duration().weeks();
 
         Ok(cx.number(weeks))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.Duration.prototype.days (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.days)
-    pub fn days(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn days(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.days")?;
         let days = duration.duration().days();
 
         Ok(cx.number(days))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.Duration.prototype.hours (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.hours)
-    pub fn hours(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn hours(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.hours")?;
         let hours = duration.duration().hours();
 
         Ok(cx.number(hours))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.Duration.prototype.minutes (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.minutes)
-    pub fn minutes(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn minutes(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.minutes")?;
         let minutes = duration.duration().minutes();
 
         Ok(cx.number(minutes))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.Duration.prototype.seconds (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.seconds)
-    pub fn seconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn seconds(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.seconds")?;
         let seconds = duration.duration().seconds();
 
         Ok(cx.number(seconds))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.Duration.prototype.milliseconds (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.milliseconds)
-    pub fn milliseconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn milliseconds(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.milliseconds")?;
         let millis = duration.duration().milliseconds();
 
         Ok(cx.number(millis))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.Duration.prototype.microseconds (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.microseconds)
-    pub fn microseconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn microseconds(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.microseconds")?;
         let micros = duration.duration().microseconds();
         Ok(cx.number(micros as f64))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.Duration.prototype.nanoseconds (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.nanoseconds)
-    pub fn nanoseconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn nanoseconds(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.nanoseconds")?;
         let nanos = duration.duration().nanoseconds();
         Ok(cx.number(nanos as f64))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.Duration.prototype.sign (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.sign)
-    pub fn sign(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn sign(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.sign")?;
         let sign = duration.duration().sign();
 
         Ok(cx.smi(sign as i8))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.Duration.prototype.blank (https://tc39.es/proposal-temporal/#sec-get-temporal.duration.prototype.blank)
-    pub fn blank(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn blank(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.blank")?;
         let is_zero = duration.duration().is_zero();
 
         Ok(cx.bool(is_zero))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Duration.prototype.with (https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.with)
-    pub fn with(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with(cx, this_value, arguments) {
         const NAME: &str = "Duration.prototype.with";
 
         let duration_object = this_duration(cx, this_value, NAME)?;
@@ -374,34 +344,29 @@ impl DurationPrototype {
         let new_duration = map_temporal_result(cx, new_duration_result, NAME)?;
 
         Ok(DurationObject::new(cx, new_duration)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Duration.prototype.negated (https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.negated)
-    pub fn negated(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn negated(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.negated")?;
         let negated_duration = duration.duration().negated();
 
         Ok(DurationObject::new(cx, negated_duration)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Duration.prototype.abs (https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.abs)
-    pub fn abs(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn abs(cx, this_value, _) {
         let duration = this_duration(cx, this_value, "Duration.prototype.abs")?;
         let abs_duration = duration.duration().abs();
 
         Ok(DurationObject::new(cx, abs_duration)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Duration.prototype.add (https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.add)
-    pub fn add(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn add(cx, this_value, arguments) {
         const NAME: &str = "Duration.prototype.add";
 
         let duration = this_duration(cx, this_value, NAME)?;
@@ -412,14 +377,11 @@ impl DurationPrototype {
         let sum = map_temporal_result(cx, sum_result, NAME)?;
 
         Ok(DurationObject::new(cx, sum)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Duration.prototype.subtract (https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.subtract)
-    pub fn subtract(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn subtract(cx, this_value, arguments) {
         const NAME: &str = "Duration.prototype.subtract";
 
         let duration = this_duration(cx, this_value, NAME)?;
@@ -430,14 +392,11 @@ impl DurationPrototype {
         let difference = map_temporal_result(cx, difference_result, NAME)?;
 
         Ok(DurationObject::new(cx, difference)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Duration.prototype.round (https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.round)
-    pub fn round(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn round(cx, this_value, arguments) {
         const NAME: &str = "Duration.prototype.round";
 
         let duration = this_duration(cx, this_value, NAME)?;
@@ -466,14 +425,11 @@ impl DurationPrototype {
         let rounded = map_temporal_result(cx, rounded_result, NAME)?;
 
         Ok(DurationObject::new(cx, rounded)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Duration.prototype.total (https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.total)
-    pub fn total(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn total(cx, this_value, arguments) {
         const NAME: &str = "Duration.prototype.total";
 
         let duration = this_duration(cx, this_value, NAME)?;
@@ -507,14 +463,11 @@ impl DurationPrototype {
         let total = map_temporal_result(cx, total_result, NAME)?;
 
         Ok(cx.number(total.as_inner()))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Duration.prototype.toString (https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tostring)
-    pub fn to_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, arguments) {
         const NAME: &str = "Duration.prototype.toString";
 
         let duration = this_duration(cx, this_value, NAME)?;
@@ -537,14 +490,11 @@ impl DurationPrototype {
         let string = map_temporal_result(cx, string_result, NAME)?;
 
         Ok(cx.alloc_string(&string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Duration.prototype.toLocaleString (https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tolocalestring)
-    pub fn to_locale_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_string(cx, this_value, _) {
         const NAME: &str = "Duration.prototype.toLocaleString";
 
         let duration = this_duration(cx, this_value, NAME)?;
@@ -555,14 +505,11 @@ impl DurationPrototype {
         let string = map_temporal_result(cx, string_result, NAME)?;
 
         Ok(cx.alloc_string(&string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Duration.prototype.toJSON (https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.tojson)
-    pub fn to_json(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_json(cx, this_value, _) {
         const NAME: &str = "Duration.prototype.toJSON";
 
         let duration = this_duration(cx, this_value, NAME)?;
@@ -573,12 +520,13 @@ impl DurationPrototype {
         let string = map_temporal_result(cx, string_result, NAME)?;
 
         Ok(cx.alloc_string(&string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Duration.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.valueof)
-    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, _, _) {
         type_error(cx, "Duration.prototype.valueOf must not be called")
-    }
+    }}
 }
 
 fn this_duration(

--- a/src/js/runtime/intrinsics/temporal/instant_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_constructor.rs
@@ -4,7 +4,7 @@ use temporal_rs::Instant;
 use crate::{
     common::constants::NANOSECONDS_IN_ONE_MILLISECOND,
     runtime::{
-        Arguments, Context, Handle, Realm, Value,
+        Context, Handle, Realm, Value,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::type_error,
@@ -21,6 +21,7 @@ use crate::{
         object_value::ObjectValue,
         type_utilities::{ToPrimitivePreferredType, to_bigint, to_number, to_primitive},
     },
+    runtime_fn,
 };
 
 pub struct InstantConstructor;
@@ -75,12 +76,9 @@ impl InstantConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Temporal.Instant (https://tc39.es/proposal-temporal/#sec-temporal-instant)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let Some(new_target) = cx.current_new_target() else {
             return type_error(cx, "Temporal.Instant constructor must be called with new");
         };
@@ -96,22 +94,20 @@ impl InstantConstructor {
         )?;
 
         Ok(instant.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.from (https://tc39.es/proposal-temporal/#sec-temporal.instant.from)
-    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn from(cx, _, arguments) {
         let item_arg = arguments.get(cx, 0);
         let instant = to_temporal_instant(cx, item_arg, "Instant.from")?;
 
         Ok(InstantObject::new(cx, instant)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.fromEpochMilliseconds (https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochmilliseconds)
-    pub fn from_epoch_milliseconds(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn from_epoch_milliseconds(cx, _, arguments) {
         const NAME: &str = "Instant.fromEpochMilliseconds";
         let epoch_millis_arg = arguments.get(cx, 0);
         let epoch_millis_number = to_number(cx, epoch_millis_arg)?;
@@ -120,14 +116,11 @@ impl InstantConstructor {
         let epoch_nanos = epoch_millis_bigint.bigint() * NANOSECONDS_IN_ONE_MILLISECOND;
 
         Ok(create_temporal_instant(cx, &epoch_nanos, None, NAME)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.fromEpochNanoseconds (https://tc39.es/proposal-temporal/#sec-temporal.instant.fromepochnanoseconds)
-    pub fn from_epoch_nanoseconds(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn from_epoch_nanoseconds(cx, _, arguments) {
         let epoch_nanos_arg = arguments.get(cx, 0);
         let epoch_nanos = to_bigint(cx, epoch_nanos_arg)?;
 
@@ -139,14 +132,11 @@ impl InstantConstructor {
         )?;
 
         Ok(instant.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.compare (https://tc39.es/proposal-temporal/#sec-temporal.instant.compare)
-    pub fn compare(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn compare(cx, _, arguments) {
         const NAME: &str = "Instant.compare";
 
         let arg_1 = arguments.get(cx, 0);
@@ -156,7 +146,7 @@ impl InstantConstructor {
         let instant_2 = to_temporal_instant(cx, arg_2, NAME)?;
 
         Ok(cx.smi(instant_1.cmp(&instant_2) as i8))
-    }
+    }}
 }
 
 /// CreateTemporalInstant (https://tc39.es/proposal-temporal/#sec-temporal-createtemporalinstant)

--- a/src/js/runtime/intrinsics/temporal/instant_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_prototype.rs
@@ -1,30 +1,33 @@
 use num_bigint::BigInt;
 use temporal_rs::options::{RoundingMode, RoundingOptions, ToStringRoundingOptions};
 
-use crate::runtime::{
-    Arguments, Context, EvalResult, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    error::type_error,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            duration_constructor::to_temporal_duration,
-            duration_object::DurationObject,
-            instant_constructor::to_temporal_instant,
-            instant_object::InstantObject,
-            utils::{
-                DiffOperation, get_difference_settings, get_fractional_second_digits_option,
-                get_rounding_increment_option, get_rounding_mode_option, get_time_zone_option,
-                get_unit_valued_option, map_temporal_result, parse_round_options_argument,
-                to_time_zone_identifier, validate_options_object,
+use crate::{
+    runtime::{
+        Arguments, Context, EvalResult, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        error::type_error,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                duration_constructor::to_temporal_duration,
+                duration_object::DurationObject,
+                instant_constructor::to_temporal_instant,
+                instant_object::InstantObject,
+                utils::{
+                    DiffOperation, get_difference_settings, get_fractional_second_digits_option,
+                    get_rounding_increment_option, get_rounding_mode_option, get_time_zone_option,
+                    get_unit_valued_option, map_temporal_result, parse_round_options_argument,
+                    to_time_zone_identifier, validate_options_object,
+                },
+                zoned_date_time_object::ZonedDateTimeObject,
             },
-            zoned_date_time_object::ZonedDateTimeObject,
         },
+        object_value::ObjectValue,
+        property::Property,
+        value::BigIntValue,
     },
-    object_value::ObjectValue,
-    property::Property,
-    value::BigIntValue,
+    runtime_fn,
 };
 
 pub struct InstantPrototype;
@@ -140,36 +143,27 @@ impl InstantPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// get Temporal.Instant.prototype.epochMilliseconds (https://tc39.es/proposal-temporal/#sec-get-temporal.instant.prototype.epochmilliseconds)
-    pub fn epoch_milliseconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn epoch_milliseconds(cx, this_value, _) {
         let instant = this_instant(cx, this_value, "Instant.prototype.epochMilliseconds")?;
         let epoch_millis = instant.instant().epoch_milliseconds();
 
         Ok(cx.number(epoch_millis))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.Instant.prototype.epochNanoseconds (https://tc39.es/proposal-temporal/#sec-get-temporal.instant.prototype.epochnanoseconds)
-    pub fn epoch_nanoseconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn epoch_nanoseconds(cx, this_value, _) {
         let instant = this_instant(cx, this_value, "Instant.prototype.epochNanoseconds")?;
         let epoch_nanos = instant.instant().epoch_nanoseconds().as_i128();
 
         Ok(BigIntValue::new(cx, BigInt::from(epoch_nanos))?.into())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.prototype.add (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.add)
-    pub fn add(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn add(cx, this_value, arguments) {
         const NAME: &str = "Instant.prototype.add";
 
         let instant = this_instant(cx, this_value, NAME)?;
@@ -181,14 +175,11 @@ impl InstantPrototype {
         let new_instant = map_temporal_result(cx, new_instant_result, NAME)?;
 
         Ok(InstantObject::new(cx, new_instant)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.prototype.subtract (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.subtract)
-    pub fn subtract(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn subtract(cx, this_value, arguments) {
         const NAME: &str = "Instant.prototype.subtract";
 
         let instant = this_instant(cx, this_value, NAME)?;
@@ -200,25 +191,19 @@ impl InstantPrototype {
         let new_instant = map_temporal_result(cx, new_instant_result, NAME)?;
 
         Ok(InstantObject::new(cx, new_instant)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.prototype.until (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.until)
-    pub fn until(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn until(cx, this_value, arguments) {
         Self::diff(cx, this_value, arguments, DiffOperation::Until, "Instant.prototype.until")
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.prototype.since (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.since)
-    pub fn since(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn since(cx, this_value, arguments) {
         Self::diff(cx, this_value, arguments, DiffOperation::Since, "Instant.prototype.since")
-    }
+    }}
 
     fn diff(
         cx: Context,
@@ -246,12 +231,9 @@ impl InstantPrototype {
         Ok(DurationObject::new(cx, duration)?.as_value())
     }
 
+    runtime_fn! {
     /// Temporal.Instant.prototype.round (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.round)
-    pub fn round(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn round(cx, this_value, arguments) {
         const NAME: &str = "Instant.prototype.round";
 
         let instant = this_instant(cx, this_value, NAME)?;
@@ -273,14 +255,11 @@ impl InstantPrototype {
         let rounded = map_temporal_result(cx, rounded_result, NAME)?;
 
         Ok(InstantObject::new(cx, rounded)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.prototype.equals (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.equals)
-    pub fn equals(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn equals(cx, this_value, arguments) {
         const NAME: &str = "Instant.prototype.equals";
 
         let instant = this_instant(cx, this_value, NAME)?;
@@ -289,14 +268,11 @@ impl InstantPrototype {
         let other_instant = to_temporal_instant(cx, other_arg, NAME)?;
 
         Ok(cx.bool(instant.instant() == other_instant))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.prototype.toString (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tostring)
-    pub fn to_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, arguments) {
         const NAME: &str = "Instant.prototype.toString";
 
         let instant = this_instant(cx, this_value, NAME)?;
@@ -324,14 +300,11 @@ impl InstantPrototype {
         let instant_string = map_temporal_result(cx, instant_string_result, NAME)?;
 
         Ok(cx.alloc_string(&instant_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.prototype.toLocaleString (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tolocalestring)
-    pub fn to_locale_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_string(cx, this_value, _) {
         const NAME: &str = "Instant.prototype.toLocaleString";
 
         let instant = this_instant(cx, this_value, NAME)?;
@@ -344,14 +317,11 @@ impl InstantPrototype {
         let instant_string = map_temporal_result(cx, instant_string_result, NAME)?;
 
         Ok(cx.alloc_string(&instant_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.prototype.toJSON (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tojson)
-    pub fn to_json(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_json(cx, this_value, _) {
         const NAME: &str = "Instant.prototype.toJSON";
 
         let instant = this_instant(cx, this_value, NAME)?;
@@ -364,19 +334,17 @@ impl InstantPrototype {
         let instant_string = map_temporal_result(cx, instant_string_result, NAME)?;
 
         Ok(cx.alloc_string(&instant_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.valueof)
-    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, _, _) {
         type_error(cx, "Instant.prototype.valueOf must not be called")
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Instant.prototype.toZonedDateTimeISO (https://tc39.es/proposal-temporal/#sec-temporal.instant.prototype.tozoneddatetimeiso)
-    pub fn to_zoned_date_time_iso(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_zoned_date_time_iso(cx, this_value, arguments) {
         const NAME: &str = "Instant.prototype.toZonedDateTimeISO";
 
         let instant = this_instant(cx, this_value, NAME)?;
@@ -390,7 +358,7 @@ impl InstantPrototype {
         let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, zoned_date_time)?.as_value())
-    }
+    }}
 }
 
 fn this_instant(

--- a/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
@@ -2,25 +2,28 @@ use temporal_rs::{
     PlainDate, options::Overflow, parsed_intermediates::ParsedDate, partial::PartialDate,
 };
 
-use crate::runtime::{
-    Arguments, Context, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            plain_date_object::PlainDateObject,
-            utils::{
-                DateField, RequiredFieldNames, get_calendar_identifier_with_iso_default,
-                get_overflow_option, map_temporal_result, parse_calendar_argument,
-                prepare_calendar_fields, to_integer_with_truncation, validate_options_object,
+use crate::{
+    runtime::{
+        Context, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        error::type_error,
+        eval_result::EvalResult,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                plain_date_object::PlainDateObject,
+                utils::{
+                    DateField, RequiredFieldNames, get_calendar_identifier_with_iso_default,
+                    get_overflow_option, map_temporal_result, parse_calendar_argument,
+                    prepare_calendar_fields, to_integer_with_truncation, validate_options_object,
+                },
             },
         },
+        object_value::ObjectValue,
     },
-    object_value::ObjectValue,
+    runtime_fn,
 };
 
 pub struct PlainDateConstructor;
@@ -61,12 +64,9 @@ impl PlainDateConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Temporal.PlainDate (https://tc39.es/proposal-temporal/#sec-temporal-plaindate)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         const NAME: &str = "Temporal.PlainDate constructor";
 
         let Some(new_target) = cx.current_new_target() else {
@@ -91,14 +91,11 @@ impl PlainDateConstructor {
         let plain_date = map_temporal_result(cx, plain_date_result, NAME)?;
 
         Ok(PlainDateObject::new_from_constructor(cx, new_target, plain_date)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.compare (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.compare)
-    pub fn compare(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn compare(cx, _, arguments) {
         const NAME: &str = "PlainDate.compare";
 
         let arg_1 = arguments.get(cx, 0);
@@ -108,10 +105,11 @@ impl PlainDateConstructor {
         let date_2 = to_temporal_date(cx, arg_2, NAME)?;
 
         Ok(cx.smi(date_1.compare_iso(&date_2) as i8))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.from (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.from)
-    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn from(cx, _, arguments) {
         let item_arg = arguments.get(cx, 0);
         let options_arg = arguments.get(cx, 1);
 
@@ -119,7 +117,7 @@ impl PlainDateConstructor {
             to_temporal_date_with_options(cx, item_arg, options_arg, "PlainDate.from")?;
 
         Ok(PlainDateObject::new(cx, plain_date)?.as_value())
-    }
+    }}
 }
 
 /// ToTemporalDate (https://tc39.es/proposal-temporal/#sec-temporal-totemporaldate)

--- a/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
@@ -1,33 +1,36 @@
 use temporal_rs::options::DisplayCalendar;
 
-use crate::runtime::{
-    Arguments, Context, EvalResult, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    error::type_error,
-    get,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            duration_constructor::to_temporal_duration,
-            duration_object::DurationObject,
-            plain_date_constructor::to_temporal_date,
-            plain_date_object::PlainDateObject,
-            plain_date_time_object::PlainDateTimeObject,
-            plain_month_day_object::PlainMonthDayObject,
-            plain_time_constructor::to_temporal_time,
-            plain_year_month_object::PlainYearMonthObject,
-            utils::{
-                DateField, DiffOperation, RequiredFieldNames, get_difference_settings,
-                get_overflow_option, get_show_calendar_name_option, is_partial_temporal_object,
-                map_temporal_result, prepare_calendar_fields, to_temporal_calendar_identifier,
-                to_time_zone_identifier, validate_options_object,
+use crate::{
+    runtime::{
+        Arguments, Context, EvalResult, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        error::type_error,
+        get,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                duration_constructor::to_temporal_duration,
+                duration_object::DurationObject,
+                plain_date_constructor::to_temporal_date,
+                plain_date_object::PlainDateObject,
+                plain_date_time_object::PlainDateTimeObject,
+                plain_month_day_object::PlainMonthDayObject,
+                plain_time_constructor::to_temporal_time,
+                plain_year_month_object::PlainYearMonthObject,
+                utils::{
+                    DateField, DiffOperation, RequiredFieldNames, get_difference_settings,
+                    get_overflow_option, get_show_calendar_name_option, is_partial_temporal_object,
+                    map_temporal_result, prepare_calendar_fields, to_temporal_calendar_identifier,
+                    to_time_zone_identifier, validate_options_object,
+                },
+                zoned_date_time_object::ZonedDateTimeObject,
             },
-            zoned_date_time_object::ZonedDateTimeObject,
         },
+        object_value::ObjectValue,
+        property::Property,
     },
-    object_value::ObjectValue,
-    property::Property,
+    runtime_fn,
 };
 
 pub struct PlainDatePrototype;
@@ -255,204 +258,161 @@ impl PlainDatePrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.calendarId (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.calendarid)
-    pub fn calendar_id(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn calendar_id(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.calendarId")?;
         let calendar_str = this_date.date().calendar().identifier();
 
         Ok(cx.alloc_static_string(calendar_str)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.era (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.era)
-    pub fn era(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn era(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.era")?;
 
         match this_date.date().era() {
             None => Ok(cx.undefined()),
             Some(era) => Ok(cx.alloc_string(era.as_str())?.as_value()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.eraYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.erayear)
-    pub fn era_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn era_year(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.eraYear")?;
 
         match this_date.date().era_year() {
             None => Ok(cx.undefined()),
             Some(year_number) => Ok(cx.smi(year_number)),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.year (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.year)
-    pub fn year(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn year(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.year")?;
         let year_number = this_date.date().year();
 
         Ok(cx.smi(year_number))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.month (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.month)
-    pub fn month(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn month(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.month")?;
         let month_number = this_date.date().month();
 
         Ok(cx.smi(month_number))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.monthCode (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.monthcode)
-    pub fn month_code(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn month_code(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.monthCode")?;
         let month_code = this_date.date().month_code();
 
         Ok(cx.alloc_string(month_code.as_str())?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.day (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.day)
-    pub fn day(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn day(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.day")?;
         let day_number = this_date.date().day();
 
         Ok(cx.smi(day_number))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.dayOfWeek (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.dayofweek)
-    pub fn day_of_week(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn day_of_week(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.dayOfWeek")?;
         let day_of_week_number = this_date.date().day_of_week();
 
         Ok(cx.smi(day_of_week_number))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.dayOfYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.dayofyear)
-    pub fn day_of_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn day_of_year(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.dayOfYear")?;
         let day_of_year_number = this_date.date().day_of_year();
 
         Ok(cx.smi(day_of_year_number))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.weekOfYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.weekofyear)
-    pub fn week_of_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn week_of_year(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.weekOfYear")?;
 
         match this_date.date().week_of_year() {
             None => Ok(cx.undefined()),
             Some(week_number) => Ok(cx.smi(week_number)),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.yearOfWeek (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.yearofweek)
-    pub fn year_of_week(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn year_of_week(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.yearOfWeek")?;
 
         match this_date.date().year_of_week() {
             None => Ok(cx.undefined()),
             Some(year_number) => Ok(cx.smi(year_number)),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.daysInWeek (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinweek)
-    pub fn days_in_week(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn days_in_week(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.daysInWeek")?;
         let num_days_in_week = this_date.date().days_in_week();
 
         Ok(cx.smi(num_days_in_week))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.daysInMonth (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinmonth)
-    pub fn days_in_month(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn days_in_month(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.daysInMonth")?;
         let num_days_in_month = this_date.date().days_in_month();
 
         Ok(cx.smi(num_days_in_month))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.daysInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.daysinyear)
-    pub fn days_in_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn days_in_year(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.daysInYear")?;
         let num_days_in_year = this_date.date().days_in_year();
 
         Ok(cx.smi(num_days_in_year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.monthsInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.monthsinyear)
-    pub fn months_in_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn months_in_year(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.monthsInYear")?;
         let num_months_in_year = this_date.date().months_in_year();
 
         Ok(cx.smi(num_months_in_year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDate.prototype.inLeapYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.inleapyear)
-    pub fn in_leap_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn in_leap_year(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.inLeapYear")?;
         let in_leap_year = this_date.date().in_leap_year();
 
         Ok(cx.bool(in_leap_year))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.add (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.add)
-    pub fn add(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn add(cx, this_value, arguments) {
         const NAME: &str = "PlainDate.prototype.add";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
@@ -468,14 +428,11 @@ impl PlainDatePrototype {
         let new_date = map_temporal_result(cx, new_date_result, NAME)?;
 
         Ok(PlainDateObject::new(cx, new_date)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.subtract (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.subtract)
-    pub fn subtract(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn subtract(cx, this_value, arguments) {
         const NAME: &str = "PlainDate.prototype.subtract";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
@@ -491,25 +448,19 @@ impl PlainDatePrototype {
         let new_date = map_temporal_result(cx, new_date_result, NAME)?;
 
         Ok(PlainDateObject::new(cx, new_date)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.until (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.until)
-    pub fn until(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn until(cx, this_value, arguments) {
         Self::diff(cx, this_value, arguments, DiffOperation::Until, "PlainDate.prototype.until")
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.since (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.since)
-    pub fn since(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn since(cx, this_value, arguments) {
         Self::diff(cx, this_value, arguments, DiffOperation::Since, "PlainDate.prototype.since")
-    }
+    }}
 
     fn diff(
         cx: Context,
@@ -537,12 +488,9 @@ impl PlainDatePrototype {
         Ok(DurationObject::new(cx, duration)?.as_value())
     }
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.equals (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.equals)
-    pub fn equals(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn equals(cx, this_value, arguments) {
         const NAME: &str = "PlainDate.prototype.equals";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
@@ -551,14 +499,11 @@ impl PlainDatePrototype {
         let other_date = to_temporal_date(cx, other_arg, NAME)?;
 
         Ok(cx.bool(this_date.date() == &other_date))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.toPlainDateTime (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplaindatetime)
-    pub fn to_plain_date_time(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_plain_date_time(cx, this_value, arguments) {
         const NAME: &str = "PlainDate.prototype.toPlainDateTime";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
@@ -574,14 +519,11 @@ impl PlainDatePrototype {
         let plain_date_time = map_temporal_result(cx, plain_date_time_result, NAME)?;
 
         Ok(PlainDateTimeObject::new(cx, plain_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.toPlainMonthDay (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainmonthday)
-    pub fn to_plain_month_day(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_plain_month_day(cx, this_value, _) {
         const NAME: &str = "PlainDate.prototype.toPlainMonthDay";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
@@ -590,14 +532,11 @@ impl PlainDatePrototype {
         let plain_month_day = map_temporal_result(cx, plain_month_day_result, NAME)?;
 
         Ok(PlainMonthDayObject::new(cx, plain_month_day)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.toPlainYearMonth (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.toplainyearmonth)
-    pub fn to_plain_year_month(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_plain_year_month(cx, this_value, _) {
         const NAME: &str = "PlainDate.prototype.toPlainYearMonth";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
@@ -606,14 +545,11 @@ impl PlainDatePrototype {
         let plain_year_month = map_temporal_result(cx, plain_year_month_result, NAME)?;
 
         Ok(PlainYearMonthObject::new(cx, plain_year_month)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.toZonedDateTime (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tozoneddatetime)
-    pub fn to_zoned_date_time(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_zoned_date_time(cx, this_value, arguments) {
         const NAME: &str = "PlainDate.prototype.toZonedDateTime";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
@@ -654,14 +590,11 @@ impl PlainDatePrototype {
         let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, zoned_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.toString (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tostring)
-    pub fn to_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, arguments) {
         const NAME: &str = "PlainDate.prototype.toString";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
@@ -674,43 +607,35 @@ impl PlainDatePrototype {
         let date_string = this_date.date().to_ixdtf_string(display_name);
 
         Ok(cx.alloc_string(&date_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.toLocaleString (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tolocalestring)
-    pub fn to_locale_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_string(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.toLocaleString")?;
         let date_string = this_date.date().to_ixdtf_string(DisplayCalendar::Auto);
 
         Ok(cx.alloc_string(&date_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.toJSON (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tojson)
-    pub fn to_json(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_json(cx, this_value, _) {
         let this_date = this_plain_date(cx, this_value, "PlainDate.prototype.toJSON")?;
         let date_string = this_date.date().to_ixdtf_string(DisplayCalendar::Auto);
 
         Ok(cx.alloc_string(&date_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.valueof)
-    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, _, _) {
         type_error(cx, "PlainDate.prototype.valueOf must not be called")
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.with (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.with)
-    pub fn with(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with(cx, this_value, arguments) {
         const NAME: &str = "PlainDate.prototype.with";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
@@ -746,14 +671,11 @@ impl PlainDatePrototype {
         let new_date = map_temporal_result(cx, new_date_result, NAME)?;
 
         Ok(PlainDateObject::new(cx, new_date)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDate.prototype.withCalendar (https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.withcalendar)
-    pub fn with_calendar(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with_calendar(cx, this_value, arguments) {
         const NAME: &str = "PlainDate.prototype.withCalendar";
 
         let this_date = this_plain_date(cx, this_value, NAME)?;
@@ -764,7 +686,7 @@ impl PlainDatePrototype {
         let new_date = this_date.date().with_calendar(calendar);
 
         Ok(PlainDateObject::new(cx, new_date)?.as_value())
-    }
+    }}
 }
 
 fn this_plain_date(

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
@@ -1,26 +1,29 @@
 use temporal_rs::{PlainDateTime, parsed_intermediates::ParsedDateTime, partial::PartialDateTime};
 
-use crate::runtime::{
-    Arguments, Context, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            plain_date_time_object::PlainDateTimeObject,
-            utils::{
-                DateField, RequiredFieldNames, TimeField, get_calendar_identifier_with_iso_default,
-                get_overflow_option, map_temporal_result, parse_calendar_argument,
-                prepare_calendar_fields, to_integer_with_truncation,
-                to_integer_with_truncation_or_zero, validate_options_object,
-                validate_time_arguments,
+use crate::{
+    runtime::{
+        Context, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        error::type_error,
+        eval_result::EvalResult,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                plain_date_time_object::PlainDateTimeObject,
+                utils::{
+                    DateField, RequiredFieldNames, TimeField,
+                    get_calendar_identifier_with_iso_default, get_overflow_option,
+                    map_temporal_result, parse_calendar_argument, prepare_calendar_fields,
+                    to_integer_with_truncation, to_integer_with_truncation_or_zero,
+                    validate_options_object, validate_time_arguments,
+                },
             },
         },
+        object_value::ObjectValue,
     },
-    object_value::ObjectValue,
+    runtime_fn,
 };
 
 pub struct PlainDateTimeConstructor;
@@ -63,12 +66,9 @@ impl PlainDateTimeConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Temporal.PlainDateTime (https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         const NAME: &str = "Temporal.PlainDateTime constructor";
 
         let Some(new_target) = cx.current_new_target() else {
@@ -118,10 +118,11 @@ impl PlainDateTimeConstructor {
         let plain_date_time = map_temporal_result(cx, plain_date_time_result, NAME)?;
 
         Ok(PlainDateTimeObject::new_from_constructor(cx, new_target, plain_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.from (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.from)
-    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn from(cx, _, arguments) {
         let item_arg = arguments.get(cx, 0);
         let options_arg = arguments.get(cx, 1);
 
@@ -129,14 +130,11 @@ impl PlainDateTimeConstructor {
             to_temporal_date_time_with_options(cx, item_arg, options_arg, "PlainDateTime.from")?;
 
         Ok(PlainDateTimeObject::new(cx, plain_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.compare (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.compare)
-    pub fn compare(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn compare(cx, _, arguments) {
         const NAME: &str = "PlainDateTime.compare";
 
         let arg_1 = arguments.get(cx, 0);
@@ -146,7 +144,7 @@ impl PlainDateTimeConstructor {
         let date_time_2 = to_temporal_date_time(cx, arg_2, NAME)?;
 
         Ok(cx.smi(date_time_1.compare_iso(&date_time_2) as i8))
-    }
+    }}
 }
 
 /// ToTemporalDateTime (https://tc39.es/proposal-temporal/#sec-temporal-totemporaldatetime)

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
@@ -2,34 +2,39 @@ use temporal_rs::options::{
     DisplayCalendar, RoundingMode, RoundingOptions, ToStringRoundingOptions,
 };
 
-use crate::runtime::{
-    Arguments, Context, EvalResult, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    error::type_error,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            duration_constructor::to_temporal_duration,
-            duration_object::DurationObject,
-            plain_date_object::PlainDateObject,
-            plain_date_time_constructor::to_temporal_date_time,
-            plain_date_time_object::PlainDateTimeObject,
-            plain_time_constructor::to_temporal_time,
-            plain_time_object::PlainTimeObject,
-            utils::{
-                DateField, DiffOperation, RequiredFieldNames, TimeField, get_difference_settings,
-                get_disambiguation_option, get_fractional_second_digits_option,
-                get_overflow_option, get_rounding_increment_option, get_rounding_mode_option,
-                get_show_calendar_name_option, get_unit_valued_option, is_partial_temporal_object,
-                map_temporal_result, parse_round_options_argument, prepare_calendar_fields,
-                to_temporal_calendar_identifier, to_time_zone_identifier, validate_options_object,
+use crate::{
+    runtime::{
+        Arguments, Context, EvalResult, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        error::type_error,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                duration_constructor::to_temporal_duration,
+                duration_object::DurationObject,
+                plain_date_object::PlainDateObject,
+                plain_date_time_constructor::to_temporal_date_time,
+                plain_date_time_object::PlainDateTimeObject,
+                plain_time_constructor::to_temporal_time,
+                plain_time_object::PlainTimeObject,
+                utils::{
+                    DateField, DiffOperation, RequiredFieldNames, TimeField,
+                    get_difference_settings, get_disambiguation_option,
+                    get_fractional_second_digits_option, get_overflow_option,
+                    get_rounding_increment_option, get_rounding_mode_option,
+                    get_show_calendar_name_option, get_unit_valued_option,
+                    is_partial_temporal_object, map_temporal_result, parse_round_options_argument,
+                    prepare_calendar_fields, to_temporal_calendar_identifier,
+                    to_time_zone_identifier, validate_options_object,
+                },
+                zoned_date_time_object::ZonedDateTimeObject,
             },
-            zoned_date_time_object::ZonedDateTimeObject,
         },
+        object_value::ObjectValue,
+        property::Property,
     },
-    object_value::ObjectValue,
-    property::Property,
+    runtime_fn,
 };
 
 pub struct PlainDateTimePrototype;
@@ -307,39 +312,30 @@ impl PlainDateTimePrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.calendarId (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.calendarid)
-    pub fn calendar_id(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn calendar_id(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.calendarId")?;
         let calendar_str = this_date_time.date_time().calendar().identifier();
 
         Ok(cx.alloc_static_string(calendar_str)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.era (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.era)
-    pub fn era(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn era(cx, this_value, _) {
         let this_date_time = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.era")?;
 
         match this_date_time.date_time().era() {
             None => Ok(cx.undefined()),
             Some(era) => Ok(cx.alloc_string(era.as_str())?.as_value()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.eraYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.erayear)
-    pub fn era_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn era_year(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.eraYear")?;
 
@@ -347,81 +343,68 @@ impl PlainDateTimePrototype {
             None => Ok(cx.undefined()),
             Some(year_number) => Ok(cx.smi(year_number)),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.year (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.year)
-    pub fn year(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn year(cx, this_value, _) {
         let this_date_time = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.year")?;
         let year = this_date_time.date_time().year();
 
         Ok(cx.smi(year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.month (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.month)
-    pub fn month(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn month(cx, this_value, _) {
         let this_date_time = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.month")?;
         let month = this_date_time.date_time().month();
 
         Ok(cx.smi(month))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.monthCode (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.monthcode)
-    pub fn month_code(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn month_code(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.monthCode")?;
         let month_code = this_date_time.date_time().month_code();
 
         Ok(cx.alloc_string(month_code.as_str())?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.day (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.day)
-    pub fn day(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn day(cx, this_value, _) {
         let this_date_time = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.day")?;
         let day = this_date_time.date_time().day();
 
         Ok(cx.smi(day))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.dayOfWeek (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.dayofweek)
-    pub fn day_of_week(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn day_of_week(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.dayOfWeek")?;
         let day_of_week = this_date_time.date_time().day_of_week();
 
         Ok(cx.smi(day_of_week))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.dayOfYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.dayofyear)
-    pub fn day_of_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn day_of_year(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.dayOfYear")?;
         let day_of_year = this_date_time.date_time().day_of_year();
 
         Ok(cx.smi(day_of_year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.weekOfYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.weekofyear)
-    pub fn week_of_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn week_of_year(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.weekOfYear")?;
 
@@ -429,14 +412,11 @@ impl PlainDateTimePrototype {
             None => Ok(cx.undefined()),
             Some(week_number) => Ok(cx.smi(week_number)),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.yearOfWeek (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.yearofweek)
-    pub fn year_of_week(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn year_of_week(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.yearOfWeek")?;
 
@@ -444,152 +424,120 @@ impl PlainDateTimePrototype {
             None => Ok(cx.undefined()),
             Some(year_number) => Ok(cx.smi(year_number)),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.daysInWeek (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinweek)
-    pub fn days_in_week(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn days_in_week(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.daysInWeek")?;
         let days_in_week = this_date_time.date_time().days_in_week();
 
         Ok(cx.smi(days_in_week))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.daysInMonth (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinmonth)
-    pub fn days_in_month(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn days_in_month(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.daysInMonth")?;
         let days_in_month = this_date_time.date_time().days_in_month();
 
         Ok(cx.smi(days_in_month))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.daysInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.daysinyear)
-    pub fn days_in_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn days_in_year(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.daysInYear")?;
         let days_in_year = this_date_time.date_time().days_in_year();
 
         Ok(cx.smi(days_in_year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.monthsInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.monthsinyear)
-    pub fn months_in_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn months_in_year(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.monthsInYear")?;
         let months_in_year = this_date_time.date_time().months_in_year();
 
         Ok(cx.smi(months_in_year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.inLeapYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.inleapyear)
-    pub fn in_leap_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn in_leap_year(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.inLeapYear")?;
         let in_leap_year = this_date_time.date_time().in_leap_year();
 
         Ok(cx.bool(in_leap_year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.hour (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.hour)
-    pub fn hour(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn hour(cx, this_value, _) {
         let this_date_time = this_plain_date_time(cx, this_value, "PlainDateTime.prototype.hour")?;
         let hour = this_date_time.date_time().hour();
 
         Ok(cx.smi(hour))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.minute (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.minute)
-    pub fn minute(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn minute(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.minute")?;
         let minute = this_date_time.date_time().minute();
 
         Ok(cx.smi(minute))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.second (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.second)
-    pub fn second(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn second(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.second")?;
         let second = this_date_time.date_time().second();
 
         Ok(cx.smi(second))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.millisecond (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.millisecond)
-    pub fn millisecond(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn millisecond(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.millisecond")?;
         let millis = this_date_time.date_time().millisecond();
 
         Ok(cx.smi(millis))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.microsecond (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.microsecond)
-    pub fn microsecond(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn microsecond(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.microsecond")?;
         let micros = this_date_time.date_time().microsecond();
 
         Ok(cx.smi(micros))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainDateTime.prototype.nanosecond (https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.nanosecond)
-    pub fn nanosecond(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn nanosecond(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.nanosecond")?;
         let nanos = this_date_time.date_time().nanosecond();
 
         Ok(cx.smi(nanos))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.add (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.add)
-    pub fn add(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn add(cx, this_value, arguments) {
         const NAME: &str = "PlainDateTime.prototype.add";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
@@ -605,14 +553,11 @@ impl PlainDateTimePrototype {
         let new_date_time = map_temporal_result(cx, new_date_time_result, NAME)?;
 
         Ok(PlainDateTimeObject::new(cx, new_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.subtract (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.subtract)
-    pub fn subtract(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn subtract(cx, this_value, arguments) {
         const NAME: &str = "PlainDateTime.prototype.subtract";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
@@ -630,25 +575,19 @@ impl PlainDateTimePrototype {
         let new_date_time = map_temporal_result(cx, new_date_time_result, NAME)?;
 
         Ok(PlainDateTimeObject::new(cx, new_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.until (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.until)
-    pub fn until(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn until(cx, this_value, arguments) {
         Self::diff(cx, this_value, arguments, DiffOperation::Until, "PlainDateTime.prototype.until")
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.since (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.since)
-    pub fn since(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn since(cx, this_value, arguments) {
         Self::diff(cx, this_value, arguments, DiffOperation::Since, "PlainDateTime.prototype.since")
-    }
+    }}
 
     fn diff(
         cx: Context,
@@ -680,12 +619,9 @@ impl PlainDateTimePrototype {
         Ok(DurationObject::new(cx, duration)?.as_value())
     }
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.round (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.round)
-    pub fn round(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn round(cx, this_value, arguments) {
         const NAME: &str = "PlainDateTime.prototype.round";
 
         let plain_date_time = this_plain_date_time(cx, this_value, NAME)?;
@@ -707,14 +643,11 @@ impl PlainDateTimePrototype {
         let rounded = map_temporal_result(cx, rounded_result, NAME)?;
 
         Ok(PlainDateTimeObject::new(cx, rounded)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.equals (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.equals)
-    pub fn equals(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn equals(cx, this_value, arguments) {
         const NAME: &str = "PlainDateTime.prototype.equals";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
@@ -723,40 +656,31 @@ impl PlainDateTimePrototype {
         let other_date_time = to_temporal_date_time(cx, other_arg, NAME)?;
 
         Ok(cx.bool(this_date_time.date_time() == &other_date_time))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.toPlainDate (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaindate)
-    pub fn to_plain_date(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_plain_date(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.toPlainDate")?;
         let plain_date = this_date_time.date_time().to_plain_date();
 
         Ok(PlainDateObject::new(cx, plain_date)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.toPlainTime (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.toplaintime)
-    pub fn to_plain_time(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_plain_time(cx, this_value, _) {
         let this_date_time =
             this_plain_date_time(cx, this_value, "PlainDateTime.prototype.toPlainTime")?;
         let plain_time = this_date_time.date_time().to_plain_time();
 
         Ok(PlainTimeObject::new(cx, plain_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.toZonedDateTime (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tozoneddatetime)
-    pub fn to_zoned_date_time(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_zoned_date_time(cx, this_value, arguments) {
         const NAME: &str = "PlainDateTime.prototype.toZonedDateTime";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
@@ -776,14 +700,11 @@ impl PlainDateTimePrototype {
         let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, zoned_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.toString (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tostring)
-    pub fn to_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, arguments) {
         const NAME: &str = "PlainDateTime.prototype.toString";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
@@ -809,14 +730,11 @@ impl PlainDateTimePrototype {
         let date_time_string = map_temporal_result(cx, date_time_string_result, NAME)?;
 
         Ok(cx.alloc_string(&date_time_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.toLocaleString (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tolocalestring)
-    pub fn to_locale_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_string(cx, this_value, _) {
         const NAME: &str = "PlainDateTime.prototype.toLocaleString";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
@@ -826,14 +744,11 @@ impl PlainDateTimePrototype {
         let date_time_string = map_temporal_result(cx, date_time_string_result, NAME)?;
 
         Ok(cx.alloc_string(&date_time_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.toJSON (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tojson)
-    pub fn to_json(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_json(cx, this_value, _) {
         const NAME: &str = "PlainDateTime.prototype.toJSON";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
@@ -843,19 +758,17 @@ impl PlainDateTimePrototype {
         let date_time_string = map_temporal_result(cx, date_time_string_result, NAME)?;
 
         Ok(cx.alloc_string(&date_time_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.valueof)
-    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, _, _) {
         type_error(cx, "PlainDateTime.prototype.valueOf must not be called")
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.with (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.with)
-    pub fn with(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with(cx, this_value, arguments) {
         const NAME: &str = "PlainDateTime.prototype.with";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
@@ -901,14 +814,11 @@ impl PlainDateTimePrototype {
         let new_date_time = map_temporal_result(cx, new_date_time_result, NAME)?;
 
         Ok(PlainDateTimeObject::new(cx, new_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.withPlainTime (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaintime)
-    pub fn with_plain_time(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with_plain_time(cx, this_value, arguments) {
         const NAME: &str = "PlainDateTime.prototype.withPlainTime";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
@@ -924,14 +834,11 @@ impl PlainDateTimePrototype {
         let new_date_time = map_temporal_result(cx, new_date_time_result, NAME)?;
 
         Ok(PlainDateTimeObject::new(cx, new_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainDateTime.prototype.withCalendar (https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withcalendar)
-    pub fn with_calendar(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with_calendar(cx, this_value, arguments) {
         const NAME: &str = "PlainDateTime.prototype.withCalendar";
 
         let this_date_time = this_plain_date_time(cx, this_value, NAME)?;
@@ -942,7 +849,7 @@ impl PlainDateTimePrototype {
         let new_date_time = this_date_time.date_time().with_calendar(calendar);
 
         Ok(PlainDateTimeObject::new(cx, new_date_time)?.as_value())
-    }
+    }}
 }
 
 fn this_plain_date_time(

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
@@ -2,25 +2,28 @@ use temporal_rs::{
     PlainMonthDay, options::Overflow, parsed_intermediates::ParsedDate, partial::PartialDate,
 };
 
-use crate::runtime::{
-    Arguments, Context, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            plain_month_day_object::PlainMonthDayObject,
-            utils::{
-                DateField, RequiredFieldNames, get_calendar_identifier_with_iso_default,
-                get_overflow_option, map_temporal_result, parse_calendar_argument,
-                prepare_calendar_fields, to_integer_with_truncation, validate_options_object,
+use crate::{
+    runtime::{
+        Context, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        error::type_error,
+        eval_result::EvalResult,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                plain_month_day_object::PlainMonthDayObject,
+                utils::{
+                    DateField, RequiredFieldNames, get_calendar_identifier_with_iso_default,
+                    get_overflow_option, map_temporal_result, parse_calendar_argument,
+                    prepare_calendar_fields, to_integer_with_truncation, validate_options_object,
+                },
             },
         },
+        object_value::ObjectValue,
     },
-    object_value::ObjectValue,
+    runtime_fn,
 };
 
 pub struct PlainMonthDayConstructor;
@@ -56,12 +59,9 @@ impl PlainMonthDayConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Temporal.PlainMonthDay (https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         const NAME: &str = "Temporal.PlainMonthDay constructor";
 
         let Some(new_target) = cx.current_new_target() else {
@@ -95,10 +95,11 @@ impl PlainMonthDayConstructor {
         let plain_month_day = map_temporal_result(cx, plain_month_day_result, NAME)?;
 
         Ok(PlainMonthDayObject::new_from_constructor(cx, new_target, plain_month_day)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainMonthDay.from (https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.from)
-    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn from(cx, _, arguments) {
         let item_arg = arguments.get(cx, 0);
         let options_arg = arguments.get(cx, 1);
 
@@ -106,7 +107,7 @@ impl PlainMonthDayConstructor {
             to_temporal_month_day(cx, item_arg, Some(options_arg), "PlainMonthDay.from")?;
 
         Ok(PlainMonthDayObject::new(cx, plain_month_day)?.as_value())
-    }
+    }}
 }
 
 /// ToTemporalMonthDay (https://tc39.es/proposal-temporal/#sec-temporal-totemporalmonthday)

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
@@ -1,25 +1,28 @@
 use temporal_rs::options::DisplayCalendar;
 
-use crate::runtime::{
-    Arguments, Context, EvalResult, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    error::type_error,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            plain_date_object::PlainDateObject,
-            plain_month_day_constructor::to_temporal_month_day,
-            plain_month_day_object::PlainMonthDayObject,
-            utils::{
-                DateField, RequiredFieldNames, get_overflow_option, get_show_calendar_name_option,
-                is_partial_temporal_object, map_temporal_result, prepare_calendar_fields,
-                validate_options_object,
+use crate::{
+    runtime::{
+        Context, EvalResult, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        error::type_error,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                plain_date_object::PlainDateObject,
+                plain_month_day_constructor::to_temporal_month_day,
+                plain_month_day_object::PlainMonthDayObject,
+                utils::{
+                    DateField, RequiredFieldNames, get_overflow_option,
+                    get_show_calendar_name_option, is_partial_temporal_object, map_temporal_result,
+                    prepare_calendar_fields, validate_options_object,
+                },
             },
         },
+        object_value::ObjectValue,
+        property::Property,
     },
-    object_value::ObjectValue,
-    property::Property,
+    runtime_fn,
 };
 
 pub struct PlainMonthDayPrototype;
@@ -118,46 +121,38 @@ impl PlainMonthDayPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// get Temporal.PlainMonthDay.prototype.calendarId (https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.calendarid)
-    pub fn calendar_id(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn calendar_id(cx, this_value, _) {
         let this_month_day =
             this_plain_month_day(cx, this_value, "PlainMonthDay.prototype.calendarId")?;
         let calendar_str = this_month_day.month_day().calendar_id();
 
         Ok(cx.alloc_static_string(calendar_str)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainMonthDay.prototype.monthCode (https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.monthcode)
-    pub fn month_code(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn month_code(cx, this_value, _) {
         let this_month_day =
             this_plain_month_day(cx, this_value, "PlainMonthDay.prototype.monthCode")?;
         let month_code = this_month_day.month_day().month_code();
 
         Ok(cx.alloc_string(month_code.as_str())?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainMonthDay.prototype.day (https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.day)
-    pub fn day(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn day(cx, this_value, _) {
         let this_month_day = this_plain_month_day(cx, this_value, "PlainMonthDay.prototype.day")?;
         let day = this_month_day.month_day().day();
 
         Ok(cx.smi(day))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainMonthDay.prototype.equals (https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.equals)
-    pub fn equals(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn equals(cx, this_value, arguments) {
         const NAME: &str = "PlainMonthDay.prototype.equals";
 
         let this_month_day = this_plain_month_day(cx, this_value, NAME)?;
@@ -166,14 +161,11 @@ impl PlainMonthDayPrototype {
         let other_month_day = to_temporal_month_day(cx, other_arg, None, NAME)?;
 
         Ok(cx.bool(this_month_day.month_day() == &other_month_day))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainMonthDay.prototype.toPlainDate (https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.toplaindate)
-    pub fn to_plain_date(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_plain_date(cx, this_value, arguments) {
         const NAME: &str = "PlainMonthDay.prototype.toPlainDate";
 
         let this_month_day = this_plain_month_day(cx, this_value, NAME)?;
@@ -201,14 +193,11 @@ impl PlainMonthDayPrototype {
         let plain_date = map_temporal_result(cx, plain_date_result, NAME)?;
 
         Ok(PlainDateObject::new(cx, plain_date)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainMonthDay.prototype.toString (https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tostring)
-    pub fn to_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, arguments) {
         const NAME: &str = "PlainMonthDay.prototype.toString";
 
         let this_month_day = this_plain_month_day(cx, this_value, NAME)?;
@@ -220,14 +209,11 @@ impl PlainMonthDayPrototype {
         let month_day_string = this_month_day.month_day().to_ixdtf_string(display_calendar);
 
         Ok(cx.alloc_string(&month_day_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainMonthDay.prototype.toLocaleString (https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tolocalestring)
-    pub fn to_locale_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_string(cx, this_value, _) {
         let this_month_day =
             this_plain_month_day(cx, this_value, "PlainMonthDay.prototype.toLocaleString")?;
         let month_day_string = this_month_day
@@ -235,14 +221,11 @@ impl PlainMonthDayPrototype {
             .to_ixdtf_string(DisplayCalendar::Auto);
 
         Ok(cx.alloc_string(&month_day_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainMonthDay.prototype.toJSON (https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.tojson)
-    pub fn to_json(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_json(cx, this_value, _) {
         let this_month_day =
             this_plain_month_day(cx, this_value, "PlainMonthDay.prototype.toJSON")?;
         let month_day_string = this_month_day
@@ -250,19 +233,17 @@ impl PlainMonthDayPrototype {
             .to_ixdtf_string(DisplayCalendar::Auto);
 
         Ok(cx.alloc_string(&month_day_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainMonthDay.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.valueof)
-    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, _, _) {
         type_error(cx, "PlainMonthDay.prototype.valueOf must not be called")
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainMonthDay.prototype.with (https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.with)
-    pub fn with(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with(cx, this_value, arguments) {
         const NAME: &str = "PlainMonthDay.prototype.with";
 
         let this_month_day = this_plain_month_day(cx, this_value, NAME)?;
@@ -301,7 +282,7 @@ impl PlainMonthDayPrototype {
         let new_month_day = map_temporal_result(cx, new_month_day_result, NAME)?;
 
         Ok(PlainMonthDayObject::new(cx, new_month_day)?.as_value())
-    }
+    }}
 }
 
 fn this_plain_month_day(

--- a/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
@@ -1,23 +1,26 @@
 use temporal_rs::PlainTime;
 
-use crate::runtime::{
-    Arguments, Context, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            plain_time_object::PlainTimeObject,
-            utils::{
-                get_overflow_option, map_temporal_result, to_integer_with_truncation_or_zero,
-                to_partial_time_record, validate_options_object, validate_time_arguments,
+use crate::{
+    runtime::{
+        Context, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        error::type_error,
+        eval_result::EvalResult,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                plain_time_object::PlainTimeObject,
+                utils::{
+                    get_overflow_option, map_temporal_result, to_integer_with_truncation_or_zero,
+                    to_partial_time_record, validate_options_object, validate_time_arguments,
+                },
             },
         },
+        object_value::ObjectValue,
     },
-    object_value::ObjectValue,
+    runtime_fn,
 };
 
 pub struct PlainTimeConstructor;
@@ -58,12 +61,9 @@ impl PlainTimeConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Temporal.PlainTime (https://tc39.es/proposal-temporal/#sec-temporal-plaintime)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         const NAME: &str = "Temporal.PlainTime constructor";
 
         let Some(new_target) = cx.current_new_target() else {
@@ -98,10 +98,11 @@ impl PlainTimeConstructor {
         let plain_time = map_temporal_result(cx, plain_time_result, NAME)?;
 
         Ok(PlainTimeObject::new_from_constructor(cx, new_target, plain_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainTime.from (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.from)
-    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn from(cx, _, arguments) {
         let item_arg = arguments.get(cx, 0);
         let options_arg = arguments.get(cx, 1);
 
@@ -109,14 +110,11 @@ impl PlainTimeConstructor {
             to_temporal_time_with_options(cx, item_arg, options_arg, "PlainTime.from")?;
 
         Ok(PlainTimeObject::new(cx, plain_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainTime.compare (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.compare)
-    pub fn compare(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn compare(cx, _, arguments) {
         const NAME: &str = "PlainTime.compare";
 
         let arg_1 = arguments.get(cx, 0);
@@ -126,7 +124,7 @@ impl PlainTimeConstructor {
         let time_2 = to_temporal_time(cx, arg_2, NAME)?;
 
         Ok(cx.smi(time_1.cmp(&time_2) as i8))
-    }
+    }}
 }
 
 /// ToTemporalTime (https://tc39.es/proposal-temporal/#sec-temporal-totemporaltime)

--- a/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
@@ -1,27 +1,30 @@
 use temporal_rs::options::{RoundingMode, RoundingOptions, ToStringRoundingOptions};
 
-use crate::runtime::{
-    Arguments, Context, EvalResult, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    error::type_error,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            duration_constructor::to_temporal_duration,
-            duration_object::DurationObject,
-            plain_time_constructor::to_temporal_time,
-            plain_time_object::PlainTimeObject,
-            utils::{
-                DiffOperation, get_difference_settings, get_fractional_second_digits_option,
-                get_overflow_option, get_rounding_increment_option, get_rounding_mode_option,
-                get_unit_valued_option, is_partial_temporal_object, map_temporal_result,
-                parse_round_options_argument, to_partial_time_record, validate_options_object,
+use crate::{
+    runtime::{
+        Arguments, Context, EvalResult, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        error::type_error,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                duration_constructor::to_temporal_duration,
+                duration_object::DurationObject,
+                plain_time_constructor::to_temporal_time,
+                plain_time_object::PlainTimeObject,
+                utils::{
+                    DiffOperation, get_difference_settings, get_fractional_second_digits_option,
+                    get_overflow_option, get_rounding_increment_option, get_rounding_mode_option,
+                    get_unit_valued_option, is_partial_temporal_object, map_temporal_result,
+                    parse_round_options_argument, to_partial_time_record, validate_options_object,
+                },
             },
         },
+        object_value::ObjectValue,
+        property::Property,
     },
-    object_value::ObjectValue,
-    property::Property,
+    runtime_fn,
 };
 
 pub struct PlainTimePrototype;
@@ -161,80 +164,63 @@ impl PlainTimePrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// get Temporal.PlainTime.prototype.hour (https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.hour)
-    pub fn hour(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn hour(cx, this_value, _) {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.hour")?;
         let hour = this_time.time().hour();
 
         Ok(cx.smi(hour))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainTime.prototype.minute (https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.minute)
-    pub fn minute(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn minute(cx, this_value, _) {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.minute")?;
         let minute = this_time.time().minute();
 
         Ok(cx.smi(minute))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainTime.prototype.second (https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.second)
-    pub fn second(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn second(cx, this_value, _) {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.second")?;
         let second = this_time.time().second();
 
         Ok(cx.smi(second))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainTime.prototype.millisecond (https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.millisecond)
-    pub fn millisecond(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn millisecond(cx, this_value, _) {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.millisecond")?;
         let millis = this_time.time().millisecond();
 
         Ok(cx.smi(millis))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainTime.prototype.microsecond (https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.microsecond)
-    pub fn microsecond(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn microsecond(cx, this_value, _) {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.microsecond")?;
         let micros = this_time.time().microsecond();
 
         Ok(cx.smi(micros))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainTime.prototype.nanosecond (https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.nanosecond)
-    pub fn nanosecond(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn nanosecond(cx, this_value, _) {
         let this_time = this_plain_time(cx, this_value, "PlainTime.prototype.nanosecond")?;
         let nanos = this_time.time().nanosecond();
 
         Ok(cx.smi(nanos))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainTime.prototype.add (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.add)
-    pub fn add(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn add(cx, this_value, arguments) {
         const NAME: &str = "PlainTime.prototype.add";
 
         let this_time = this_plain_time(cx, this_value, NAME)?;
@@ -246,14 +232,11 @@ impl PlainTimePrototype {
         let new_time = map_temporal_result(cx, new_time_result, NAME)?;
 
         Ok(PlainTimeObject::new(cx, new_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainTime.prototype.subtract (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.subtract)
-    pub fn subtract(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn subtract(cx, this_value, arguments) {
         const NAME: &str = "PlainTime.prototype.subtract";
 
         let this_time = this_plain_time(cx, this_value, NAME)?;
@@ -265,14 +248,11 @@ impl PlainTimePrototype {
         let new_time = map_temporal_result(cx, new_time_result, NAME)?;
 
         Ok(PlainTimeObject::new(cx, new_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainTime.prototype.with (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.with)
-    pub fn with(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with(cx, this_value, arguments) {
         const NAME: &str = "PlainTime.prototype.with";
 
         let plain_time = this_plain_time(cx, this_value, NAME)?;
@@ -297,25 +277,19 @@ impl PlainTimePrototype {
         let new_time = map_temporal_result(cx, new_time_result, NAME)?;
 
         Ok(PlainTimeObject::new(cx, new_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainTime.prototype.until (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.until)
-    pub fn until(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn until(cx, this_value, arguments) {
         Self::diff(cx, this_value, arguments, DiffOperation::Until, "PlainTime.prototype.until")
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainTime.prototype.since (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.since)
-    pub fn since(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn since(cx, this_value, arguments) {
         Self::diff(cx, this_value, arguments, DiffOperation::Since, "PlainTime.prototype.since")
-    }
+    }}
 
     fn diff(
         cx: Context,
@@ -343,12 +317,9 @@ impl PlainTimePrototype {
         Ok(DurationObject::new(cx, duration)?.as_value())
     }
 
+    runtime_fn! {
     /// Temporal.PlainTime.prototype.round (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.round)
-    pub fn round(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn round(cx, this_value, arguments) {
         const NAME: &str = "PlainTime.prototype.round";
 
         let plain_time = this_plain_time(cx, this_value, NAME)?;
@@ -370,14 +341,11 @@ impl PlainTimePrototype {
         let rounded = map_temporal_result(cx, rounded_result, NAME)?;
 
         Ok(PlainTimeObject::new(cx, rounded)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainTime.prototype.equals (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.equals)
-    pub fn equals(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn equals(cx, this_value, arguments) {
         const NAME: &str = "PlainTime.prototype.equals";
 
         let this_time = this_plain_time(cx, this_value, NAME)?;
@@ -386,14 +354,11 @@ impl PlainTimePrototype {
         let other_time = to_temporal_time(cx, other_arg, NAME)?;
 
         Ok(cx.bool(this_time.time() == other_time))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainTime.prototype.toString (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tostring)
-    pub fn to_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, arguments) {
         const NAME: &str = "PlainTime.prototype.toString";
 
         let this_time = this_plain_time(cx, this_value, NAME)?;
@@ -416,14 +381,11 @@ impl PlainTimePrototype {
         let time_string = map_temporal_result(cx, time_string_result, NAME)?;
 
         Ok(cx.alloc_string(&time_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainTime.prototype.toLocaleString (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tolocalestring)
-    pub fn to_locale_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_string(cx, this_value, _) {
         const NAME: &str = "PlainTime.prototype.toLocaleString";
 
         let this_time = this_plain_time(cx, this_value, NAME)?;
@@ -433,14 +395,11 @@ impl PlainTimePrototype {
         let time_string = map_temporal_result(cx, time_string_result, NAME)?;
 
         Ok(cx.alloc_string(&time_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainTime.prototype.toJSON (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tojson)
-    pub fn to_json(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_json(cx, this_value, _) {
         const NAME: &str = "PlainTime.prototype.toJSON";
 
         let this_time = this_plain_time(cx, this_value, NAME)?;
@@ -450,12 +409,13 @@ impl PlainTimePrototype {
         let time_string = map_temporal_result(cx, time_string_result, NAME)?;
 
         Ok(cx.alloc_string(&time_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainTime.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.valueof)
-    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, _, _) {
         type_error(cx, "PlainTime.prototype.valueOf must not be called")
-    }
+    }}
 }
 
 fn this_plain_time(

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
@@ -1,24 +1,27 @@
 use temporal_rs::{PlainYearMonth, parsed_intermediates::ParsedDate, partial::PartialYearMonth};
 
-use crate::runtime::{
-    Arguments, Context, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            plain_year_month_object::PlainYearMonthObject,
-            utils::{
-                DateField, RequiredFieldNames, get_calendar_identifier_with_iso_default,
-                get_overflow_option, map_temporal_result, parse_calendar_argument,
-                prepare_calendar_fields, to_integer_with_truncation, validate_options_object,
+use crate::{
+    runtime::{
+        Context, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        error::type_error,
+        eval_result::EvalResult,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                plain_year_month_object::PlainYearMonthObject,
+                utils::{
+                    DateField, RequiredFieldNames, get_calendar_identifier_with_iso_default,
+                    get_overflow_option, map_temporal_result, parse_calendar_argument,
+                    prepare_calendar_fields, to_integer_with_truncation, validate_options_object,
+                },
             },
         },
+        object_value::ObjectValue,
     },
-    object_value::ObjectValue,
+    runtime_fn,
 };
 
 pub struct PlainYearMonthConstructor;
@@ -61,12 +64,9 @@ impl PlainYearMonthConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth (https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         const NAME: &str = "Temporal.PlainYearMonth constructor";
 
         let Some(new_target) = cx.current_new_target() else {
@@ -98,10 +98,11 @@ impl PlainYearMonthConstructor {
             PlainYearMonthObject::new_from_constructor(cx, new_target, plain_year_month)?
                 .as_value(),
         )
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth.from (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.from)
-    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn from(cx, _, arguments) {
         let item_arg = arguments.get(cx, 0);
         let options_arg = arguments.get(cx, 1);
 
@@ -109,14 +110,11 @@ impl PlainYearMonthConstructor {
             to_temporal_year_month(cx, item_arg, Some(options_arg), "PlainYearMonth.from")?;
 
         Ok(PlainYearMonthObject::new(cx, plain_year_month)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth.compare (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.compare)
-    pub fn compare(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn compare(cx, _, arguments) {
         const NAME: &str = "PlainYearMonth.compare";
 
         let arg_1 = arguments.get(cx, 0);
@@ -126,7 +124,7 @@ impl PlainYearMonthConstructor {
         let year_month_2 = to_temporal_year_month(cx, arg_2, None, NAME)?;
 
         Ok(cx.smi(year_month_1.compare_iso(&year_month_2) as i8))
-    }
+    }}
 }
 
 /// ToTemporalYearMonth (https://tc39.es/proposal-temporal/#sec-temporal-totemporalyearmonth)

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
@@ -1,27 +1,30 @@
 use temporal_rs::options::DisplayCalendar;
 
-use crate::runtime::{
-    Arguments, Context, EvalResult, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    error::type_error,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            duration_constructor::to_temporal_duration,
-            duration_object::DurationObject,
-            plain_date_object::PlainDateObject,
-            plain_year_month_constructor::to_temporal_year_month,
-            plain_year_month_object::PlainYearMonthObject,
-            utils::{
-                DateField, DiffOperation, RequiredFieldNames, get_difference_settings,
-                get_overflow_option, get_show_calendar_name_option, is_partial_temporal_object,
-                map_temporal_result, prepare_calendar_fields, validate_options_object,
+use crate::{
+    runtime::{
+        Arguments, Context, EvalResult, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        error::type_error,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                duration_constructor::to_temporal_duration,
+                duration_object::DurationObject,
+                plain_date_object::PlainDateObject,
+                plain_year_month_constructor::to_temporal_year_month,
+                plain_year_month_object::PlainYearMonthObject,
+                utils::{
+                    DateField, DiffOperation, RequiredFieldNames, get_difference_settings,
+                    get_overflow_option, get_show_calendar_name_option, is_partial_temporal_object,
+                    map_temporal_result, prepare_calendar_fields, validate_options_object,
+                },
             },
         },
+        object_value::ObjectValue,
+        property::Property,
     },
-    object_value::ObjectValue,
-    property::Property,
+    runtime_fn,
 };
 
 pub struct PlainYearMonthPrototype;
@@ -190,25 +193,19 @@ impl PlainYearMonthPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// get Temporal.PlainYearMonth.prototype.calendarId (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.calendarid)
-    pub fn calendar_id(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn calendar_id(cx, this_value, _) {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.calendarId")?;
         let calendar_str = this_year_month.year_month().calendar_id();
 
         Ok(cx.alloc_static_string(calendar_str)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainYearMonth.prototype.era (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.era)
-    pub fn era(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn era(cx, this_value, _) {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.era")?;
 
@@ -216,14 +213,11 @@ impl PlainYearMonthPrototype {
             None => Ok(cx.undefined()),
             Some(era) => Ok(cx.alloc_string(era.as_str())?.as_value()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainYearMonth.prototype.eraYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.erayear)
-    pub fn era_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn era_year(cx, this_value, _) {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.eraYear")?;
 
@@ -231,101 +225,81 @@ impl PlainYearMonthPrototype {
             None => Ok(cx.undefined()),
             Some(year_number) => Ok(cx.smi(year_number)),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainYearMonth.prototype.year (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.year)
-    pub fn year(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn year(cx, this_value, _) {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.year")?;
         let year = this_year_month.year_month().year();
 
         Ok(cx.smi(year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainYearMonth.prototype.month (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.month)
-    pub fn month(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn month(cx, this_value, _) {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.month")?;
         let month = this_year_month.year_month().month();
 
         Ok(cx.smi(month))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainYearMonth.prototype.monthCode (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthcode)
-    pub fn month_code(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn month_code(cx, this_value, _) {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.monthCode")?;
         let month_code = this_year_month.year_month().month_code();
 
         Ok(cx.alloc_string(month_code.as_str())?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainYearMonth.prototype.daysInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.daysinyear)
-    pub fn days_in_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn days_in_year(cx, this_value, _) {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.daysInYear")?;
         let days_in_year = this_year_month.year_month().days_in_year();
 
         Ok(cx.smi(days_in_year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainYearMonth.prototype.daysInMonth (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.daysinmonth)
-    pub fn days_in_month(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn days_in_month(cx, this_value, _) {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.daysInMonth")?;
         let days_in_month = this_year_month.year_month().days_in_month();
 
         Ok(cx.smi(days_in_month))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainYearMonth.prototype.monthsInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.monthsinyear)
-    pub fn months_in_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn months_in_year(cx, this_value, _) {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.monthsInYear")?;
         let months_in_year = this_year_month.year_month().months_in_year();
 
         Ok(cx.smi(months_in_year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.PlainYearMonth.prototype.inLeapYear (https://tc39.es/proposal-temporal/#sec-get-temporal.plainyearmonth.prototype.inleapyear)
-    pub fn in_leap_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn in_leap_year(cx, this_value, _) {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.inLeapYear")?;
         let in_leap_year = this_year_month.year_month().in_leap_year();
 
         Ok(cx.bool(in_leap_year))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth.prototype.add (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.add)
-    pub fn add(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn add(cx, this_value, arguments) {
         const NAME: &str = "PlainYearMonth.prototype.add";
 
         let this_year_month = this_plain_year_month(cx, this_value, NAME)?;
@@ -341,14 +315,11 @@ impl PlainYearMonthPrototype {
         let new_year_month = map_temporal_result(cx, new_year_month_result, NAME)?;
 
         Ok(PlainYearMonthObject::new(cx, new_year_month)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth.prototype.subtract (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.subtract)
-    pub fn subtract(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn subtract(cx, this_value, arguments) {
         const NAME: &str = "PlainYearMonth.prototype.subtract";
 
         let this_year_month = this_plain_year_month(cx, this_value, NAME)?;
@@ -364,14 +335,11 @@ impl PlainYearMonthPrototype {
         let new_year_month = map_temporal_result(cx, new_year_month_result, NAME)?;
 
         Ok(PlainYearMonthObject::new(cx, new_year_month)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth.prototype.until (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.until)
-    pub fn until(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn until(cx, this_value, arguments) {
         Self::diff(
             cx,
             this_value,
@@ -379,14 +347,11 @@ impl PlainYearMonthPrototype {
             DiffOperation::Until,
             "PlainYearMonth.prototype.until",
         )
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth.prototype.since (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.since)
-    pub fn since(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn since(cx, this_value, arguments) {
         Self::diff(
             cx,
             this_value,
@@ -394,7 +359,7 @@ impl PlainYearMonthPrototype {
             DiffOperation::Since,
             "PlainYearMonth.prototype.since",
         )
-    }
+    }}
 
     fn diff(
         cx: Context,
@@ -426,12 +391,9 @@ impl PlainYearMonthPrototype {
         Ok(DurationObject::new(cx, duration)?.as_value())
     }
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth.prototype.equals (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.equals)
-    pub fn equals(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn equals(cx, this_value, arguments) {
         const NAME: &str = "PlainYearMonth.prototype.equals";
 
         let this_year_month = this_plain_year_month(cx, this_value, NAME)?;
@@ -440,14 +402,11 @@ impl PlainYearMonthPrototype {
         let other_year_month = to_temporal_year_month(cx, other_arg, None, NAME)?;
 
         Ok(cx.bool(this_year_month.year_month() == &other_year_month))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth.prototype.toPlainDate (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.toplaindate)
-    pub fn to_plain_date(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_plain_date(cx, this_value, arguments) {
         const NAME: &str = "PlainYearMonth.prototype.toPlainDate";
 
         let this_year_month = this_plain_year_month(cx, this_value, NAME)?;
@@ -475,14 +434,11 @@ impl PlainYearMonthPrototype {
         let plain_date = map_temporal_result(cx, plain_date_result, NAME)?;
 
         Ok(PlainDateObject::new(cx, plain_date)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth.prototype.toString (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tostring)
-    pub fn to_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, arguments) {
         const NAME: &str = "PlainYearMonth.prototype.toString";
 
         let this_year_month = this_plain_year_month(cx, this_value, NAME)?;
@@ -496,14 +452,11 @@ impl PlainYearMonthPrototype {
             .to_ixdtf_string(display_calendar);
 
         Ok(cx.alloc_string(&year_month_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth.prototype.toLocaleString (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tolocalestring)
-    pub fn to_locale_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_string(cx, this_value, _) {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.toLocaleString")?;
         let year_month_string = this_year_month
@@ -511,14 +464,11 @@ impl PlainYearMonthPrototype {
             .to_ixdtf_string(DisplayCalendar::Auto);
 
         Ok(cx.alloc_string(&year_month_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth.prototype.toJSON (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tojson)
-    pub fn to_json(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_json(cx, this_value, _) {
         let this_year_month =
             this_plain_year_month(cx, this_value, "PlainYearMonth.prototype.toJSON")?;
         let year_month_string = this_year_month
@@ -526,19 +476,17 @@ impl PlainYearMonthPrototype {
             .to_ixdtf_string(DisplayCalendar::Auto);
 
         Ok(cx.alloc_string(&year_month_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.valueof)
-    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, _, _) {
         type_error(cx, "PlainYearMonth.prototype.valueOf must not be called")
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.PlainYearMonth.prototype.with (https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.with)
-    pub fn with(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with(cx, this_value, arguments) {
         const NAME: &str = "PlainYearMonth.prototype.with";
 
         let this_year_month = this_plain_year_month(cx, this_value, NAME)?;
@@ -572,7 +520,7 @@ impl PlainYearMonthPrototype {
         let new_year_month = map_temporal_result(cx, new_year_month_result, NAME)?;
 
         Ok(PlainYearMonthObject::new(cx, new_year_month)?.as_value())
-    }
+    }}
 }
 
 fn this_plain_year_month(

--- a/src/js/runtime/intrinsics/temporal/temporal_now_object.rs
+++ b/src/js/runtime/intrinsics/temporal/temporal_now_object.rs
@@ -6,23 +6,26 @@ use temporal_rs::{
     unix_time::EpochNanoseconds,
 };
 
-use crate::runtime::{
-    Arguments, Context, EvalResult, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            instant_object::InstantObject,
-            plain_date_object::PlainDateObject,
-            plain_date_time_object::PlainDateTimeObject,
-            plain_time_object::PlainTimeObject,
-            utils::{map_temporal_result, to_time_zone_identifier},
-            zoned_date_time_object::ZonedDateTimeObject,
+use crate::{
+    runtime::{
+        Context, EvalResult, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                instant_object::InstantObject,
+                plain_date_object::PlainDateObject,
+                plain_date_time_object::PlainDateTimeObject,
+                plain_time_object::PlainTimeObject,
+                utils::{map_temporal_result, to_time_zone_identifier},
+                zoned_date_time_object::ZonedDateTimeObject,
+            },
         },
+        object_value::ObjectValue,
+        property::Property,
     },
-    object_value::ObjectValue,
-    property::Property,
+    runtime_fn,
 };
 
 /// The Temporal.Now Object (https://tc39.es/proposal-temporal/#sec-temporal-now-object)
@@ -92,12 +95,9 @@ impl TemporalNowObject {
         Ok(object)
     }
 
+    runtime_fn! {
     /// Temporal.Now.timeZoneId (https://tc39.es/proposal-temporal/#sec-temporal.now.timezoneid)
-    pub fn time_zone_id(
-        mut cx: Context,
-        _: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn time_zone_id(cx, _, _) {
         const NAME: &str = "Now.timeZoneId";
 
         let time_zone_result = Self::now(cx).time_zone_with_provider(cx.temporal_provider());
@@ -107,22 +107,20 @@ impl TemporalNowObject {
         let time_zone_str = map_temporal_result(cx, time_zone_str_result, NAME)?;
 
         Ok(cx.alloc_string(&time_zone_str)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Now.instant (https://tc39.es/proposal-temporal/#sec-temporal.now.instant)
-    pub fn instant(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn instant(cx, _, _) {
         let instant_result = Self::now(cx).instant();
         let instant = map_temporal_result(cx, instant_result, "Now.instant")?;
 
         Ok(InstantObject::new(cx, instant)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Now.plainDateTimeISO (https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetimeiso)
-    pub fn plain_date_time_iso(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn plain_date_time_iso(cx, _, arguments) {
         const NAME: &str = "Now.plainDateTimeISO";
 
         let time_zone_arg = arguments.get(cx, 0);
@@ -133,14 +131,11 @@ impl TemporalNowObject {
         let date_time = map_temporal_result(cx, date_time_result, NAME)?;
 
         Ok(PlainDateTimeObject::new(cx, date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Now.zonedDateTimeISO (https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetimeiso)
-    pub fn zoned_date_time_iso(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn zoned_date_time_iso(cx, _, arguments) {
         const NAME: &str = "Now.zonedDateTimeISO";
 
         let time_zone_arg = arguments.get(cx, 0);
@@ -151,14 +146,11 @@ impl TemporalNowObject {
         let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, zoned_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Now.plainDateISO (https://tc39.es/proposal-temporal/#sec-temporal.now.plaindateiso)
-    pub fn plain_date_iso(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn plain_date_iso(cx, _, arguments) {
         const NAME: &str = "Now.plainDateISO";
 
         let time_zone_arg = arguments.get(cx, 0);
@@ -169,14 +161,11 @@ impl TemporalNowObject {
         let date = map_temporal_result(cx, date_result, NAME)?;
 
         Ok(PlainDateObject::new(cx, date)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.Now.plainTimeISO (https://tc39.es/proposal-temporal/#sec-temporal.now.plaintimeiso)
-    pub fn plain_time_iso(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn plain_time_iso(cx, _, arguments) {
         const NAME: &str = "Now.plainTimeISO";
 
         let time_zone_arg = arguments.get(cx, 0);
@@ -187,7 +176,7 @@ impl TemporalNowObject {
         let time = map_temporal_result(cx, time_result, NAME)?;
 
         Ok(PlainTimeObject::new(cx, time)?.as_value())
-    }
+    }}
 
     fn now(cx: Context) -> Now<NowImpl> {
         Now::new(NowImpl { cx })

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
@@ -5,28 +5,31 @@ use temporal_rs::{
     partial::PartialZonedDateTime,
 };
 
-use crate::runtime::{
-    Arguments, Context, Handle, Realm, Value,
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        intrinsics::Intrinsic,
-        rust_runtime::RuntimeFunction,
-        temporal::{
-            utils::{
-                DateField, RequiredFieldNames, TimeField, clamp_epoch_nanos_to_i128,
-                get_calendar_identifier_with_iso_default, get_disambiguation_option,
-                get_offset_option, get_overflow_option, map_temporal_result,
-                parse_calendar_argument, parse_time_zone_identifier_argument,
-                prepare_calendar_fields, validate_options_object,
+use crate::{
+    runtime::{
+        Context, Handle, Realm, Value,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        error::type_error,
+        eval_result::EvalResult,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            rust_runtime::RuntimeFunction,
+            temporal::{
+                utils::{
+                    DateField, RequiredFieldNames, TimeField, clamp_epoch_nanos_to_i128,
+                    get_calendar_identifier_with_iso_default, get_disambiguation_option,
+                    get_offset_option, get_overflow_option, map_temporal_result,
+                    parse_calendar_argument, parse_time_zone_identifier_argument,
+                    prepare_calendar_fields, validate_options_object,
+                },
+                zoned_date_time_object::ZonedDateTimeObject,
             },
-            zoned_date_time_object::ZonedDateTimeObject,
         },
+        object_value::ObjectValue,
+        type_utilities::to_bigint,
     },
-    object_value::ObjectValue,
-    type_utilities::to_bigint,
+    runtime_fn,
 };
 
 pub struct ZonedDateTimeConstructor;
@@ -69,12 +72,9 @@ impl ZonedDateTimeConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime (https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         const NAME: &str = "Temporal.ZonedDateTime constructor";
 
         let Some(new_target) = cx.current_new_target() else {
@@ -100,14 +100,11 @@ impl ZonedDateTimeConstructor {
         let zoned_date_time = map_temporal_result(cx, zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new_from_constructor(cx, new_target, zoned_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.compare (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.compare)
-    pub fn compare(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn compare(cx, _, arguments) {
         const NAME: &str = "ZonedDateTime.compare";
 
         let arg_1 = arguments.get(cx, 0);
@@ -117,10 +114,11 @@ impl ZonedDateTimeConstructor {
         let zoned_date_time_2 = to_temporal_zoned_date_time(cx, arg_2, NAME)?;
 
         Ok(cx.smi(zoned_date_time_1.compare_instant(&zoned_date_time_2) as i8))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.from (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.from)
-    pub fn from(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn from(cx, _, arguments) {
         let item_arg = arguments.get(cx, 0);
         let options_arg = arguments.get(cx, 1);
 
@@ -132,7 +130,7 @@ impl ZonedDateTimeConstructor {
         )?;
 
         Ok(ZonedDateTimeObject::new(cx, zoned_date_time)?.as_value())
-    }
+    }}
 }
 
 /// ToTemporalZonedDateTime (https://tc39.es/proposal-temporal/#sec-temporal-totemporalzoneddatetime)

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
@@ -43,6 +43,7 @@ use crate::{
         property::Property,
         value::BigIntValue,
     },
+    runtime_fn,
 };
 
 pub struct ZonedDateTimePrototype;
@@ -382,12 +383,9 @@ impl ZonedDateTimePrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.calendarId (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.calendarid)
-    pub fn calendar_id(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn calendar_id(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.calendarId")?;
         let calendar_str = this_zoned_date_time
@@ -396,14 +394,11 @@ impl ZonedDateTimePrototype {
             .identifier();
 
         Ok(cx.alloc_static_string(calendar_str)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.timeZoneId (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.timezoneid)
-    pub fn time_zone_id(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn time_zone_id(cx, this_value, _) {
         const NAME: &str = "ZonedDateTime.prototype.timeZoneId";
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
         let time_zone_id_result = this_zoned_date_time
@@ -413,27 +408,21 @@ impl ZonedDateTimePrototype {
         let time_zone_id = map_temporal_result(cx, time_zone_id_result, NAME)?;
 
         Ok(cx.alloc_string(&time_zone_id)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.epochMilliseconds (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmilliseconds)
-    pub fn epoch_milliseconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn epoch_milliseconds(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.epochMilliseconds")?;
         let epoch_millis = this_zoned_date_time.zoned_date_time().epoch_milliseconds();
 
         Ok(cx.number(epoch_millis))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.epochNanoseconds (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochnanoseconds)
-    pub fn epoch_nanoseconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn epoch_nanoseconds(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.epochNanoseconds")?;
         let epoch_nanos = this_zoned_date_time
@@ -442,14 +431,11 @@ impl ZonedDateTimePrototype {
             .as_i128();
 
         Ok(BigIntValue::new(cx, BigInt::from(epoch_nanos))?.into())
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.era (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.era)
-    pub fn era(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn era(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.era")?;
 
@@ -457,14 +443,11 @@ impl ZonedDateTimePrototype {
             None => Ok(cx.undefined()),
             Some(era) => Ok(cx.alloc_string(era.as_str())?.as_value()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.eraYear (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.erayear)
-    pub fn era_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn era_year(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.eraYear")?;
 
@@ -472,184 +455,151 @@ impl ZonedDateTimePrototype {
             None => Ok(cx.undefined()),
             Some(year_number) => Ok(cx.smi(year_number)),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.year (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.year)
-    pub fn year(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn year(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.year")?;
         let year = this_zoned_date_time.zoned_date_time().year();
 
         Ok(cx.smi(year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.month (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.month)
-    pub fn month(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn month(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.month")?;
         let month = this_zoned_date_time.zoned_date_time().month();
 
         Ok(cx.smi(month))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.monthCode (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.monthcode)
-    pub fn month_code(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn month_code(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.monthCode")?;
         let month_code = this_zoned_date_time.zoned_date_time().month_code();
 
         Ok(cx.alloc_string(month_code.as_str())?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.day (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.day)
-    pub fn day(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn day(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.day")?;
         let day = this_zoned_date_time.zoned_date_time().day();
 
         Ok(cx.smi(day))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.hour (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.hour)
-    pub fn hour(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn hour(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.hour")?;
         let hour = this_zoned_date_time.zoned_date_time().hour();
 
         Ok(cx.smi(hour))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.minute (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.minute)
-    pub fn minute(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn minute(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.minute")?;
         let minute = this_zoned_date_time.zoned_date_time().minute();
 
         Ok(cx.smi(minute))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.second (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.second)
-    pub fn second(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn second(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.second")?;
         let second = this_zoned_date_time.zoned_date_time().second();
 
         Ok(cx.smi(second))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.millisecond (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.millisecond)
-    pub fn millisecond(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn millisecond(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.millisecond")?;
         let millis = this_zoned_date_time.zoned_date_time().millisecond();
 
         Ok(cx.smi(millis))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.microsecond (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.microsecond)
-    pub fn microsecond(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn microsecond(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.microsecond")?;
         let micros = this_zoned_date_time.zoned_date_time().microsecond();
 
         Ok(cx.smi(micros))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.nanosecond (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.nanosecond)
-    pub fn nanosecond(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn nanosecond(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.nanosecond")?;
         let nanos = this_zoned_date_time.zoned_date_time().nanosecond();
 
         Ok(cx.smi(nanos))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.offset (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.offset)
-    pub fn offset(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn offset(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.offset")?;
         let offset_str = this_zoned_date_time.zoned_date_time().offset();
 
         Ok(cx.alloc_string(&offset_str)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.offsetNanoseconds (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.offsetnanoseconds)
-    pub fn offset_nanoseconds(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn offset_nanoseconds(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.offsetNanoseconds")?;
         let offset_nanos = this_zoned_date_time.zoned_date_time().offset_nanoseconds();
 
         Ok(cx.number(offset_nanos))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.dayOfWeek (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.dayofweek)
-    pub fn day_of_week(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn day_of_week(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.dayOfWeek")?;
         let day_of_week = this_zoned_date_time.zoned_date_time().day_of_week();
 
         Ok(cx.smi(day_of_week))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.dayOfYear (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.dayofyear)
-    pub fn day_of_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn day_of_year(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.dayOfYear")?;
         let day_of_year = this_zoned_date_time.zoned_date_time().day_of_year();
 
         Ok(cx.smi(day_of_year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.weekOfYear (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.weekofyear)
-    pub fn week_of_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn week_of_year(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.weekOfYear")?;
 
@@ -657,14 +607,11 @@ impl ZonedDateTimePrototype {
             None => Ok(cx.undefined()),
             Some(week_number) => Ok(cx.smi(week_number)),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.yearOfWeek (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.yearofweek)
-    pub fn year_of_week(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn year_of_week(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.yearOfWeek")?;
 
@@ -672,79 +619,61 @@ impl ZonedDateTimePrototype {
             None => Ok(cx.undefined()),
             Some(year_number) => Ok(cx.smi(year_number)),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.daysInWeek (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinweek)
-    pub fn days_in_week(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn days_in_week(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.daysInWeek")?;
         let days_in_week = this_zoned_date_time.zoned_date_time().days_in_week();
 
         Ok(cx.smi(days_in_week))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.daysInMonth (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinmonth)
-    pub fn days_in_month(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn days_in_month(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.daysInMonth")?;
         let days_in_month = this_zoned_date_time.zoned_date_time().days_in_month();
 
         Ok(cx.smi(days_in_month))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.daysInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.daysinyear)
-    pub fn days_in_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn days_in_year(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.daysInYear")?;
         let days_in_year = this_zoned_date_time.zoned_date_time().days_in_year();
 
         Ok(cx.smi(days_in_year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.monthsInYear (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.monthsinyear)
-    pub fn months_in_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn months_in_year(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.monthsInYear")?;
         let months_in_year = this_zoned_date_time.zoned_date_time().months_in_year();
 
         Ok(cx.smi(months_in_year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.inLeapYear (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.inleapyear)
-    pub fn in_leap_year(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn in_leap_year(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.inLeapYear")?;
         let in_leap_year = this_zoned_date_time.zoned_date_time().in_leap_year();
 
         Ok(cx.bool(in_leap_year))
-    }
+    }}
 
+    runtime_fn! {
     /// get Temporal.ZonedDateTime.prototype.hoursInDay (https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.hoursinday)
-    pub fn hours_in_day(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn hours_in_day(cx, this_value, _) {
         const NAME: &str = "ZonedDateTime.prototype.hoursInDay";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -755,14 +684,11 @@ impl ZonedDateTimePrototype {
         let hours_in_day = map_temporal_result(cx, hours_in_day_result, NAME)?;
 
         Ok(cx.number(hours_in_day))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.add (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.add)
-    pub fn add(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn add(cx, this_value, arguments) {
         const NAME: &str = "ZonedDateTime.prototype.add";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -782,14 +708,11 @@ impl ZonedDateTimePrototype {
         let new_zoned_date_time = map_temporal_result(cx, new_zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, new_zoned_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.subtract (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.subtract)
-    pub fn subtract(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn subtract(cx, this_value, arguments) {
         const NAME: &str = "ZonedDateTime.prototype.subtract";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -807,25 +730,19 @@ impl ZonedDateTimePrototype {
         let new_zoned_date_time = map_temporal_result(cx, new_zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, new_zoned_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.until (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.until)
-    pub fn until(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn until(cx, this_value, arguments) {
         Self::diff(cx, this_value, arguments, DiffOperation::Until, "ZonedDateTime.prototype.until")
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.since (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.since)
-    pub fn since(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn since(cx, this_value, arguments) {
         Self::diff(cx, this_value, arguments, DiffOperation::Since, "ZonedDateTime.prototype.since")
-    }
+    }}
 
     fn diff(
         cx: Context,
@@ -861,12 +778,9 @@ impl ZonedDateTimePrototype {
         Ok(DurationObject::new(cx, duration)?.as_value())
     }
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.round (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.round)
-    pub fn round(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn round(cx, this_value, arguments) {
         const NAME: &str = "ZonedDateTime.prototype.round";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -890,14 +804,11 @@ impl ZonedDateTimePrototype {
         let rounded = map_temporal_result(cx, rounded_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, rounded)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.equals (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.equals)
-    pub fn equals(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn equals(cx, this_value, arguments) {
         const NAME: &str = "ZonedDateTime.prototype.equals";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -911,66 +822,51 @@ impl ZonedDateTimePrototype {
         let is_equal = map_temporal_result(cx, is_equal_result, NAME)?;
 
         Ok(cx.bool(is_equal))
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.toInstant (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toinstant)
-    pub fn to_instant(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_instant(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.toInstant")?;
         let instant = this_zoned_date_time.zoned_date_time().to_instant();
 
         Ok(InstantObject::new(cx, instant)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.toPlainDate (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplaindate)
-    pub fn to_plain_date(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_plain_date(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.toPlainDate")?;
         let plain_date = this_zoned_date_time.zoned_date_time().to_plain_date();
 
         Ok(PlainDateObject::new(cx, plain_date)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.toPlainTime (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplaintime)
-    pub fn to_plain_time(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_plain_time(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.toPlainTime")?;
         let plain_time = this_zoned_date_time.zoned_date_time().to_plain_time();
 
         Ok(PlainTimeObject::new(cx, plain_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.toPlainDateTime (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.toplaindatetime)
-    pub fn to_plain_date_time(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_plain_date_time(cx, this_value, _) {
         let this_zoned_date_time =
             this_zoned_date_time(cx, this_value, "ZonedDateTime.prototype.toPlainDateTime")?;
         let plain_date_time = this_zoned_date_time.zoned_date_time().to_plain_date_time();
 
         Ok(PlainDateTimeObject::new(cx, plain_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.toString (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tostring)
-    pub fn to_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_string(cx, this_value, arguments) {
         const NAME: &str = "ZonedDateTime.prototype.toString";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -1004,14 +900,11 @@ impl ZonedDateTimePrototype {
         let zoned_date_time_string = map_temporal_result(cx, zoned_date_time_string_result, NAME)?;
 
         Ok(cx.alloc_string(&zoned_date_time_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.toLocaleString (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tolocalestring)
-    pub fn to_locale_string(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_string(cx, this_value, _) {
         const NAME: &str = "ZonedDateTime.prototype.toLocaleString";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -1028,14 +921,11 @@ impl ZonedDateTimePrototype {
         let zoned_date_time_string = map_temporal_result(cx, zoned_date_time_string_result, NAME)?;
 
         Ok(cx.alloc_string(&zoned_date_time_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.toJSON (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.tojson)
-    pub fn to_json(
-        mut cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_json(cx, this_value, _) {
         const NAME: &str = "ZonedDateTime.prototype.toJSON";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -1052,19 +942,17 @@ impl ZonedDateTimePrototype {
         let zoned_date_time_string = map_temporal_result(cx, zoned_date_time_string_result, NAME)?;
 
         Ok(cx.alloc_string(&zoned_date_time_string)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.valueOf (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.valueof)
-    pub fn value_of(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn value_of(cx, _, _) {
         type_error(cx, "ZonedDateTime.prototype.valueOf must not be called")
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.with (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.with)
-    pub fn with(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with(cx, this_value, arguments) {
         const NAME: &str = "ZonedDateTime.prototype.with";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -1119,14 +1007,11 @@ impl ZonedDateTimePrototype {
         let new_zoned_date_time = map_temporal_result(cx, new_zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, new_zoned_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.withPlainTime (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withplaintime)
-    pub fn with_plain_time(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with_plain_time(cx, this_value, arguments) {
         const NAME: &str = "ZonedDateTime.prototype.withPlainTime";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -1144,14 +1029,11 @@ impl ZonedDateTimePrototype {
         let new_zoned_date_time = map_temporal_result(cx, new_zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, new_zoned_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.withTimeZone (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withtimezone)
-    pub fn with_time_zone(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with_time_zone(cx, this_value, arguments) {
         const NAME: &str = "ZonedDateTime.prototype.withTimeZone";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -1165,14 +1047,11 @@ impl ZonedDateTimePrototype {
         let new_zoned_date_time = map_temporal_result(cx, new_zoned_date_time_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, new_zoned_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.withCalendar (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.withcalendar)
-    pub fn with_calendar(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with_calendar(cx, this_value, arguments) {
         const NAME: &str = "ZonedDateTime.prototype.withCalendar";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -1185,14 +1064,11 @@ impl ZonedDateTimePrototype {
             .with_calendar(calendar);
 
         Ok(ZonedDateTimeObject::new(cx, new_zoned_date_time)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.startOfDay (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.startofday)
-    pub fn start_of_day(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn start_of_day(cx, this_value, _) {
         const NAME: &str = "ZonedDateTime.prototype.startOfDay";
 
         let zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -1203,14 +1079,11 @@ impl ZonedDateTimePrototype {
         let start_of_day = map_temporal_result(cx, start_of_day_result, NAME)?;
 
         Ok(ZonedDateTimeObject::new(cx, start_of_day)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Temporal.ZonedDateTime.prototype.getTimeZoneTransition (https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.prototype.gettimezonetransition)
-    pub fn get_time_zone_transition(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_time_zone_transition(cx, this_value, arguments) {
         const NAME: &str = "ZonedDateTime.prototype.getTimeZoneTransition";
 
         let this_zoned_date_time = this_zoned_date_time(cx, this_value, NAME)?;
@@ -1243,7 +1116,7 @@ impl ZonedDateTimePrototype {
             }
             None => Ok(cx.null()),
         }
-    }
+    }}
 }
 
 fn this_zoned_date_time(

--- a/src/js/runtime/intrinsics/typed_array.rs
+++ b/src/js/runtime/intrinsics/typed_array.rs
@@ -8,7 +8,7 @@ use crate::{
     common::math::f64_to_f16,
     create_typed_array_constructor, create_typed_array_prototype, extend_object, heap_trait_object,
     runtime::{
-        Arguments, Context, Handle, HeapPtr,
+        Context, Handle, HeapPtr,
         abstract_operations::{get, get_method, length_of_array_like, set},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -1,7 +1,7 @@
 use crate::{
     eval_err, must, must_a,
     runtime::{
-        Arguments, Context, Handle, PropertyKey, Realm,
+        Context, Handle, PropertyKey, Realm,
         abstract_operations::{call_object, get_method, length_of_array_like, set},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -30,6 +30,7 @@ use crate::{
         },
         value::Value,
     },
+    runtime_fn,
 };
 
 /// The %TypedArray% Intrinsic Object (https://tc39.es/ecma262/#sec-%typedarray%-intrinsic-object)
@@ -94,17 +95,15 @@ impl TypedArrayConstructor {
         Ok(())
     }
 
+    runtime_fn! {
     /// %TypedArray% (https://tc39.es/ecma262/#sec-%typedarray%)
-    pub fn construct(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, _) {
         type_error(cx, "TypedArray constructor is abstract and cannot be called")
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.from (https://tc39.es/ecma262/#sec-%typedarray%.from)
-    pub fn from(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn from(cx, this_value, arguments) {
         if !is_constructor_value(this_value) {
             return type_error(cx, "TypedArray.from must be called on a constructor");
         }
@@ -199,14 +198,11 @@ impl TypedArrayConstructor {
         }
 
         Ok(target_object.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Uint8Array.fromBase64 (https://tc39.es/ecma262/#sec-uint8array.frombase64)
-    pub fn from_base64(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn from_base64(cx, _, arguments) {
         let string_arg = arguments.get(cx, 0);
         if !string_arg.is_string() {
             return type_error(cx, "Uint8Array.fromBase64 argument must be a string");
@@ -232,14 +228,11 @@ impl TypedArrayConstructor {
         }
 
         Self::new_uint8_array_from_bytes(cx, &decode_result.bytes)
-    }
+    }}
 
+    runtime_fn! {
     /// Uint8Array.fromHex (https://tc39.es/ecma262/#sec-uint8array.fromhex)
-    pub fn from_hex(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn from_hex(cx, _, arguments) {
         let string_arg = arguments.get(cx, 0);
         if !string_arg.is_string() {
             return type_error(cx, "Uint8Array.fromHex argument must be a string");
@@ -251,7 +244,7 @@ impl TypedArrayConstructor {
         }
 
         Self::new_uint8_array_from_bytes(cx, &decode_result.bytes)
-    }
+    }}
 
     fn new_uint8_array_from_bytes(cx: Context, bytes: &[u8]) -> EvalResult<Handle<Value>> {
         // Create an uninitialized Uint8Array to hold the bytes
@@ -272,12 +265,9 @@ impl TypedArrayConstructor {
         Ok(array_value)
     }
 
+    runtime_fn! {
     /// %TypedArray%.of (https://tc39.es/ecma262/#sec-%typedarray%.of)
-    pub fn of(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn of(cx, this_value, arguments) {
         if !is_constructor_value(this_value) {
             return type_error(cx, "TypedArray.of must be called on a constructor");
         }
@@ -303,7 +293,7 @@ impl TypedArrayConstructor {
         }
 
         Ok(object.as_value())
-    }
+    }}
 }
 
 #[macro_export]
@@ -748,12 +738,9 @@ macro_rules! create_typed_array_constructor {
                 Ok(func)
             }
 
+            $crate::runtime_fn! {
             /// TypedArray (https://tc39.es/ecma262/#sec-typedarray)
-            pub fn construct(
-                mut cx: Context,
-                _: Handle<Value>,
-                arguments: Arguments,
-            ) -> EvalResult<Handle<Value>> {
+            fn construct(cx, _, arguments) {
                 let new_target = if let Some(new_target) = cx.current_new_target() {
                     new_target
                 } else {
@@ -806,7 +793,7 @@ macro_rules! create_typed_array_constructor {
                 } else {
                     Self::initialize_typed_array_from_array_like(cx, proto, argument)
                 }
-            }
+            }}
 
             /// AllocateTypedArray (https://tc39.es/ecma262/#sec-allocatetypedarray)
             /// AllocateTypedArrayBuffer (https://tc39.es/ecma262/#sec-allocatetypedarraybuffer)

--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -5,7 +5,7 @@ use num_bigint::{BigUint, Sign};
 use crate::{
     eval_err, must,
     runtime::{
-        Arguments, Context, EvalResult, Handle, PropertyKey, Realm, Value,
+        Context, EvalResult, Handle, PropertyKey, Realm, Value,
         abstract_operations::{
             call_object, construct, create_data_property_or_throw, has_property, invoke,
             length_of_array_like, set, species_constructor,
@@ -39,6 +39,7 @@ use crate::{
             same_value_zero, to_bigint, to_boolean, to_integer_or_infinity, to_number, to_object,
         },
     },
+    runtime_fn,
 };
 
 pub struct TypedArrayPrototype;
@@ -353,12 +354,9 @@ impl TypedArrayPrototype {
         Ok(())
     }
 
+    runtime_fn! {
     /// %TypedArray%.prototype.at (https://tc39.es/ecma262/#sec-%typedarray%.prototype.at)
-    pub fn at(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn at(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "at")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -383,24 +381,18 @@ impl TypedArrayPrototype {
         };
 
         get(cx, object, key)
-    }
+    }}
 
+    runtime_fn! {
     /// get %TypedArray%.prototype.buffer (https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer)
-    pub fn buffer(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn buffer(cx, this_value, _) {
         let typed_array = this_typed_array(cx, this_value, "buffer")?;
         Ok(typed_array.viewed_array_buffer().as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get %TypedArray%.prototype.byteLength (https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.bytelength)
-    pub fn byte_length(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn byte_length(cx, this_value, _) {
         let typed_array = this_typed_array(cx, this_value, "byteLength")?;
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
@@ -411,14 +403,11 @@ impl TypedArrayPrototype {
         let byte_length = typed_array_byte_length(&typed_array_record);
 
         Ok(cx.number(byte_length))
-    }
+    }}
 
+    runtime_fn! {
     /// get %TypedArray%.prototype.byteOffset (https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.byteoffset)
-    pub fn byte_offset(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn byte_offset(cx, this_value, _) {
         let typed_array = this_typed_array(cx, this_value, "byteOffset")?;
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
@@ -427,14 +416,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(cx.number(typed_array.byte_offset()))
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.copyWithin (https://tc39.es/ecma262/#sec-%typedarray%.prototype.copywithin)
-    pub fn copy_within(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn copy_within(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "copyWithin")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -534,26 +520,20 @@ impl TypedArrayPrototype {
         }
 
         Ok(object.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.entries (https://tc39.es/ecma262/#sec-%typedarray%.prototype.entries)
-    pub fn entries(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn entries(cx, this_value, _) {
         let typed_array_record = this_typed_array_record(cx, this_value, "entries")?;
         let typed_array_object = typed_array_record.typed_array.into_object_value();
 
         Ok(ArrayIterator::new(cx, typed_array_object, ArrayIteratorKind::KeyAndValue)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.every (https://tc39.es/ecma262/#sec-%typedarray%.prototype.every)
-    pub fn every(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn every(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "every")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -586,14 +566,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(cx.bool(true))
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.fill (https://tc39.es/ecma262/#sec-%typedarray%.prototype.fill)
-    pub fn fill(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn fill(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "fill")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -632,14 +609,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(object.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.filter (https://tc39.es/ecma262/#sec-%typedarray%.prototype.filter)
-    pub fn filter(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn filter(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "filter")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -690,14 +664,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.find (https://tc39.es/ecma262/#sec-%typedarray%.prototype.find)
-    pub fn find(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn find(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "find")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -718,14 +689,11 @@ impl TypedArrayPrototype {
             Some((value, _)) => Ok(value),
             None => Ok(cx.undefined()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.findIndex (https://tc39.es/ecma262/#sec-%typedarray%.prototype.findindex)
-    pub fn find_index(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn find_index(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "findIndex")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -746,14 +714,11 @@ impl TypedArrayPrototype {
             Some((_, index_value)) => Ok(index_value),
             None => Ok(cx.negative_one()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.findLast (https://tc39.es/ecma262/#sec-%typedarray%.prototype.findlast)
-    pub fn find_last(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn find_last(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "findLast")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -775,14 +740,11 @@ impl TypedArrayPrototype {
             Some((value, _)) => Ok(value),
             None => Ok(cx.undefined()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.findLastIndex (https://tc39.es/ecma262/#sec-%typedarray%.prototype.findlastindex)
-    pub fn find_last_index(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn find_last_index(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "findLastIndex")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -807,14 +769,11 @@ impl TypedArrayPrototype {
             Some((_, index_value)) => Ok(index_value),
             None => Ok(cx.negative_one()),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.forEach (https://tc39.es/ecma262/#sec-%typedarray%.prototype.foreach)
-    pub fn for_each(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn for_each(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "forEach")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -844,14 +803,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(cx.undefined())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.includes (https://tc39.es/ecma262/#sec-%typedarray%.prototype.includes)
-    pub fn includes(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn includes(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "includes")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -880,14 +836,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(cx.bool(false))
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.indexOf (https://tc39.es/ecma262/#sec-%typedarray%.prototype.indexof)
-    pub fn index_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn index_of(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "indexOf")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -917,14 +870,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(cx.negative_one())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.join (https://tc39.es/ecma262/#sec-%typedarray%.prototype.join)
-    pub fn join(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn join(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "join")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -958,22 +908,20 @@ impl TypedArrayPrototype {
         }
 
         Ok(joined.into())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.keys (https://tc39.es/ecma262/#sec-%typedarray%.prototype.keys)
-    pub fn keys(cx: Context, this_value: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    fn keys(cx, this_value, _) {
         let typed_array_record = this_typed_array_record(cx, this_value, "keys")?;
         let typed_array_object = typed_array_record.typed_array.into_object_value();
 
         Ok(ArrayIterator::new(cx, typed_array_object, ArrayIteratorKind::Key)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.lastIndexOf (https://tc39.es/ecma262/#sec-%typedarray%.prototype.lastindexof)
-    pub fn last_index_of(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn last_index_of(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "lastIndexOf")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -1022,14 +970,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(cx.negative_one())
-    }
+    }}
 
+    runtime_fn! {
     /// get %TypedArray%.prototype.length (https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.length)
-    pub fn length(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn length(cx, this_value, _) {
         let typed_array = this_typed_array(cx, this_value, "length")?;
 
         let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
@@ -1040,14 +985,11 @@ impl TypedArrayPrototype {
         let length = typed_array_length(&typed_array_record);
 
         Ok(cx.number(length))
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.map (https://tc39.es/ecma262/#sec-%typedarray%.prototype.map)
-    pub fn map(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn map(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "map")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -1081,14 +1023,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.reduce (https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduce)
-    pub fn reduce(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn reduce(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "reduce")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -1128,14 +1067,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(accumulator)
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.reduceRight (https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduceright)
-    pub fn reduce_right(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn reduce_right(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "reduceRight")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -1178,14 +1114,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(accumulator)
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.reverse (https://tc39.es/ecma262/#sec-%typedarray%.prototype.reverse)
-    pub fn reverse(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn reverse(cx, this_value, _) {
         let typed_array_record = this_typed_array_record(cx, this_value, "reverse")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -1216,14 +1149,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(object.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.set (https://tc39.es/ecma262/#sec-%typedarray%.prototype.set)
-    pub fn set(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "set")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -1246,7 +1176,7 @@ impl TypedArrayPrototype {
         }
 
         Ok(cx.undefined())
-    }
+    }}
 
     /// SetTypedArrayFromTypedArray (https://tc39.es/ecma262/#sec-settypedarrayfromtypedarray)
     pub fn set_typed_array_from_typed_array(
@@ -1367,12 +1297,9 @@ impl TypedArrayPrototype {
         Ok(())
     }
 
+    runtime_fn! {
     /// Uint8Array.prototype.setFromBase64 (https://tc39.es/ecma262/#sec-uint8array.prototype.setfrombase64)
-    pub fn set_from_base64(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_from_base64(cx, this_value, arguments) {
         let typed_array = validate_uint8_array(cx, this_value, "setFromBase64")?;
 
         let string_arg = arguments.get(cx, 0);
@@ -1412,14 +1339,11 @@ impl TypedArrayPrototype {
         )?;
 
         Self::set_from_decode_result(cx, typed_array, decode_result)
-    }
+    }}
 
+    runtime_fn! {
     /// Uint8Array.prototype.setFromHex (https://tc39.es/ecma262/#sec-uint8array.prototype.setfromhex)
-    pub fn set_from_hex(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set_from_hex(cx, this_value, arguments) {
         let typed_array = validate_uint8_array(cx, this_value, "setFromHex")?;
 
         let string_arg = arguments.get(cx, 0);
@@ -1442,7 +1366,7 @@ impl TypedArrayPrototype {
         )?;
 
         Self::set_from_decode_result(cx, typed_array, decode_result)
-    }
+    }}
 
     fn set_from_decode_result(
         cx: Context,
@@ -1479,12 +1403,9 @@ impl TypedArrayPrototype {
         Ok(result_object.as_value())
     }
 
+    runtime_fn! {
     /// %TypedArray%.prototype.slice (https://tc39.es/ecma262/#sec-%typedarray%.prototype.slice)
-    pub fn slice(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn slice(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "slice")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -1559,14 +1480,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.some (https://tc39.es/ecma262/#sec-%typedarray%.prototype.some)
-    pub fn some(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn some(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "some")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -1599,14 +1517,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(cx.bool(false))
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.sort (https://tc39.es/ecma262/#sec-%typedarray%.prototype.sort)
-    pub fn sort(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn sort(cx, this_value, arguments) {
         let compare_function_arg = arguments.get(cx, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
             return type_error(cx, "TypedArray.prototype.sort comparator must be a function");
@@ -1635,14 +1550,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(object.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.subarray (https://tc39.es/ecma262/#sec-%typedarray%.prototype.subarray)
-    pub fn subarray(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn subarray(cx, this_value, arguments) {
         let typed_array = this_typed_array(cx, this_value, "subarray")?;
         let buffer = typed_array.viewed_array_buffer();
 
@@ -1688,14 +1600,11 @@ impl TypedArrayPrototype {
         };
 
         Ok(subarray.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Uint8Array.prototype.toBase64 (https://tc39.es/ecma262/#sec-uint8array.prototype.tobase64)
-    pub fn to_base64(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_base64(cx, this_value, arguments) {
         let typed_array = validate_uint8_array(cx, this_value, "toBase64")?;
 
         let options_arg = arguments.get(cx, 0);
@@ -1719,14 +1628,11 @@ impl TypedArrayPrototype {
         let base64_string = FlatString::from_one_byte_slice(cx, &base64_code_points)?.to_handle();
 
         Ok(base64_string.as_string().as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// Uint8Array.prototype.toHex (https://tc39.es/ecma262/#sec-uint8array.prototype.tohex)
-    pub fn to_hex(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_hex(cx, this_value, _) {
         let typed_array = validate_uint8_array(cx, this_value, "toHex")?;
 
         // Inlined validation from GetUint8ArrayBytes
@@ -1743,14 +1649,11 @@ impl TypedArrayPrototype {
         let hex_string = FlatString::from_one_byte_slice(cx, &hex_code_points)?.to_handle();
 
         Ok(hex_string.as_string().as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.toLocaleString (https://tc39.es/ecma262/#sec-%typedarray%.prototype.tolocalestring)
-    pub fn to_locale_string(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_locale_string(cx, this_value, _) {
         let typed_array_record = this_typed_array_record(cx, this_value, "toLocaleString")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -1777,14 +1680,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(result.into())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.toReversed (https://tc39.es/ecma262/#sec-%typedarray%.prototype.toreversed)
-    pub fn to_reversed(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_reversed(cx, this_value, _) {
         let typed_array_record = this_typed_array_record(cx, this_value, "toReversed")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -1806,14 +1706,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.toSorted (https://tc39.es/ecma262/#sec-%typedarray%.prototype.tosorted)
-    pub fn to_sorted(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn to_sorted(cx, this_value, arguments) {
         let compare_function_arg = arguments.get(cx, 0);
         if !compare_function_arg.is_undefined() && !is_callable(compare_function_arg) {
             return type_error(cx, "TypedArray.prototype.toSorted comparator must be a function");
@@ -1844,26 +1741,20 @@ impl TypedArrayPrototype {
         }
 
         Ok(sorted_array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.values (https://tc39.es/ecma262/#sec-%typedarray%.prototype.values)
-    pub fn values(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn values(cx, this_value, _) {
         let typed_array_record = this_typed_array_record(cx, this_value, "values")?;
         let typed_array_object = typed_array_record.typed_array.into_object_value();
 
         Ok(ArrayIterator::new(cx, typed_array_object, ArrayIteratorKind::Value)?.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// %TypedArray%.prototype.with (https://tc39.es/ecma262/#sec-%typedarray%.prototype.with)
-    pub fn with(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn with(cx, this_value, arguments) {
         let typed_array_record = this_typed_array_record(cx, this_value, "with")?;
         let typed_array = typed_array_record.typed_array;
 
@@ -1928,14 +1819,11 @@ impl TypedArrayPrototype {
         }
 
         Ok(array.as_value())
-    }
+    }}
 
+    runtime_fn! {
     /// get %TypedArray%.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-%symbol.tostringtag%)
-    pub fn get_to_string_tag(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_to_string_tag(cx, this_value, _) {
         if !this_value.is_object() {
             return Ok(cx.undefined());
         }
@@ -1946,7 +1834,7 @@ impl TypedArrayPrototype {
         }
 
         Ok(this_object.as_typed_array().name(cx).into())
-    }
+    }}
 }
 
 #[macro_export]

--- a/src/js/runtime/intrinsics/weak_map_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_map_constructor.rs
@@ -1,17 +1,19 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    abstract_operations::{call_object, get},
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        intrinsics::Intrinsic, map_constructor::add_entries_from_iterable,
-        rust_runtime::RuntimeFunction, weak_map_object::WeakMapObject,
+use crate::{
+    runtime::{
+        Context, Handle,
+        abstract_operations::{call_object, get},
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        error::type_error,
+        intrinsics::{
+            intrinsics::Intrinsic, map_constructor::add_entries_from_iterable,
+            rust_runtime::RuntimeFunction, weak_map_object::WeakMapObject,
+        },
+        object_value::ObjectValue,
+        realm::Realm,
+        type_utilities::is_callable,
     },
-    object_value::ObjectValue,
-    realm::Realm,
-    type_utilities::is_callable,
+    runtime_fn,
 };
 
 pub struct WeakMapConstructor;
@@ -37,12 +39,9 @@ impl WeakMapConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// WeakMap (https://tc39.es/ecma262/#sec-weakmap-iterable)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
@@ -65,5 +64,5 @@ impl WeakMapConstructor {
             call_object(cx, adder.as_object(), weak_map.into(), &[key, value])?;
             Ok(())
         })
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/weak_map_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_map_prototype.rs
@@ -1,18 +1,21 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    abstract_operations::call,
-    alloc_error::AllocResult,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        intrinsics::Intrinsic, rust_runtime::RuntimeFunction, weak_map_object::WeakMapObject,
-        weak_ref_constructor::can_be_held_weakly,
+use crate::{
+    runtime::{
+        Context, Handle, Value,
+        abstract_operations::call,
+        alloc_error::AllocResult,
+        error::type_error,
+        eval_result::EvalResult,
+        intrinsics::{
+            intrinsics::Intrinsic, rust_runtime::RuntimeFunction, weak_map_object::WeakMapObject,
+            weak_ref_constructor::can_be_held_weakly,
+        },
+        object_value::ObjectValue,
+        property::Property,
+        realm::Realm,
+        type_utilities::is_callable,
+        value::ValueCollectionKey,
     },
-    object_value::ObjectValue,
-    property::Property,
-    realm::Realm,
-    type_utilities::is_callable,
-    value::ValueCollectionKey,
+    runtime_fn,
 };
 
 pub struct WeakMapPrototype;
@@ -78,12 +81,9 @@ impl WeakMapPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// WeakMap.prototype.delete (https://tc39.es/ecma262/#sec-weakmap.prototype.delete)
-    pub fn delete(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn delete(cx, this_value, arguments) {
         let weak_map_object = this_weak_map_object(cx, this_value, "delete")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value map
@@ -95,14 +95,11 @@ impl WeakMapPrototype {
         let removed_value = weak_map_object.weak_map_data().remove(&map_key);
 
         Ok(cx.bool(removed_value))
-    }
+    }}
 
+    runtime_fn! {
     /// WeakMap.prototype.get (https://tc39.es/ecma262/#sec-weakmap.prototype.get)
-    pub fn get(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get(cx, this_value, arguments) {
         let weak_map_object = this_weak_map_object(cx, this_value, "get")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value map
@@ -118,14 +115,11 @@ impl WeakMapPrototype {
             None => Ok(cx.undefined()),
             Some(value) => Ok(value.to_handle(cx)),
         }
-    }
+    }}
 
+    runtime_fn! {
     /// WeakMap.prototype.getOrInsert (https://tc39.es/ecma262/#sec-weakmap.prototype.getorinsert)
-    pub fn get_or_insert(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_or_insert(cx, this_value, arguments) {
         let weak_map_object = this_weak_map_object(cx, this_value, "getOrInsert")?;
 
         let key = arguments.get(cx, 0);
@@ -142,14 +136,11 @@ impl WeakMapPrototype {
             weak_map_object.insert(cx, key, value)?;
             Ok(value)
         }
-    }
+    }}
 
+    runtime_fn! {
     /// WeakMap.prototype.getOrInsertComputed (https://tc39.es/ecma262/#sec-weakmap.prototype.getorinsertcomputed)
-    pub fn get_or_insert_computed(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn get_or_insert_computed(cx, this_value, arguments) {
         let weak_map_object = this_weak_map_object(cx, this_value, "getOrInsertComputed")?;
 
         let key = arguments.get(cx, 0);
@@ -177,14 +168,11 @@ impl WeakMapPrototype {
         weak_map_object.insert(cx, key, value)?;
 
         Ok(value.to_handle(cx))
-    }
+    }}
 
+    runtime_fn! {
     /// WeakMap.prototype.has (https://tc39.es/ecma262/#sec-weakmap.prototype.has)
-    pub fn has(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn has(cx, this_value, arguments) {
         let weak_map_object = this_weak_map_object(cx, this_value, "has")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value map
@@ -196,14 +184,11 @@ impl WeakMapPrototype {
         let has_key = weak_map_object.weak_map_data().contains_key(&map_key);
 
         Ok(cx.bool(has_key))
-    }
+    }}
 
+    runtime_fn! {
     /// WeakMap.prototype.set (https://tc39.es/ecma262/#sec-weakmap.prototype.set)
-    pub fn set(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn set(cx, this_value, arguments) {
         let weak_map_object = this_weak_map_object(cx, this_value, "set")?;
 
         let key = arguments.get(cx, 0);
@@ -214,7 +199,7 @@ impl WeakMapPrototype {
         weak_map_object.insert(cx, key, value)?;
 
         Ok(this_value)
-    }
+    }}
 }
 
 fn this_weak_map_object(

--- a/src/js/runtime/intrinsics/weak_ref_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_ref_constructor.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Arguments, Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::type_error,
@@ -15,7 +15,7 @@ use crate::{
         ordinary_object::object_create_from_constructor,
         realm::Realm,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // WeakRef Objects (https://tc39.es/ecma262/#sec-weak-ref-objects)
@@ -87,12 +87,9 @@ impl WeakRefConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// WeakRef (https://tc39.es/ecma262/#sec-weak-ref-target)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
@@ -108,7 +105,7 @@ impl WeakRefConstructor {
         }
 
         Ok(WeakRefObject::new_from_constructor(cx, new_target, target_value)?.as_value())
-    }
+    }}
 }
 
 /// CanBeHeldWeakly (https://tc39.es/ecma262/#sec-canbeheldweakly)

--- a/src/js/runtime/intrinsics/weak_ref_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_ref_prototype.rs
@@ -1,14 +1,17 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    alloc_error::AllocResult,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        intrinsics::Intrinsic, rust_runtime::RuntimeFunction, weak_ref_constructor::WeakRefObject,
+use crate::{
+    runtime::{
+        Context, Handle, Value,
+        alloc_error::AllocResult,
+        error::type_error,
+        intrinsics::{
+            intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
+            weak_ref_constructor::WeakRefObject,
+        },
+        object_value::ObjectValue,
+        property::Property,
+        realm::Realm,
     },
-    object_value::ObjectValue,
-    property::Property,
-    realm::Realm,
+    runtime_fn,
 };
 
 pub struct WeakRefPrototype;
@@ -39,18 +42,15 @@ impl WeakRefPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// WeakRef.prototype.deref (https://tc39.es/ecma262/#sec-weak-ref.prototype.deref)
-    pub fn deref(
-        cx: Context,
-        this_value: Handle<Value>,
-        _: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn deref(cx, this_value, _) {
         if let Some(weak_ref_object) = this_weak_ref_value(this_value) {
             Ok(weak_ref_object.weak_ref_target().to_handle(cx))
         } else {
             type_error(cx, "WeakRef.prototype.deref must be called on a WeakRef")
         }
-    }
+    }}
 }
 
 fn this_weak_ref_value(value: Handle<Value>) -> Option<Handle<WeakRefObject>> {

--- a/src/js/runtime/intrinsics/weak_set_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_set_constructor.rs
@@ -1,17 +1,19 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    abstract_operations::{call_object, get},
-    alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        intrinsics::Intrinsic, rust_runtime::RuntimeFunction, weak_set_object::WeakSetObject,
+use crate::{
+    runtime::{
+        Context, Handle,
+        abstract_operations::{call_object, get},
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        error::type_error,
+        intrinsics::{
+            intrinsics::Intrinsic, rust_runtime::RuntimeFunction, weak_set_object::WeakSetObject,
+        },
+        iterator::{IteratorHint, get_iterator, iterator_close, iterator_step, iterator_value},
+        object_value::ObjectValue,
+        realm::Realm,
+        type_utilities::is_callable,
     },
-    iterator::{IteratorHint, get_iterator, iterator_close, iterator_step, iterator_value},
-    object_value::ObjectValue,
-    realm::Realm,
-    type_utilities::is_callable,
+    runtime_fn,
 };
 
 pub struct WeakSetConstructor;
@@ -37,12 +39,9 @@ impl WeakSetConstructor {
         Ok(func)
     }
 
+    runtime_fn! {
     /// WeakSet (https://tc39.es/ecma262/#sec-weakset-iterable)
-    pub fn construct(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn construct(cx, _, arguments) {
         let new_target = if let Some(new_target) = cx.current_new_target() {
             new_target
         } else {
@@ -79,5 +78,5 @@ impl WeakSetConstructor {
                 }
             }
         }
-    }
+    }}
 }

--- a/src/js/runtime/intrinsics/weak_set_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_set_prototype.rs
@@ -1,16 +1,19 @@
-use crate::runtime::{
-    Arguments, Context, Handle, Value,
-    alloc_error::AllocResult,
-    error::type_error,
-    eval_result::EvalResult,
-    intrinsics::{
-        intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
-        weak_ref_constructor::can_be_held_weakly, weak_set_object::WeakSetObject,
+use crate::{
+    runtime::{
+        Context, Handle, Value,
+        alloc_error::AllocResult,
+        error::type_error,
+        eval_result::EvalResult,
+        intrinsics::{
+            intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
+            weak_ref_constructor::can_be_held_weakly, weak_set_object::WeakSetObject,
+        },
+        object_value::ObjectValue,
+        property::Property,
+        realm::Realm,
+        value::ValueCollectionKey,
     },
-    object_value::ObjectValue,
-    property::Property,
-    realm::Realm,
-    value::ValueCollectionKey,
+    runtime_fn,
 };
 
 pub struct WeakSetPrototype;
@@ -55,12 +58,9 @@ impl WeakSetPrototype {
         Ok(object)
     }
 
+    runtime_fn! {
     /// WeakSet.prototype.add (https://tc39.es/ecma262/#sec-weakset.prototype.add)
-    pub fn add(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn add(cx, this_value, arguments) {
         let weak_set_object = this_weak_set_value(cx, this_value, "add")?;
 
         let value = arguments.get(cx, 0);
@@ -74,14 +74,11 @@ impl WeakSetPrototype {
         weak_set_object.insert(cx, value)?;
 
         Ok(this_value)
-    }
+    }}
 
+    runtime_fn! {
     /// WeakSet.prototype.delete (https://tc39.es/ecma262/#sec-weakset.prototype.delete)
-    pub fn delete(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn delete(cx, this_value, arguments) {
         let weak_set_object = this_weak_set_value(cx, this_value, "delete")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value set
@@ -93,14 +90,11 @@ impl WeakSetPrototype {
         let removed_value = weak_set_object.weak_set_data().remove(&set_key);
 
         Ok(cx.bool(removed_value))
-    }
+    }}
 
+    runtime_fn! {
     /// WeakSet.prototype.has (https://tc39.es/ecma262/#sec-weakset.prototype.has)
-    pub fn has(
-        cx: Context,
-        this_value: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn has(cx, this_value, arguments) {
         let weak_set_object = this_weak_set_value(cx, this_value, "has")?;
 
         // Do not need to call can_be_held_weakly, instead look up directly in the value set
@@ -112,7 +106,7 @@ impl WeakSetPrototype {
         let has_value = weak_set_object.weak_set_data().contains(&set_key);
 
         Ok(cx.bool(has_value))
-    }
+    }}
 }
 
 fn this_weak_set_value(

--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::Path};
 use crate::{
     completion_value, eval_err, if_abrupt_reject_promise, must, must_a,
     runtime::{
-        Arguments, Context, EvalResult, Handle, PropertyKey, Value,
+        Context, EvalResult, Handle, PropertyKey, Value,
         abstract_operations::{KeyOrValue, call_object, enumerable_own_property_names},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -28,6 +28,7 @@ use crate::{
         string_value::FlatString,
         to_string,
     },
+    runtime_fn,
 };
 
 /// Execute a module - loading, linking, and evaluating it and its dependencies.
@@ -133,11 +134,8 @@ fn set_capability(
     function.private_element_set(cx, cx.well_known_symbols.capability().cast(), value.into())
 }
 
-pub fn load_requested_modules_static_resolve(
-    mut cx: Context,
-    _: Handle<Value>,
-    _: Arguments,
-) -> EvalResult<Handle<Value>> {
+runtime_fn! {
+fn load_requested_modules_static_resolve(cx, _, _) {
     // Fetch the module and capbility passed from `execute_module`
     let current_function = cx.current_function();
     let module = get_module(cx, current_function);
@@ -161,13 +159,10 @@ pub fn load_requested_modules_static_resolve(
         cx.undefined(),
         Some(capability),
     )?)
-}
+}}
 
-pub fn load_requested_modules_reject(
-    mut cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+runtime_fn! {
+fn load_requested_modules_reject(cx, _, arguments) {
     // Fetch the capbility passed from `execute_module`
     let current_function = cx.current_function();
     let capability = get_capability(cx, current_function);
@@ -176,7 +171,7 @@ pub fn load_requested_modules_reject(
     must!(call_object(cx, capability.reject(), cx.undefined(), &[error]));
 
     Ok(cx.undefined())
-}
+}}
 
 fn callback(cx: Context, func: RuntimeFunction) -> AllocResult<Handle<ObjectValue>> {
     let realm = cx.current_realm();
@@ -412,12 +407,9 @@ fn execute_async_module(mut cx: Context, module: Handle<SourceTextModule>) -> Al
     Ok(())
 }
 
+runtime_fn! {
 /// AsyncModuleExecutionFulfilled (https://tc39.es/ecma262/#sec-async-module-execution-fulfilled)
-pub fn async_module_execution_fulfilled(
-    mut cx: Context,
-    _: Handle<Value>,
-    _: Arguments,
-) -> EvalResult<Handle<Value>> {
+fn async_module_execution_fulfilled(cx, _, _) {
     // Fetch the module passed from `execute_async_module`
     let current_function = cx.current_function();
     let mut module = get_module(cx, current_function);
@@ -477,7 +469,7 @@ pub fn async_module_execution_fulfilled(
     }
 
     Ok(cx.undefined())
-}
+}}
 
 /// GatherAvailableAncestors (https://tc39.es/ecma262/#sec-gather-available-ancestors)
 fn gather_available_ancestors(
@@ -555,11 +547,8 @@ fn async_module_execution_rejected(
     Ok(())
 }
 
-pub fn async_module_execution_rejected_runtime(
-    mut cx: Context,
-    _: Handle<Value>,
-    arguments: Arguments,
-) -> EvalResult<Handle<Value>> {
+runtime_fn! {
+fn async_module_execution_rejected_runtime(cx, _, arguments) {
     // Fetch the module passed from `execute_async_module`
     let current_function = cx.current_function();
     let module = get_module(cx, current_function);
@@ -568,7 +557,7 @@ pub fn async_module_execution_rejected_runtime(
     async_module_execution_rejected(cx, module, error)?;
 
     Ok(cx.undefined())
-}
+}}
 
 /// Start a dynamic import within a module, passing the argument provided to `import()`.
 pub fn dynamic_import(
@@ -686,11 +675,8 @@ fn continue_dynamic_import(
     Ok(())
 }
 
-pub fn load_requested_modules_dynamic_resolve(
-    mut cx: Context,
-    _: Handle<Value>,
-    _: Arguments,
-) -> EvalResult<Handle<Value>> {
+runtime_fn! {
+fn load_requested_modules_dynamic_resolve(cx, _, _) {
     // Fetch the module and capability passed from the caller
     let current_function = cx.current_function();
     let module = get_dyn_module(cx, current_function);
@@ -729,13 +715,10 @@ pub fn load_requested_modules_dynamic_resolve(
     perform_promise_then(cx, evaluate_promise, on_resolve.into(), on_reject.into(), None)?;
 
     Ok(cx.undefined())
-}
+}}
 
-pub fn module_evaluate_dynamic_resolve(
-    mut cx: Context,
-    _: Handle<Value>,
-    _: Arguments,
-) -> EvalResult<Handle<Value>> {
+runtime_fn! {
+fn module_evaluate_dynamic_resolve(cx, _, _) {
     // Fetch the module and capbility passed from the caller
     let current_function = cx.current_function();
     let mut module = get_dyn_module(cx, current_function);
@@ -751,4 +734,4 @@ pub fn module_evaluate_dynamic_resolve(
     ));
 
     Ok(cx.undefined())
-}
+}}

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     completion_value, extend_object,
     runtime::{
-        Arguments, Context, EvalResult, Handle, HeapPtr,
+        Context, EvalResult, Handle, HeapPtr,
         abstract_operations::{call_object, construct, get_function_realm_no_error},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -17,7 +17,7 @@ use crate::{
         type_utilities::{is_callable, is_constructor_value, same_object_value, same_value},
         value::Value,
     },
-    set_uninit,
+    runtime_fn, set_uninit,
 };
 
 // Properties of Promise Instances (https://tc39.es/ecma262/#sec-properties-of-promise-instances)
@@ -536,11 +536,8 @@ impl PromiseCapability {
         self.reject.as_object().to_handle()
     }
 
-    pub fn executor(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn executor(cx, _, arguments) {
         // Get the capability object that was attached to the executor function
         let current_function = cx.current_function();
         let mut capability = current_function
@@ -564,7 +561,7 @@ impl PromiseCapability {
         capability.reject = *reject;
 
         Ok(cx.undefined())
-    }
+    }}
 }
 
 impl HeapItem for HeapPtr<PromiseObject> {

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -4,7 +4,7 @@ use crate::{
     handle_scope, must_a,
     parser::source::Source,
     runtime::{
-        Arguments, Context, EvalResult, Handle, PropertyKey, Realm, Value,
+        Context, EvalResult, Handle, PropertyKey, Realm,
         abstract_operations::set,
         alloc_error::AllocResult,
         error::{syntax_parse_error, type_error},
@@ -17,6 +17,7 @@ use crate::{
         object_value::ObjectValue,
         string_value::StringValue,
     },
+    runtime_fn,
 };
 
 /// Utility functions used in test262 tests. Must be included in the main library for now so that
@@ -126,8 +127,9 @@ impl Test262Object {
         set(cx, global_object, Self::print_log_key(cx)?, print_log.into(), true)
     }
 
+    runtime_fn! {
     /// Adds strings to a running print log stored on the global object.
-    pub fn print(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn print(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
         if !argument.is_string() {
             return type_error(cx, "print expects a string");
@@ -140,21 +142,19 @@ impl Test262Object {
         Self::set_print_log(cx, global_object, new_print_log)?;
 
         Ok(cx.undefined())
-    }
+    }}
 
-    pub fn create_realm(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn create_realm(cx, _, _) {
         // Create a new realm that also has the test262 object installed
         let mut realm = Realm::new(cx)?;
         realm.install_optional_globals(cx)?;
 
         get(cx, realm.global_object(), test_262_key(cx)?)
-    }
+    }}
 
-    pub fn eval_script(
-        mut cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn eval_script(cx, _, arguments) {
         let script_text = arguments.get(cx, 0);
         if !script_text.is_string() {
             return type_error(cx, "expected a string");
@@ -173,13 +173,10 @@ impl Test262Object {
             };
 
         evaluate_script(cx, cx.current_realm(), source)
-    }
+    }}
 
-    pub fn detach_array_buffer(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn detach_array_buffer(cx, _, arguments) {
         let value = arguments.get(cx, 0);
         if !value.is_object() {
             return Ok(cx.undefined());
@@ -194,7 +191,7 @@ impl Test262Object {
         array_buffer.detach();
 
         Ok(cx.undefined())
-    }
+    }}
 }
 
 fn test_262_key(mut cx: Context) -> AllocResult<Handle<PropertyKey>> {

--- a/src/js/runtime/test_shell.rs
+++ b/src/js/runtime/test_shell.rs
@@ -8,7 +8,7 @@ use crate::{
     must_a,
     parser::source::Source,
     runtime::{
-        Arguments, Context, EvalResult, Handle, PropertyDescriptor, PropertyKey, Realm, Value,
+        Context, EvalResult, Handle, PropertyDescriptor, PropertyKey, Realm, Value,
         abstract_operations::{create_data_property_or_throw, define_property_or_throw},
         alloc_error::AllocResult,
         array_object::array_create_in_realm,
@@ -24,6 +24,7 @@ use crate::{
         object_value::ObjectValue,
         to_string,
     },
+    runtime_fn,
 };
 
 /// Global methods used in the shell for other engines, used for compatibility with some third-party
@@ -129,8 +130,9 @@ impl TestShell {
         Ok(())
     }
 
+    runtime_fn! {
     /// Read a file at the given path and evaluate it as a script in the current realm.
-    fn load(cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn load(cx, _, arguments) {
         let path_arg = arguments.get(cx, 0);
         let path = resolve_path_arg(cx, path_arg)?;
 
@@ -140,24 +142,22 @@ impl TestShell {
         };
 
         evaluate_script(cx, cx.current_realm(), source)
-    }
+    }}
 
+    runtime_fn! {
     /// Evaluate a script in the current realm.
-    fn load_string(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn load_string(cx, _, arguments) {
         let script_arg = arguments.get(cx, 0);
         let script_string = to_string(cx, script_arg)?.to_wtf8_string()?;
         let source = source_from_string(cx, script_string)?;
 
         evaluate_script(cx, cx.current_realm(), source)
-    }
+    }}
 
+    runtime_fn! {
     /// Read a file to either a string or an ArrayBuffer depending on the value of the second
     /// argument.
-    fn read(mut cx: Context, _: Handle<Value>, arguments: Arguments) -> EvalResult<Handle<Value>> {
+    fn read(cx, _, arguments) {
         let path_arg = arguments.get(cx, 0);
         let path = resolve_path_arg(cx, path_arg)?;
 
@@ -189,21 +189,19 @@ impl TestShell {
 
             Ok(cx.alloc_string(&string)?.as_value())
         }
-    }
+    }}
 
-    fn performance_now(cx: Context, _: Handle<Value>, _: Arguments) -> EvalResult<Handle<Value>> {
+    runtime_fn! {
+    fn performance_now(cx, _, _) {
         let time_origin = cx.current_realm().time_origin();
         let duration_millis = time_origin.elapsed().as_secs_f64() * 1000.0;
 
         Ok(cx.number(duration_millis))
-    }
+    }}
 
+    runtime_fn! {
     /// Create a new realm, evaluate the script in it, and return the new realm's global object.
-    fn run_string(
-        cx: Context,
-        _: Handle<Value>,
-        arguments: Arguments,
-    ) -> EvalResult<Handle<Value>> {
+    fn run_string(cx, _, arguments) {
         let script_arg = arguments.get(cx, 0);
         let script_string = to_string(cx, script_arg)?.to_wtf8_string()?;
         let source = source_from_string(cx, script_string)?;
@@ -214,7 +212,7 @@ impl TestShell {
         evaluate_script(cx, new_realm, source)?;
 
         Ok(new_realm.global_object().as_value())
-    }
+    }}
 }
 
 /// Resolve a path argument relative to the directory of the currently executing source


### PR DESCRIPTION
## Summary

There is a ton of boilerplate in the runtime. Let's reduce ~2k lines by introducing a new `runtime_fn!` macro for defining Rust runtime functions. This also gives us a single macros for creating all rust runtime function definitions, so changing their structure/types/etc is now much easier.

## Tests

- CI