### PR TITLE
[runtime] Avoid using intrinsic_* creators in the wrong place

### DIFF
--- a/src/js/runtime/intrinsics/error_constructor.rs
+++ b/src/js/runtime/intrinsics/error_constructor.rs
@@ -97,9 +97,12 @@ impl ErrorObject {
         let error_object =
             Self::new(cx, Intrinsic::ErrorPrototype, /* skip_current_frame */ false)?;
 
-        error_object
-            .as_object()
-            .intrinsic_data_prop(cx, cx.names.message(), message_value)?;
+        create_non_enumerable_data_property_or_throw(
+            cx,
+            error_object.as_object(),
+            cx.names.message(),
+            message_value,
+        )?;
 
         Ok(error_object)
     }

--- a/src/js/runtime/intrinsics/native_error.rs
+++ b/src/js/runtime/intrinsics/native_error.rs
@@ -41,9 +41,12 @@ macro_rules! create_native_error {
                     /* skip_current_frame */ false,
                 )?;
 
-                object
-                    .as_object()
-                    .intrinsic_data_prop(cx, cx.names.message(), message.into())?;
+                create_non_enumerable_data_property_or_throw(
+                    cx,
+                    object.as_object(),
+                    cx.names.message(),
+                    message.into(),
+                )?;
 
                 Ok(object)
             }


### PR DESCRIPTION
## Summary

The `intrinsic_*` family of utility methods should only be used when constructing builtin constructor and prototype objects. Instead correctly use the spec method `CreateNonEnumerableDataPropertyOrThrow`.

## Tests

- CI