### PR TITLE
[runtime] Rename cx.well_known_symbols field to cx.symbols

### DIFF
--- a/src/js/runtime/abstract_operations.rs
+++ b/src/js/runtime/abstract_operations.rs
@@ -402,7 +402,7 @@ pub fn species_constructor(
         return type_error(cx, "expected a constructor");
     }
 
-    let species_key = cx.well_known_symbols.species();
+    let species_key = cx.symbols.species();
     let species = get(cx, constructor.as_object(), species_key)?;
 
     if species.is_nullish() {

--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -122,7 +122,7 @@ impl MappedArgumentsObject {
         must!(define_property_or_throw(cx, object.into(), cx.names.length(), length_desc));
 
         // Set @@iterator to Array.prototype.values
-        let iterator_key = cx.well_known_symbols.iterator();
+        let iterator_key = cx.symbols.iterator();
         let iterator_value = cx.get_intrinsic(Intrinsic::ArrayPrototypeValues);
         let iterator_desc = PropertyDescriptor::data(iterator_value.into(), true, false, true);
         must!(define_property_or_throw(cx, object.into(), iterator_key, iterator_desc));
@@ -300,7 +300,7 @@ pub fn create_unmapped_arguments_object(
     }
 
     // Set @@iterator to Array.prototype.values
-    let iterator_key = cx.well_known_symbols.iterator();
+    let iterator_key = cx.symbols.iterator();
     let iterator_value = cx.get_intrinsic(Intrinsic::ArrayPrototypeValues);
     let iterator_desc = PropertyDescriptor::data(iterator_value.into(), true, false, true);
     must!(define_property_or_throw(cx, object, iterator_key, iterator_desc));

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -178,7 +178,7 @@ pub fn array_species_create(
     }
 
     if constructor.is_object() {
-        let species_key = cx.well_known_symbols.species();
+        let species_key = cx.symbols.species();
         constructor = get(cx, constructor.as_object(), species_key)?;
 
         if constructor.is_null() {

--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -432,7 +432,7 @@ fn await_return_reject(cx, _, arguments) {
 
 fn get_async_generator(cx: Context, function: Handle<ObjectValue>) -> Handle<AsyncGeneratorObject> {
     function
-        .private_element_find(cx, cx.well_known_symbols.async_generator().cast())
+        .private_element_find(cx, cx.symbols.async_generator().cast())
         .unwrap()
         .value()
         .as_object()
@@ -444,11 +444,7 @@ fn set_async_generator(
     mut function: Handle<ObjectValue>,
     async_generator: Handle<AsyncGeneratorObject>,
 ) -> AllocResult<()> {
-    function.private_element_set(
-        cx,
-        cx.well_known_symbols.async_generator().cast(),
-        async_generator.into(),
-    )
+    function.private_element_set(cx, cx.symbols.async_generator().cast(), async_generator.into())
 }
 
 /// AsyncGeneratorDrainQueue (https://tc39.es/ecma262/#sec-asyncgeneratordrainqueue)

--- a/src/js/runtime/bound_function_object.rs
+++ b/src/js/runtime/bound_function_object.rs
@@ -67,7 +67,7 @@ impl BoundFunctionObject {
         bound_function: Handle<ObjectValue>,
     ) -> Handle<ObjectValue> {
         bound_function
-            .private_element_find(cx, cx.well_known_symbols.bound_target().cast())
+            .private_element_find(cx, cx.symbols.bound_target().cast())
             .unwrap()
             .value()
             .as_object()
@@ -78,11 +78,7 @@ impl BoundFunctionObject {
         mut bound_function: Handle<ObjectValue>,
         target: Handle<ObjectValue>,
     ) -> AllocResult<()> {
-        bound_function.private_element_set(
-            cx,
-            cx.well_known_symbols.bound_target().cast(),
-            target.into(),
-        )
+        bound_function.private_element_set(cx, cx.symbols.bound_target().cast(), target.into())
     }
 
     /// If this object is a bound function, return the target function. Otherwise, return None.
@@ -91,17 +87,17 @@ impl BoundFunctionObject {
         object: Handle<ObjectValue>,
     ) -> Option<Handle<ObjectValue>> {
         object
-            .private_element_find(cx, cx.well_known_symbols.bound_target().cast())
+            .private_element_find(cx, cx.symbols.bound_target().cast())
             .map(|p| p.value().as_object())
     }
 
     pub fn is_bound_function(cx: Context, object: HeapPtr<ObjectValue>) -> bool {
-        object.has_private_element(cx.well_known_symbols.bound_target().cast())
+        object.has_private_element(cx.symbols.bound_target().cast())
     }
 
     fn get_bound_this(cx: Context, bound_function: Handle<ObjectValue>) -> Handle<Value> {
         bound_function
-            .private_element_find(cx, cx.well_known_symbols.bound_this().cast())
+            .private_element_find(cx, cx.symbols.bound_this().cast())
             .unwrap()
             .value()
     }
@@ -111,11 +107,7 @@ impl BoundFunctionObject {
         mut bound_function: Handle<ObjectValue>,
         bound_this: Handle<Value>,
     ) -> AllocResult<()> {
-        bound_function.private_element_set(
-            cx,
-            cx.well_known_symbols.bound_this().cast(),
-            bound_this,
-        )
+        bound_function.private_element_set(cx, cx.symbols.bound_this().cast(), bound_this)
     }
 
     fn get_bound_arguments(
@@ -123,7 +115,7 @@ impl BoundFunctionObject {
         bound_function: Handle<ObjectValue>,
     ) -> Handle<ArrayObject> {
         bound_function
-            .private_element_find(cx, cx.well_known_symbols.bound_arguments().cast())
+            .private_element_find(cx, cx.symbols.bound_arguments().cast())
             .unwrap()
             .value()
             .cast::<ArrayObject>()
@@ -136,7 +128,7 @@ impl BoundFunctionObject {
     ) -> AllocResult<()> {
         bound_function.private_element_set(
             cx,
-            cx.well_known_symbols.bound_arguments().cast(),
+            cx.symbols.bound_arguments().cast(),
             arguments.into(),
         )
     }

--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -629,7 +629,7 @@ macro_rules! builtin_symbols {
             pub fn init_builtin_symbols(&mut self) -> AllocResult<()> {
                 $({
                     handle_scope_guard!(*self);
-                    self.well_known_symbols.$rust_name = {
+                    self.symbols.$rust_name = {
                         let description = self.alloc_static_string($description)?;
                         *PropertyKey::symbol(SymbolValue::new(*self, Some(description), /* is_private */ false)?)
                     };

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -74,9 +74,8 @@ pub struct Context {
 
 pub struct ContextCell {
     pub heap: Heap,
-    global_symbol_registry: HeapPtr<GlobalSymbolRegistry>,
     pub names: BuiltinNames,
-    pub well_known_symbols: BuiltinSymbols,
+    pub symbols: BuiltinSymbols,
     pub descriptors: DescriptorRegistry,
     pub rust_runtime_functions: RustRuntimeFunctionRegistry,
 
@@ -103,6 +102,9 @@ pub struct ContextCell {
 
     /// Canonical string values for strings that appear in the AST
     pub interned_strings: InternedStrings,
+
+    /// All symbols that have been registered under a specific key with `Symbol.for`.
+    global_symbol_registry: HeapPtr<GlobalSymbolRegistry>,
 
     /// Cache modules by their canonical absolute path and import attributes
     pub modules: HeapPtr<ModuleCache>,
@@ -143,7 +145,7 @@ impl Context {
             heap: Heap::new(options.min_heap_size),
             global_symbol_registry: HeapPtr::uninit(),
             names: BuiltinNames::uninit(),
-            well_known_symbols: BuiltinSymbols::uninit(),
+            symbols: BuiltinSymbols::uninit(),
             descriptors: DescriptorRegistry::uninit_empty(),
             rust_runtime_functions: RustRuntimeFunctionRegistry::new(),
             vm: None,
@@ -632,7 +634,7 @@ impl Context {
     /// Visit all heap roots that are guaranteed to point to the permanent semispace.
     fn visit_permanent_roots(&mut self, visitor: &mut impl HeapVisitor) {
         self.names.visit_roots(visitor);
-        self.well_known_symbols.visit_roots(visitor);
+        self.symbols.visit_roots(visitor);
         self.descriptors.visit_roots(visitor);
         visitor.visit_pointer(&mut self.initial_realm);
 

--- a/src/js/runtime/eval/expression.rs
+++ b/src/js/runtime/eval/expression.rs
@@ -563,7 +563,7 @@ pub fn eval_instanceof_expression(
         return type_error(cx, "invalid `instanceof` operand");
     }
 
-    let has_instance_key = cx.well_known_symbols.has_instance();
+    let has_instance_key = cx.symbols.has_instance();
     let instance_of_handler = get_method(cx, target, has_instance_key)?;
     if let Some(instance_of_handler) = instance_of_handler {
         let result = call_object(cx, instance_of_handler, target, &[value])?;

--- a/src/js/runtime/intrinsics/array_buffer_constructor.rs
+++ b/src/js/runtime/intrinsics/array_buffer_constructor.rs
@@ -181,7 +181,7 @@ impl ArrayBufferConstructor {
         )?;
 
         // get ArrayBuffer [ @@species ] (https://tc39.es/ecma262/#sec-get-arraybuffer-%symbol.species%)
-        let species_key = cx.well_known_symbols.species();
+        let species_key = cx.symbols.species();
         func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
 
         Ok(func)

--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -84,7 +84,7 @@ impl ArrayBufferPrototype {
         )?;
 
         // ArrayBuffer.prototype [ %Symbol.toStringTag% ] (https://tc39.es/ecma262/#sec-arraybuffer.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/array_constructor.rs
+++ b/src/js/runtime/intrinsics/array_constructor.rs
@@ -63,7 +63,7 @@ impl ArrayConstructor {
         func.intrinsic_func(cx, cx.names.of(), RuntimeFunction::ArrayConstructor_of, 0, realm)?;
 
         // get Array [ @@species ] (https://tc39.es/ecma262/#sec-get-array-%symbol.species%)
-        let species_key = cx.well_known_symbols.species();
+        let species_key = cx.symbols.species();
         func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
 
         Ok(func)
@@ -137,7 +137,7 @@ impl ArrayConstructor {
         let this_arg = arguments.get(cx, 2);
 
         // If an iterator was supplied use it to create array
-        let iterator = get_method(cx, items_arg, cx.well_known_symbols.iterator())?;
+        let iterator = get_method(cx, items_arg, cx.symbols.iterator())?;
         if let Some(iterator) = iterator {
             let array = if is_constructor_value(this_value) {
                 construct(cx, this_value.as_object(), &[], None)?

--- a/src/js/runtime/intrinsics/array_from_async_generator.rs
+++ b/src/js/runtime/intrinsics/array_from_async_generator.rs
@@ -111,7 +111,7 @@ impl ArrayFromAsyncGenerator {
             None
         };
 
-        let async_iterator = get_method(cx, items_arg, cx.well_known_symbols.async_iterator())?;
+        let async_iterator = get_method(cx, items_arg, cx.symbols.async_iterator())?;
 
         // Async iterator has priority if present
         let iterator = if let Some(async_iterator) = async_iterator {
@@ -120,7 +120,7 @@ impl ArrayFromAsyncGenerator {
             Some(async_iterator_record)
         } else {
             // Otherwise if sync iterator is present convert it to an async iterator
-            let sync_iterator = get_method(cx, items_arg, cx.well_known_symbols.iterator())?;
+            let sync_iterator = get_method(cx, items_arg, cx.symbols.iterator())?;
             if let Some(sync_iterator) = sync_iterator {
                 let sync_iterator_record =
                     get_iterator(cx, items_arg, IteratorHint::Sync, Some(sync_iterator))?;

--- a/src/js/runtime/intrinsics/array_iterator.rs
+++ b/src/js/runtime/intrinsics/array_iterator.rs
@@ -115,7 +115,7 @@ impl ArrayIteratorPrototype {
         )?;
 
         // %ArrayIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         let to_string_tag_value = cx.alloc_static_string("Array Iterator")?.into();
         object.set_property(
             cx,

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -300,11 +300,11 @@ impl ArrayPrototype {
         )?;
 
         // Array.prototype [ @@iterator ] (https://tc39.es/ecma262/#sec-array.prototype-%symbol.iterator%)
-        let iterator_key = cx.well_known_symbols.iterator();
+        let iterator_key = cx.symbols.iterator();
         array.set_property(cx, iterator_key, Property::data(values_function, true, false, true))?;
 
         // Array.prototype [ @@unscopables ] (https://tc39.es/ecma262/#sec-array.prototype-%symbol.unscopables%)
-        let unscopables_key = cx.well_known_symbols.unscopables();
+        let unscopables_key = cx.symbols.unscopables();
         let unscopables = Property::data(Self::create_unscopables(cx)?.into(), false, false, true);
         array.set_property(cx, unscopables_key, unscopables)?;
 
@@ -363,8 +363,7 @@ impl ArrayPrototype {
             return Ok(false);
         }
 
-        let is_spreadable =
-            get(cx, object.as_object(), cx.well_known_symbols.is_concat_spreadable())?;
+        let is_spreadable = get(cx, object.as_object(), cx.symbols.is_concat_spreadable())?;
 
         if !is_spreadable.is_undefined() {
             return Ok(to_boolean(*is_spreadable));

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
@@ -333,7 +333,7 @@ fn async_from_sync_iterator_continuation_on_reject(cx, _, arguments) {
 
 fn get_sync_iterator(cx: Context, function: Handle<ObjectValue>) -> Handle<ObjectValue> {
     function
-        .private_element_find(cx, cx.well_known_symbols.index().as_symbol())
+        .private_element_find(cx, cx.symbols.index().as_symbol())
         .unwrap()
         .value()
         .as_object()
@@ -344,5 +344,5 @@ fn set_sync_iterator(
     mut function: Handle<ObjectValue>,
     value: Handle<ObjectValue>,
 ) -> AllocResult<()> {
-    function.private_element_set(cx, cx.well_known_symbols.index().as_symbol(), value.into())
+    function.private_element_set(cx, cx.symbols.index().as_symbol(), value.into())
 }

--- a/src/js/runtime/intrinsics/async_function_prototype.rs
+++ b/src/js/runtime/intrinsics/async_function_prototype.rs
@@ -14,7 +14,7 @@ impl AsyncFunctionPrototype {
         // Constructor property is added once AsyncFunctionConstructor has been created
 
         // AsyncFunction.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-async-function-prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/async_generator_function_prototype.rs
+++ b/src/js/runtime/intrinsics/async_generator_function_prototype.rs
@@ -19,7 +19,7 @@ impl AsyncGeneratorFunctionPrototype {
         object.set_property(cx, cx.names.prototype(), proto_prop)?;
 
         // AsyncGeneratorFunction.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/async_generator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_generator_prototype.rs
@@ -60,7 +60,7 @@ impl AsyncGeneratorPrototype {
         )?;
 
         // %AsyncGeneratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-asyncgenerator-prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/async_iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_iterator_prototype.rs
@@ -15,7 +15,7 @@ impl AsyncIteratorPrototype {
             ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
 
         // %AsyncIteratorPrototype% [ @@asyncIterator ] (https://tc39.es/ecma262/#sec-%asynciteratorprototype%-%symbol.asynciterator%)
-        let async_iterator_key = cx.well_known_symbols.async_iterator();
+        let async_iterator_key = cx.symbols.async_iterator();
         object.intrinsic_func(cx, async_iterator_key, RuntimeFunction::ReturnThis, 0, realm)?;
 
         Ok(object)

--- a/src/js/runtime/intrinsics/bigint_prototype.rs
+++ b/src/js/runtime/intrinsics/bigint_prototype.rs
@@ -41,7 +41,7 @@ impl BigIntPrototype {
         )?;
 
         // BigInt.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-bigint.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/data_view_prototype.rs
+++ b/src/js/runtime/intrinsics/data_view_prototype.rs
@@ -209,7 +209,7 @@ impl DataViewPrototype {
         )?;
 
         // DataView.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-dataview.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -349,7 +349,7 @@ impl DatePrototype {
         )?;
 
         // [Symbol.toPrimitive] property
-        let to_primitive_key = cx.well_known_symbols.to_primitive();
+        let to_primitive_key = cx.symbols.to_primitive();
         let to_primitive_func = BuiltinFunction::create(
             cx,
             RuntimeFunction::DatePrototype_to_primitive,

--- a/src/js/runtime/intrinsics/finalization_registry_prototype.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_prototype.rs
@@ -45,7 +45,7 @@ impl FinalizationRegistryPrototype {
         )?;
 
         // [Symbol.toStringTag] property
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -106,16 +106,12 @@ impl FunctionPrototype {
             cx,
             RuntimeFunction::FunctionPrototype_has_instance,
             1,
-            cx.well_known_symbols.has_instance(),
+            cx.symbols.has_instance(),
             realm,
             None,
         )?
         .into();
-        object.intrinsic_frozen_property(
-            cx,
-            cx.well_known_symbols.has_instance(),
-            has_instance_func,
-        )?;
+        object.intrinsic_frozen_property(cx, cx.symbols.has_instance(), has_instance_func)?;
 
         Ok(())
     }

--- a/src/js/runtime/intrinsics/generator_function_prototype.rs
+++ b/src/js/runtime/intrinsics/generator_function_prototype.rs
@@ -19,7 +19,7 @@ impl GeneratorFunctionPrototype {
         object.set_property(cx, cx.names.prototype(), proto_prop)?;
 
         // GeneratorFunction.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-generatorfunction.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/generator_prototype.rs
+++ b/src/js/runtime/intrinsics/generator_prototype.rs
@@ -49,7 +49,7 @@ impl GeneratorPrototype {
         )?;
 
         // %GeneratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-generator.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/iterator_constructor.rs
+++ b/src/js/runtime/intrinsics/iterator_constructor.rs
@@ -93,7 +93,7 @@ impl IteratorConstructor {
                 return type_error(cx, "Iterator.concat argument is not an object");
             }
 
-            if let Some(method) = get_method(cx, *argument, cx.well_known_symbols.iterator())? {
+            if let Some(method) = get_method(cx, *argument, cx.symbols.iterator())? {
                 iterator_methods.push(method.as_value());
             } else {
                 return type_error(cx, "Iterator.concat argument is not iterable");

--- a/src/js/runtime/intrinsics/iterator_helper_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_prototype.rs
@@ -39,7 +39,7 @@ impl IteratorHelperPrototype {
         )?;
 
         // %IteratorHelperPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%iteratorhelperprototype%-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         let iterator_helper = cx.alloc_static_string("Iterator Helper")?;
         object.set_property(
             cx,

--- a/src/js/runtime/intrinsics/iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_prototype.rs
@@ -114,11 +114,11 @@ impl IteratorPrototype {
         )?;
 
         // Iterator.prototype [ @@iterator ] (https://tc39.es/ecma262/#sec-iterator.prototype-%symbol.iterator%)
-        let iterator_key = cx.well_known_symbols.iterator();
+        let iterator_key = cx.symbols.iterator();
         object.intrinsic_func(cx, iterator_key, RuntimeFunction::ReturnThis, 0, realm)?;
 
         // Iterator.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-iterator.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.intrinsic_getter_and_setter(
             cx,
             to_string_tag_key,
@@ -441,7 +441,7 @@ impl IteratorPrototype {
             cx,
             this_value,
             cx.get_intrinsic(Intrinsic::IteratorPrototype),
-            cx.well_known_symbols.to_string_tag(),
+            cx.symbols.to_string_tag(),
             value,
         )?;
 

--- a/src/js/runtime/intrinsics/json_object.rs
+++ b/src/js/runtime/intrinsics/json_object.rs
@@ -64,7 +64,7 @@ impl JSONObject {
         )?;
 
         // JSON [ @@toStringTag ] (https://tc39.es/ecma262/#sec-json-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         let math_name_value = cx.names.json().as_string().into();
         object.set_property(
             cx,

--- a/src/js/runtime/intrinsics/map_constructor.rs
+++ b/src/js/runtime/intrinsics/map_constructor.rs
@@ -49,7 +49,7 @@ impl MapConstructor {
         )?;
 
         // get Map [ %Symbol.species% ] (https://tc39.es/ecma262/#sec-get-map-%symbol.species%)
-        let species_key = cx.well_known_symbols.species();
+        let species_key = cx.symbols.species();
         func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
 
         Ok(func)

--- a/src/js/runtime/intrinsics/map_iterator.rs
+++ b/src/js/runtime/intrinsics/map_iterator.rs
@@ -96,7 +96,7 @@ impl MapIteratorPrototype {
         )?;
 
         // %MapIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%mapiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         let to_string_tag_value = cx.alloc_static_string("Map Iterator")?.into();
         object.set_property(
             cx,

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -91,7 +91,7 @@ impl MapPrototype {
         )?;
 
         // Map.prototype [ @@iterator ] (https://tc39.es/ecma262/#sec-map.prototype-%symbol.iterator%)
-        let iterator_key = cx.well_known_symbols.iterator();
+        let iterator_key = cx.symbols.iterator();
         object.set_property(
             cx,
             iterator_key,
@@ -99,7 +99,7 @@ impl MapPrototype {
         )?;
 
         // Map.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-map.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/math_object.rs
+++ b/src/js/runtime/intrinsics/math_object.rs
@@ -56,7 +56,7 @@ impl MathObject {
         object.intrinsic_frozen_property(cx, cx.names.sqrt2(), sqrt_2_value)?;
 
         // Math [ @@toStringTag ] (https://tc39.es/ecma262/#sec-math-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         let math_name_value = cx.names.math().as_string().into();
         object.set_property(
             cx,

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -199,7 +199,7 @@ impl ObjectPrototype {
 
         let is_array = is_array(cx, object.into())?;
 
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         let tag = get(cx, object, to_string_tag_key)?;
 
         let tag_string = if tag.is_string() {

--- a/src/js/runtime/intrinsics/promise_constructor.rs
+++ b/src/js/runtime/intrinsics/promise_constructor.rs
@@ -106,7 +106,7 @@ impl PromiseConstructor {
         )?;
 
         // get Promise [ @@species ] (https://tc39.es/ecma262/#sec-get-promise-%symbol.species%)
-        let species_key = cx.well_known_symbols.species();
+        let species_key = cx.symbols.species();
         func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
 
         Ok(func)
@@ -170,7 +170,7 @@ impl PromiseConstructor {
 
     fn get_already_called_or_false(cx: Context, function: Handle<ObjectValue>) -> bool {
         if let Some(property) =
-            function.private_element_find(cx, cx.well_known_symbols.already_called().cast())
+            function.private_element_find(cx, cx.symbols.already_called().cast())
         {
             property.value().as_bool()
         } else {
@@ -183,7 +183,7 @@ impl PromiseConstructor {
         function: Handle<ObjectValue>,
     ) -> Handle<BooleanObject> {
         function
-            .private_element_find(cx, cx.well_known_symbols.already_called().cast())
+            .private_element_find(cx, cx.symbols.already_called().cast())
             .unwrap()
             .value()
             .cast::<BooleanObject>()
@@ -194,23 +194,23 @@ impl PromiseConstructor {
         mut function: Handle<ObjectValue>,
         value: Handle<Value>,
     ) -> AllocResult<()> {
-        function.private_element_set(cx, cx.well_known_symbols.already_called().cast(), value)
+        function.private_element_set(cx, cx.symbols.already_called().cast(), value)
     }
 
     fn get_index(cx: Context, function: Handle<ObjectValue>) -> Handle<Value> {
         function
-            .private_element_find(cx, cx.well_known_symbols.index().cast())
+            .private_element_find(cx, cx.symbols.index().cast())
             .unwrap()
             .value()
     }
 
     fn set_index(cx: Context, mut function: Handle<ObjectValue>, value: Value) -> AllocResult<()> {
-        function.private_element_set(cx, cx.well_known_symbols.index().cast(), value.to_handle(cx))
+        function.private_element_set(cx, cx.symbols.index().cast(), value.to_handle(cx))
     }
 
     fn get_values(cx: Context, function: Handle<ObjectValue>) -> Handle<ArrayObject> {
         function
-            .private_element_find(cx, cx.well_known_symbols.values().cast())
+            .private_element_find(cx, cx.symbols.values().cast())
             .unwrap()
             .value()
             .as_object()
@@ -222,12 +222,12 @@ impl PromiseConstructor {
         mut function: Handle<ObjectValue>,
         value: Handle<ArrayObject>,
     ) -> AllocResult<()> {
-        function.private_element_set(cx, cx.well_known_symbols.values().cast(), value.into())
+        function.private_element_set(cx, cx.symbols.values().cast(), value.into())
     }
 
     fn get_capability(cx: Context, function: Handle<ObjectValue>) -> Handle<PromiseCapability> {
         function
-            .private_element_find(cx, cx.well_known_symbols.capability().cast())
+            .private_element_find(cx, cx.symbols.capability().cast())
             .unwrap()
             .value()
             .as_object()
@@ -239,12 +239,12 @@ impl PromiseConstructor {
         mut function: Handle<ObjectValue>,
         value: Handle<PromiseCapability>,
     ) -> AllocResult<()> {
-        function.private_element_set(cx, cx.well_known_symbols.capability().cast(), value.into())
+        function.private_element_set(cx, cx.symbols.capability().cast(), value.into())
     }
 
     fn get_remaining_elements(cx: Context, function: Handle<ObjectValue>) -> Handle<NumberObject> {
         function
-            .private_element_find(cx, cx.well_known_symbols.remaining_elements().cast())
+            .private_element_find(cx, cx.symbols.remaining_elements().cast())
             .unwrap()
             .value()
             .as_object()
@@ -256,11 +256,7 @@ impl PromiseConstructor {
         mut function: Handle<ObjectValue>,
         value: Handle<NumberObject>,
     ) -> AllocResult<()> {
-        function.private_element_set(
-            cx,
-            cx.well_known_symbols.remaining_elements().cast(),
-            value.into(),
-        )
+        function.private_element_set(cx, cx.symbols.remaining_elements().cast(), value.into())
     }
 
     runtime_fn! {
@@ -822,14 +818,14 @@ fn create_settle_function(
     let mut function =
         BuiltinFunction::create(cx, func, 1, cx.names.empty_string(), cx.current_realm(), None)?;
 
-    function.private_element_set(cx, cx.well_known_symbols.promise().cast(), promise.into())?;
+    function.private_element_set(cx, cx.symbols.promise().cast(), promise.into())?;
 
     Ok(function)
 }
 
 fn get_promise(cx: Context, settle_function: Handle<ObjectValue>) -> Handle<PromiseObject> {
     settle_function
-        .private_element_find(cx, cx.well_known_symbols.promise().cast())
+        .private_element_find(cx, cx.symbols.promise().cast())
         .unwrap()
         .value()
         .as_object()

--- a/src/js/runtime/intrinsics/promise_prototype.rs
+++ b/src/js/runtime/intrinsics/promise_prototype.rs
@@ -49,7 +49,7 @@ impl PromisePrototype {
         )?;
 
         // Promise.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-promise.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,
@@ -121,7 +121,7 @@ impl PromisePrototype {
 
     fn get_constructor(cx: Context, function: Handle<ObjectValue>) -> Handle<ObjectValue> {
         function
-            .private_element_find(cx, cx.well_known_symbols.constructor().cast())
+            .private_element_find(cx, cx.symbols.constructor().cast())
             .unwrap()
             .value()
             .as_object()
@@ -132,12 +132,12 @@ impl PromisePrototype {
         mut function: Handle<ObjectValue>,
         value: Handle<ObjectValue>,
     ) -> AllocResult<()> {
-        function.private_element_set(cx, cx.well_known_symbols.constructor().cast(), value.into())
+        function.private_element_set(cx, cx.symbols.constructor().cast(), value.into())
     }
 
     fn get_on_finally(cx: Context, function: Handle<ObjectValue>) -> Handle<ObjectValue> {
         function
-            .private_element_find(cx, cx.well_known_symbols.on_finally().cast())
+            .private_element_find(cx, cx.symbols.on_finally().cast())
             .unwrap()
             .value()
             .as_object()
@@ -148,12 +148,12 @@ impl PromisePrototype {
         mut function: Handle<ObjectValue>,
         value: Handle<ObjectValue>,
     ) -> AllocResult<()> {
-        function.private_element_set(cx, cx.well_known_symbols.on_finally().cast(), value.into())
+        function.private_element_set(cx, cx.symbols.on_finally().cast(), value.into())
     }
 
     fn get_value(cx: Context, function: Handle<ObjectValue>) -> Handle<Value> {
         function
-            .private_element_find(cx, cx.well_known_symbols.values().cast())
+            .private_element_find(cx, cx.symbols.values().cast())
             .unwrap()
             .value()
     }
@@ -163,7 +163,7 @@ impl PromisePrototype {
         mut function: Handle<ObjectValue>,
         value: Handle<Value>,
     ) -> AllocResult<()> {
-        function.private_element_set(cx, cx.well_known_symbols.values().cast(), value)
+        function.private_element_set(cx, cx.symbols.values().cast(), value)
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/proxy_constructor.rs
+++ b/src/js/runtime/intrinsics/proxy_constructor.rs
@@ -74,7 +74,7 @@ impl ProxyConstructor {
         // Attach the proxy to the revoker so it can be accessed when the revoker is called
         revoker.private_element_set(
             cx,
-            cx.well_known_symbols.revocable_proxy().cast(),
+            cx.symbols.revocable_proxy().cast(),
             proxy.into(),
         )?;
 
@@ -92,11 +92,11 @@ fn revoke(cx, _, _) {
     // Find the proxy object attached to this closure via a private property
     let mut revoke_function = cx.current_function();
     let proxy_object_property =
-        revoke_function.private_element_find(cx, cx.well_known_symbols.revocable_proxy().cast());
+        revoke_function.private_element_find(cx, cx.symbols.revocable_proxy().cast());
 
     // Revoke the proxy object and remove from closure
     if let Some(proxy_object_property) = proxy_object_property {
-        revoke_function.remove_property(cx.well_known_symbols.revocable_proxy());
+        revoke_function.remove_property(cx.symbols.revocable_proxy());
 
         let mut proxy_object = proxy_object_property.value().cast::<ProxyObject>();
         proxy_object.revoke();

--- a/src/js/runtime/intrinsics/reflect_object.rs
+++ b/src/js/runtime/intrinsics/reflect_object.rs
@@ -98,7 +98,7 @@ impl ReflectObject {
         )?;
 
         // Reflect [ @@toStringTag ] (https://tc39.es/ecma262/#sec-reflect-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         let reflect_name_value = cx.names.reflect().as_string().into();
         object.set_property(
             cx,

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -159,7 +159,7 @@ impl RegExpConstructor {
         )?;
 
         // get RegExp [ @@species ] (https://tc39.es/ecma262/#sec-get-regexp-%symbol.species%)
-        let species_key = cx.well_known_symbols.species();
+        let species_key = cx.symbols.species();
         func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
 
         Ok(func)

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -88,14 +88,14 @@ impl RegExpPrototype {
         )?;
         object.intrinsic_func(
             cx,
-            cx.well_known_symbols.match_(),
+            cx.symbols.match_(),
             RuntimeFunction::RegExpPrototype_match_,
             1,
             realm,
         )?;
         object.intrinsic_func(
             cx,
-            cx.well_known_symbols.match_all(),
+            cx.symbols.match_all(),
             RuntimeFunction::RegExpPrototype_match_all,
             1,
             realm,
@@ -108,14 +108,14 @@ impl RegExpPrototype {
         )?;
         object.intrinsic_func(
             cx,
-            cx.well_known_symbols.replace(),
+            cx.symbols.replace(),
             RuntimeFunction::RegExpPrototype_replace,
             2,
             realm,
         )?;
         object.intrinsic_func(
             cx,
-            cx.well_known_symbols.search(),
+            cx.symbols.search(),
             RuntimeFunction::RegExpPrototype_search,
             1,
             realm,
@@ -128,7 +128,7 @@ impl RegExpPrototype {
         )?;
         object.intrinsic_func(
             cx,
-            cx.well_known_symbols.split(),
+            cx.symbols.split(),
             RuntimeFunction::RegExpPrototype_split,
             2,
             realm,

--- a/src/js/runtime/intrinsics/regexp_string_iterator.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator.rs
@@ -92,7 +92,7 @@ impl RegExpStringIteratorPrototype {
         )?;
 
         // %RegExpStringIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%regexpstringiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         let to_string_tag_value = cx.alloc_static_string("RegExp String Iterator")?.into();
         object.set_property(
             cx,

--- a/src/js/runtime/intrinsics/set_constructor.rs
+++ b/src/js/runtime/intrinsics/set_constructor.rs
@@ -36,7 +36,7 @@ impl SetConstructor {
         )?;
 
         // get Set [ @@species ] (https://tc39.es/ecma262/#sec-get-set-%symbol.species%)
-        let species_key = cx.well_known_symbols.species();
+        let species_key = cx.symbols.species();
         func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
 
         Ok(func)

--- a/src/js/runtime/intrinsics/set_iterator.rs
+++ b/src/js/runtime/intrinsics/set_iterator.rs
@@ -91,7 +91,7 @@ impl SetIteratorPrototype {
         )?;
 
         // %SetIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%setiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         let to_string_tag_value = cx.alloc_static_string("Set Iterator")?.into();
         object.set_property(
             cx,

--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -132,7 +132,7 @@ impl SetPrototype {
         object.intrinsic_data_prop(cx, cx.names.values(), values_function)?;
 
         // Set.prototype [ @@iterator ] (https://tc39.es/ecma262/#sec-set.prototype-%symbol.iterator%)
-        let iterator_key = cx.well_known_symbols.iterator();
+        let iterator_key = cx.symbols.iterator();
         object.set_property(
             cx,
             iterator_key,
@@ -140,7 +140,7 @@ impl SetPrototype {
         )?;
 
         // Set.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-set.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/string_iterator.rs
+++ b/src/js/runtime/intrinsics/string_iterator.rs
@@ -60,7 +60,7 @@ impl StringIteratorPrototype {
         )?;
 
         // %StringIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%stringiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         let to_string_tag_value = cx.alloc_static_string("String Iterator")?.into();
         object.set_property(
             cx,

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -285,7 +285,7 @@ impl StringPrototype {
         )?;
 
         // String.prototype [ @@iterator ] (https://tc39.es/ecma262/#sec-string.prototype-%symbol.iterator%)
-        let iterator_key = cx.well_known_symbols.iterator();
+        let iterator_key = cx.symbols.iterator();
         object.intrinsic_func(
             cx,
             iterator_key,
@@ -597,7 +597,7 @@ impl StringPrototype {
 
         let regexp_arg = arguments.get(cx, 0);
         if regexp_arg.is_object() {
-            let matcher = get_method(cx, regexp_arg, cx.well_known_symbols.match_())?;
+            let matcher = get_method(cx, regexp_arg, cx.symbols.match_())?;
             if let Some(matcher) = matcher {
                 return call_object(cx, matcher, regexp_arg, &[this_object]);
             }
@@ -612,7 +612,7 @@ impl StringPrototype {
         let regexp_constructor = cx.get_intrinsic(Intrinsic::RegExpConstructor);
         let regexp_object = regexp_create(cx, regexp_source, regexp_constructor)?;
 
-        invoke(cx, regexp_object, cx.well_known_symbols.match_(), &[this_string.into()])
+        invoke(cx, regexp_object, cx.symbols.match_(), &[this_string.into()])
     }}
 
     runtime_fn! {
@@ -645,7 +645,7 @@ impl StringPrototype {
                 }
             }
 
-            let matcher = get_method(cx, regexp_arg, cx.well_known_symbols.match_all())?;
+            let matcher = get_method(cx, regexp_arg, cx.symbols.match_all())?;
             if let Some(matcher) = matcher {
                 return call_object(cx, matcher, regexp_arg, &[this_object]);
             }
@@ -660,7 +660,7 @@ impl StringPrototype {
         let regexp_constructor = cx.get_intrinsic(Intrinsic::RegExpConstructor);
         let regexp_object = regexp_create(cx, regexp_source, regexp_constructor)?;
 
-        invoke(cx, regexp_object, cx.well_known_symbols.match_all(), &[this_string.into()])
+        invoke(cx, regexp_object, cx.symbols.match_all(), &[this_string.into()])
     }}
 
     runtime_fn! {
@@ -820,7 +820,7 @@ impl StringPrototype {
 
         // Use the @@replace method of the argument if one exists
         if search_arg.is_object() {
-            let replacer = get_method(cx, search_arg, cx.well_known_symbols.replace())?;
+            let replacer = get_method(cx, search_arg, cx.symbols.replace())?;
             if let Some(replacer) = replacer {
                 return call_object(cx, replacer, search_arg, &[object, replace_arg]);
             }
@@ -916,7 +916,7 @@ impl StringPrototype {
                 }
             }
 
-            let replacer = get_method(cx, search_arg, cx.well_known_symbols.replace())?;
+            let replacer = get_method(cx, search_arg, cx.symbols.replace())?;
             if let Some(replacer) = replacer {
                 return call_object(cx, replacer, search_arg, &[object, replace_arg]);
             }
@@ -1008,7 +1008,7 @@ impl StringPrototype {
         // Use the @@search method of the argument if one exists
         let regexp_arg = arguments.get(cx, 0);
         if regexp_arg.is_object() {
-            let searcher = get_method(cx, regexp_arg, cx.well_known_symbols.search())?;
+            let searcher = get_method(cx, regexp_arg, cx.symbols.search())?;
             if let Some(searcher) = searcher {
                 return call_object(cx, searcher, regexp_arg, &[object]);
             }
@@ -1024,7 +1024,7 @@ impl StringPrototype {
         let regexp_constructor = cx.get_intrinsic(Intrinsic::RegExpConstructor);
         let regexp_object = regexp_create(cx, regexp_source, regexp_constructor)?;
 
-        invoke(cx, regexp_object, cx.well_known_symbols.search(), &[string.into()])
+        invoke(cx, regexp_object, cx.symbols.search(), &[string.into()])
     }}
 
     runtime_fn! {
@@ -1061,7 +1061,7 @@ impl StringPrototype {
 
         // Use the @@split method of the separator if one exists
         if separator_argument.is_object() {
-            let split_key = cx.well_known_symbols.split();
+            let split_key = cx.symbols.split();
             let splitter = get_method(cx, separator_argument, split_key)?;
 
             if let Some(splitter) = splitter {

--- a/src/js/runtime/intrinsics/symbol_constructor.rs
+++ b/src/js/runtime/intrinsics/symbol_constructor.rs
@@ -70,47 +70,47 @@ impl SymbolConstructor {
         )?;
 
         // Well known symbols
-        let async_iterator = cx.well_known_symbols.async_iterator().as_symbol();
+        let async_iterator = cx.symbols.async_iterator().as_symbol();
         func.intrinsic_frozen_property(cx, cx.names.async_iterator(), async_iterator.into())?;
 
-        let has_instance = cx.well_known_symbols.has_instance().as_symbol();
+        let has_instance = cx.symbols.has_instance().as_symbol();
         func.intrinsic_frozen_property(cx, cx.names.has_instance(), has_instance.into())?;
 
-        let is_concat_spreadable = cx.well_known_symbols.is_concat_spreadable().as_symbol();
+        let is_concat_spreadable = cx.symbols.is_concat_spreadable().as_symbol();
         func.intrinsic_frozen_property(
             cx,
             cx.names.is_concat_spreadable(),
             is_concat_spreadable.into(),
         )?;
 
-        let iterator = cx.well_known_symbols.iterator().as_symbol();
+        let iterator = cx.symbols.iterator().as_symbol();
         func.intrinsic_frozen_property(cx, cx.names.iterator_(), iterator.into())?;
 
-        let match_ = cx.well_known_symbols.match_().as_symbol();
+        let match_ = cx.symbols.match_().as_symbol();
         func.intrinsic_frozen_property(cx, cx.names.match_(), match_.into())?;
 
-        let match_all = cx.well_known_symbols.match_all().as_symbol();
+        let match_all = cx.symbols.match_all().as_symbol();
         func.intrinsic_frozen_property(cx, cx.names.match_all(), match_all.into())?;
 
-        let replace = cx.well_known_symbols.replace().as_symbol();
+        let replace = cx.symbols.replace().as_symbol();
         func.intrinsic_frozen_property(cx, cx.names.replace(), replace.into())?;
 
-        let search = cx.well_known_symbols.search().as_symbol();
+        let search = cx.symbols.search().as_symbol();
         func.intrinsic_frozen_property(cx, cx.names.search(), search.into())?;
 
-        let species = cx.well_known_symbols.species().as_symbol();
+        let species = cx.symbols.species().as_symbol();
         func.intrinsic_frozen_property(cx, cx.names.species(), species.into())?;
 
-        let split = cx.well_known_symbols.split().as_symbol();
+        let split = cx.symbols.split().as_symbol();
         func.intrinsic_frozen_property(cx, cx.names.split(), split.into())?;
 
-        let to_primitive = cx.well_known_symbols.to_primitive().as_symbol();
+        let to_primitive = cx.symbols.to_primitive().as_symbol();
         func.intrinsic_frozen_property(cx, cx.names.to_primitive(), to_primitive.into())?;
 
-        let to_string_tag = cx.well_known_symbols.to_string_tag().as_symbol();
+        let to_string_tag = cx.symbols.to_string_tag().as_symbol();
         func.intrinsic_frozen_property(cx, cx.names.to_string_tag(), to_string_tag.into())?;
 
-        let unscopables = cx.well_known_symbols.unscopables().as_symbol();
+        let unscopables = cx.symbols.unscopables().as_symbol();
         func.intrinsic_frozen_property(cx, cx.names.unscopables(), unscopables.into())?;
 
         func.intrinsic_func(

--- a/src/js/runtime/intrinsics/symbol_prototype.rs
+++ b/src/js/runtime/intrinsics/symbol_prototype.rs
@@ -46,7 +46,7 @@ impl SymbolPrototype {
         )?;
 
         // [Symbol.toPrimitive] property
-        let to_primitive_key = cx.well_known_symbols.to_primitive();
+        let to_primitive_key = cx.symbols.to_primitive();
         let to_primitive_func = BuiltinFunction::create(
             cx,
             RuntimeFunction::SymbolPrototype_value_of,
@@ -63,7 +63,7 @@ impl SymbolPrototype {
         )?;
 
         // [Symbol.toStringTag] property
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/temporal/duration_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_prototype.rs
@@ -41,7 +41,7 @@ impl DurationPrototype {
 
         // Constructor property is added once DurationConstructor has been created
 
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/temporal/instant_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_prototype.rs
@@ -40,7 +40,7 @@ impl InstantPrototype {
 
         // Constructor property is added once InstantConstructor has been created
 
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
@@ -43,7 +43,7 @@ impl PlainDatePrototype {
 
         // Constructor property is added once PlainDateConstructor has been created
 
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
@@ -47,7 +47,7 @@ impl PlainDateTimePrototype {
 
         // Constructor property is added once PlainDateTimeConstructor has been created
 
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
@@ -35,7 +35,7 @@ impl PlainMonthDayPrototype {
 
         // Constructor property is added once PlainMonthDayConstructor has been created
 
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
@@ -37,7 +37,7 @@ impl PlainTimePrototype {
 
         // Constructor property is added once PlainTimeConstructor has been created
 
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
@@ -37,7 +37,7 @@ impl PlainYearMonthPrototype {
 
         // Constructor property is added once PlainYearMonthConstructor has been created
 
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/temporal/temporal_now_object.rs
+++ b/src/js/runtime/intrinsics/temporal/temporal_now_object.rs
@@ -37,7 +37,7 @@ impl TemporalNowObject {
             ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
 
         // Temporal.Now [ @@toStringTag ] (https://tc39.es/proposal-temporal/#sec-temporal-now-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/temporal/temporal_object.rs
+++ b/src/js/runtime/intrinsics/temporal/temporal_object.rs
@@ -56,7 +56,7 @@ impl TemporalObject {
         )?;
 
         // Temporal [ %Symbol.toStringTag% ] (https://tc39.es/proposal-temporal/#sec-temporal-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
@@ -56,7 +56,7 @@ impl ZonedDateTimePrototype {
 
         // Constructor property is added once ZonedDateTimeConstructor has been created
 
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -69,7 +69,7 @@ impl TypedArrayConstructor {
         )?;
 
         // get %TypedArray% [ @@species ] (https://tc39.es/ecma262/#sec-get-%typedarray%-%symbol.species%)
-        let species_key = cx.well_known_symbols.species();
+        let species_key = cx.symbols.species();
         func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
 
         Ok(func)
@@ -124,7 +124,7 @@ impl TypedArrayConstructor {
         let source = arguments.get(cx, 0);
         let this_argument = arguments.get(cx, 2);
 
-        let iterator_key = cx.well_known_symbols.iterator();
+        let iterator_key = cx.symbols.iterator();
         let iterator = get_method(cx, source, iterator_key)?;
 
         // If source is iterable then add all values from iterator
@@ -785,7 +785,7 @@ macro_rules! create_typed_array_constructor {
                     );
                 }
 
-                let iterator_key = cx.well_known_symbols.iterator();
+                let iterator_key = cx.symbols.iterator();
                 let iterator = get_method(cx, argument.into(), iterator_key)?;
 
                 if let Some(iterator) = iterator {

--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -301,7 +301,7 @@ impl TypedArrayPrototype {
         )?;
 
         // %TypedArray%.prototype [ @@iterator ] (https://tc39.es/ecma262/#sec-%typedarray%.prototype-%symbol.iterator%)
-        let iterator_key = cx.well_known_symbols.iterator();
+        let iterator_key = cx.symbols.iterator();
         object.set_property(
             cx,
             iterator_key,
@@ -309,7 +309,7 @@ impl TypedArrayPrototype {
         )?;
 
         // get %TypedArray%.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.intrinsic_getter(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/weak_map_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_map_prototype.rs
@@ -71,7 +71,7 @@ impl WeakMapPrototype {
         )?;
 
         // [Symbol.toStringTag] property
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/weak_ref_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_ref_prototype.rs
@@ -32,7 +32,7 @@ impl WeakRefPrototype {
         )?;
 
         // [Symbol.toStringTag] property
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/intrinsics/weak_set_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_set_prototype.rs
@@ -48,7 +48,7 @@ impl WeakSetPrototype {
         )?;
 
         // [Symbol.toStringTag] property
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/iterator.rs
+++ b/src/js/runtime/iterator.rs
@@ -70,13 +70,13 @@ pub fn get_iterator(
         method
     } else {
         if hint == IteratorHint::Async {
-            let async_iterator_key = cx.well_known_symbols.async_iterator();
+            let async_iterator_key = cx.symbols.async_iterator();
             let method = get_method(cx, object, async_iterator_key)?;
 
             if let Some(method) = method {
                 method
             } else {
-                let sync_iterator_key = cx.well_known_symbols.iterator();
+                let sync_iterator_key = cx.symbols.iterator();
                 let sync_method = get_method(cx, object, sync_iterator_key)?;
                 let sync_iterator_record =
                     get_iterator(cx, object, IteratorHint::Sync, sync_method)?;
@@ -84,7 +84,7 @@ pub fn get_iterator(
                 return Ok(create_async_from_sync_iterator(cx, sync_iterator_record)?);
             }
         } else {
-            let iterator_key = cx.well_known_symbols.iterator();
+            let iterator_key = cx.symbols.iterator();
             let method = get_method(cx, object, iterator_key)?;
 
             if let Some(method) = method {
@@ -128,7 +128,7 @@ pub fn get_iterator_flattenable(
         }
     }
 
-    let iterator = match get_method(cx, value, cx.well_known_symbols.iterator())? {
+    let iterator = match get_method(cx, value, cx.symbols.iterator())? {
         None => value,
         Some(method) => call_object(cx, method, value, &[])?,
     };

--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -71,7 +71,7 @@ pub fn execute_module(
 
 fn get_module(cx: Context, function: Handle<ObjectValue>) -> Handle<SourceTextModule> {
     function
-        .private_element_find(cx, cx.well_known_symbols.module().cast())
+        .private_element_find(cx, cx.symbols.module().cast())
         .unwrap()
         .value()
         .as_object()
@@ -83,12 +83,12 @@ fn set_module(
     mut function: Handle<ObjectValue>,
     value: Handle<SourceTextModule>,
 ) -> AllocResult<()> {
-    function.private_element_set(cx, cx.well_known_symbols.module().cast(), value.into())
+    function.private_element_set(cx, cx.symbols.module().cast(), value.into())
 }
 
 fn get_dyn_module(cx: Context, function: Handle<ObjectValue>) -> DynModule {
     let item = function
-        .private_element_find(cx, cx.well_known_symbols.module().cast())
+        .private_element_find(cx, cx.symbols.module().cast())
         .unwrap()
         .value()
         .as_pointer();
@@ -110,16 +110,12 @@ fn set_dyn_module(
     mut function: Handle<ObjectValue>,
     value: DynModule,
 ) -> AllocResult<()> {
-    function.private_element_set(
-        cx,
-        cx.well_known_symbols.module().cast(),
-        value.as_heap_item().into(),
-    )
+    function.private_element_set(cx, cx.symbols.module().cast(), value.as_heap_item().into())
 }
 
 fn get_capability(cx: Context, function: Handle<ObjectValue>) -> Handle<PromiseCapability> {
     function
-        .private_element_find(cx, cx.well_known_symbols.capability().cast())
+        .private_element_find(cx, cx.symbols.capability().cast())
         .unwrap()
         .value()
         .as_object()
@@ -131,7 +127,7 @@ fn set_capability(
     mut function: Handle<ObjectValue>,
     value: Handle<PromiseCapability>,
 ) -> AllocResult<()> {
-    function.private_element_set(cx, cx.well_known_symbols.capability().cast(), value.into())
+    function.private_element_set(cx, cx.symbols.capability().cast(), value.into())
 }
 
 runtime_fn! {

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -59,7 +59,7 @@ impl ModuleNamespaceObject {
         let object = object.to_handle();
 
         // Module Namespace Objects [ %Symbol.toStringTag% ] (https://tc39.es/ecma262/#sec-%symbol.tostringtag%)
-        let to_string_tag_key = cx.well_known_symbols.to_string_tag();
+        let to_string_tag_key = cx.symbols.to_string_tag();
         object.as_object().set_property(
             cx,
             to_string_tag_key,

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -502,11 +502,7 @@ impl PromiseCapability {
             None,
         )?;
 
-        executor.private_element_set(
-            cx,
-            cx.well_known_symbols.capability().cast(),
-            capability.into(),
-        )?;
+        executor.private_element_set(cx, cx.symbols.capability().cast(), capability.into())?;
 
         // Construct the promise using the provided constructor. This will fill the resolve and
         // reject fields of the capability.
@@ -541,7 +537,7 @@ impl PromiseCapability {
         // Get the capability object that was attached to the executor function
         let current_function = cx.current_function();
         let mut capability = current_function
-            .private_element_find(cx, cx.well_known_symbols.capability().cast())
+            .private_element_find(cx, cx.symbols.capability().cast())
             .unwrap()
             .value()
             .cast::<PromiseCapability>();

--- a/src/js/runtime/scope.rs
+++ b/src/js/runtime/scope.rs
@@ -436,7 +436,7 @@ impl Handle<Scope> {
         }
 
         // With statements must also ignore properties in @@unscopables
-        let unscopables_key = cx.well_known_symbols.unscopables();
+        let unscopables_key = cx.symbols.unscopables();
         let unscopables = get(cx, object, unscopables_key)?;
         if unscopables.is_object() {
             let unscopables = unscopables.as_object();

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -52,7 +52,7 @@ pub fn to_primitive(
         return Ok(value);
     }
 
-    let to_primitive_key = cx.well_known_symbols.to_primitive();
+    let to_primitive_key = cx.symbols.to_primitive();
     let exotic_prim = get_method(cx, value, to_primitive_key)?;
     match exotic_prim {
         Some(exotic_prim) => {
@@ -772,7 +772,7 @@ pub fn is_regexp(cx: Context, value: Handle<Value>) -> EvalResult<bool> {
     }
 
     let object = value.as_object();
-    let match_key = cx.well_known_symbols.match_();
+    let match_key = cx.symbols.match_();
     let matcher = get(cx, object, match_key)?;
 
     if !matcher.is_undefined() {


### PR DESCRIPTION
## Summary

Rename the `Context` field `well_known_symbols` to just `symbols` for conciseness and since it contains other builtin symbols beyond the spec's set of "well known symbols".

## Tests

- CI