### PR TITLE
[runtime] Use numeric try_from conversions instead of bounds checks followed by casts

### DIFF
--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -191,11 +191,7 @@ impl RustRuntimeFunctionRegistry {
     /// Register a new Rust runtime function and return its assigned id.
     pub fn register(&mut self, function: RuntimeFunctionPtr) -> Option<RuntimeFunctionId> {
         // Check that we have room to register another function
-        if self.id_to_function.len() >= u16::MAX as usize {
-            return None;
-        }
-
-        let id = self.id_to_function.len() as RuntimeFunctionId;
+        let id = RuntimeFunctionId::try_from(self.id_to_function.len()).ok()?;
         self.id_to_function.push(function);
 
         Some(id)

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -757,7 +757,7 @@ impl StringPrototype {
             return Ok(string.as_value());
         }
 
-        if int_max_length > u32::MAX as u64 {
+        let Ok(int_max_length) = u32::try_from(int_max_length) else {
             return range_error(
                 cx,
                 &format!(
@@ -765,9 +765,7 @@ impl StringPrototype {
                     method_name
                 ),
             );
-        }
-
-        let int_max_length = int_max_length as u32;
+        };
         let fill_length = int_max_length - string_length;
 
         // Find the number of whole pad strings we can fit into the padding length

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -935,8 +935,8 @@ pub fn to_property_key(
     let value = *value_handle;
     if value.is_smi() {
         let smi_value = value.as_smi();
-        if smi_value >= 0 {
-            return Ok(PropertyKey::array_index_handle(cx, smi_value as u32)?);
+        if let Ok(array_index) = u32::try_from(smi_value) {
+            return Ok(PropertyKey::array_index_handle(cx, array_index)?);
         }
     }
 

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -378,36 +378,36 @@ impl Value {
             Value::raw_smi(value.as_())
         } else if T::IS_U32 {
             let value_u32: u32 = value.as_();
-            if value_u32 <= i32::MAX as u32 {
-                Value::raw_smi(value.as_())
+            if let Ok(smi) = i32::try_from(value_u32) {
+                Value::raw_smi(smi)
             } else {
                 Value::raw_double(value.as_())
             }
         } else if T::IS_U64 {
             let value_u64: u64 = value.as_();
-            if value_u64 <= i32::MAX as u64 {
-                Value::raw_smi(value.as_())
+            if let Ok(smi) = i32::try_from(value_u64) {
+                Value::raw_smi(smi)
             } else {
                 Value::raw_double(value.as_())
             }
         } else if T::IS_I64 {
             let value_i64: i64 = value.as_();
-            if (i32::MIN as i64..=i32::MAX as i64).contains(&value_i64) {
-                Value::raw_smi(value.as_())
+            if let Ok(smi) = i32::try_from(value_i64) {
+                Value::raw_smi(smi)
             } else {
                 Value::raw_double(value.as_())
             }
         } else if T::IS_USIZE {
             let value_usize: usize = value.as_();
-            if value_usize <= i32::MAX as usize {
-                Value::raw_smi(value.as_())
+            if let Ok(smi) = i32::try_from(value_usize) {
+                Value::raw_smi(smi)
             } else {
                 Value::raw_double(value.as_())
             }
         } else if T::IS_ISIZE {
             let value_isize: isize = value.as_();
-            if (i32::MIN as isize..=i32::MAX as isize).contains(&value_isize) {
-                Value::raw_smi(value.as_())
+            if let Ok(smi) = i32::try_from(value_isize) {
+                Value::raw_smi(smi)
             } else {
                 Value::raw_double(value.as_())
             }


### PR DESCRIPTION
## Summary

Misc cleanup of some manual numeric bounds checks followed by casts that can be replaced by `try_from`.

## Tests

- CI