### PR TITLE
[runtime] Use IntrinsicsBuilder and macros to set up builtin objects

### DIFF
--- a/src/js/runtime/console.rs
+++ b/src/js/runtime/console.rs
@@ -3,16 +3,17 @@ use crate::{
         error::{ErrorFormatter, FormatOptions},
         terminal::stdout_should_use_colors,
     },
+    intrinsic_methods,
     runtime::{
         Arguments, Context, Handle, Value,
         alloc_error::AllocResult,
         eval_result::EvalResult,
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             error_constructor::{ErrorObject, new_heap_source_info},
             error_prototype::{error_message, error_name},
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
         },
         object_value::ObjectValue,
         realm::Realm,
@@ -34,40 +35,17 @@ pub struct ConsoleObject;
 
 impl ConsoleObject {
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
-        object.intrinsic_func(
-            cx,
-            cx.names.debug(),
-            RuntimeFunction::ConsoleObject_debug,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.error_(),
-            RuntimeFunction::ConsoleObject_error,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.info(),
-            RuntimeFunction::ConsoleObject_info,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(cx, cx.names.log(), RuntimeFunction::ConsoleObject_log, 0, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.warn(),
-            RuntimeFunction::ConsoleObject_warn,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            debug  ConsoleObject_debug (0),
+            error_ ConsoleObject_error (0),
+            info   ConsoleObject_info  (0),
+            log    ConsoleObject_log   (0),
+            warn   ConsoleObject_warn  (0),
+        });
 
-        Ok(object.to_handle())
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/gc_object.rs
+++ b/src/js/runtime/gc_object.rs
@@ -1,11 +1,12 @@
 use crate::{
-    handle_scope, must_a,
+    handle_scope, intrinsic_methods, must_a,
     runtime::{
         Context, Handle, PropertyDescriptor,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         gc::{GcType, Heap},
-        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        intrinsic_builder::IntrinsicBuilder,
+        intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         realm::Realm,
     },
@@ -16,12 +17,13 @@ pub struct GcObject;
 
 impl GcObject {
     fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
-        object.intrinsic_func(cx, cx.names.run(), RuntimeFunction::GcObject_run, 0, realm)?;
+        intrinsic_methods!(cx, builder, {
+            run GcObject_run (0),
+        });
 
-        Ok(object.to_handle())
+        builder.build()
     }
 
     /// Install the GC object on the realm's global object.

--- a/src/js/runtime/intrinsic_builder.rs
+++ b/src/js/runtime/intrinsic_builder.rs
@@ -1,0 +1,178 @@
+use crate::{
+    handle_scope_guard,
+    runtime::{
+        Context, Handle, Realm, Value,
+        accessor::Accessor,
+        alloc_error::AllocResult,
+        builtin_function::BuiltinFunction,
+        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        object_value::ObjectValue,
+        property::Property,
+        property_key::PropertyKey,
+    },
+};
+
+/// Installs properties on an intrinsic object (prototype, constructor, or global object).
+pub struct IntrinsicBuilder {
+    cx: Context,
+    realm: Handle<Realm>,
+    object: Handle<ObjectValue>,
+}
+
+impl IntrinsicBuilder {
+    /// Wrap an already-created object.
+    pub fn new(cx: Context, realm: Handle<Realm>, object: Handle<ObjectValue>) -> Self {
+        Self { cx, realm, object }
+    }
+
+    /// Create an ordinary object with the given prototype.
+    pub fn object(cx: Context, realm: Handle<Realm>, prototype: Intrinsic) -> AllocResult<Self> {
+        let object = ObjectValue::new(cx, Some(realm.get_intrinsic(prototype)), true)?;
+        Ok(Self::new(cx, realm, object))
+    }
+
+    /// Create a constructor function object with the given prototype.
+    pub fn constructor(
+        cx: Context,
+        realm: Handle<Realm>,
+        func: RuntimeFunction,
+        length: u32,
+        name: Handle<PropertyKey>,
+        prototype: Intrinsic,
+    ) -> AllocResult<Self> {
+        let object =
+            BuiltinFunction::intrinsic_constructor(cx, func, length, name, realm, prototype)?;
+        Ok(Self::new(cx, realm, object))
+    }
+
+    /// Install a builtin method (writable, non-enumerable, configurable).
+    pub fn method(
+        &mut self,
+        name: Handle<PropertyKey>,
+        func: RuntimeFunction,
+        length: u32,
+    ) -> AllocResult<()> {
+        handle_scope_guard!(self.cx);
+
+        let func = BuiltinFunction::create(self.cx, func, length, name, self.realm, None)?.into();
+        let property = Property::data(func, true, false, true);
+        self.object.set_property(self.cx, name, property)
+    }
+
+    /// Install a data property (writable, non-enumerable, configurable).
+    pub fn data(&mut self, name: Handle<PropertyKey>, value: Handle<Value>) -> AllocResult<()> {
+        handle_scope_guard!(self.cx);
+
+        let property = Property::data(value, true, false, true);
+        self.object.set_property(self.cx, name, property)
+    }
+
+    /// Install a getter-only accessor (non-enumerable, configurable).
+    pub fn getter(&mut self, name: Handle<PropertyKey>, func: RuntimeFunction) -> AllocResult<()> {
+        handle_scope_guard!(self.cx);
+
+        let getter = BuiltinFunction::create(self.cx, func, 0, name, self.realm, Some("get"))?;
+        let accessor_value = Accessor::new(self.cx, Some(getter), None)?;
+        let property = Property::accessor(accessor_value.into(), false, true);
+        self.object.set_property(self.cx, name, property)
+    }
+
+    /// Install a getter/setter accessor (non-enumerable, configurable).
+    pub fn getter_setter(
+        &mut self,
+        name: Handle<PropertyKey>,
+        getter: RuntimeFunction,
+        setter: RuntimeFunction,
+    ) -> AllocResult<()> {
+        handle_scope_guard!(self.cx);
+
+        let getter = BuiltinFunction::create(self.cx, getter, 0, name, self.realm, Some("get"))?;
+        let setter = BuiltinFunction::create(self.cx, setter, 1, name, self.realm, Some("set"))?;
+        let accessor_value = Accessor::new(self.cx, Some(getter), Some(setter))?;
+        let property = Property::accessor(accessor_value.into(), false, true);
+        self.object.set_property(self.cx, name, property)
+    }
+
+    /// Install a frozen data property (non-writable, non-enumerable, non-configurable).
+    pub fn frozen(&mut self, name: Handle<PropertyKey>, value: Handle<Value>) -> AllocResult<()> {
+        handle_scope_guard!(self.cx);
+
+        let property = Property::data(value, false, false, false);
+        self.object.set_property(self.cx, name, property)
+    }
+
+    /// Install the given intrinsic as a frozen prototype property.
+    pub fn prototype(&mut self, prototype: Intrinsic) -> AllocResult<()> {
+        let value = self.realm.get_intrinsic(prototype).into();
+        self.frozen(self.cx.names.prototype(), value)
+    }
+
+    /// Install @@toStringTag with a particular string value.
+    pub fn to_string_tag(&mut self, tag: Handle<PropertyKey>) -> AllocResult<()> {
+        let key = self.cx.symbols.to_string_tag();
+        let value = tag.as_string().into();
+        self.property(key, Property::data(value, false, false, true))
+    }
+
+    /// Install any key/property pair on the object.
+    pub fn property(&mut self, key: Handle<PropertyKey>, property: Property) -> AllocResult<()> {
+        self.object.set_property(self.cx, key, property)
+    }
+
+    /// Create a builtin function without installing it on the object.
+    pub fn function(
+        &self,
+        func: RuntimeFunction,
+        length: u32,
+        name: Handle<PropertyKey>,
+    ) -> AllocResult<Handle<ObjectValue>> {
+        BuiltinFunction::create(self.cx, func, length, name, self.realm, None)
+    }
+
+    /// Create an alias for an existing property under a new key. All attributes of the property
+    /// are preserved.
+    pub fn alias(
+        &mut self,
+        from_key: Handle<PropertyKey>,
+        to_key: Handle<PropertyKey>,
+    ) -> AllocResult<()> {
+        handle_scope_guard!(self.cx);
+
+        let property = self.object.get_property(self.cx, from_key).unwrap();
+        self.object.set_property(self.cx, to_key, property)
+    }
+
+    /// Finish, returning the object.
+    pub fn build(self) -> AllocResult<Handle<ObjectValue>> {
+        Ok(self.object)
+    }
+}
+
+/// Installs a list of builtin methods on an IntrinsicBuilder.
+/// Uses the syntax: `builtin_name RuntimeFunctionVariant (length)` for each line.
+#[macro_export]
+macro_rules! intrinsic_methods {
+    ($cx:expr, $builder:expr, { $( $name:ident $variant:ident ( $length:expr ) ),* $(,)? }) => {
+        $(
+            $builder.method(
+                $cx.names.$name(),
+                $crate::runtime::intrinsics::rust_runtime::RuntimeFunction::$variant,
+                $length,
+            )?;
+        )*
+    };
+}
+
+/// Installs a list of getters on an IntrinsicBuilder.
+/// Uses the syntax: `builtin_name RuntimeFunctionVariant` for each line.
+#[macro_export]
+macro_rules! intrinsic_getter_methods {
+    ($cx:expr, $builder:expr, { $( $name:ident $variant:ident ),* $(,)? }) => {
+        $(
+            $builder.getter(
+                $cx.names.$name(),
+                $crate::runtime::intrinsics::rust_runtime::RuntimeFunction::$variant,
+            )?;
+        )*
+    };
+}

--- a/src/js/runtime/intrinsics/aggregate_error_constructor.rs
+++ b/src/js/runtime/intrinsics/aggregate_error_constructor.rs
@@ -8,7 +8,7 @@ use crate::{
         },
         alloc_error::AllocResult,
         array_object::create_array_from_list,
-        builtin_function::BuiltinFunction,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             error_constructor::{ErrorObject, install_error_cause},
             intrinsics::Intrinsic,
@@ -45,24 +45,18 @@ pub struct AggregateErrorConstructor;
 impl AggregateErrorConstructor {
     /// Properties of the AggregateError Constructor (https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-constructors)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::AggregateErrorConstructor_construct,
             2,
             cx.names.aggregate_error(),
-            realm,
             Intrinsic::ErrorConstructor,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm
-                .get_intrinsic(Intrinsic::AggregateErrorPrototype)
-                .into(),
-        )?;
+        builder.prototype(Intrinsic::AggregateErrorPrototype)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/aggregate_error_prototype.rs
+++ b/src/js/runtime/intrinsics/aggregate_error_prototype.rs
@@ -1,6 +1,6 @@
 use crate::runtime::{
-    Context, Handle, alloc_error::AllocResult, intrinsics::intrinsics::Intrinsic,
-    object_value::ObjectValue, realm::Realm,
+    Context, Handle, alloc_error::AllocResult, intrinsic_builder::IntrinsicBuilder,
+    intrinsics::intrinsics::Intrinsic, object_value::ObjectValue, realm::Realm,
 };
 
 pub struct AggregateErrorPrototype;
@@ -8,22 +8,12 @@ pub struct AggregateErrorPrototype;
 impl AggregateErrorPrototype {
     /// Properties of the AggregateError Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-prototype-objects)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ErrorPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ErrorPrototype)?;
 
         // Constructor property is added once AggregateErrorConstructor has been created
-        object.intrinsic_name_prop(cx, "AggregateError")?;
-        object.intrinsic_data_prop(
-            cx,
-            cx.names.message(),
-            cx.names.empty_string().as_string().into(),
-        )?;
-        object.intrinsic_data_prop(
-            cx,
-            cx.names.name(),
-            cx.names.aggregate_error().as_string().into(),
-        )?;
+        builder.data(cx.names.message(), cx.names.empty_string().as_string().into())?;
+        builder.data(cx.names.name(), cx.names.aggregate_error().as_string().into())?;
 
-        Ok(object.to_handle())
+        builder.build()
     }
 }

--- a/src/js/runtime/intrinsics/array_buffer_constructor.rs
+++ b/src/js/runtime/intrinsics/array_buffer_constructor.rs
@@ -1,17 +1,17 @@
 use std::mem::size_of;
 
 use crate::{
-    extend_object,
+    extend_object, intrinsic_methods,
     runtime::{
         Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         collections::{BsArray, array::ByteArray},
         error::{range_error, type_error},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         get,
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -157,34 +157,25 @@ pub struct ArrayBufferConstructor;
 impl ArrayBufferConstructor {
     /// Properties of the ArrayBuffer Constructor (https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::ArrayBufferConstructor_construct,
             1,
             cx.names.array_buffer(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::ArrayBufferPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::ArrayBufferPrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.is_view(),
-            RuntimeFunction::ArrayBufferConstructor_is_view,
-            1,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            is_view ArrayBufferConstructor_is_view (1),
+        });
 
         // get ArrayBuffer [ @@species ] (https://tc39.es/ecma262/#sec-get-arraybuffer-%symbol.species%)
-        let species_key = cx.symbols.species();
-        func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
+        builder.getter(cx.symbols.species(), RuntimeFunction::ReturnThis)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -1,4 +1,5 @@
 use crate::{
+    intrinsic_getter_methods, intrinsic_methods,
     runtime::{
         Context, EvalResult, Handle, Value,
         abstract_operations::{construct, species_constructor},
@@ -6,15 +7,14 @@ use crate::{
         collections::BsArray,
         error::{range_error, type_error},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             array_buffer_constructor::{
                 ArrayBufferObject, array_buffer_copy_and_detach, throw_if_detached,
             },
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
         },
         object_value::ObjectValue,
-        property::Property,
         realm::Realm,
         type_utilities::{resolve_relative_index_argument, to_index},
     },
@@ -26,72 +26,27 @@ pub struct ArrayBufferPrototype;
 impl ArrayBufferPrototype {
     /// Properties of the ArrayBuffer Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once ArrayBufferConstructor has been created
-        object.intrinsic_getter(
-            cx,
-            cx.names.byte_length(),
-            RuntimeFunction::ArrayBufferPrototype_get_byte_length,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.detached(),
-            RuntimeFunction::ArrayBufferPrototype_get_detached,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.max_byte_length(),
-            RuntimeFunction::ArrayBufferPrototype_get_max_byte_length,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.resize(),
-            RuntimeFunction::ArrayBufferPrototype_resize,
-            1,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.resizable(),
-            RuntimeFunction::ArrayBufferPrototype_get_resizable,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.slice(),
-            RuntimeFunction::ArrayBufferPrototype_slice,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.transfer(),
-            RuntimeFunction::ArrayBufferPrototype_transfer,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.transfer_to_fixed_length(),
-            RuntimeFunction::ArrayBufferPrototype_transfer_to_fixed_length,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            resize                   ArrayBufferPrototype_resize                   (1),
+            slice                    ArrayBufferPrototype_slice                    (2),
+            transfer                 ArrayBufferPrototype_transfer                 (0),
+            transfer_to_fixed_length ArrayBufferPrototype_transfer_to_fixed_length (0),
+        });
+
+        intrinsic_getter_methods!(cx, builder, {
+            byte_length     ArrayBufferPrototype_get_byte_length,
+            detached        ArrayBufferPrototype_get_detached,
+            max_byte_length ArrayBufferPrototype_get_max_byte_length,
+            resizable       ArrayBufferPrototype_get_resizable,
+        });
 
         // ArrayBuffer.prototype [ %Symbol.toStringTag% ] (https://tc39.es/ecma262/#sec-arraybuffer.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.array_buffer().as_string().into(), false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.array_buffer())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/array_constructor.rs
+++ b/src/js/runtime/intrinsics/array_constructor.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::numeric::MAX_SAFE_INTEGER_U64,
-    must,
+    intrinsic_methods, must,
     runtime::{
         Context, Handle, Realm, Value,
         abstract_operations::{
@@ -9,9 +9,9 @@ use crate::{
         },
         alloc_error::AllocResult,
         array_object::array_create,
-        builtin_function::BuiltinFunction,
         error::{range_error, type_error},
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             array_from_async_generator::ArrayFromAsyncGenerator, intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
@@ -30,43 +30,28 @@ pub struct ArrayConstructor;
 impl ArrayConstructor {
     /// Properties of the Array Constructor (https://tc39.es/ecma262/#sec-properties-of-the-array-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::ArrayConstructor_construct,
             1,
             cx.names.array(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::ArrayPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::ArrayPrototype)?;
 
-        func.intrinsic_func(cx, cx.names.from(), RuntimeFunction::ArrayConstructor_from, 1, realm)?;
-        func.intrinsic_func(
-            cx,
-            cx.names.from_async(),
-            RuntimeFunction::ArrayConstructor_from_async,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.is_array(),
-            RuntimeFunction::ArrayConstructor_is_array,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(cx, cx.names.of(), RuntimeFunction::ArrayConstructor_of, 0, realm)?;
+        intrinsic_methods!(cx, builder, {
+            from       ArrayConstructor_from       (1),
+            from_async ArrayConstructor_from_async (1),
+            is_array   ArrayConstructor_is_array   (1),
+            of         ArrayConstructor_of         (0),
+        });
 
         // get Array [ @@species ] (https://tc39.es/ecma262/#sec-get-array-%symbol.species%)
-        let species_key = cx.symbols.species();
-        func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
+        builder.getter(cx.symbols.species(), RuntimeFunction::ReturnThis)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/array_iterator.rs
+++ b/src/js/runtime/intrinsics/array_iterator.rs
@@ -1,7 +1,7 @@
 use std::mem::size_of;
 
 use crate::{
-    cast_from_value_fn, extend_object,
+    cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
         Context, Handle, HeapPtr,
         abstract_operations::length_of_array_like,
@@ -11,9 +11,9 @@ use crate::{
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
             typed_array_prototype::{
                 is_typed_array_out_of_bounds, make_typed_array_with_buffer_witness_record,
                 typed_array_length,
@@ -103,27 +103,20 @@ pub struct ArrayIteratorPrototype;
 
 impl ArrayIteratorPrototype {
     pub fn new(mut cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let proto = realm.get_intrinsic(Intrinsic::IteratorPrototype);
-        let mut object = ObjectValue::new(cx, Some(proto), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::IteratorPrototype)?;
 
-        object.intrinsic_func(
-            cx,
-            cx.names.next(),
-            RuntimeFunction::ArrayIteratorPrototype_next,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            next ArrayIteratorPrototype_next (0),
+        });
 
         // %ArrayIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
         let to_string_tag_value = cx.alloc_static_string("Array Iterator")?.into();
-        object.set_property(
-            cx,
-            to_string_tag_key,
+        builder.property(
+            cx.symbols.to_string_tag(),
             Property::data(to_string_tag_value, false, false, true),
         )?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use crate::{
     common::numeric::MAX_SAFE_INTEGER_U64,
-    must, must_a,
+    intrinsic_methods, must, must_a,
     runtime::{
         Context, EvalResult, Handle, Value,
         abstract_operations::{
@@ -11,13 +11,12 @@ use crate::{
         },
         alloc_error::AllocResult,
         array_object::{ArrayObject, array_create, array_species_create},
-        builtin_function::BuiltinFunction,
         error::{range_error, type_error},
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             array_iterator::{ArrayIterator, ArrayIteratorKind},
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
             typed_array_prototype::compare_typed_array_elements,
         },
         object_value::ObjectValue,
@@ -42,273 +41,59 @@ impl ArrayPrototype {
     /// Properties of the Array Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-array-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
         let object_proto = realm.get_intrinsic(Intrinsic::ObjectPrototype);
-        let mut array = ArrayObject::new(cx, object_proto)?.as_object();
-
-        // Create values function as it is referenced by multiple properties
-        let values_function = BuiltinFunction::create(
-            cx,
-            RuntimeFunction::ArrayPrototype_values,
-            0,
-            cx.names.values(),
-            realm,
-            None,
-        )?
-        .into();
+        let array = ArrayObject::new(cx, object_proto)?.as_object();
+        let mut builder = IntrinsicBuilder::new(cx, realm, array);
 
         // Constructor property is added once ArrayConstructor has been created
-        array.intrinsic_func(cx, cx.names.at(), RuntimeFunction::ArrayPrototype_at, 1, realm)?;
-        array.intrinsic_func(
-            cx,
-            cx.names.concat(),
-            RuntimeFunction::ArrayPrototype_concat,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.copy_within(),
-            RuntimeFunction::ArrayPrototype_copy_within,
-            2,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.entries(),
-            RuntimeFunction::ArrayPrototype_entries,
-            0,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.every(),
-            RuntimeFunction::ArrayPrototype_every,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.fill(),
-            RuntimeFunction::ArrayPrototype_fill,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.filter(),
-            RuntimeFunction::ArrayPrototype_filter,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.find(),
-            RuntimeFunction::ArrayPrototype_find,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.find_index(),
-            RuntimeFunction::ArrayPrototype_find_index,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.find_last(),
-            RuntimeFunction::ArrayPrototype_find_last,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.find_last_index(),
-            RuntimeFunction::ArrayPrototype_find_last_index,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.flat(),
-            RuntimeFunction::ArrayPrototype_flat,
-            0,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.flat_map(),
-            RuntimeFunction::ArrayPrototype_flat_map,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.for_each(),
-            RuntimeFunction::ArrayPrototype_for_each,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.includes(),
-            RuntimeFunction::ArrayPrototype_includes,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.index_of(),
-            RuntimeFunction::ArrayPrototype_index_of,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.join(),
-            RuntimeFunction::ArrayPrototype_join,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.keys(),
-            RuntimeFunction::ArrayPrototype_keys,
-            0,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.last_index_of(),
-            RuntimeFunction::ArrayPrototype_last_index_of,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(cx, cx.names.map_(), RuntimeFunction::ArrayPrototype_map, 1, realm)?;
-        array.intrinsic_func(cx, cx.names.pop(), RuntimeFunction::ArrayPrototype_pop, 0, realm)?;
-        array.intrinsic_func(
-            cx,
-            cx.names.push(),
-            RuntimeFunction::ArrayPrototype_push,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.reduce(),
-            RuntimeFunction::ArrayPrototype_reduce,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.reduce_right(),
-            RuntimeFunction::ArrayPrototype_reduce_right,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.reverse(),
-            RuntimeFunction::ArrayPrototype_reverse,
-            0,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.shift(),
-            RuntimeFunction::ArrayPrototype_shift,
-            0,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.slice(),
-            RuntimeFunction::ArrayPrototype_slice,
-            2,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.some(),
-            RuntimeFunction::ArrayPrototype_some,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.sort(),
-            RuntimeFunction::ArrayPrototype_sort,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.splice(),
-            RuntimeFunction::ArrayPrototype_splice,
-            2,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.to_locale_string(),
-            RuntimeFunction::ArrayPrototype_to_locale_string,
-            0,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.to_reversed(),
-            RuntimeFunction::ArrayPrototype_to_reversed,
-            0,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.to_sorted(),
-            RuntimeFunction::ArrayPrototype_to_sorted,
-            1,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.to_spliced(),
-            RuntimeFunction::ArrayPrototype_to_spliced,
-            2,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::ArrayPrototype_to_string,
-            0,
-            realm,
-        )?;
-        array.intrinsic_func(
-            cx,
-            cx.names.unshift(),
-            RuntimeFunction::ArrayPrototype_unshift,
-            1,
-            realm,
-        )?;
-        array.intrinsic_data_prop(cx, cx.names.values(), values_function)?;
-        array.intrinsic_func(
-            cx,
-            cx.names.with(),
-            RuntimeFunction::ArrayPrototype_with,
-            2,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            at               ArrayPrototype_at               (1),
+            concat           ArrayPrototype_concat           (1),
+            copy_within      ArrayPrototype_copy_within      (2),
+            entries          ArrayPrototype_entries          (0),
+            every            ArrayPrototype_every            (1),
+            fill             ArrayPrototype_fill             (1),
+            filter           ArrayPrototype_filter           (1),
+            find             ArrayPrototype_find             (1),
+            find_index       ArrayPrototype_find_index       (1),
+            find_last        ArrayPrototype_find_last        (1),
+            find_last_index  ArrayPrototype_find_last_index  (1),
+            flat             ArrayPrototype_flat             (0),
+            flat_map         ArrayPrototype_flat_map         (1),
+            for_each         ArrayPrototype_for_each         (1),
+            includes         ArrayPrototype_includes         (1),
+            index_of         ArrayPrototype_index_of         (1),
+            join             ArrayPrototype_join             (1),
+            keys             ArrayPrototype_keys             (0),
+            last_index_of    ArrayPrototype_last_index_of    (1),
+            map_             ArrayPrototype_map              (1),
+            pop              ArrayPrototype_pop              (0),
+            push             ArrayPrototype_push             (1),
+            reduce           ArrayPrototype_reduce           (1),
+            reduce_right     ArrayPrototype_reduce_right     (1),
+            reverse          ArrayPrototype_reverse          (0),
+            shift            ArrayPrototype_shift            (0),
+            slice            ArrayPrototype_slice            (2),
+            some             ArrayPrototype_some             (1),
+            sort             ArrayPrototype_sort             (1),
+            splice           ArrayPrototype_splice           (2),
+            to_locale_string ArrayPrototype_to_locale_string (0),
+            to_reversed      ArrayPrototype_to_reversed      (0),
+            to_sorted        ArrayPrototype_to_sorted        (1),
+            to_spliced       ArrayPrototype_to_spliced       (2),
+            to_string        ArrayPrototype_to_string        (0),
+            unshift          ArrayPrototype_unshift          (1),
+            values           ArrayPrototype_values           (0),
+            with             ArrayPrototype_with             (2),
+        });
 
         // Array.prototype [ @@iterator ] (https://tc39.es/ecma262/#sec-array.prototype-%symbol.iterator%)
-        let iterator_key = cx.symbols.iterator();
-        array.set_property(cx, iterator_key, Property::data(values_function, true, false, true))?;
+        builder.alias(cx.names.values(), cx.symbols.iterator())?;
 
         // Array.prototype [ @@unscopables ] (https://tc39.es/ecma262/#sec-array.prototype-%symbol.unscopables%)
-        let unscopables_key = cx.symbols.unscopables();
         let unscopables = Property::data(Self::create_unscopables(cx)?.into(), false, false, true);
-        array.set_property(cx, unscopables_key, unscopables)?;
+        builder.property(cx.symbols.unscopables(), unscopables)?;
 
-        Ok(array)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
@@ -1,5 +1,5 @@
 use crate::{
-    eval_err, extend_object, if_abrupt_reject_promise, must,
+    eval_err, extend_object, if_abrupt_reject_promise, intrinsic_methods, must,
     runtime::{
         Context, Handle, HeapPtr, Value,
         abstract_operations::{call_object, get_method},
@@ -9,6 +9,7 @@ use crate::{
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic, promise_prototype::perform_promise_then,
             rust_runtime::RuntimeFunction,
@@ -74,35 +75,15 @@ pub struct AsyncFromSyncIteratorPrototype;
 impl AsyncFromSyncIteratorPrototype {
     /// The %AsyncFromSyncIteratorPrototype% Object (https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object = ObjectValue::new(
-            cx,
-            Some(realm.get_intrinsic(Intrinsic::AsyncIteratorPrototype)),
-            true,
-        )?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::AsyncIteratorPrototype)?;
 
-        object.intrinsic_func(
-            cx,
-            cx.names.next(),
-            RuntimeFunction::AsyncFromSyncIteratorPrototype_next,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.return_(),
-            RuntimeFunction::AsyncFromSyncIteratorPrototype_return_,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.throw(),
-            RuntimeFunction::AsyncFromSyncIteratorPrototype_throw,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            next    AsyncFromSyncIteratorPrototype_next    (0),
+            return_ AsyncFromSyncIteratorPrototype_return_ (0),
+            throw   AsyncFromSyncIteratorPrototype_throw   (0),
+        });
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/async_function_constructor.rs
+++ b/src/js/runtime/intrinsics/async_function_constructor.rs
@@ -2,8 +2,8 @@ use crate::{
     runtime::{
         Context, Handle,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         eval::create_dynamic_function::create_dynamic_function,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         realm::Realm,
@@ -16,24 +16,18 @@ pub struct AsyncFunctionConstructor;
 impl AsyncFunctionConstructor {
     /// Properties of the AsyncFunction Constructor (https://tc39.es/ecma262/#sec-async-function-constructor-properties)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::AsyncFunctionConstructor_construct,
             1,
             cx.names.async_function(),
-            realm,
             Intrinsic::FunctionConstructor,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm
-                .get_intrinsic(Intrinsic::AsyncFunctionPrototype)
-                .into(),
-        )?;
+        builder.prototype(Intrinsic::AsyncFunctionPrototype)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/async_function_prototype.rs
+++ b/src/js/runtime/intrinsics/async_function_prototype.rs
@@ -1,6 +1,6 @@
 use crate::runtime::{
-    Context, Handle, alloc_error::AllocResult, intrinsics::intrinsics::Intrinsic,
-    object_value::ObjectValue, property::Property, realm::Realm,
+    Context, Handle, alloc_error::AllocResult, intrinsic_builder::IntrinsicBuilder,
+    intrinsics::intrinsics::Intrinsic, object_value::ObjectValue, realm::Realm,
 };
 
 pub struct AsyncFunctionPrototype;
@@ -8,19 +8,13 @@ pub struct AsyncFunctionPrototype;
 impl AsyncFunctionPrototype {
     /// Properties of the AsyncFunction Prototype Object (https://tc39.es/ecma262/#sec-async-function-prototype-properties)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::FunctionPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::FunctionPrototype)?;
 
         // Constructor property is added once AsyncFunctionConstructor has been created
 
         // AsyncFunction.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-async-function-prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.async_function().as_string().into(), false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.async_function())?;
 
-        Ok(object)
+        builder.build()
     }
 }

--- a/src/js/runtime/intrinsics/async_generator_function_constructor.rs
+++ b/src/js/runtime/intrinsics/async_generator_function_constructor.rs
@@ -2,8 +2,8 @@ use crate::{
     runtime::{
         Context, Handle,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         eval::create_dynamic_function::create_dynamic_function,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         realm::Realm,
@@ -16,24 +16,18 @@ pub struct AsyncGeneratorFunctionConstructor;
 impl AsyncGeneratorFunctionConstructor {
     /// Properties of the AsyncGeneratorFunction Constructor (https://tc39.es/ecma262/#sec-properties-of-asyncgeneratorfunction)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::AsyncGeneratorFunctionConstructor_construct,
             1,
             cx.names.async_generator_function(),
-            realm,
             Intrinsic::FunctionConstructor,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm
-                .get_intrinsic(Intrinsic::AsyncGeneratorFunctionPrototype)
-                .into(),
-        )?;
+        builder.prototype(Intrinsic::AsyncGeneratorFunctionPrototype)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/async_generator_function_prototype.rs
+++ b/src/js/runtime/intrinsics/async_generator_function_prototype.rs
@@ -1,6 +1,6 @@
 use crate::runtime::{
-    Context, Handle, alloc_error::AllocResult, intrinsics::intrinsics::Intrinsic,
-    object_value::ObjectValue, property::Property, realm::Realm,
+    Context, Handle, alloc_error::AllocResult, intrinsic_builder::IntrinsicBuilder,
+    intrinsics::intrinsics::Intrinsic, object_value::ObjectValue, property::Property, realm::Realm,
 };
 
 pub struct AsyncGeneratorFunctionPrototype;
@@ -8,29 +8,17 @@ pub struct AsyncGeneratorFunctionPrototype;
 impl AsyncGeneratorFunctionPrototype {
     /// Properties of the AsyncGeneratorFunction Prototype Object (https://tc39.es/ecma262/#sec-properties-of-asyncgeneratorfunction-prototype)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::FunctionPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::FunctionPrototype)?;
 
         // Constructor property is added once AsyncGeneratorFunctionConstructor has been created
 
         // AsyncGeneratorFunction.prototype.prototype (https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-prototype)
         let proto = realm.get_intrinsic(Intrinsic::AsyncGeneratorPrototype);
-        let proto_prop = Property::data(proto.into(), false, false, true);
-        object.set_property(cx, cx.names.prototype(), proto_prop)?;
+        builder.property(cx.names.prototype(), Property::data(proto.into(), false, false, true))?;
 
         // AsyncGeneratorFunction.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(
-                cx.names.async_generator_function().as_string().into(),
-                false,
-                false,
-                true,
-            ),
-        )?;
+        builder.to_string_tag(cx.names.async_generator_function())?;
 
-        Ok(object)
+        builder.build()
     }
 }

--- a/src/js/runtime/intrinsics/async_generator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_generator_prototype.rs
@@ -1,5 +1,5 @@
 use crate::{
-    if_abrupt_reject_promise, must,
+    if_abrupt_reject_promise, intrinsic_methods, must,
     runtime::{
         Context, Handle,
         abstract_operations::{call_object, define_property_or_throw},
@@ -12,12 +12,12 @@ use crate::{
         eval_result::EvalResult,
         generator_object::GeneratorCompletionType,
         heap_item_descriptor::HeapItemKind,
-        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        intrinsic_builder::IntrinsicBuilder,
+        intrinsics::intrinsics::Intrinsic,
         iterator::create_iter_result_object,
         object_value::ObjectValue,
         ordinary_object::object_create,
         promise_object::PromiseCapability,
-        property::Property,
         property_descriptor::PropertyDescriptor,
         realm::Realm,
     },
@@ -29,45 +29,19 @@ pub struct AsyncGeneratorPrototype;
 impl AsyncGeneratorPrototype {
     /// The %AsyncGeneratorPrototype% Object (https://tc39.es/ecma262/#sec-properties-of-asyncgenerator-prototype)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object = ObjectValue::new(
-            cx,
-            Some(realm.get_intrinsic(Intrinsic::AsyncIteratorPrototype)),
-            true,
-        )?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::AsyncIteratorPrototype)?;
 
         // Constructor property is added once AsyncGeneratorFunctionPrototype has been created
-
-        object.intrinsic_func(
-            cx,
-            cx.names.next(),
-            RuntimeFunction::AsyncGeneratorPrototype_next,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.return_(),
-            RuntimeFunction::AsyncGeneratorPrototype_return_,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.throw(),
-            RuntimeFunction::AsyncGeneratorPrototype_throw,
-            1,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            next    AsyncGeneratorPrototype_next    (1),
+            return_ AsyncGeneratorPrototype_return_ (1),
+            throw   AsyncGeneratorPrototype_throw   (1),
+        });
 
         // %AsyncGeneratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-asyncgenerator-prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.async_generator().as_string().into(), false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.async_generator())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/async_iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_iterator_prototype.rs
@@ -1,6 +1,7 @@
 use crate::runtime::{
     Context, Handle,
     alloc_error::AllocResult,
+    intrinsic_builder::IntrinsicBuilder,
     intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
     object_value::ObjectValue,
     realm::Realm,
@@ -11,13 +12,11 @@ pub struct AsyncIteratorPrototype;
 
 impl AsyncIteratorPrototype {
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // %AsyncIteratorPrototype% [ @@asyncIterator ] (https://tc39.es/ecma262/#sec-%asynciteratorprototype%-%symbol.asynciterator%)
-        let async_iterator_key = cx.symbols.async_iterator();
-        object.intrinsic_func(cx, async_iterator_key, RuntimeFunction::ReturnThis, 0, realm)?;
+        builder.method(cx.symbols.async_iterator(), RuntimeFunction::ReturnThis, 0)?;
 
-        Ok(object)
+        builder.build()
     }
 }

--- a/src/js/runtime/intrinsics/bigint_constructor.rs
+++ b/src/js/runtime/intrinsics/bigint_constructor.rs
@@ -4,15 +4,15 @@ use num_bigint::BigInt;
 use num_traits::FromPrimitive;
 
 use crate::{
-    extend_object,
+    extend_object, intrinsic_methods,
     runtime::{
         Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::{range_error, type_error},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         ordinary_object::object_create,
@@ -59,37 +59,23 @@ pub struct BigIntConstructor;
 impl BigIntConstructor {
     //// The BigInt Constructor (https://tc39.es/ecma262/#sec-bigint-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::BigIntConstructor_construct,
             1,
             cx.names.bigint(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::BigIntPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::BigIntPrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.as_int_n(),
-            RuntimeFunction::BigIntConstructor_as_int_n,
-            2,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.as_uint_n(),
-            RuntimeFunction::BigIntConstructor_as_uint_n,
-            2,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            as_int_n  BigIntConstructor_as_int_n  (2),
+            as_uint_n BigIntConstructor_as_uint_n (2),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/bigint_prototype.rs
+++ b/src/js/runtime/intrinsics/bigint_prototype.rs
@@ -1,14 +1,13 @@
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Value,
         alloc_error::AllocResult,
         error::{range_error, type_error},
         eval_result::EvalResult,
-        intrinsics::{
-            bigint_constructor::BigIntObject, intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
-        },
+        intrinsic_builder::IntrinsicBuilder,
+        intrinsics::{bigint_constructor::BigIntObject, intrinsics::Intrinsic},
         object_value::ObjectValue,
-        property::Property,
         realm::Realm,
         type_utilities::to_integer_or_infinity,
         value::BigIntValue,
@@ -21,34 +20,18 @@ pub struct BigIntPrototype;
 impl BigIntPrototype {
     /// Properties of the BigInt Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-bigint-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once BigIntConstructor has been created
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::BigIntPrototype_to_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::BigIntPrototype_value_of,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            to_string BigIntPrototype_to_string (0),
+            value_of  BigIntPrototype_value_of  (0),
+        });
 
         // BigInt.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-bigint.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.bigint().as_string().into(), false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.bigint())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/boolean_constructor.rs
+++ b/src/js/runtime/intrinsics/boolean_constructor.rs
@@ -5,10 +5,10 @@ use crate::{
     runtime::{
         Context, HeapPtr,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         ordinary_object::{
@@ -85,22 +85,18 @@ pub struct BooleanConstructor;
 impl BooleanConstructor {
     /// Properties of the Boolean Constructor (https://tc39.es/ecma262/#sec-properties-of-the-boolean-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::BooleanConstructor_construct,
             1,
             cx.names.boolean(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::BooleanPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::BooleanPrototype)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/boolean_prototype.rs
+++ b/src/js/runtime/intrinsics/boolean_prototype.rs
@@ -1,13 +1,12 @@
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Value,
         alloc_error::AllocResult,
         error::type_error,
         eval_result::EvalResult,
-        intrinsics::{
-            boolean_constructor::BooleanObject, intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
-        },
+        intrinsic_builder::IntrinsicBuilder,
+        intrinsics::{boolean_constructor::BooleanObject, intrinsics::Intrinsic},
         object_value::ObjectValue,
         realm::Realm,
     },
@@ -20,25 +19,16 @@ impl BooleanPrototype {
     /// Properties of the Boolean Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-boolean-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
         let object_proto = realm.get_intrinsic(Intrinsic::ObjectPrototype);
-        let object = BooleanObject::new_with_proto(cx, object_proto, false)?;
+        let object = BooleanObject::new_with_proto(cx, object_proto, false)?.as_object();
+        let mut builder = IntrinsicBuilder::new(cx, realm, object);
 
         // Constructor property is added once BooleanConstructor has been created
-        object.as_object().intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::BooleanPrototype_to_string,
-            0,
-            realm,
-        )?;
-        object.as_object().intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::BooleanPrototype_value_of,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            to_string BooleanPrototype_to_string (0),
+            value_of  BooleanPrototype_value_of  (0),
+        });
 
-        Ok(object.into())
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/data_view_constructor.rs
+++ b/src/js/runtime/intrinsics/data_view_constructor.rs
@@ -5,11 +5,11 @@ use crate::{
     runtime::{
         Context, Handle, HeapPtr,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::{range_error, type_error},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             array_buffer_constructor::{ArrayBufferObject, throw_if_detached},
             intrinsics::Intrinsic,
@@ -79,22 +79,18 @@ pub struct DataViewConstructor;
 impl DataViewConstructor {
     /// Properties of the DataView Constructor (https://tc39.es/ecma262/#sec-properties-of-the-dataview-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::DataViewConstructor_construct,
             1,
             cx.names.data_view(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::DataViewPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::DataViewPrototype)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/data_view_prototype.rs
+++ b/src/js/runtime/intrinsics/data_view_prototype.rs
@@ -1,14 +1,15 @@
 use half::f16;
 
 use crate::{
+    intrinsic_getter_methods, intrinsic_methods,
     runtime::{
         Arguments, Context, EvalResult, Handle, Value,
         alloc_error::AllocResult,
         error::{range_error, type_error},
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             data_view_constructor::DataViewObject,
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
             typed_array::{
                 ContentType, from_big_int64_element, from_big_uint64_element, from_float16_element,
                 from_float32_element, from_float64_element, from_int8_element, from_int16_element,
@@ -19,7 +20,6 @@ use crate::{
             },
         },
         object_value::ObjectValue,
-        property::Property,
         realm::Realm,
         type_utilities::{to_bigint, to_boolean, to_index, to_number},
     },
@@ -31,192 +31,44 @@ pub struct DataViewPrototype;
 impl DataViewPrototype {
     /// Properties of the DataView Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-dataview-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once DataViewConstructor has been created
-        object.intrinsic_getter(
-            cx,
-            cx.names.buffer(),
-            RuntimeFunction::DataViewPrototype_get_buffer,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.byte_length(),
-            RuntimeFunction::DataViewPrototype_get_byte_length,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.byte_offset(),
-            RuntimeFunction::DataViewPrototype_get_byte_offset,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_big_int64(),
-            RuntimeFunction::DataViewPrototype_get_big_int64,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_big_uint64(),
-            RuntimeFunction::DataViewPrototype_get_big_uint64,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_float16(),
-            RuntimeFunction::DataViewPrototype_get_float16,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_float32(),
-            RuntimeFunction::DataViewPrototype_get_float32,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_float64(),
-            RuntimeFunction::DataViewPrototype_get_float64,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_int8(),
-            RuntimeFunction::DataViewPrototype_get_int8,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_int16(),
-            RuntimeFunction::DataViewPrototype_get_int16,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_int32(),
-            RuntimeFunction::DataViewPrototype_get_int32,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_uint8(),
-            RuntimeFunction::DataViewPrototype_get_uint8,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_uint16(),
-            RuntimeFunction::DataViewPrototype_get_uint16,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_uint32(),
-            RuntimeFunction::DataViewPrototype_get_uint32,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_big_int64(),
-            RuntimeFunction::DataViewPrototype_set_big_int64,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_big_uint64(),
-            RuntimeFunction::DataViewPrototype_set_big_uint64,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_float16(),
-            RuntimeFunction::DataViewPrototype_set_float16,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_float32(),
-            RuntimeFunction::DataViewPrototype_set_float32,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_float64(),
-            RuntimeFunction::DataViewPrototype_set_float64,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_int8(),
-            RuntimeFunction::DataViewPrototype_set_int8,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_int16(),
-            RuntimeFunction::DataViewPrototype_set_int16,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_int32(),
-            RuntimeFunction::DataViewPrototype_set_int32,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_uint8(),
-            RuntimeFunction::DataViewPrototype_set_uint8,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_uint16(),
-            RuntimeFunction::DataViewPrototype_set_uint16,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_uint32(),
-            RuntimeFunction::DataViewPrototype_set_uint32,
-            2,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            get_big_int64  DataViewPrototype_get_big_int64  (1),
+            get_big_uint64 DataViewPrototype_get_big_uint64 (1),
+            get_float16    DataViewPrototype_get_float16    (1),
+            get_float32    DataViewPrototype_get_float32    (1),
+            get_float64    DataViewPrototype_get_float64    (1),
+            get_int8       DataViewPrototype_get_int8       (1),
+            get_int16      DataViewPrototype_get_int16      (1),
+            get_int32      DataViewPrototype_get_int32      (1),
+            get_uint8      DataViewPrototype_get_uint8      (1),
+            get_uint16     DataViewPrototype_get_uint16     (1),
+            get_uint32     DataViewPrototype_get_uint32     (1),
+            set_big_int64  DataViewPrototype_set_big_int64  (2),
+            set_big_uint64 DataViewPrototype_set_big_uint64 (2),
+            set_float16    DataViewPrototype_set_float16    (2),
+            set_float32    DataViewPrototype_set_float32    (2),
+            set_float64    DataViewPrototype_set_float64    (2),
+            set_int8       DataViewPrototype_set_int8       (2),
+            set_int16      DataViewPrototype_set_int16      (2),
+            set_int32      DataViewPrototype_set_int32      (2),
+            set_uint8      DataViewPrototype_set_uint8      (2),
+            set_uint16     DataViewPrototype_set_uint16     (2),
+            set_uint32     DataViewPrototype_set_uint32     (2),
+        });
+
+        intrinsic_getter_methods!(cx, builder, {
+            buffer      DataViewPrototype_get_buffer,
+            byte_length DataViewPrototype_get_byte_length,
+            byte_offset DataViewPrototype_get_byte_offset,
+        });
 
         // DataView.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-dataview.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.data_view().as_string().into(), false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.data_view())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/date_constructor.rs
+++ b/src/js/runtime/intrinsics/date_constructor.rs
@@ -1,9 +1,10 @@
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         gc::Handle,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             date_object::{
                 DateObject, make_date, make_day, make_full_year, make_time, time_clip, utc,
@@ -26,32 +27,24 @@ pub struct DateConstructor;
 impl DateConstructor {
     /// The Date Constructor (https://tc39.es/ecma262/#sec-date-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::DateConstructor_construct,
             7,
             cx.names.date(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::DatePrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::DatePrototype)?;
 
-        func.intrinsic_func(cx, cx.names.now_(), RuntimeFunction::DateConstructor_now, 0, realm)?;
-        func.intrinsic_func(
-            cx,
-            cx.names.parse(),
-            RuntimeFunction::DateConstructor_parse,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(cx, cx.names.utc(), RuntimeFunction::DateConstructor_utc, 7, realm)?;
+        intrinsic_methods!(cx, builder, {
+            now_  DateConstructor_now   (0),
+            parse DateConstructor_parse (1),
+            utc   DateConstructor_utc   (7),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -1,13 +1,13 @@
 use crate::{
     common::constants::NANOSECONDS_IN_ONE_MILLISECOND,
-    must_a,
+    intrinsic_methods, must_a,
     runtime::{
         Context, EvalResult, Handle, PropertyKey, Realm, Value,
         abstract_operations::invoke,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::{range_error, type_error},
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             bigint_constructor::number_to_bigint,
             date_object::{
@@ -35,371 +35,91 @@ pub struct DatePrototype;
 impl DatePrototype {
     /// Properties of the Date Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-date-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once DateConstructor has been created
-        object.intrinsic_func(
-            cx,
-            cx.names.get_date(),
-            RuntimeFunction::DatePrototype_get_date,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_day(),
-            RuntimeFunction::DatePrototype_get_day,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_full_year(),
-            RuntimeFunction::DatePrototype_get_full_year,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_hours(),
-            RuntimeFunction::DatePrototype_get_hours,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_milliseconds(),
-            RuntimeFunction::DatePrototype_get_milliseconds,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_minutes(),
-            RuntimeFunction::DatePrototype_get_minutes,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_month(),
-            RuntimeFunction::DatePrototype_get_month,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_seconds(),
-            RuntimeFunction::DatePrototype_get_seconds,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_time(),
-            RuntimeFunction::DatePrototype_get_time,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_timezone_offset(),
-            RuntimeFunction::DatePrototype_get_timezone_offset,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_utc_date(),
-            RuntimeFunction::DatePrototype_get_utc_date,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_utc_day(),
-            RuntimeFunction::DatePrototype_get_utc_day,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_utc_full_year(),
-            RuntimeFunction::DatePrototype_get_utc_full_year,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_utc_hours(),
-            RuntimeFunction::DatePrototype_get_utc_hours,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_utc_milliseconds(),
-            RuntimeFunction::DatePrototype_get_utc_milliseconds,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_utc_minutes(),
-            RuntimeFunction::DatePrototype_get_utc_minutes,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_utc_month(),
-            RuntimeFunction::DatePrototype_get_utc_month,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_utc_seconds(),
-            RuntimeFunction::DatePrototype_get_utc_seconds,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_date(),
-            RuntimeFunction::DatePrototype_set_date,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_full_year(),
-            RuntimeFunction::DatePrototype_set_full_year,
-            3,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_hours(),
-            RuntimeFunction::DatePrototype_set_hours,
-            4,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_milliseconds(),
-            RuntimeFunction::DatePrototype_set_milliseconds,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_minutes(),
-            RuntimeFunction::DatePrototype_set_minutes,
-            3,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_month(),
-            RuntimeFunction::DatePrototype_set_month,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_seconds(),
-            RuntimeFunction::DatePrototype_set_seconds,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_time(),
-            RuntimeFunction::DatePrototype_set_time,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_utc_date(),
-            RuntimeFunction::DatePrototype_set_utc_date,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_utc_full_year(),
-            RuntimeFunction::DatePrototype_set_utc_full_year,
-            3,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_utc_hours(),
-            RuntimeFunction::DatePrototype_set_utc_hours,
-            4,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_utc_milliseconds(),
-            RuntimeFunction::DatePrototype_set_utc_milliseconds,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_utc_minutes(),
-            RuntimeFunction::DatePrototype_set_utc_minutes,
-            3,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_utc_month(),
-            RuntimeFunction::DatePrototype_set_utc_month,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_utc_seconds(),
-            RuntimeFunction::DatePrototype_set_utc_seconds,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_date_string(),
-            RuntimeFunction::DatePrototype_to_date_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_iso_string(),
-            RuntimeFunction::DatePrototype_to_iso_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_json(),
-            RuntimeFunction::DatePrototype_to_json,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_date_string(),
-            RuntimeFunction::DatePrototype_to_locale_date_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_string(),
-            RuntimeFunction::DatePrototype_to_locale_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_time_string(),
-            RuntimeFunction::DatePrototype_to_locale_time_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::DatePrototype_to_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_temporal_instant(),
-            RuntimeFunction::DatePrototype_to_temporal_instant,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_time_string(),
-            RuntimeFunction::DatePrototype_to_time_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_utc_string(),
-            RuntimeFunction::DatePrototype_to_utc_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::DatePrototype_value_of,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            get_date              DatePrototype_get_date              (0),
+            get_day               DatePrototype_get_day               (0),
+            get_full_year         DatePrototype_get_full_year         (0),
+            get_hours             DatePrototype_get_hours             (0),
+            get_milliseconds      DatePrototype_get_milliseconds      (0),
+            get_minutes           DatePrototype_get_minutes           (0),
+            get_month             DatePrototype_get_month             (0),
+            get_seconds           DatePrototype_get_seconds           (0),
+            get_time              DatePrototype_get_time              (0),
+            get_timezone_offset   DatePrototype_get_timezone_offset   (0),
+            get_utc_date          DatePrototype_get_utc_date          (0),
+            get_utc_day           DatePrototype_get_utc_day           (0),
+            get_utc_full_year     DatePrototype_get_utc_full_year     (0),
+            get_utc_hours         DatePrototype_get_utc_hours         (0),
+            get_utc_milliseconds  DatePrototype_get_utc_milliseconds  (0),
+            get_utc_minutes       DatePrototype_get_utc_minutes       (0),
+            get_utc_month         DatePrototype_get_utc_month         (0),
+            get_utc_seconds       DatePrototype_get_utc_seconds       (0),
+            set_date              DatePrototype_set_date              (1),
+            set_full_year         DatePrototype_set_full_year         (3),
+            set_hours             DatePrototype_set_hours             (4),
+            set_milliseconds      DatePrototype_set_milliseconds      (1),
+            set_minutes           DatePrototype_set_minutes           (3),
+            set_month             DatePrototype_set_month             (2),
+            set_seconds           DatePrototype_set_seconds           (2),
+            set_time              DatePrototype_set_time              (1),
+            set_utc_date          DatePrototype_set_utc_date          (1),
+            set_utc_full_year     DatePrototype_set_utc_full_year     (3),
+            set_utc_hours         DatePrototype_set_utc_hours         (4),
+            set_utc_milliseconds  DatePrototype_set_utc_milliseconds  (1),
+            set_utc_minutes       DatePrototype_set_utc_minutes       (3),
+            set_utc_month         DatePrototype_set_utc_month         (2),
+            set_utc_seconds       DatePrototype_set_utc_seconds       (2),
+            to_date_string        DatePrototype_to_date_string        (0),
+            to_iso_string         DatePrototype_to_iso_string         (0),
+            to_json               DatePrototype_to_json               (1),
+            to_locale_date_string DatePrototype_to_locale_date_string (0),
+            to_locale_string      DatePrototype_to_locale_string      (0),
+            to_locale_time_string DatePrototype_to_locale_time_string (0),
+            to_string             DatePrototype_to_string             (0),
+            to_temporal_instant   DatePrototype_to_temporal_instant   (0),
+            to_time_string        DatePrototype_to_time_string        (0),
+            to_utc_string         DatePrototype_to_utc_string         (0),
+            value_of              DatePrototype_value_of              (0),
+        });
 
         // [Symbol.toPrimitive] property
         let to_primitive_key = cx.symbols.to_primitive();
-        let to_primitive_func = BuiltinFunction::create(
-            cx,
-            RuntimeFunction::DatePrototype_to_primitive,
-            1,
+        let to_primitive_func =
+            builder.function(RuntimeFunction::DatePrototype_to_primitive, 1, to_primitive_key)?;
+        builder.property(
             to_primitive_key,
-            realm,
-            None,
-        )?
-        .into();
-        object.set_property(
-            cx,
-            to_primitive_key,
-            Property::data(to_primitive_func, false, false, true),
+            Property::data(to_primitive_func.into(), false, false, true),
         )?;
 
-        Ok(object)
+        builder.build()
     }
 
     /// Additional Properties of the Date.prototype Object (https://tc39.es/ecma262/#sec-additional-properties-of-the-date.prototype-object)
     pub fn init_annex_b_methods(
-        mut date_prototype: Handle<ObjectValue>,
+        date_prototype: Handle<ObjectValue>,
         mut cx: Context,
         realm: Handle<Realm>,
     ) -> AllocResult<()> {
+        let mut builder = IntrinsicBuilder::new(cx, realm, date_prototype);
+
         let get_year_name = cx.alloc_static_string("getYear")?;
         let get_year_key = PropertyKey::string_not_array_index_handle(cx, get_year_name)?;
-        date_prototype.intrinsic_func(
-            cx,
-            get_year_key,
-            RuntimeFunction::DatePrototype_get_year,
-            0,
-            realm,
-        )?;
+        builder.method(get_year_key, RuntimeFunction::DatePrototype_get_year, 0)?;
 
         let set_year_name = cx.alloc_static_string("setYear")?;
         let set_year_key = PropertyKey::string_not_array_index_handle(cx, set_year_name)?;
-        date_prototype.intrinsic_func(
-            cx,
-            set_year_key,
-            RuntimeFunction::DatePrototype_set_year,
-            1,
-            realm,
-        )?;
+        builder.method(set_year_key, RuntimeFunction::DatePrototype_set_year, 1)?;
 
         // Date.prototype.toGMTString is a direct alias for Date.prototype.toUTCString
         let to_gmt_string_name = cx.alloc_static_string("toGMTString")?;
         let to_gmt_string_key = PropertyKey::string_not_array_index_handle(cx, to_gmt_string_name)?;
         let to_gmt_string_method = must_a!(get(cx, date_prototype, cx.names.to_utc_string()));
+        builder.data(to_gmt_string_key, to_gmt_string_method)?;
 
-        date_prototype.intrinsic_data_prop(cx, to_gmt_string_key, to_gmt_string_method)?;
+        builder.build()?;
 
         Ok(())
     }

--- a/src/js/runtime/intrinsics/error_constructor.rs
+++ b/src/js/runtime/intrinsics/error_constructor.rs
@@ -2,15 +2,15 @@ use std::mem::size_of;
 
 use crate::{
     common::error::SourceInfo,
-    extend_object,
+    extend_object, intrinsic_methods,
     runtime::{
         Context, Handle, HeapPtr, Value,
         abstract_operations::{create_non_enumerable_data_property_or_throw, get, has_property},
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         ordinary_object::{object_create, object_create_from_constructor},
@@ -154,30 +154,22 @@ pub struct ErrorConstructor;
 impl ErrorConstructor {
     /// Properties of the Error Constructor (https://tc39.es/ecma262/#sec-properties-of-the-error-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::ErrorConstructor_construct,
             1,
             cx.names.error(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::ErrorPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::ErrorPrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.is_error(),
-            RuntimeFunction::ErrorConstructor_is_error,
-            1,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            is_error ErrorConstructor_is_error (1),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/error_prototype.rs
+++ b/src/js/runtime/intrinsics/error_prototype.rs
@@ -1,10 +1,12 @@
 use crate::{
     common::error::FormatOptions,
+    intrinsic_methods,
     runtime::{
         Context, Handle,
         abstract_operations::get,
         alloc_error::AllocResult,
         error::type_error,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             error_constructor::ErrorObject, intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
         },
@@ -22,31 +24,18 @@ pub struct ErrorPrototype;
 impl ErrorPrototype {
     /// Properties of the Error Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-error-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once ErrorConstructor has been created
-        object.intrinsic_data_prop(cx, cx.names.name(), cx.names.error().as_string().into())?;
-        object.intrinsic_data_prop(
-            cx,
-            cx.names.message(),
-            cx.names.empty_string().as_string().into(),
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.stack(),
-            RuntimeFunction::ErrorPrototype_get_stack,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::ErrorPrototype_to_string,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            to_string ErrorPrototype_to_string (0),
+        });
 
-        Ok(object)
+        builder.data(cx.names.name(), cx.names.error().as_string().into())?;
+        builder.data(cx.names.message(), cx.names.empty_string().as_string().into())?;
+        builder.getter(cx.names.stack(), RuntimeFunction::ErrorPrototype_get_stack)?;
+
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/finalization_registry_constructor.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_constructor.rs
@@ -2,8 +2,8 @@ use crate::{
     runtime::{
         Context, Handle,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             finalization_registry_object::FinalizationRegistryObject, intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
@@ -20,24 +20,18 @@ pub struct FinalizationRegistryConstructor;
 impl FinalizationRegistryConstructor {
     /// Properties of the FinalizationRegistry Constructor (https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::FinalizationRegistryConstructor_construct,
             1,
             cx.names.finalization_registry(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm
-                .get_intrinsic(Intrinsic::FinalizationRegistryPrototype)
-                .into(),
-        )?;
+        builder.prototype(Intrinsic::FinalizationRegistryPrototype)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/finalization_registry_prototype.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_prototype.rs
@@ -1,19 +1,19 @@
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Value,
         alloc_error::AllocResult,
         error::type_error,
         eval_result::EvalResult,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             finalization_registry_object::{
                 FinalizationRegistryCell, FinalizationRegistryCells, FinalizationRegistryObject,
             },
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
             weak_ref_constructor::can_be_held_weakly,
         },
         object_value::ObjectValue,
-        property::Property,
         realm::Realm,
         type_utilities::same_value,
     },
@@ -25,34 +25,18 @@ pub struct FinalizationRegistryPrototype;
 impl FinalizationRegistryPrototype {
     /// Properties of the FinalizationRegistry Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once FinalizationRegistryConstructor has been created
-        object.intrinsic_func(
-            cx,
-            cx.names.register(),
-            RuntimeFunction::FinalizationRegistryPrototype_register,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.unregister(),
-            RuntimeFunction::FinalizationRegistryPrototype_unregister,
-            1,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            register   FinalizationRegistryPrototype_register   (2),
+            unregister FinalizationRegistryPrototype_unregister (1),
+        });
 
-        // [Symbol.toStringTag] property
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.finalization_registry().as_string().into(), false, false, true),
-        )?;
+        // FinalizationRegistry.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-finalization-registry.prototype-%symbol.tostringtag%)
+        builder.to_string_tag(cx.names.finalization_registry())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/function_constructor.rs
+++ b/src/js/runtime/intrinsics/function_constructor.rs
@@ -2,8 +2,8 @@ use crate::{
     runtime::{
         Context, Handle,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         eval::create_dynamic_function::create_dynamic_function,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         realm::Realm,
@@ -16,22 +16,18 @@ pub struct FunctionConstructor;
 impl FunctionConstructor {
     /// Properties of the Function Constructor (https://tc39.es/ecma262/#sec-properties-of-the-function-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::FunctionConstructor_construct,
             1,
             cx.names.function(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::FunctionPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::FunctionPrototype)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -1,5 +1,5 @@
 use crate::{
-    must,
+    intrinsic_methods, must,
     runtime::{
         Context, Handle, HeapPtr, Value,
         abstract_operations::{
@@ -8,16 +8,17 @@ use crate::{
         },
         alloc_error::AllocResult,
         bound_function_object::BoundFunctionObject,
-        builtin_function::BuiltinFunction,
         bytecode::function::{BytecodeFunction, Closure},
         error::type_error,
         eval_result::EvalResult,
         function::{set_function_length_maybe_infinity, set_function_name},
         get,
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         ordinary_object::{object_create_with_optional_proto, object_ordinary_init},
+        property::Property,
         property_key::PropertyKey,
         realm::Realm,
         string_value::{FlatString, StringValue},
@@ -48,7 +49,7 @@ impl FunctionPrototype {
     ) -> AllocResult<()> {
         let object_proto_ptr = realm.get_intrinsic_ptr(Intrinsic::ObjectPrototype);
 
-        let mut object = function_prototype.as_object();
+        let object = function_prototype.as_object();
 
         // Initialize all fields of the prototype object
         let descriptor_ptr = cx.descriptors.get(HeapItemKind::Closure);
@@ -69,49 +70,31 @@ impl FunctionPrototype {
             .cast::<Closure>()
             .init_extra_fields(*function, *scope);
 
-        object.intrinsic_length_prop(cx, 0)?;
-        object.intrinsic_name_prop(cx, "")?;
+        let mut builder = IntrinsicBuilder::new(cx, realm, object);
 
-        object.intrinsic_func(
-            cx,
-            cx.names.apply(),
-            RuntimeFunction::FunctionPrototype_apply,
-            2,
-            realm,
+        // Function prototype is a function with the standard name and length properties
+        builder.property(cx.names.length(), Property::data(cx.smi(0), false, false, true))?;
+        builder.property(
+            cx.names.name(),
+            Property::data(cx.names.empty_string().as_string().into(), false, false, true),
         )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.bind(),
-            RuntimeFunction::FunctionPrototype_bind,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.call(),
-            RuntimeFunction::FunctionPrototype_call_intrinsic,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::FunctionPrototype_to_string,
-            0,
-            realm,
-        )?;
+
+        intrinsic_methods!(cx, builder, {
+            apply     FunctionPrototype_apply          (2),
+            bind      FunctionPrototype_bind           (1),
+            call      FunctionPrototype_call_intrinsic (1),
+            to_string FunctionPrototype_to_string      (0),
+        });
 
         // [Function.hasInstance] property
-        let has_instance_func = BuiltinFunction::create(
-            cx,
+        let has_instance_func = builder.function(
             RuntimeFunction::FunctionPrototype_has_instance,
             1,
             cx.symbols.has_instance(),
-            realm,
-            None,
-        )?
-        .into();
-        object.intrinsic_frozen_property(cx, cx.symbols.has_instance(), has_instance_func)?;
+        )?;
+        builder.frozen(cx.symbols.has_instance(), has_instance_func.into())?;
+
+        builder.build()?;
 
         Ok(())
     }

--- a/src/js/runtime/intrinsics/generator_function_constructor.rs
+++ b/src/js/runtime/intrinsics/generator_function_constructor.rs
@@ -2,8 +2,8 @@ use crate::{
     runtime::{
         Context, Handle,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         eval::create_dynamic_function::create_dynamic_function,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         realm::Realm,
@@ -16,24 +16,18 @@ pub struct GeneratorFunctionConstructor;
 impl GeneratorFunctionConstructor {
     /// Properties of the GeneratorFunction Constructor (https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::GeneratorFunctionConstructor_construct,
             1,
             cx.names.generator_function(),
-            realm,
             Intrinsic::FunctionConstructor,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm
-                .get_intrinsic(Intrinsic::GeneratorFunctionPrototype)
-                .into(),
-        )?;
+        builder.prototype(Intrinsic::GeneratorFunctionPrototype)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/generator_function_prototype.rs
+++ b/src/js/runtime/intrinsics/generator_function_prototype.rs
@@ -1,6 +1,6 @@
 use crate::runtime::{
-    Context, Handle, alloc_error::AllocResult, intrinsics::intrinsics::Intrinsic,
-    object_value::ObjectValue, property::Property, realm::Realm,
+    Context, Handle, alloc_error::AllocResult, intrinsic_builder::IntrinsicBuilder,
+    intrinsics::intrinsics::Intrinsic, object_value::ObjectValue, property::Property, realm::Realm,
 };
 
 pub struct GeneratorFunctionPrototype;
@@ -8,24 +8,17 @@ pub struct GeneratorFunctionPrototype;
 impl GeneratorFunctionPrototype {
     /// Properties of the GeneratorFunction Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::FunctionPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::FunctionPrototype)?;
 
         // Constructor property is added once GeneratorFunctionConstructor has been created
 
         // GeneratorFunction.prototype.prototype (https://tc39.es/ecma262/#sec-generatorfunction.prototype.prototype)
         let proto = realm.get_intrinsic(Intrinsic::GeneratorPrototype);
-        let proto_prop = Property::data(proto.into(), false, false, true);
-        object.set_property(cx, cx.names.prototype(), proto_prop)?;
+        builder.property(cx.names.prototype(), Property::data(proto.into(), false, false, true))?;
 
         // GeneratorFunction.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-generatorfunction.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.generator_function().as_string().into(), false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.generator_function())?;
 
-        Ok(object)
+        builder.build()
     }
 }

--- a/src/js/runtime/intrinsics/generator_prototype.rs
+++ b/src/js/runtime/intrinsics/generator_prototype.rs
@@ -1,4 +1,5 @@
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, PropertyDescriptor,
         abstract_operations::define_property_or_throw,
@@ -7,10 +8,10 @@ use crate::{
         eval_result::EvalResult,
         generator_object::{GeneratorCompletionType, generator_resume, generator_resume_abrupt},
         heap_item_descriptor::HeapItemKind,
-        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        intrinsic_builder::IntrinsicBuilder,
+        intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create,
-        property::Property,
         realm::Realm,
     },
     runtime_fn,
@@ -21,42 +22,19 @@ pub struct GeneratorPrototype;
 impl GeneratorPrototype {
     /// The %GeneratorPrototype% Object (https://tc39.es/ecma262/#sec-properties-of-generator-prototype)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::IteratorPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::IteratorPrototype)?;
 
         // Constructor property is added once GeneratorFunctionPrototype has been created
-
-        object.intrinsic_func(
-            cx,
-            cx.names.next(),
-            RuntimeFunction::GeneratorPrototype_next,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.return_(),
-            RuntimeFunction::GeneratorPrototype_return_,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.throw(),
-            RuntimeFunction::GeneratorPrototype_throw,
-            1,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            next    GeneratorPrototype_next    (1),
+            return_ GeneratorPrototype_return_ (1),
+            throw   GeneratorPrototype_throw   (1),
+        });
 
         // %GeneratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-generator.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.generator().as_string().into(), false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.generator())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/global_object.rs
+++ b/src/js/runtime/intrinsics/global_object.rs
@@ -19,6 +19,7 @@ use crate::{
         error::uri_error,
         eval::eval::perform_eval,
         gc_object::GcObject,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         property_descriptor::PropertyDescriptor,
         string_parsing::{StringLexer, parse_signed_decimal_literal, skip_string_whitespace},
@@ -583,27 +584,17 @@ fn encode<const INCLUDE_URI_UNESCAPED: bool>(
 
 // Additional Properties of the Global Object (https://tc39.es/ecma262/#sec-additional-properties-of-the-global-object)
 pub fn init_global_annex_b_methods(mut cx: Context, realm: Handle<Realm>) -> AllocResult<()> {
-    let mut global_object = realm.global_object();
+    let mut builder = IntrinsicBuilder::new(cx, realm, realm.global_object());
 
     let escape_name = cx.alloc_static_string("escape")?;
     let escape_key = PropertyKey::string_not_array_index_handle(cx, escape_name)?;
-    global_object.intrinsic_func(
-        cx,
-        escape_key,
-        RuntimeFunction::global_object_escape,
-        1,
-        realm,
-    )?;
+    builder.method(escape_key, RuntimeFunction::global_object_escape, 1)?;
 
     let unescape_name = cx.alloc_static_string("unescape")?;
     let unescape_key = PropertyKey::string_not_array_index_handle(cx, unescape_name)?;
-    global_object.intrinsic_func(
-        cx,
-        unescape_key,
-        RuntimeFunction::global_object_unescape,
-        1,
-        realm,
-    )?;
+    builder.method(unescape_key, RuntimeFunction::global_object_unescape, 1)?;
+
+    builder.build()?;
 
     Ok(())
 }

--- a/src/js/runtime/intrinsics/iterator_constructor.rs
+++ b/src/js/runtime/intrinsics/iterator_constructor.rs
@@ -1,15 +1,15 @@
 use crate::{
-    extend_object,
+    extend_object, intrinsic_methods,
     runtime::{
         Context, HeapPtr, Value,
         abstract_operations::{call, call_object, get_method, ordinary_has_instance},
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         collections::array::value_array_from_slice,
         error::type_error,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic, iterator_helper_object::IteratorHelperObject,
             rust_runtime::RuntimeFunction,
@@ -27,37 +27,23 @@ pub struct IteratorConstructor;
 impl IteratorConstructor {
     /// Properties of the Iterator Constructor (https://tc39.es/ecma262/#sec-properties-of-the-iterator-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::IteratorConstructor_construct,
             0,
             cx.names.iterator(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::IteratorPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::IteratorPrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.concat(),
-            RuntimeFunction::IteratorConstructor_concat,
-            0,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.from(),
-            RuntimeFunction::IteratorConstructor_from,
-            1,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            concat IteratorConstructor_concat (0),
+            from   IteratorConstructor_from   (1),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {
@@ -175,30 +161,14 @@ pub struct WrapForValidIteratorPrototype;
 
 impl WrapForValidIteratorPrototype {
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let iterator_prototype = realm.get_intrinsic(Intrinsic::IteratorPrototype);
-        let mut object = object_create_with_proto::<ObjectValue>(
-            cx,
-            HeapItemKind::OrdinaryObject,
-            iterator_prototype,
-        )?
-        .to_handle();
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::IteratorPrototype)?;
 
-        object.intrinsic_func(
-            cx,
-            cx.names.next(),
-            RuntimeFunction::WrapForValidIteratorPrototype_next,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.return_(),
-            RuntimeFunction::WrapForValidIteratorPrototype_return_,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            next    WrapForValidIteratorPrototype_next    (0),
+            return_ WrapForValidIteratorPrototype_return_ (0),
+        });
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/iterator_helper_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_prototype.rs
@@ -1,13 +1,12 @@
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, EvalResult, Handle, Realm, Value,
         alloc_error::AllocResult,
         error::type_error,
         generator_object::GeneratorState,
-        intrinsics::{
-            intrinsics::Intrinsic, iterator_helper_object::IteratorHelperObject,
-            rust_runtime::RuntimeFunction,
-        },
+        intrinsic_builder::IntrinsicBuilder,
+        intrinsics::{intrinsics::Intrinsic, iterator_helper_object::IteratorHelperObject},
         iterator::{create_iter_result_object, iterator_close},
         object_value::ObjectValue,
         property::Property,
@@ -20,34 +19,21 @@ pub struct IteratorHelperPrototype;
 
 impl IteratorHelperPrototype {
     pub fn new(mut cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::IteratorPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::IteratorPrototype)?;
 
-        object.intrinsic_func(
-            cx,
-            cx.names.next(),
-            RuntimeFunction::IteratorHelperPrototype_next,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.return_(),
-            RuntimeFunction::IteratorHelperPrototype_return_,
-            1,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            next    IteratorHelperPrototype_next    (0),
+            return_ IteratorHelperPrototype_return_ (1),
+        });
 
         // %IteratorHelperPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%iteratorhelperprototype%-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
         let iterator_helper = cx.alloc_static_string("Iterator Helper")?;
-        object.set_property(
-            cx,
-            to_string_tag_key,
+        builder.property(
+            cx.symbols.to_string_tag(),
             Property::data(iterator_helper.as_value(), false, false, true),
         )?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_prototype.rs
@@ -1,11 +1,12 @@
 use crate::{
-    eval_err, must,
+    eval_err, intrinsic_methods, must,
     runtime::{
         Context, EvalResult, Handle, Value,
         abstract_operations::{call_object, setter_that_ignores_prototype_properties},
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         error::{range_error_value, type_error, type_error_value},
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic, iterator_helper_object::IteratorHelperObject,
             rust_runtime::RuntimeFunction,
@@ -23,111 +24,40 @@ pub struct IteratorPrototype;
 
 impl IteratorPrototype {
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
+
+        intrinsic_methods!(cx, builder, {
+            drop     IteratorPrototype_drop     (1),
+            every    IteratorPrototype_every    (1),
+            filter   IteratorPrototype_filter   (1),
+            find     IteratorPrototype_find     (1),
+            flat_map IteratorPrototype_flat_map (1),
+            for_each IteratorPrototype_for_each (1),
+            map_     IteratorPrototype_map      (1),
+            reduce   IteratorPrototype_reduce   (1),
+            some     IteratorPrototype_some     (1),
+            take     IteratorPrototype_take     (1),
+            to_array IteratorPrototype_to_array (0),
+        });
 
         // Iterator.prototype.constructor (https://tc39.es/ecma262/#sec-iterator.prototype.constructor)
-        object.intrinsic_getter_and_setter(
-            cx,
+        builder.getter_setter(
             cx.names.constructor(),
             RuntimeFunction::IteratorPrototype_get_constructor,
             RuntimeFunction::IteratorPrototype_set_constructor,
-            realm,
-        )?;
-
-        object.intrinsic_func(
-            cx,
-            cx.names.drop(),
-            RuntimeFunction::IteratorPrototype_drop,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.every(),
-            RuntimeFunction::IteratorPrototype_every,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.filter(),
-            RuntimeFunction::IteratorPrototype_filter,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.find(),
-            RuntimeFunction::IteratorPrototype_find,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.flat_map(),
-            RuntimeFunction::IteratorPrototype_flat_map,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.for_each(),
-            RuntimeFunction::IteratorPrototype_for_each,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.map_(),
-            RuntimeFunction::IteratorPrototype_map,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.reduce(),
-            RuntimeFunction::IteratorPrototype_reduce,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.some(),
-            RuntimeFunction::IteratorPrototype_some,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.take(),
-            RuntimeFunction::IteratorPrototype_take,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_array(),
-            RuntimeFunction::IteratorPrototype_to_array,
-            0,
-            realm,
         )?;
 
         // Iterator.prototype [ @@iterator ] (https://tc39.es/ecma262/#sec-iterator.prototype-%symbol.iterator%)
-        let iterator_key = cx.symbols.iterator();
-        object.intrinsic_func(cx, iterator_key, RuntimeFunction::ReturnThis, 0, realm)?;
+        builder.method(cx.symbols.iterator(), RuntimeFunction::ReturnThis, 0)?;
 
         // Iterator.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-iterator.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.intrinsic_getter_and_setter(
-            cx,
-            to_string_tag_key,
+        builder.getter_setter(
+            cx.symbols.to_string_tag(),
             RuntimeFunction::IteratorPrototype_iterator_prototype_get_to_string_tag,
             RuntimeFunction::IteratorPrototype_set_to_string_tag,
-            realm,
         )?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/json_object.rs
+++ b/src/js/runtime/intrinsics/json_object.rs
@@ -5,7 +5,7 @@ use crate::{
         unicode::{CodePoint, CodeUnit, is_ascii_lowercase_alphabetic, is_decimal_digit},
         wtf_8::Wtf8String,
     },
-    must,
+    intrinsic_methods, must,
     runtime::{
         Context, EvalResult, Handle, PropertyKey, Realm, Value,
         abstract_operations::{
@@ -15,16 +15,15 @@ use crate::{
         alloc_error::AllocResult,
         error::syntax_error,
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             json_parser::{JSONParseRecord, JSONParseRecordChildren, parse_json},
             json_serializer::JSONSerializer,
             raw_json_object::RawJSONObject,
-            rust_runtime::RuntimeFunction,
         },
         object_value::ObjectValue,
         ordinary_object::ordinary_object_create,
-        property::Property,
         string_value::FlatString,
         to_string,
         type_utilities::{is_array, is_callable, same_value, to_integer_or_infinity, to_number},
@@ -37,42 +36,19 @@ pub struct JSONObject;
 
 impl JSONObject {
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
-        object.intrinsic_func(
-            cx,
-            cx.names.is_raw_json(),
-            RuntimeFunction::JSONObject_is_raw_json,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(cx, cx.names.parse(), RuntimeFunction::JSONObject_parse, 2, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.raw_json(),
-            RuntimeFunction::JSONObject_raw_json,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.stringify(),
-            RuntimeFunction::JSONObject_stringify,
-            3,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            is_raw_json JSONObject_is_raw_json (1),
+            parse       JSONObject_parse       (2),
+            raw_json    JSONObject_raw_json    (1),
+            stringify   JSONObject_stringify   (3),
+        });
 
         // JSON [ @@toStringTag ] (https://tc39.es/ecma262/#sec-json-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        let math_name_value = cx.names.json().as_string().into();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(math_name_value, false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.json())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/map_constructor.rs
+++ b/src/js/runtime/intrinsics/map_constructor.rs
@@ -1,14 +1,14 @@
 use crate::{
-    must,
+    intrinsic_methods, must,
     runtime::{
         Context, Handle,
         abstract_operations::{GroupByKeyCoercion, call_object, construct, group_by},
         alloc_error::AllocResult,
         array_object::create_array_from_list,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, map_object::MapObject, rust_runtime::RuntimeFunction},
         iterator::iter_iterator_values,
         object_value::ObjectValue,
@@ -25,34 +25,25 @@ pub struct MapConstructor;
 impl MapConstructor {
     /// The Map Constructor (https://tc39.es/ecma262/#sec-map-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::MapConstructor_construct,
             0,
             cx.names.map(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::MapPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::MapPrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.group_by(),
-            RuntimeFunction::MapConstructor_group_by,
-            2,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            group_by MapConstructor_group_by (2),
+        });
 
         // get Map [ %Symbol.species% ] (https://tc39.es/ecma262/#sec-get-map-%symbol.species%)
-        let species_key = cx.symbols.species();
-        func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
+        builder.getter(cx.symbols.species(), RuntimeFunction::ReturnThis)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/map_iterator.rs
+++ b/src/js/runtime/intrinsics/map_iterator.rs
@@ -1,7 +1,7 @@
 use std::mem::size_of;
 
 use crate::{
-    cast_from_value_fn, extend_object,
+    cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
         Context, Handle, HeapPtr,
         alloc_error::AllocResult,
@@ -11,10 +11,10 @@ use crate::{
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             map_object::{MapObject, ValueMap},
-            rust_runtime::RuntimeFunction,
         },
         iterator::create_iter_result_object,
         object_value::ObjectValue,
@@ -84,27 +84,20 @@ pub struct MapIteratorPrototype;
 
 impl MapIteratorPrototype {
     pub fn new(mut cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::IteratorPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::IteratorPrototype)?;
 
-        object.intrinsic_func(
-            cx,
-            cx.names.next(),
-            RuntimeFunction::MapIteratorPrototype_next,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            next MapIteratorPrototype_next (0),
+        });
 
         // %MapIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%mapiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
         let to_string_tag_value = cx.alloc_static_string("Map Iterator")?.into();
-        object.set_property(
-            cx,
-            to_string_tag_key,
+        builder.property(
+            cx.symbols.to_string_tag(),
             Property::data(to_string_tag_value, false, false, true),
         )?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -1,11 +1,12 @@
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle,
         abstract_operations::{call, call_object},
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             map_iterator::{MapIterator, MapIteratorKind},
@@ -13,7 +14,6 @@ use crate::{
             rust_runtime::RuntimeFunction,
         },
         object_value::ObjectValue,
-        property::Property,
         realm::Realm,
         type_utilities::is_callable,
         value::{Value, ValueCollectionKey},
@@ -26,87 +26,33 @@ pub struct MapPrototype;
 impl MapPrototype {
     /// Properties of the Map Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-map-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
-
-        // Create values function as it is referenced by multiple properties
-        let entries_function = BuiltinFunction::create(
-            cx,
-            RuntimeFunction::MapPrototype_entries,
-            0,
-            cx.names.entries(),
-            realm,
-            None,
-        )?
-        .into();
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once MapConstructor has been created
-        object.intrinsic_func(
-            cx,
-            cx.names.clear(),
-            RuntimeFunction::MapPrototype_clear,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.delete(),
-            RuntimeFunction::MapPrototype_delete,
-            1,
-            realm,
-        )?;
-        object.intrinsic_data_prop(cx, cx.names.entries(), entries_function)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.for_each(),
-            RuntimeFunction::MapPrototype_for_each,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(cx, cx.names.get(), RuntimeFunction::MapPrototype_get, 1, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_or_insert(),
-            RuntimeFunction::MapPrototype_get_or_insert,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_or_insert_computed(),
-            RuntimeFunction::MapPrototype_get_or_insert_computed,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(cx, cx.names.has(), RuntimeFunction::MapPrototype_has, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.keys(), RuntimeFunction::MapPrototype_keys, 0, realm)?;
-        object.intrinsic_func(cx, cx.names.set_(), RuntimeFunction::MapPrototype_set, 2, realm)?;
-        object.intrinsic_getter(cx, cx.names.size(), RuntimeFunction::MapPrototype_size, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.values(),
-            RuntimeFunction::MapPrototype_values,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            clear                  MapPrototype_clear                  (0),
+            delete                 MapPrototype_delete                 (1),
+            entries                MapPrototype_entries                (0),
+            for_each               MapPrototype_for_each               (1),
+            get                    MapPrototype_get                    (1),
+            get_or_insert          MapPrototype_get_or_insert          (2),
+            get_or_insert_computed MapPrototype_get_or_insert_computed (2),
+            has                    MapPrototype_has                    (1),
+            keys                   MapPrototype_keys                   (0),
+            set_                   MapPrototype_set                    (2),
+            values                 MapPrototype_values                 (0),
+        });
 
         // Map.prototype [ @@iterator ] (https://tc39.es/ecma262/#sec-map.prototype-%symbol.iterator%)
-        let iterator_key = cx.symbols.iterator();
-        object.set_property(
-            cx,
-            iterator_key,
-            Property::data(entries_function, true, false, true),
-        )?;
+        builder.alias(cx.names.entries(), cx.symbols.iterator())?;
+
+        // get Map.prototype.size (https://tc39.es/ecma262/#sec-get-map.prototype.size)
+        builder.getter(cx.names.size(), RuntimeFunction::MapPrototype_size)?;
 
         // Map.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-map.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.map().as_string().into(), false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.map())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/math_object.rs
+++ b/src/js/runtime/intrinsics/math_object.rs
@@ -6,15 +6,16 @@ use crate::{
         math::{f64_to_f16, is_negative_zero},
         numeric::{MAX_I32_PLUS_ONE_AS_F64, MAX_SAFE_INTEGER_U64},
     },
+    intrinsic_methods,
     runtime::{
         Context, Handle,
         alloc_error::AllocResult,
         error::{range_error, type_error},
-        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        intrinsic_builder::IntrinsicBuilder,
+        intrinsics::intrinsics::Intrinsic,
         iterator::{IteratorHint, get_iterator, iterator_close, iterator_step_value},
         numeric_operations::number_exponentiate,
         object_value::ObjectValue,
-        property::Property,
         realm::Realm,
         type_utilities::{to_number, to_uint32},
         value::Value,
@@ -27,106 +28,62 @@ pub struct MathObject;
 
 impl MathObject {
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut math = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
+
+        intrinsic_methods!(cx, math, {
+            abs         MathObject_abs         (1),
+            acos        MathObject_acos        (1),
+            acosh       MathObject_acosh       (1),
+            asin        MathObject_asin        (1),
+            asinh       MathObject_asinh       (1),
+            atan        MathObject_atan        (1),
+            atanh       MathObject_atanh       (1),
+            atan2       MathObject_atan2       (2),
+            cbrt        MathObject_cbrt        (1),
+            ceil        MathObject_ceil        (1),
+            clz32       MathObject_clz32       (1),
+            cos         MathObject_cos         (1),
+            cosh        MathObject_cosh        (1),
+            exp         MathObject_exp         (1),
+            expm1       MathObject_expm1       (1),
+            f16_round   MathObject_f16_round   (1),
+            floor       MathObject_floor       (1),
+            fround      MathObject_fround      (1),
+            hypot       MathObject_hypot       (2),
+            imul        MathObject_imul        (2),
+            log         MathObject_log         (1),
+            log1p       MathObject_log1p       (1),
+            log10       MathObject_log10       (1),
+            log2        MathObject_log2        (1),
+            max         MathObject_max         (2),
+            min         MathObject_min         (2),
+            pow         MathObject_pow         (2),
+            random      MathObject_random      (0),
+            round       MathObject_round       (1),
+            sign        MathObject_sign        (1),
+            sin         MathObject_sin         (1),
+            sinh        MathObject_sinh        (1),
+            sqrt        MathObject_sqrt        (1),
+            sum_precise MathObject_sum_precise (1),
+            tan         MathObject_tan         (1),
+            tanh        MathObject_tanh        (1),
+            trunc       MathObject_trunc       (1),
+        });
 
         // Value Properties of the Math Object (https://tc39.es/ecma262/#sec-value-properties-of-the-math-object)
-        let e_value = cx.number(std::f64::consts::E);
-        object.intrinsic_frozen_property(cx, cx.names.e(), e_value)?;
-
-        let ln_10_value = cx.number(std::f64::consts::LN_10);
-        object.intrinsic_frozen_property(cx, cx.names.ln10(), ln_10_value)?;
-
-        let ln_2_value = cx.number(std::f64::consts::LN_2);
-        object.intrinsic_frozen_property(cx, cx.names.ln2(), ln_2_value)?;
-
-        let log10_e_value = cx.number(std::f64::consts::LOG10_E);
-        object.intrinsic_frozen_property(cx, cx.names.log10e(), log10_e_value)?;
-
-        let log2_e_value = cx.number(std::f64::consts::LOG2_E);
-        object.intrinsic_frozen_property(cx, cx.names.log2e(), log2_e_value)?;
-
-        let pi_value = cx.number(std::f64::consts::PI);
-        object.intrinsic_frozen_property(cx, cx.names.pi(), pi_value)?;
-
-        let sqrt1_2_value = cx.number(std::f64::consts::FRAC_1_SQRT_2);
-        object.intrinsic_frozen_property(cx, cx.names.sqrt1_2(), sqrt1_2_value)?;
-
-        let sqrt_2_value = cx.number(std::f64::consts::SQRT_2);
-        object.intrinsic_frozen_property(cx, cx.names.sqrt2(), sqrt_2_value)?;
+        math.frozen(cx.names.e(), cx.number(std::f64::consts::E))?;
+        math.frozen(cx.names.ln10(), cx.number(std::f64::consts::LN_10))?;
+        math.frozen(cx.names.ln2(), cx.number(std::f64::consts::LN_2))?;
+        math.frozen(cx.names.log10e(), cx.number(std::f64::consts::LOG10_E))?;
+        math.frozen(cx.names.log2e(), cx.number(std::f64::consts::LOG2_E))?;
+        math.frozen(cx.names.pi(), cx.number(std::f64::consts::PI))?;
+        math.frozen(cx.names.sqrt1_2(), cx.number(std::f64::consts::FRAC_1_SQRT_2))?;
+        math.frozen(cx.names.sqrt2(), cx.number(std::f64::consts::SQRT_2))?;
 
         // Math [ @@toStringTag ] (https://tc39.es/ecma262/#sec-math-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        let math_name_value = cx.names.math().as_string().into();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(math_name_value, false, false, true),
-        )?;
+        math.to_string_tag(cx.names.math())?;
 
-        object.intrinsic_func(cx, cx.names.abs(), RuntimeFunction::MathObject_abs, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.acos(), RuntimeFunction::MathObject_acos, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.acosh(), RuntimeFunction::MathObject_acosh, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.asin(), RuntimeFunction::MathObject_asin, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.asinh(), RuntimeFunction::MathObject_asinh, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.atan(), RuntimeFunction::MathObject_atan, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.atanh(), RuntimeFunction::MathObject_atanh, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.atan2(), RuntimeFunction::MathObject_atan2, 2, realm)?;
-        object.intrinsic_func(cx, cx.names.cbrt(), RuntimeFunction::MathObject_cbrt, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.ceil(), RuntimeFunction::MathObject_ceil, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.clz32(), RuntimeFunction::MathObject_clz32, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.cos(), RuntimeFunction::MathObject_cos, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.cosh(), RuntimeFunction::MathObject_cosh, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.exp(), RuntimeFunction::MathObject_exp, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.expm1(), RuntimeFunction::MathObject_expm1, 1, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.f16_round(),
-            RuntimeFunction::MathObject_f16_round,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(cx, cx.names.floor(), RuntimeFunction::MathObject_floor, 1, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.fround(),
-            RuntimeFunction::MathObject_fround,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(cx, cx.names.hypot(), RuntimeFunction::MathObject_hypot, 2, realm)?;
-        object.intrinsic_func(cx, cx.names.imul(), RuntimeFunction::MathObject_imul, 2, realm)?;
-        object.intrinsic_func(cx, cx.names.log(), RuntimeFunction::MathObject_log, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.log1p(), RuntimeFunction::MathObject_log1p, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.log10(), RuntimeFunction::MathObject_log10, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.log2(), RuntimeFunction::MathObject_log2, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.max(), RuntimeFunction::MathObject_max, 2, realm)?;
-        object.intrinsic_func(cx, cx.names.min(), RuntimeFunction::MathObject_min, 2, realm)?;
-        object.intrinsic_func(cx, cx.names.pow(), RuntimeFunction::MathObject_pow, 2, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.random(),
-            RuntimeFunction::MathObject_random,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(cx, cx.names.round(), RuntimeFunction::MathObject_round, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.sign(), RuntimeFunction::MathObject_sign, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.sin(), RuntimeFunction::MathObject_sin, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.sinh(), RuntimeFunction::MathObject_sinh, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.sqrt(), RuntimeFunction::MathObject_sqrt, 1, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.sum_precise(),
-            RuntimeFunction::MathObject_sum_precise,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(cx, cx.names.tan(), RuntimeFunction::MathObject_tan, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.tanh(), RuntimeFunction::MathObject_tanh, 1, realm)?;
-        object.intrinsic_func(cx, cx.names.trunc(), RuntimeFunction::MathObject_trunc, 1, realm)?;
-
-        Ok(object)
+        math.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/native_error.rs
+++ b/src/js/runtime/intrinsics/native_error.rs
@@ -2,8 +2,8 @@ use crate::runtime::{
     Context, Handle, HeapPtr,
     abstract_operations::{construct, create_non_enumerable_data_property_or_throw},
     alloc_error::AllocResult,
-    builtin_function::BuiltinFunction,
     eval_result::EvalResult,
+    intrinsic_builder::IntrinsicBuilder,
     intrinsics::{
         error_constructor::{ErrorObject, install_error_cause},
         intrinsics::Intrinsic,
@@ -68,22 +68,18 @@ macro_rules! create_native_error {
         impl $constructor {
             /// Properties of the NativeError Constructors (https://tc39.es/ecma262/#sec-properties-of-the-nativeerror-constructors)
             pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-                let mut func = BuiltinFunction::intrinsic_constructor(
+                let mut builder = IntrinsicBuilder::constructor(
                     cx,
+                    realm,
                     $construct_fn,
                     1,
                     cx.names.$rust_name(),
-                    realm,
                     Intrinsic::ErrorConstructor,
                 )?;
 
-                func.intrinsic_frozen_property(
-                    cx,
-                    cx.names.prototype(),
-                    realm.get_intrinsic(Intrinsic::$prototype).into(),
-                )?;
+                builder.prototype(Intrinsic::$prototype)?;
 
-                Ok(func)
+                builder.build()
             }
 
             $crate::runtime_fn! {
@@ -125,22 +121,13 @@ macro_rules! create_native_error {
         impl $prototype {
             /// Properties of the NativeError Prototype Objects (https://tc39.es/ecma262/#sec-properties-of-the-nativeerror-prototype-objects)
             pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-                let proto = realm.get_intrinsic(Intrinsic::ErrorPrototype);
-                let mut object = ObjectValue::new(cx, Some(proto), true)?;
+                let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ErrorPrototype)?;
 
                 // Constructor property is added once NativeErrorConstructor has been created
-                object.intrinsic_data_prop(
-                    cx,
-                    cx.names.name(),
-                    cx.names.$rust_name().as_string().into(),
-                )?;
-                object.intrinsic_data_prop(
-                    cx,
-                    cx.names.message(),
-                    cx.names.empty_string().as_string().into(),
-                )?;
+                builder.data(cx.names.name(), cx.names.$rust_name().as_string().into())?;
+                builder.data(cx.names.message(), cx.names.empty_string().as_string().into())?;
 
-                Ok(object)
+                builder.build()
             }
         }
     };

--- a/src/js/runtime/intrinsics/number_constructor.rs
+++ b/src/js/runtime/intrinsics/number_constructor.rs
@@ -4,14 +4,14 @@ use num_traits::ToPrimitive;
 
 use crate::{
     common::numeric::{MAX_SAFE_INTEGER_F64, MIN_POSITIVE_SUBNORMAL_F64, MIN_SAFE_INTEGER_F64},
-    extend_object,
+    extend_object, intrinsic_methods,
     runtime::{
         Context, HeapPtr,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         ordinary_object::{
@@ -88,81 +88,40 @@ pub struct NumberConstructor;
 impl NumberConstructor {
     /// Properties of the Number Constructor (https://tc39.es/ecma262/#sec-properties-of-the-number-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::NumberConstructor_construct,
             1,
             cx.names.number(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::NumberPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::NumberPrototype)?;
 
-        let epsilon_value = cx.number(f64::EPSILON);
-        func.intrinsic_frozen_property(cx, cx.names.epsilon(), epsilon_value)?;
+        intrinsic_methods!(cx, builder, {
+            is_finite       NumberConstructor_is_finite       (1),
+            is_integer      NumberConstructor_is_integer      (1),
+            is_nan          NumberConstructor_is_nan          (1),
+            is_safe_integer NumberConstructor_is_safe_integer (1),
+        });
 
-        let max_safe_integer_value = cx.number(MAX_SAFE_INTEGER_F64);
-        func.intrinsic_frozen_property(cx, cx.names.max_safe_integer(), max_safe_integer_value)?;
-
-        let max_value = cx.number(f64::MAX);
-        func.intrinsic_frozen_property(cx, cx.names.max_value(), max_value)?;
-
-        let min_safe_integer_value = cx.number(MIN_SAFE_INTEGER_F64);
-        func.intrinsic_frozen_property(cx, cx.names.min_safe_integer(), min_safe_integer_value)?;
-
-        let min_value = cx.number(MIN_POSITIVE_SUBNORMAL_F64);
-        func.intrinsic_frozen_property(cx, cx.names.min_value(), min_value)?;
-
-        let nan_value = cx.nan();
-        func.intrinsic_frozen_property(cx, cx.names.nan(), nan_value)?;
-
-        let neg_infinity_value = cx.number(f64::NEG_INFINITY);
-        func.intrinsic_frozen_property(cx, cx.names.negative_infinity(), neg_infinity_value)?;
-
-        let infinity_value = cx.number(f64::INFINITY);
-        func.intrinsic_frozen_property(cx, cx.names.positive_infinity(), infinity_value)?;
-
-        func.intrinsic_func(
-            cx,
-            cx.names.is_finite(),
-            RuntimeFunction::NumberConstructor_is_finite,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.is_integer(),
-            RuntimeFunction::NumberConstructor_is_integer,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.is_nan(),
-            RuntimeFunction::NumberConstructor_is_nan,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.is_safe_integer(),
-            RuntimeFunction::NumberConstructor_is_safe_integer,
-            1,
-            realm,
-        )?;
+        builder.frozen(cx.names.epsilon(), cx.number(f64::EPSILON))?;
+        builder.frozen(cx.names.max_safe_integer(), cx.number(MAX_SAFE_INTEGER_F64))?;
+        builder.frozen(cx.names.max_value(), cx.number(f64::MAX))?;
+        builder.frozen(cx.names.min_safe_integer(), cx.number(MIN_SAFE_INTEGER_F64))?;
+        builder.frozen(cx.names.min_value(), cx.number(MIN_POSITIVE_SUBNORMAL_F64))?;
+        builder.frozen(cx.names.nan(), cx.nan())?;
+        builder.frozen(cx.names.negative_infinity(), cx.number(f64::NEG_INFINITY))?;
+        builder.frozen(cx.names.positive_infinity(), cx.number(f64::INFINITY))?;
 
         let parse_float = realm.get_intrinsic(Intrinsic::ParseFloat);
-        func.intrinsic_data_prop(cx, cx.names.parse_float(), parse_float.into())?;
+        builder.data(cx.names.parse_float(), parse_float.into())?;
 
         let parse_int = realm.get_intrinsic(Intrinsic::ParseInt);
-        func.intrinsic_data_prop(cx, cx.names.parse_int(), parse_int.into())?;
+        builder.data(cx.names.parse_int(), parse_int.into())?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/number_prototype.rs
+++ b/src/js/runtime/intrinsics/number_prototype.rs
@@ -1,12 +1,12 @@
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle,
         alloc_error::AllocResult,
         error::{range_error, type_error},
         eval_result::EvalResult,
-        intrinsics::{
-            intrinsics::Intrinsic, number_constructor::NumberObject, rust_runtime::RuntimeFunction,
-        },
+        intrinsic_builder::IntrinsicBuilder,
+        intrinsics::{intrinsics::Intrinsic, number_constructor::NumberObject},
         object_value::ObjectValue,
         realm::Realm,
         string_value::FlatString,
@@ -23,53 +23,20 @@ impl NumberPrototype {
     /// Properties of the Number Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-number-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
         let object_proto = realm.get_intrinsic(Intrinsic::ObjectPrototype);
-        let mut object = NumberObject::new_with_proto(cx, object_proto, 0.0)?.as_object();
+        let object = NumberObject::new_with_proto(cx, object_proto, 0.0)?.as_object();
+        let mut builder = IntrinsicBuilder::new(cx, realm, object);
 
         // Constructor property is added once NumberConstructor has been created
-        object.intrinsic_func(
-            cx,
-            cx.names.to_exponential(),
-            RuntimeFunction::NumberPrototype_to_exponential,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_fixed(),
-            RuntimeFunction::NumberPrototype_to_fixed,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_string(),
-            RuntimeFunction::NumberPrototype_to_locale_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_precision(),
-            RuntimeFunction::NumberPrototype_to_precision,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::NumberPrototype_to_string,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::NumberPrototype_value_of,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            to_exponential   NumberPrototype_to_exponential   (1),
+            to_fixed         NumberPrototype_to_fixed         (1),
+            to_locale_string NumberPrototype_to_locale_string (0),
+            to_precision     NumberPrototype_to_precision     (1),
+            to_string        NumberPrototype_to_string        (1),
+            value_of         NumberPrototype_value_of         (0),
+        });
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/object_constructor.rs
+++ b/src/js/runtime/intrinsics/object_constructor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    must,
+    intrinsic_methods, must,
     runtime::{
         Context, Handle, Value,
         abstract_operations::{
@@ -9,10 +9,10 @@ use crate::{
         },
         alloc_error::AllocResult,
         array_object::create_array_from_list,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic, map_constructor::add_entries_from_iterable,
             rust_runtime::RuntimeFunction,
@@ -35,178 +35,44 @@ pub struct ObjectConstructor;
 impl ObjectConstructor {
     /// Properties of the Object Constructor (https://tc39.es/ecma262/#sec-properties-of-the-object-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::ObjectConstructor_construct,
             1,
             cx.names.object(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::ObjectPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::ObjectPrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.assign(),
-            RuntimeFunction::ObjectConstructor_assign,
-            2,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.create(),
-            RuntimeFunction::ObjectConstructor_create,
-            2,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.define_properties(),
-            RuntimeFunction::ObjectConstructor_define_properties,
-            2,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.define_property(),
-            RuntimeFunction::ObjectConstructor_define_property,
-            3,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.from_entries(),
-            RuntimeFunction::ObjectConstructor_from_entries,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.get_own_property_descriptor(),
-            RuntimeFunction::ObjectConstructor_get_own_property_descriptor,
-            2,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.get_own_property_descriptors(),
-            RuntimeFunction::ObjectConstructor_get_own_property_descriptors,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.entries(),
-            RuntimeFunction::ObjectConstructor_entries,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.freeze(),
-            RuntimeFunction::ObjectConstructor_freeze,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.get_own_property_names(),
-            RuntimeFunction::ObjectConstructor_get_own_property_names,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.get_own_property_symbols(),
-            RuntimeFunction::ObjectConstructor_get_own_property_symbols,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.get_prototype_of(),
-            RuntimeFunction::ObjectConstructor_get_prototype_of,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.group_by(),
-            RuntimeFunction::ObjectConstructor_group_by,
-            2,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.has_own(),
-            RuntimeFunction::ObjectConstructor_has_own,
-            2,
-            realm,
-        )?;
-        func.intrinsic_func(cx, cx.names.is(), RuntimeFunction::ObjectConstructor_is, 2, realm)?;
-        func.intrinsic_func(
-            cx,
-            cx.names.is_extensible(),
-            RuntimeFunction::ObjectConstructor_is_extensible,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.is_frozen(),
-            RuntimeFunction::ObjectConstructor_is_frozen,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.is_sealed(),
-            RuntimeFunction::ObjectConstructor_is_sealed,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.keys(),
-            RuntimeFunction::ObjectConstructor_keys,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.prevent_extensions(),
-            RuntimeFunction::ObjectConstructor_prevent_extensions,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.seal(),
-            RuntimeFunction::ObjectConstructor_seal,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.set_prototype_of(),
-            RuntimeFunction::ObjectConstructor_set_prototype_of,
-            2,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.values(),
-            RuntimeFunction::ObjectConstructor_values,
-            1,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            assign                       ObjectConstructor_assign                       (2),
+            create                       ObjectConstructor_create                       (2),
+            define_properties            ObjectConstructor_define_properties            (2),
+            define_property              ObjectConstructor_define_property              (3),
+            from_entries                 ObjectConstructor_from_entries                 (1),
+            get_own_property_descriptor  ObjectConstructor_get_own_property_descriptor  (2),
+            get_own_property_descriptors ObjectConstructor_get_own_property_descriptors (1),
+            entries                      ObjectConstructor_entries                      (1),
+            freeze                       ObjectConstructor_freeze                       (1),
+            get_own_property_names       ObjectConstructor_get_own_property_names       (1),
+            get_own_property_symbols     ObjectConstructor_get_own_property_symbols     (1),
+            get_prototype_of             ObjectConstructor_get_prototype_of             (1),
+            group_by                     ObjectConstructor_group_by                     (2),
+            has_own                      ObjectConstructor_has_own                      (2),
+            is                           ObjectConstructor_is                           (2),
+            is_extensible                ObjectConstructor_is_extensible                (1),
+            is_frozen                    ObjectConstructor_is_frozen                    (1),
+            is_sealed                    ObjectConstructor_is_sealed                    (1),
+            keys                         ObjectConstructor_keys                         (1),
+            prevent_extensions           ObjectConstructor_prevent_extensions           (1),
+            seal                         ObjectConstructor_seal                         (1),
+            set_prototype_of             ObjectConstructor_set_prototype_of             (2),
+            values                       ObjectConstructor_values                       (1),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -1,7 +1,7 @@
 use std::mem::size_of;
 
 use crate::{
-    extend_object,
+    extend_object, intrinsic_methods,
     runtime::{
         Context, Handle, HeapPtr,
         abstract_operations::{define_property_or_throw, get, has_own_property, invoke},
@@ -9,6 +9,7 @@ use crate::{
         error::type_error,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::rust_runtime::RuntimeFunction,
         object_value::ObjectValue,
         ordinary_object::object_ordinary_init,
@@ -41,91 +42,35 @@ impl ObjectPrototype {
         object: Handle<ObjectPrototype>,
         realm: Handle<Realm>,
     ) -> AllocResult<()> {
-        let mut object = object.as_object();
+        let object = object.as_object();
 
         let descriptor = cx.descriptors.get(HeapItemKind::ObjectPrototype);
         object_ordinary_init(cx, *object, descriptor, None);
 
-        // Constructor property is added once ObjectConstructor has been created
-        object.intrinsic_func(
-            cx,
-            cx.names.has_own_property(),
-            RuntimeFunction::ObjectPrototype_has_own_property,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.is_prototype_of(),
-            RuntimeFunction::ObjectPrototype_is_prototype_of,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.property_is_enumerable(),
-            RuntimeFunction::ObjectPrototype_property_is_enumerable,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::ObjectPrototype_value_of,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_string(),
-            RuntimeFunction::ObjectPrototype_to_locale_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::ObjectPrototype_to_string,
-            0,
-            realm,
-        )?;
+        let mut builder = IntrinsicBuilder::new(cx, realm, object);
 
-        object.intrinsic_getter_and_setter(
-            cx,
+        // Constructor property is added once ObjectConstructor has been created
+        intrinsic_methods!(cx, builder, {
+            has_own_property       ObjectPrototype_has_own_property       (1),
+            is_prototype_of        ObjectPrototype_is_prototype_of        (1),
+            property_is_enumerable ObjectPrototype_property_is_enumerable (1),
+            value_of               ObjectPrototype_value_of               (0),
+            to_locale_string       ObjectPrototype_to_locale_string       (0),
+            to_string              ObjectPrototype_to_string              (0),
+            __define_getter__      ObjectPrototype_define_getter          (2),
+            __define_setter__      ObjectPrototype_define_setter          (2),
+            __lookup_getter__      ObjectPrototype_lookup_getter          (1),
+            __lookup_setter__      ObjectPrototype_lookup_setter          (1),
+        });
+
+        // Object.prototype.__proto__ (https://tc39.es/ecma262/#sec-object.prototype.__proto__)
+        builder.getter_setter(
             cx.names.__proto__(),
             RuntimeFunction::ObjectPrototype_get_proto,
             RuntimeFunction::ObjectPrototype_set_proto,
-            realm,
         )?;
 
-        object.intrinsic_func(
-            cx,
-            cx.names.__define_getter__(),
-            RuntimeFunction::ObjectPrototype_define_getter,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.__define_setter__(),
-            RuntimeFunction::ObjectPrototype_define_setter,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.__lookup_getter__(),
-            RuntimeFunction::ObjectPrototype_lookup_getter,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.__lookup_setter__(),
-            RuntimeFunction::ObjectPrototype_lookup_setter,
-            1,
-            realm,
-        )?;
+        builder.build()?;
 
         Ok(())
     }

--- a/src/js/runtime/intrinsics/promise_constructor.rs
+++ b/src/js/runtime/intrinsics/promise_constructor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    completion_value, must,
+    completion_value, intrinsic_methods, must,
     runtime::{
         Context, Handle, PropertyKey, Value,
         abstract_operations::{call, call_object, create_data_property_or_throw, invoke},
@@ -9,6 +9,7 @@ use crate::{
         error::type_error,
         eval_result::EvalResult,
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             aggregate_error_constructor::AggregateErrorObject, boolean_constructor::BooleanObject,
             intrinsics::Intrinsic, number_constructor::NumberObject, rust_runtime::RuntimeFunction,
@@ -45,71 +46,32 @@ pub struct PromiseConstructor;
 impl PromiseConstructor {
     /// Properties of the Promise Constructor (https://tc39.es/ecma262/#sec-properties-of-the-promise-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::PromiseConstructor_construct,
             1,
             cx.names.promise(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::PromisePrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::PromisePrototype)?;
 
-        func.intrinsic_func(cx, cx.names.all(), RuntimeFunction::PromiseConstructor_all, 1, realm)?;
-        func.intrinsic_func(
-            cx,
-            cx.names.all_settled(),
-            RuntimeFunction::PromiseConstructor_all_settled,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(cx, cx.names.any(), RuntimeFunction::PromiseConstructor_any, 1, realm)?;
-        func.intrinsic_func(
-            cx,
-            cx.names.race(),
-            RuntimeFunction::PromiseConstructor_race,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.reject(),
-            RuntimeFunction::PromiseConstructor_reject,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.resolve(),
-            RuntimeFunction::PromiseConstructor_resolve,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.try_(),
-            RuntimeFunction::PromiseConstructor_try_,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.with_resolvers(),
-            RuntimeFunction::PromiseConstructor_with_resolvers,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            all            PromiseConstructor_all            (1),
+            all_settled    PromiseConstructor_all_settled    (1),
+            any            PromiseConstructor_any            (1),
+            race           PromiseConstructor_race           (1),
+            reject         PromiseConstructor_reject         (1),
+            resolve        PromiseConstructor_resolve        (1),
+            try_           PromiseConstructor_try_           (1),
+            with_resolvers PromiseConstructor_with_resolvers (0),
+        });
 
         // get Promise [ @@species ] (https://tc39.es/ecma262/#sec-get-promise-%symbol.species%)
-        let species_key = cx.symbols.species();
-        func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
+        builder.getter(cx.symbols.species(), RuntimeFunction::ReturnThis)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/promise_prototype.rs
+++ b/src/js/runtime/intrinsics/promise_prototype.rs
@@ -1,15 +1,15 @@
 use crate::{
-    eval_err,
+    eval_err, intrinsic_methods,
     runtime::{
         Context, Handle, Value,
         abstract_operations::{call_object, invoke, species_constructor},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::type_error,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         promise_object::{PromiseCapability, PromiseObject, is_promise, promise_resolve},
-        property::Property,
         realm::Realm,
         type_utilities::is_callable,
     },
@@ -21,42 +21,19 @@ pub struct PromisePrototype;
 impl PromisePrototype {
     /// Properties of the Promise Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-promise-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once PromiseConstructor has been created
-
-        object.intrinsic_func(
-            cx,
-            cx.names.catch(),
-            RuntimeFunction::PromisePrototype_catch,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.finally(),
-            RuntimeFunction::PromisePrototype_finally,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.then(),
-            RuntimeFunction::PromisePrototype_then,
-            2,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            catch   PromisePrototype_catch   (1),
+            finally PromisePrototype_finally (1),
+            then    PromisePrototype_then    (2),
+        });
 
         // Promise.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-promise.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.promise().as_string().into(), false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.promise())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/proxy_constructor.rs
+++ b/src/js/runtime/intrinsics/proxy_constructor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    must,
+    intrinsic_methods, must,
     runtime::{
         Context,
         abstract_operations::create_data_property_or_throw,
@@ -7,6 +7,7 @@ use crate::{
         builtin_function::BuiltinFunction,
         error::type_error,
         gc::Handle,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         ordinary_object::ordinary_object_create,
@@ -21,24 +22,21 @@ pub struct ProxyConstructor;
 impl ProxyConstructor {
     /// Properties of the Proxy Constructor (https://tc39.es/ecma262/#sec-properties-of-the-proxy-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::ProxyConstructor_construct,
             2,
             cx.names.proxy(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.revocable(),
-            RuntimeFunction::ProxyConstructor_revocable,
-            2,
-            realm,
-        )?;
+        // Proxy has no `prototype` property.
+        intrinsic_methods!(cx, builder, {
+            revocable ProxyConstructor_revocable (2),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/reflect_object.rs
+++ b/src/js/runtime/intrinsics/reflect_object.rs
@@ -1,13 +1,14 @@
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle,
         abstract_operations::{call_object, construct, create_list_from_array_like_arguments},
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         error::type_error,
-        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        intrinsic_builder::IntrinsicBuilder,
+        intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        property::Property,
         property_descriptor::{from_property_descriptor, to_property_descriptor},
         realm::Realm,
         type_utilities::{is_callable, is_constructor_value, to_property_key},
@@ -20,93 +21,28 @@ pub struct ReflectObject;
 
 impl ReflectObject {
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
-        object.intrinsic_func(
-            cx,
-            cx.names.apply(),
-            RuntimeFunction::ReflectObject_apply,
-            3,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.construct(),
-            RuntimeFunction::ReflectObject_construct,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.define_property(),
-            RuntimeFunction::ReflectObject_define_property,
-            3,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.delete_property(),
-            RuntimeFunction::ReflectObject_delete_property,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(cx, cx.names.get(), RuntimeFunction::ReflectObject_get, 2, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_own_property_descriptor(),
-            RuntimeFunction::ReflectObject_get_own_property_descriptor,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_prototype_of(),
-            RuntimeFunction::ReflectObject_get_prototype_of,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(cx, cx.names.has(), RuntimeFunction::ReflectObject_has, 2, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.is_extensible(),
-            RuntimeFunction::ReflectObject_is_extensible,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.own_keys(),
-            RuntimeFunction::ReflectObject_own_keys,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.prevent_extensions(),
-            RuntimeFunction::ReflectObject_prevent_extensions,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(cx, cx.names.set_(), RuntimeFunction::ReflectObject_set, 3, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_prototype_of(),
-            RuntimeFunction::ReflectObject_set_prototype_of,
-            2,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            apply                       ReflectObject_apply                       (3),
+            construct                   ReflectObject_construct                   (2),
+            define_property             ReflectObject_define_property             (3),
+            delete_property             ReflectObject_delete_property             (2),
+            get                         ReflectObject_get                         (2),
+            get_own_property_descriptor ReflectObject_get_own_property_descriptor (2),
+            get_prototype_of            ReflectObject_get_prototype_of            (1),
+            has                         ReflectObject_has                         (2),
+            is_extensible               ReflectObject_is_extensible               (1),
+            own_keys                    ReflectObject_own_keys                    (1),
+            prevent_extensions          ReflectObject_prevent_extensions          (1),
+            set_                        ReflectObject_set                         (3),
+            set_prototype_of            ReflectObject_set_prototype_of            (2),
+        });
 
         // Reflect [ @@toStringTag ] (https://tc39.es/ecma262/#sec-reflect-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        let reflect_name_value = cx.names.reflect().as_string().into();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(reflect_name_value, false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.reflect())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -12,7 +12,7 @@ use crate::{
         },
         wtf_8::Wtf8String,
     },
-    extend_object, must, must_a,
+    extend_object, intrinsic_methods, must, must_a,
     parser::{
         ast::AstAlloc,
         lexer_stream::{
@@ -26,12 +26,12 @@ use crate::{
         Context, HeapPtr, PropertyDescriptor, Value,
         abstract_operations::{define_property_or_throw, set},
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::{syntax_parse_error, type_error},
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
         get,
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -135,34 +135,25 @@ pub struct RegExpConstructor;
 impl RegExpConstructor {
     /// Properties of the RegExp Constructor (https://tc39.es/ecma262/#sec-properties-of-the-regexp-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::RegExpConstructor_construct,
             2,
             cx.names.regexp(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::RegExpPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::RegExpPrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.escape(),
-            RuntimeFunction::RegExpConstructor_escape,
-            1,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            escape RegExpConstructor_escape (1),
+        });
 
         // get RegExp [ @@species ] (https://tc39.es/ecma262/#sec-get-regexp-%symbol.species%)
-        let species_key = cx.symbols.species();
-        func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
+        builder.getter(cx.symbols.species(), RuntimeFunction::ReturnThis)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -4,7 +4,7 @@ use crate::{
     common::unicode::{
         CodePoint, is_high_surrogate_code_unit, is_low_surrogate_code_unit, needs_surrogate_pair,
     },
-    must,
+    intrinsic_getter_methods, intrinsic_methods, must,
     parser::regexp::RegExpFlags,
     runtime::{
         Context, Handle, PropertyKey, Value,
@@ -17,6 +17,7 @@ use crate::{
         error::type_error,
         eval_result::EvalResult,
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             regexp_constructor::{
@@ -45,145 +46,60 @@ pub struct RegExpPrototype;
 impl RegExpPrototype {
     /// Properties of the RegExp Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-regexp-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once RegExpConstructor has been created
-        object.intrinsic_func(
-            cx,
-            cx.names.exec(),
-            RuntimeFunction::RegExpPrototype_exec,
-            1,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.dot_all(),
-            RuntimeFunction::RegExpPrototype_dot_all,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.flags(),
-            RuntimeFunction::RegExpPrototype_flags,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.global(),
-            RuntimeFunction::RegExpPrototype_global,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.has_indices(),
-            RuntimeFunction::RegExpPrototype_has_indices,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.ignore_case(),
-            RuntimeFunction::RegExpPrototype_ignore_case,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.symbols.match_(),
-            RuntimeFunction::RegExpPrototype_match_,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.symbols.match_all(),
-            RuntimeFunction::RegExpPrototype_match_all,
-            1,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.multiline(),
-            RuntimeFunction::RegExpPrototype_multiline,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.symbols.replace(),
-            RuntimeFunction::RegExpPrototype_replace,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.symbols.search(),
-            RuntimeFunction::RegExpPrototype_search,
-            1,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.source(),
-            RuntimeFunction::RegExpPrototype_source,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.symbols.split(),
-            RuntimeFunction::RegExpPrototype_split,
-            2,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.sticky(),
-            RuntimeFunction::RegExpPrototype_sticky,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.test(),
-            RuntimeFunction::RegExpPrototype_test,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::RegExpPrototype_to_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.unicode(),
-            RuntimeFunction::RegExpPrototype_unicode,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.unicode_sets(),
-            RuntimeFunction::RegExpPrototype_unicode_sets,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            exec      RegExpPrototype_exec      (1),
+            test      RegExpPrototype_test      (1),
+            to_string RegExpPrototype_to_string (0),
+        });
 
-        Ok(object)
+        intrinsic_getter_methods!(cx, builder, {
+            dot_all      RegExpPrototype_dot_all,
+            flags        RegExpPrototype_flags,
+            global       RegExpPrototype_global,
+            has_indices  RegExpPrototype_has_indices,
+            ignore_case  RegExpPrototype_ignore_case,
+            multiline    RegExpPrototype_multiline,
+            source       RegExpPrototype_source,
+            sticky       RegExpPrototype_sticky,
+            unicode      RegExpPrototype_unicode,
+            unicode_sets RegExpPrototype_unicode_sets,
+        });
+
+        // RegExp.prototype [ @@match ] (https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.match%)
+        builder.method(cx.symbols.match_(), RuntimeFunction::RegExpPrototype_match_, 1)?;
+
+        // RegExp.prototype [ @@matchAll ] (https://tc39.es/ecma262/#sec-regexp-prototype-%symbol.matchall%)
+        builder.method(cx.symbols.match_all(), RuntimeFunction::RegExpPrototype_match_all, 1)?;
+
+        // RegExp.prototype [ @@replace ] (https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.replace%)
+        builder.method(cx.symbols.replace(), RuntimeFunction::RegExpPrototype_replace, 2)?;
+
+        // RegExp.prototype [ @@search ] (https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.search%)
+        builder.method(cx.symbols.search(), RuntimeFunction::RegExpPrototype_search, 1)?;
+
+        // RegExp.prototype [ @@split ] (https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.split%)
+        builder.method(cx.symbols.split(), RuntimeFunction::RegExpPrototype_split, 2)?;
+
+        builder.build()
     }
 
     /// Additional Properties of the RegExp.prototype Object (https://tc39.es/ecma262/#sec-additional-properties-of-the-regexp.prototype-object)
     pub fn init_annex_b_methods(
-        mut regexp_prototype: Handle<ObjectValue>,
+        regexp_prototype: Handle<ObjectValue>,
         mut cx: Context,
         realm: Handle<Realm>,
     ) -> AllocResult<()> {
         let compile_name = cx.alloc_static_string("compile")?;
         let compile_key = PropertyKey::string_not_array_index_handle(cx, compile_name)?;
-        regexp_prototype.intrinsic_func(
-            cx,
-            compile_key,
-            RuntimeFunction::RegExpPrototype_compile,
-            2,
-            realm,
-        )
+
+        let mut builder = IntrinsicBuilder::new(cx, realm, regexp_prototype);
+        builder.method(compile_key, RuntimeFunction::RegExpPrototype_compile, 2)?;
+        builder.build()?;
+
+        Ok(())
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/regexp_string_iterator.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator.rs
@@ -1,7 +1,7 @@
 use std::mem::size_of;
 
 use crate::{
-    cast_from_value_fn, extend_object,
+    cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
         Context, Handle, HeapPtr, PropertyKey, Value,
         abstract_operations::set,
@@ -11,10 +11,10 @@ use crate::{
         gc::{HeapItem, HeapVisitor},
         get,
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             regexp_prototype::{advance_u64_string_index, regexp_exec},
-            rust_runtime::RuntimeFunction,
         },
         iterator::create_iter_result_object,
         object_value::ObjectValue,
@@ -80,27 +80,20 @@ pub struct RegExpStringIteratorPrototype;
 
 impl RegExpStringIteratorPrototype {
     pub fn new(mut cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let proto = realm.get_intrinsic(Intrinsic::IteratorPrototype);
-        let mut object = ObjectValue::new(cx, Some(proto), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::IteratorPrototype)?;
 
-        object.intrinsic_func(
-            cx,
-            cx.names.next(),
-            RuntimeFunction::RegExpStringIteratorPrototype_next,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            next RegExpStringIteratorPrototype_next (0),
+        });
 
         // %RegExpStringIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%regexpstringiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
         let to_string_tag_value = cx.alloc_static_string("RegExp String Iterator")?.into();
-        object.set_property(
-            cx,
-            to_string_tag_key,
+        builder.property(
+            cx.symbols.to_string_tag(),
             Property::data(to_string_tag_value, false, false, true),
         )?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/set_constructor.rs
+++ b/src/js/runtime/intrinsics/set_constructor.rs
@@ -3,9 +3,9 @@ use crate::{
         Context, Handle,
         abstract_operations::call_object,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction, set_object::SetObject},
         iterator::iter_iterator_values,
         object_value::ObjectValue,
@@ -20,26 +20,21 @@ pub struct SetConstructor;
 impl SetConstructor {
     /// The Set Constructor (https://tc39.es/ecma262/#sec-set-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::SetConstructor_construct,
             0,
             cx.names.set(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::SetPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::SetPrototype)?;
 
         // get Set [ @@species ] (https://tc39.es/ecma262/#sec-get-set-%symbol.species%)
-        let species_key = cx.symbols.species();
-        func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
+        builder.getter(cx.symbols.species(), RuntimeFunction::ReturnThis)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/set_iterator.rs
+++ b/src/js/runtime/intrinsics/set_iterator.rs
@@ -1,7 +1,7 @@
 use std::mem::size_of;
 
 use crate::{
-    cast_from_value_fn, extend_object,
+    cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
         Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
@@ -11,7 +11,8 @@ use crate::{
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
-        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction, set_object::SetObject},
+        intrinsic_builder::IntrinsicBuilder,
+        intrinsics::{intrinsics::Intrinsic, set_object::SetObject},
         iterator::create_iter_result_object,
         object_value::ObjectValue,
         ordinary_object::object_create,
@@ -79,27 +80,20 @@ pub struct SetIteratorPrototype;
 
 impl SetIteratorPrototype {
     pub fn new(mut cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::IteratorPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::IteratorPrototype)?;
 
-        object.intrinsic_func(
-            cx,
-            cx.names.next(),
-            RuntimeFunction::SetIteratorPrototype_next,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            next SetIteratorPrototype_next (0),
+        });
 
         // %SetIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%setiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
         let to_string_tag_value = cx.alloc_static_string("Set Iterator")?.into();
-        object.set_property(
-            cx,
-            to_string_tag_key,
+        builder.property(
+            cx.symbols.to_string_tag(),
             Property::data(to_string_tag_value, false, false, true),
         )?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -1,14 +1,14 @@
 use crate::{
-    must,
+    intrinsic_methods, must,
     runtime::{
         Context, Handle,
         abstract_operations::{call_object, canonicalize_keyed_collection_key},
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         collections::BsIndexSetField,
         error::{range_error, type_error},
         eval_result::EvalResult,
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
@@ -20,7 +20,6 @@ use crate::{
             iterator_value,
         },
         object_value::ObjectValue,
-        property::Property,
         realm::Realm,
         type_utilities::{is_callable, to_integer_or_infinity, to_number},
         value::{Value, ValueCollectionKey},
@@ -33,121 +32,38 @@ pub struct SetPrototype;
 impl SetPrototype {
     /// Properties of the Set Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-set-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
-
-        // Create values function as it is referenced by multiple properties
-        let values_function = BuiltinFunction::create(
-            cx,
-            RuntimeFunction::SetPrototype_values,
-            0,
-            cx.names.values(),
-            realm,
-            None,
-        )?
-        .into();
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once SetConstructor has been created
-        object.intrinsic_func(cx, cx.names.add(), RuntimeFunction::SetPrototype_add, 1, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.clear(),
-            RuntimeFunction::SetPrototype_clear,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.delete(),
-            RuntimeFunction::SetPrototype_delete,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.difference(),
-            RuntimeFunction::SetPrototype_difference,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.entries(),
-            RuntimeFunction::SetPrototype_entries,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.for_each(),
-            RuntimeFunction::SetPrototype_for_each,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(cx, cx.names.has(), RuntimeFunction::SetPrototype_has, 1, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.intersection(),
-            RuntimeFunction::SetPrototype_intersection,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.is_disjoint_from(),
-            RuntimeFunction::SetPrototype_is_disjoint_from,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.is_subset_of(),
-            RuntimeFunction::SetPrototype_is_subset_of,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.is_superset_of(),
-            RuntimeFunction::SetPrototype_is_superset_of,
-            1,
-            realm,
-        )?;
-        object.intrinsic_data_prop(cx, cx.names.keys(), values_function)?;
-        object.intrinsic_getter(cx, cx.names.size(), RuntimeFunction::SetPrototype_size, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.symmetric_difference(),
-            RuntimeFunction::SetPrototype_symmetric_difference,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.union(),
-            RuntimeFunction::SetPrototype_union,
-            1,
-            realm,
-        )?;
-        object.intrinsic_data_prop(cx, cx.names.values(), values_function)?;
+        intrinsic_methods!(cx, builder, {
+            add                  SetPrototype_add                  (1),
+            clear                SetPrototype_clear                (0),
+            delete               SetPrototype_delete               (1),
+            difference           SetPrototype_difference           (1),
+            entries              SetPrototype_entries              (0),
+            for_each             SetPrototype_for_each             (1),
+            has                  SetPrototype_has                  (1),
+            intersection         SetPrototype_intersection         (1),
+            is_disjoint_from     SetPrototype_is_disjoint_from     (1),
+            is_subset_of         SetPrototype_is_subset_of         (1),
+            is_superset_of       SetPrototype_is_superset_of       (1),
+            symmetric_difference SetPrototype_symmetric_difference (1),
+            union                SetPrototype_union                (1),
+            values               SetPrototype_values               (0),
+        });
+
+        builder.alias(cx.names.values(), cx.names.keys())?;
 
         // Set.prototype [ @@iterator ] (https://tc39.es/ecma262/#sec-set.prototype-%symbol.iterator%)
-        let iterator_key = cx.symbols.iterator();
-        object.set_property(
-            cx,
-            iterator_key,
-            Property::data(values_function, true, false, true),
-        )?;
+        builder.alias(cx.names.values(), cx.symbols.iterator())?;
+
+        // get Set.prototype.size (https://tc39.es/ecma262/#sec-get-set.prototype.size)
+        builder.getter(cx.names.size(), RuntimeFunction::SetPrototype_size)?;
 
         // Set.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-set.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.set().as_string().into(), false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.set())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/string_constructor.rs
+++ b/src/js/runtime/intrinsics/string_constructor.rs
@@ -1,12 +1,13 @@
 use crate::{
     common::unicode::CodePoint,
+    intrinsic_methods,
     runtime::{
         Context, Handle, PropertyKey,
         abstract_operations::length_of_array_like,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::range_error,
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
             symbol_prototype::symbol_descriptive_string,
@@ -25,38 +26,24 @@ pub struct StringConstructor;
 impl StringConstructor {
     /// Properties of the String Constructor (https://tc39.es/ecma262/#sec-properties-of-the-string-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::StringConstructor_construct,
             1,
             cx.names.string(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::StringPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::StringPrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.from_char_code(),
-            RuntimeFunction::StringConstructor_from_char_code,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.from_code_point(),
-            RuntimeFunction::StringConstructor_from_code_point,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(cx, cx.names.raw(), RuntimeFunction::StringConstructor_raw, 1, realm)?;
+        intrinsic_methods!(cx, builder, {
+            from_char_code  StringConstructor_from_char_code  (1),
+            from_code_point StringConstructor_from_code_point (1),
+            raw             StringConstructor_raw             (1),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/string_iterator.rs
+++ b/src/js/runtime/intrinsics/string_iterator.rs
@@ -1,7 +1,7 @@
 use std::mem::size_of;
 
 use crate::{
-    cast_from_value_fn, extend_object,
+    cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
         Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
@@ -9,7 +9,8 @@ use crate::{
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
-        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        intrinsic_builder::IntrinsicBuilder,
+        intrinsics::intrinsics::Intrinsic,
         iterator::create_iter_result_object,
         object_value::ObjectValue,
         ordinary_object::object_create,
@@ -48,27 +49,20 @@ pub struct StringIteratorPrototype;
 
 impl StringIteratorPrototype {
     pub fn new(mut cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let proto = realm.get_intrinsic(Intrinsic::IteratorPrototype);
-        let mut object = ObjectValue::new(cx, Some(proto), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::IteratorPrototype)?;
 
-        object.intrinsic_func(
-            cx,
-            cx.names.next(),
-            RuntimeFunction::StringIteratorPrototype_next,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            next StringIteratorPrototype_next (0),
+        });
 
         // %StringIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%stringiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
         let to_string_tag_value = cx.alloc_static_string("String Iterator")?.into();
-        object.set_property(
-            cx,
-            to_string_tag_key,
+        builder.property(
+            cx.symbols.to_string_tag(),
             Property::data(to_string_tag_value, false, false, true),
         )?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -8,7 +8,7 @@ use crate::{
         },
         wtf_8::Wtf8String,
     },
-    must, must_a,
+    intrinsic_methods, must, must_a,
     parser::regexp::RegExpFlags,
     runtime::{
         Context, Handle, HeapPtr, PropertyKey,
@@ -18,6 +18,7 @@ use crate::{
         error::{range_error, type_error},
         eval_result::EvalResult,
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             regexp_constructor::{FlagsSource, RegExpSource, regexp_create},
@@ -48,270 +49,64 @@ impl StringPrototype {
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
         let object_proto = realm.get_intrinsic(Intrinsic::ObjectPrototype);
         let empty_string = cx.names.empty_string().as_string();
-        let mut object = StringObject::new_with_proto(cx, object_proto, empty_string)?.as_object();
+        let object = StringObject::new_with_proto(cx, object_proto, empty_string)?.as_object();
+        let mut builder = IntrinsicBuilder::new(cx, realm, object);
 
         // Constructor property is added once StringConstructor has been created
-        object.intrinsic_func(cx, cx.names.at(), RuntimeFunction::StringPrototype_at, 1, realm)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.char_at(),
-            RuntimeFunction::StringPrototype_char_at,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.char_code_at(),
-            RuntimeFunction::StringPrototype_char_code_at,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.code_point_at(),
-            RuntimeFunction::StringPrototype_code_point_at,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.concat(),
-            RuntimeFunction::StringPrototype_concat,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.ends_with(),
-            RuntimeFunction::StringPrototype_ends_with,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.includes(),
-            RuntimeFunction::StringPrototype_includes,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.index_of(),
-            RuntimeFunction::StringPrototype_index_of,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.is_well_formed(),
-            RuntimeFunction::StringPrototype_is_well_formed,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.last_index_of(),
-            RuntimeFunction::StringPrototype_last_index_of,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.locale_compare(),
-            RuntimeFunction::StringPrototype_locale_compare,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.match_(),
-            RuntimeFunction::StringPrototype_match_,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.match_all(),
-            RuntimeFunction::StringPrototype_match_all,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.normalize(),
-            RuntimeFunction::StringPrototype_normalize,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.pad_end(),
-            RuntimeFunction::StringPrototype_pad_end,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.pad_start(),
-            RuntimeFunction::StringPrototype_pad_start,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.repeat(),
-            RuntimeFunction::StringPrototype_repeat,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.replace(),
-            RuntimeFunction::StringPrototype_replace,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.replace_all(),
-            RuntimeFunction::StringPrototype_replace_all,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.search(),
-            RuntimeFunction::StringPrototype_search,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.slice(),
-            RuntimeFunction::StringPrototype_slice,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.split(),
-            RuntimeFunction::StringPrototype_split,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.starts_with(),
-            RuntimeFunction::StringPrototype_starts_with,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.substring(),
-            RuntimeFunction::StringPrototype_substring,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::StringPrototype_to_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_lower_case(),
-            RuntimeFunction::StringPrototype_to_lower_case,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_upper_case(),
-            RuntimeFunction::StringPrototype_to_upper_case,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_lower_case(),
-            RuntimeFunction::StringPrototype_to_lower_case,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_upper_case(),
-            RuntimeFunction::StringPrototype_to_upper_case,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_well_formed(),
-            RuntimeFunction::StringPrototype_to_well_formed,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.trim(),
-            RuntimeFunction::StringPrototype_trim,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.trim_end(),
-            RuntimeFunction::StringPrototype_trim_end,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.trim_start(),
-            RuntimeFunction::StringPrototype_trim_start,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::StringPrototype_to_string,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            at                   StringPrototype_at              (1),
+            char_at              StringPrototype_char_at         (1),
+            char_code_at         StringPrototype_char_code_at    (1),
+            code_point_at        StringPrototype_code_point_at   (1),
+            concat               StringPrototype_concat          (1),
+            ends_with            StringPrototype_ends_with       (1),
+            includes             StringPrototype_includes        (1),
+            index_of             StringPrototype_index_of        (1),
+            is_well_formed       StringPrototype_is_well_formed  (0),
+            last_index_of        StringPrototype_last_index_of   (1),
+            locale_compare       StringPrototype_locale_compare  (1),
+            match_               StringPrototype_match_          (1),
+            match_all            StringPrototype_match_all       (1),
+            normalize            StringPrototype_normalize       (0),
+            pad_end              StringPrototype_pad_end         (1),
+            pad_start            StringPrototype_pad_start       (1),
+            repeat               StringPrototype_repeat          (1),
+            replace              StringPrototype_replace         (2),
+            replace_all          StringPrototype_replace_all     (2),
+            search               StringPrototype_search          (1),
+            slice                StringPrototype_slice           (2),
+            split                StringPrototype_split           (2),
+            starts_with          StringPrototype_starts_with     (1),
+            substring            StringPrototype_substring       (2),
+            to_string            StringPrototype_to_string       (0),
+            to_locale_lower_case StringPrototype_to_lower_case   (0),
+            to_locale_upper_case StringPrototype_to_upper_case   (0),
+            to_lower_case        StringPrototype_to_lower_case   (0),
+            to_upper_case        StringPrototype_to_upper_case   (0),
+            to_well_formed       StringPrototype_to_well_formed  (0),
+            trim                 StringPrototype_trim            (0),
+            trim_end             StringPrototype_trim_end        (0),
+            trim_start           StringPrototype_trim_start      (0),
+            value_of             StringPrototype_to_string       (0),
+        });
 
         // String.prototype [ @@iterator ] (https://tc39.es/ecma262/#sec-string.prototype-%symbol.iterator%)
-        let iterator_key = cx.symbols.iterator();
-        object.intrinsic_func(
-            cx,
-            iterator_key,
-            RuntimeFunction::StringPrototype_iterator,
-            0,
-            realm,
-        )?;
+        builder.method(cx.symbols.iterator(), RuntimeFunction::StringPrototype_iterator, 0)?;
 
-        Ok(object)
+        builder.build()
     }
 
     /// Additional Properties of the String.prototype Object (https://tc39.es/ecma262/#sec-additional-properties-of-the-string.prototype-object)
     pub fn init_annex_b_methods(
-        mut string_prototype: Handle<ObjectValue>,
+        string_prototype: Handle<ObjectValue>,
         mut cx: Context,
         realm: Handle<Realm>,
     ) -> AllocResult<()> {
+        let mut builder = IntrinsicBuilder::new(cx, realm, string_prototype);
+
         let substr_name = cx.alloc_static_string("substr")?;
         let substr = PropertyKey::string_not_array_index_handle(cx, substr_name)?;
-        string_prototype.intrinsic_func(
-            cx,
-            substr,
-            RuntimeFunction::StringPrototype_substr,
-            2,
-            realm,
-        )?;
+        builder.method(substr, RuntimeFunction::StringPrototype_substr, 2)?;
 
         // String.prototype.trimLeft and String.prototype.trimRight are direct aliases for
         // String.prototype.trimStart and String.prototype.trimEnd respectively.
@@ -324,15 +119,15 @@ impl StringPrototype {
         let trim_right_name = cx.alloc_static_string("trimRight")?;
         let trim_right = PropertyKey::string_not_array_index_handle(cx, trim_right_name)?;
 
-        string_prototype.intrinsic_data_prop(cx, trim_left, trim_start)?;
-        string_prototype.intrinsic_data_prop(cx, trim_right, trim_end)?;
+        builder.data(trim_left, trim_start)?;
+        builder.data(trim_right, trim_end)?;
 
         macro_rules! html_methods {
             ($($name:expr, $method:path, $length:expr),*) => {
                 $(
                     let name = cx.alloc_static_string($name)?;
                     let key = PropertyKey::string_not_array_index_handle(cx, name)?;
-                    string_prototype.intrinsic_func(cx, key, $method, $length, realm)?;
+                    builder.method(key, $method, $length)?;
                 )*
             }
         }
@@ -352,6 +147,8 @@ impl StringPrototype {
             "sub", RuntimeFunction::StringPrototype_sub, 0,
             "sup", RuntimeFunction::StringPrototype_sup, 0
         }
+
+        builder.build()?;
 
         Ok(())
     }

--- a/src/js/runtime/intrinsics/symbol_constructor.rs
+++ b/src/js/runtime/intrinsics/symbol_constructor.rs
@@ -1,15 +1,15 @@
 use std::mem::size_of;
 
 use crate::{
-    extend_object,
+    extend_object, intrinsic_methods,
     runtime::{
         Context, Handle, HeapPtr,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         collections::BsHashMapField,
         error::type_error,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         ordinary_object::object_create,
@@ -54,81 +54,42 @@ pub struct SymbolConstructor;
 impl SymbolConstructor {
     /// Properties of the Symbol Constructor (https://tc39.es/ecma262/#sec-properties-of-the-symbol-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::SymbolConstructor_construct,
             0,
             cx.names.symbol(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::SymbolPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::SymbolPrototype)?;
+
+        intrinsic_methods!(cx, builder, {
+            for_    SymbolConstructor_for_    (1),
+            key_for SymbolConstructor_key_for (1),
+        });
 
         // Well known symbols
-        let async_iterator = cx.symbols.async_iterator().as_symbol();
-        func.intrinsic_frozen_property(cx, cx.names.async_iterator(), async_iterator.into())?;
-
-        let has_instance = cx.symbols.has_instance().as_symbol();
-        func.intrinsic_frozen_property(cx, cx.names.has_instance(), has_instance.into())?;
-
-        let is_concat_spreadable = cx.symbols.is_concat_spreadable().as_symbol();
-        func.intrinsic_frozen_property(
-            cx,
+        builder
+            .frozen(cx.names.async_iterator(), cx.symbols.async_iterator().as_symbol().into())?;
+        builder.frozen(cx.names.has_instance(), cx.symbols.has_instance().as_symbol().into())?;
+        builder.frozen(
             cx.names.is_concat_spreadable(),
-            is_concat_spreadable.into(),
+            cx.symbols.is_concat_spreadable().as_symbol().into(),
         )?;
+        builder.frozen(cx.names.iterator_(), cx.symbols.iterator().as_symbol().into())?;
+        builder.frozen(cx.names.match_(), cx.symbols.match_().as_symbol().into())?;
+        builder.frozen(cx.names.match_all(), cx.symbols.match_all().as_symbol().into())?;
+        builder.frozen(cx.names.replace(), cx.symbols.replace().as_symbol().into())?;
+        builder.frozen(cx.names.search(), cx.symbols.search().as_symbol().into())?;
+        builder.frozen(cx.names.species(), cx.symbols.species().as_symbol().into())?;
+        builder.frozen(cx.names.split(), cx.symbols.split().as_symbol().into())?;
+        builder.frozen(cx.names.to_primitive(), cx.symbols.to_primitive().as_symbol().into())?;
+        builder.frozen(cx.names.to_string_tag(), cx.symbols.to_string_tag().as_symbol().into())?;
+        builder.frozen(cx.names.unscopables(), cx.symbols.unscopables().as_symbol().into())?;
 
-        let iterator = cx.symbols.iterator().as_symbol();
-        func.intrinsic_frozen_property(cx, cx.names.iterator_(), iterator.into())?;
-
-        let match_ = cx.symbols.match_().as_symbol();
-        func.intrinsic_frozen_property(cx, cx.names.match_(), match_.into())?;
-
-        let match_all = cx.symbols.match_all().as_symbol();
-        func.intrinsic_frozen_property(cx, cx.names.match_all(), match_all.into())?;
-
-        let replace = cx.symbols.replace().as_symbol();
-        func.intrinsic_frozen_property(cx, cx.names.replace(), replace.into())?;
-
-        let search = cx.symbols.search().as_symbol();
-        func.intrinsic_frozen_property(cx, cx.names.search(), search.into())?;
-
-        let species = cx.symbols.species().as_symbol();
-        func.intrinsic_frozen_property(cx, cx.names.species(), species.into())?;
-
-        let split = cx.symbols.split().as_symbol();
-        func.intrinsic_frozen_property(cx, cx.names.split(), split.into())?;
-
-        let to_primitive = cx.symbols.to_primitive().as_symbol();
-        func.intrinsic_frozen_property(cx, cx.names.to_primitive(), to_primitive.into())?;
-
-        let to_string_tag = cx.symbols.to_string_tag().as_symbol();
-        func.intrinsic_frozen_property(cx, cx.names.to_string_tag(), to_string_tag.into())?;
-
-        let unscopables = cx.symbols.unscopables().as_symbol();
-        func.intrinsic_frozen_property(cx, cx.names.unscopables(), unscopables.into())?;
-
-        func.intrinsic_func(
-            cx,
-            cx.names.for_(),
-            RuntimeFunction::SymbolConstructor_for_,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.key_for(),
-            RuntimeFunction::SymbolConstructor_key_for,
-            1,
-            realm,
-        )?;
-
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/symbol_prototype.rs
+++ b/src/js/runtime/intrinsics/symbol_prototype.rs
@@ -1,10 +1,11 @@
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Value,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         property::Property,
@@ -20,57 +21,29 @@ pub struct SymbolPrototype;
 impl SymbolPrototype {
     /// Properties of the Symbol Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-symbol-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once SymbolConstructor has been created
-        object.intrinsic_getter(
-            cx,
-            cx.names.description(),
-            RuntimeFunction::SymbolPrototype_get_description,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::SymbolPrototype_to_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::SymbolPrototype_value_of,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            to_string SymbolPrototype_to_string (0),
+            value_of  SymbolPrototype_value_of  (0),
+        });
+
+        builder.getter(cx.names.description(), RuntimeFunction::SymbolPrototype_get_description)?;
 
         // [Symbol.toPrimitive] property
         let to_primitive_key = cx.symbols.to_primitive();
-        let to_primitive_func = BuiltinFunction::create(
-            cx,
-            RuntimeFunction::SymbolPrototype_value_of,
-            1,
+        let to_primitive_func =
+            builder.function(RuntimeFunction::SymbolPrototype_value_of, 1, to_primitive_key)?;
+        builder.property(
             to_primitive_key,
-            realm,
-            None,
-        )?
-        .into();
-        object.set_property(
-            cx,
-            to_primitive_key,
-            Property::data(to_primitive_func, false, false, true),
+            Property::data(to_primitive_func.into(), false, false, true),
         )?;
 
         // [Symbol.toStringTag] property
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.symbol().as_string().into(), false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.symbol())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/duration_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_constructor.rs
@@ -1,13 +1,14 @@
 use temporal_rs::{Duration, partial::PartialDuration};
 
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Realm, Value,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
@@ -29,37 +30,23 @@ pub struct DurationConstructor;
 impl DurationConstructor {
     /// Temporal.Duration Constructor (https://tc39.es/proposal-temporal/#sec-temporal-duration-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::DurationConstructor_construct,
             0,
             cx.names.duration(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::DurationPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::DurationPrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.from(),
-            RuntimeFunction::DurationConstructor_from,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.compare(),
-            RuntimeFunction::DurationConstructor_compare,
-            2,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            from    DurationConstructor_from    (1),
+            compare DurationConstructor_compare (2),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/duration_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_prototype.rs
@@ -4,15 +4,15 @@ use temporal_rs::{
 };
 
 use crate::{
-    must,
+    intrinsic_getter_methods, intrinsic_methods, must,
     runtime::{
         Context, EvalResult, Handle, Realm, Value,
         abstract_operations::create_data_property_or_throw,
         alloc_error::AllocResult,
         error::{range_error, type_error},
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
             temporal::{
                 duration_constructor::{to_temporal_duration, to_temporal_partial_duration_record},
                 duration_object::DurationObject,
@@ -26,7 +26,6 @@ use crate::{
         },
         object_value::ObjectValue,
         ordinary_object::ordinary_object_create_without_proto,
-        property::Property,
     },
     runtime_fn,
 };
@@ -36,172 +35,42 @@ pub struct DurationPrototype;
 impl DurationPrototype {
     /// Properties of the Temporal.Duration Prototype Object (https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-duration-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once DurationConstructor has been created
 
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.temporal_duration().as_string().into(), false, false, true),
-        )?;
+        intrinsic_methods!(cx, builder, {
+            with             DurationPrototype_with             (1),
+            negated          DurationPrototype_negated          (0),
+            abs              DurationPrototype_abs              (0),
+            add              DurationPrototype_add              (1),
+            subtract         DurationPrototype_subtract         (1),
+            round            DurationPrototype_round            (1),
+            total            DurationPrototype_total            (1),
+            to_string        DurationPrototype_toString         (0),
+            to_locale_string DurationPrototype_toLocaleString   (0),
+            to_json          DurationPrototype_toJSON           (0),
+            value_of         DurationPrototype_valueOf          (0),
+        });
 
-        // Getters
-        object.intrinsic_getter(
-            cx,
-            cx.names.years(),
-            RuntimeFunction::DurationPrototype_years,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.months(),
-            RuntimeFunction::DurationPrototype_months,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.weeks(),
-            RuntimeFunction::DurationPrototype_weeks,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.days(),
-            RuntimeFunction::DurationPrototype_days,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.hours(),
-            RuntimeFunction::DurationPrototype_hours,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.minutes(),
-            RuntimeFunction::DurationPrototype_minutes,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.seconds(),
-            RuntimeFunction::DurationPrototype_seconds,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.milliseconds(),
-            RuntimeFunction::DurationPrototype_milliseconds,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.microseconds(),
-            RuntimeFunction::DurationPrototype_microseconds,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.nanoseconds(),
-            RuntimeFunction::DurationPrototype_nanoseconds,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.sign(),
-            RuntimeFunction::DurationPrototype_sign,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.blank(),
-            RuntimeFunction::DurationPrototype_blank,
-            realm,
-        )?;
+        intrinsic_getter_methods!(cx, builder, {
+            years        DurationPrototype_years,
+            months       DurationPrototype_months,
+            weeks        DurationPrototype_weeks,
+            days         DurationPrototype_days,
+            hours        DurationPrototype_hours,
+            minutes      DurationPrototype_minutes,
+            seconds      DurationPrototype_seconds,
+            milliseconds DurationPrototype_milliseconds,
+            microseconds DurationPrototype_microseconds,
+            nanoseconds  DurationPrototype_nanoseconds,
+            sign         DurationPrototype_sign,
+            blank        DurationPrototype_blank,
+        });
 
-        // Methods
-        object.intrinsic_func(
-            cx,
-            cx.names.with(),
-            RuntimeFunction::DurationPrototype_with,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.negated(),
-            RuntimeFunction::DurationPrototype_negated,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.abs(),
-            RuntimeFunction::DurationPrototype_abs,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.add(),
-            RuntimeFunction::DurationPrototype_add,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.subtract(),
-            RuntimeFunction::DurationPrototype_subtract,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.round(),
-            RuntimeFunction::DurationPrototype_round,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.total(),
-            RuntimeFunction::DurationPrototype_total,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::DurationPrototype_toString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_string(),
-            RuntimeFunction::DurationPrototype_toLocaleString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_json(),
-            RuntimeFunction::DurationPrototype_toJSON,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::DurationPrototype_valueOf,
-            0,
-            realm,
-        )?;
+        builder.to_string_tag(cx.names.temporal_duration())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/instant_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_constructor.rs
@@ -3,12 +3,13 @@ use temporal_rs::Instant;
 
 use crate::{
     common::constants::NANOSECONDS_IN_ONE_MILLISECOND,
+    intrinsic_methods,
     runtime::{
         Context, Handle, Realm, Value,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             bigint_constructor::number_to_bigint,
             intrinsics::Intrinsic,
@@ -29,51 +30,25 @@ pub struct InstantConstructor;
 impl InstantConstructor {
     /// Temporal.Instant Constructor (https://tc39.es/proposal-temporal/#sec-temporal-instant-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::InstantConstructor_construct,
             1,
             cx.names.instant(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::InstantPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::InstantPrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.from(),
-            RuntimeFunction::InstantConstructor_from,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.from_epoch_milliseconds(),
-            RuntimeFunction::InstantConstructor_fromEpochMilliseconds,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.from_epoch_nanoseconds(),
-            RuntimeFunction::InstantConstructor_fromEpochNanoseconds,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.compare(),
-            RuntimeFunction::InstantConstructor_compare,
-            2,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            from                    InstantConstructor_from                  (1),
+            from_epoch_milliseconds InstantConstructor_fromEpochMilliseconds (1),
+            from_epoch_nanoseconds  InstantConstructor_fromEpochNanoseconds  (1),
+            compare                 InstantConstructor_compare               (2),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/instant_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_prototype.rs
@@ -2,13 +2,14 @@ use num_bigint::BigInt;
 use temporal_rs::options::{RoundingMode, RoundingOptions, ToStringRoundingOptions};
 
 use crate::{
+    intrinsic_getter_methods, intrinsic_methods,
     runtime::{
         Arguments, Context, EvalResult, Handle, Realm, Value,
         alloc_error::AllocResult,
         error::type_error,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
             temporal::{
                 duration_constructor::to_temporal_duration,
                 duration_object::DurationObject,
@@ -24,7 +25,6 @@ use crate::{
             },
         },
         object_value::ObjectValue,
-        property::Property,
         value::BigIntValue,
     },
     runtime_fn,
@@ -35,112 +35,32 @@ pub struct InstantPrototype;
 impl InstantPrototype {
     /// Properties of the Temporal.Instant Prototype Object (https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-instant-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once InstantConstructor has been created
 
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.temporal_instant().as_string().into(), false, false, true),
-        )?;
+        intrinsic_methods!(cx, builder, {
+            add                    InstantPrototype_add                (1),
+            subtract               InstantPrototype_subtract           (1),
+            until                  InstantPrototype_until              (1),
+            since                  InstantPrototype_since              (1),
+            round                  InstantPrototype_round              (1),
+            equals                 InstantPrototype_equals             (1),
+            to_string              InstantPrototype_toString           (0),
+            to_locale_string       InstantPrototype_toLocaleString     (0),
+            to_json                InstantPrototype_toJSON             (0),
+            value_of               InstantPrototype_valueOf            (0),
+            to_zoned_date_time_iso InstantPrototype_toZonedDateTimeISO (1),
+        });
 
-        // Getters
-        object.intrinsic_getter(
-            cx,
-            cx.names.epoch_milliseconds(),
-            RuntimeFunction::InstantPrototype_epochMilliseconds,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.epoch_nanoseconds(),
-            RuntimeFunction::InstantPrototype_epochNanoseconds,
-            realm,
-        )?;
+        intrinsic_getter_methods!(cx, builder, {
+            epoch_milliseconds InstantPrototype_epochMilliseconds,
+            epoch_nanoseconds  InstantPrototype_epochNanoseconds,
+        });
 
-        // Methods
-        object.intrinsic_func(
-            cx,
-            cx.names.add(),
-            RuntimeFunction::InstantPrototype_add,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.subtract(),
-            RuntimeFunction::InstantPrototype_subtract,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.until(),
-            RuntimeFunction::InstantPrototype_until,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.since(),
-            RuntimeFunction::InstantPrototype_since,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.round(),
-            RuntimeFunction::InstantPrototype_round,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.equals(),
-            RuntimeFunction::InstantPrototype_equals,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::InstantPrototype_toString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_string(),
-            RuntimeFunction::InstantPrototype_toLocaleString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_json(),
-            RuntimeFunction::InstantPrototype_toJSON,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::InstantPrototype_valueOf,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_zoned_date_time_iso(),
-            RuntimeFunction::InstantPrototype_toZonedDateTimeISO,
-            1,
-            realm,
-        )?;
+        builder.to_string_tag(cx.names.temporal_instant())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
@@ -3,12 +3,13 @@ use temporal_rs::{
 };
 
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Realm, Value,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
@@ -31,37 +32,23 @@ pub struct PlainDateConstructor;
 impl PlainDateConstructor {
     /// Temporal.PlainDate Constructor (https://tc39.es/proposal-temporal/#sec-temporal-plaindate-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::PlainDateConstructor_construct,
             3,
             cx.names.plain_date(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::PlainDatePrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::PlainDatePrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.compare(),
-            RuntimeFunction::PlainDateConstructor_compare,
-            2,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.from(),
-            RuntimeFunction::PlainDateConstructor_from,
-            1,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            compare PlainDateConstructor_compare (2),
+            from    PlainDateConstructor_from    (1),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
@@ -1,14 +1,15 @@
 use temporal_rs::options::DisplayCalendar;
 
 use crate::{
+    intrinsic_getter_methods, intrinsic_methods,
     runtime::{
         Arguments, Context, EvalResult, Handle, Realm, Value,
         alloc_error::AllocResult,
         error::type_error,
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
             temporal::{
                 duration_constructor::to_temporal_duration,
                 duration_object::DurationObject,
@@ -28,7 +29,6 @@ use crate::{
             },
         },
         object_value::ObjectValue,
-        property::Property,
     },
     runtime_fn,
 };
@@ -38,224 +38,50 @@ pub struct PlainDatePrototype;
 impl PlainDatePrototype {
     /// Properties of the Temporal.PlainDate Prototype Object (https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaindate-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once PlainDateConstructor has been created
 
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.temporal_plain_date().as_string().into(), false, false, true),
-        )?;
+        intrinsic_methods!(cx, builder, {
+            add                 PlainDatePrototype_add              (1),
+            subtract            PlainDatePrototype_subtract         (1),
+            until               PlainDatePrototype_until            (1),
+            since               PlainDatePrototype_since            (1),
+            equals              PlainDatePrototype_equals           (1),
+            to_plain_date_time  PlainDatePrototype_toPlainDateTime  (0),
+            to_plain_month_day  PlainDatePrototype_toPlainMonthDay  (0),
+            to_plain_year_month PlainDatePrototype_toPlainYearMonth (0),
+            to_zoned_date_time  PlainDatePrototype_toZonedDateTime  (1),
+            to_string           PlainDatePrototype_toString         (0),
+            to_locale_string    PlainDatePrototype_toLocaleString   (0),
+            to_json             PlainDatePrototype_toJSON           (0),
+            value_of            PlainDatePrototype_valueOf          (0),
+            with                PlainDatePrototype_with             (1),
+            with_calendar       PlainDatePrototype_withCalendar     (1),
+        });
 
-        // Getters
-        object.intrinsic_getter(
-            cx,
-            cx.names.calendar_id(),
-            RuntimeFunction::PlainDatePrototype_calendarId,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.era(),
-            RuntimeFunction::PlainDatePrototype_era,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.era_year(),
-            RuntimeFunction::PlainDatePrototype_eraYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.year(),
-            RuntimeFunction::PlainDatePrototype_year,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.month(),
-            RuntimeFunction::PlainDatePrototype_month,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.month_code(),
-            RuntimeFunction::PlainDatePrototype_monthCode,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.day(),
-            RuntimeFunction::PlainDatePrototype_day,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.day_of_week(),
-            RuntimeFunction::PlainDatePrototype_dayOfWeek,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.day_of_year(),
-            RuntimeFunction::PlainDatePrototype_dayOfYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.week_of_year(),
-            RuntimeFunction::PlainDatePrototype_weekOfYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.year_of_week(),
-            RuntimeFunction::PlainDatePrototype_yearOfWeek,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.days_in_week(),
-            RuntimeFunction::PlainDatePrototype_daysInWeek,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.days_in_month(),
-            RuntimeFunction::PlainDatePrototype_daysInMonth,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.days_in_year(),
-            RuntimeFunction::PlainDatePrototype_daysInYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.months_in_year(),
-            RuntimeFunction::PlainDatePrototype_monthsInYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.in_leap_year(),
-            RuntimeFunction::PlainDatePrototype_inLeapYear,
-            realm,
-        )?;
+        intrinsic_getter_methods!(cx, builder, {
+            calendar_id    PlainDatePrototype_calendarId,
+            era            PlainDatePrototype_era,
+            era_year       PlainDatePrototype_eraYear,
+            year           PlainDatePrototype_year,
+            month          PlainDatePrototype_month,
+            month_code     PlainDatePrototype_monthCode,
+            day            PlainDatePrototype_day,
+            day_of_week    PlainDatePrototype_dayOfWeek,
+            day_of_year    PlainDatePrototype_dayOfYear,
+            week_of_year   PlainDatePrototype_weekOfYear,
+            year_of_week   PlainDatePrototype_yearOfWeek,
+            days_in_week   PlainDatePrototype_daysInWeek,
+            days_in_month  PlainDatePrototype_daysInMonth,
+            days_in_year   PlainDatePrototype_daysInYear,
+            months_in_year PlainDatePrototype_monthsInYear,
+            in_leap_year   PlainDatePrototype_inLeapYear,
+        });
 
-        // Methods
-        object.intrinsic_func(
-            cx,
-            cx.names.add(),
-            RuntimeFunction::PlainDatePrototype_add,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.subtract(),
-            RuntimeFunction::PlainDatePrototype_subtract,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.until(),
-            RuntimeFunction::PlainDatePrototype_until,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.since(),
-            RuntimeFunction::PlainDatePrototype_since,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.equals(),
-            RuntimeFunction::PlainDatePrototype_equals,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_plain_date_time(),
-            RuntimeFunction::PlainDatePrototype_toPlainDateTime,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_plain_month_day(),
-            RuntimeFunction::PlainDatePrototype_toPlainMonthDay,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_plain_year_month(),
-            RuntimeFunction::PlainDatePrototype_toPlainYearMonth,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_zoned_date_time(),
-            RuntimeFunction::PlainDatePrototype_toZonedDateTime,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::PlainDatePrototype_toString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_string(),
-            RuntimeFunction::PlainDatePrototype_toLocaleString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_json(),
-            RuntimeFunction::PlainDatePrototype_toJSON,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::PlainDatePrototype_valueOf,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.with(),
-            RuntimeFunction::PlainDatePrototype_with,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.with_calendar(),
-            RuntimeFunction::PlainDatePrototype_withCalendar,
-            1,
-            realm,
-        )?;
+        builder.to_string_tag(cx.names.temporal_plain_date())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
@@ -1,12 +1,13 @@
 use temporal_rs::{PlainDateTime, parsed_intermediates::ParsedDateTime, partial::PartialDateTime};
 
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Realm, Value,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
@@ -31,39 +32,23 @@ pub struct PlainDateTimeConstructor;
 impl PlainDateTimeConstructor {
     /// Temporal.PlainDateTime Constructor (https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::PlainDateTimeConstructor_construct,
             3,
             cx.names.plain_date_time(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm
-                .get_intrinsic(Intrinsic::PlainDateTimePrototype)
-                .into(),
-        )?;
+        builder.prototype(Intrinsic::PlainDateTimePrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.from(),
-            RuntimeFunction::PlainDateTimeConstructor_from,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.compare(),
-            RuntimeFunction::PlainDateTimeConstructor_compare,
-            2,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            from    PlainDateTimeConstructor_from    (1),
+            compare PlainDateTimeConstructor_compare (2),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
@@ -3,13 +3,14 @@ use temporal_rs::options::{
 };
 
 use crate::{
+    intrinsic_getter_methods, intrinsic_methods,
     runtime::{
         Arguments, Context, EvalResult, Handle, Realm, Value,
         alloc_error::AllocResult,
         error::type_error,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
             temporal::{
                 duration_constructor::to_temporal_duration,
                 duration_object::DurationObject,
@@ -32,7 +33,6 @@ use crate::{
             },
         },
         object_value::ObjectValue,
-        property::Property,
     },
     runtime_fn,
 };
@@ -42,274 +42,62 @@ pub struct PlainDateTimePrototype;
 impl PlainDateTimePrototype {
     /// Properties of the Temporal.PlainDateTime Prototype Object (https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaindatetime-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once PlainDateTimeConstructor has been created
 
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(
-                cx.names.temporal_plain_date_time().as_string().into(),
-                false,
-                false,
-                true,
-            ),
-        )?;
+        intrinsic_methods!(cx, builder, {
+            add                 PlainDateTimePrototype_add              (1),
+            subtract            PlainDateTimePrototype_subtract         (1),
+            until               PlainDateTimePrototype_until            (1),
+            since               PlainDateTimePrototype_since            (1),
+            round               PlainDateTimePrototype_round            (1),
+            equals              PlainDateTimePrototype_equals           (1),
+            to_plain_date       PlainDateTimePrototype_toPlainDate      (0),
+            to_plain_time       PlainDateTimePrototype_toPlainTime      (0),
+            to_zoned_date_time  PlainDateTimePrototype_toZonedDateTime  (1),
+            to_string           PlainDateTimePrototype_toString         (0),
+            to_locale_string    PlainDateTimePrototype_toLocaleString   (0),
+            to_json             PlainDateTimePrototype_toJSON           (0),
+            value_of            PlainDateTimePrototype_valueOf          (0),
+            with                PlainDateTimePrototype_with             (1),
+            with_plain_time     PlainDateTimePrototype_withPlainTime    (0),
+            with_calendar       PlainDateTimePrototype_withCalendar     (1),
+        });
 
         // Date getters
-        object.intrinsic_getter(
-            cx,
-            cx.names.calendar_id(),
-            RuntimeFunction::PlainDateTimePrototype_calendarId,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.era(),
-            RuntimeFunction::PlainDateTimePrototype_era,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.era_year(),
-            RuntimeFunction::PlainDateTimePrototype_eraYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.year(),
-            RuntimeFunction::PlainDateTimePrototype_year,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.month(),
-            RuntimeFunction::PlainDateTimePrototype_month,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.month_code(),
-            RuntimeFunction::PlainDateTimePrototype_monthCode,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.day(),
-            RuntimeFunction::PlainDateTimePrototype_day,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.day_of_week(),
-            RuntimeFunction::PlainDateTimePrototype_dayOfWeek,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.day_of_year(),
-            RuntimeFunction::PlainDateTimePrototype_dayOfYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.week_of_year(),
-            RuntimeFunction::PlainDateTimePrototype_weekOfYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.year_of_week(),
-            RuntimeFunction::PlainDateTimePrototype_yearOfWeek,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.days_in_week(),
-            RuntimeFunction::PlainDateTimePrototype_daysInWeek,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.days_in_month(),
-            RuntimeFunction::PlainDateTimePrototype_daysInMonth,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.days_in_year(),
-            RuntimeFunction::PlainDateTimePrototype_daysInYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.months_in_year(),
-            RuntimeFunction::PlainDateTimePrototype_monthsInYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.in_leap_year(),
-            RuntimeFunction::PlainDateTimePrototype_inLeapYear,
-            realm,
-        )?;
+        intrinsic_getter_methods!(cx, builder, {
+            calendar_id    PlainDateTimePrototype_calendarId,
+            era            PlainDateTimePrototype_era,
+            era_year       PlainDateTimePrototype_eraYear,
+            year           PlainDateTimePrototype_year,
+            month          PlainDateTimePrototype_month,
+            month_code     PlainDateTimePrototype_monthCode,
+            day            PlainDateTimePrototype_day,
+            day_of_week    PlainDateTimePrototype_dayOfWeek,
+            day_of_year    PlainDateTimePrototype_dayOfYear,
+            week_of_year   PlainDateTimePrototype_weekOfYear,
+            year_of_week   PlainDateTimePrototype_yearOfWeek,
+            days_in_week   PlainDateTimePrototype_daysInWeek,
+            days_in_month  PlainDateTimePrototype_daysInMonth,
+            days_in_year   PlainDateTimePrototype_daysInYear,
+            months_in_year PlainDateTimePrototype_monthsInYear,
+            in_leap_year   PlainDateTimePrototype_inLeapYear,
+        });
 
         // Time getters
-        object.intrinsic_getter(
-            cx,
-            cx.names.hour(),
-            RuntimeFunction::PlainDateTimePrototype_hour,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.minute(),
-            RuntimeFunction::PlainDateTimePrototype_minute,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.second(),
-            RuntimeFunction::PlainDateTimePrototype_second,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.millisecond(),
-            RuntimeFunction::PlainDateTimePrototype_millisecond,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.microsecond(),
-            RuntimeFunction::PlainDateTimePrototype_microsecond,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.nanosecond(),
-            RuntimeFunction::PlainDateTimePrototype_nanosecond,
-            realm,
-        )?;
+        intrinsic_getter_methods!(cx, builder, {
+            hour        PlainDateTimePrototype_hour,
+            minute      PlainDateTimePrototype_minute,
+            second      PlainDateTimePrototype_second,
+            millisecond PlainDateTimePrototype_millisecond,
+            microsecond PlainDateTimePrototype_microsecond,
+            nanosecond  PlainDateTimePrototype_nanosecond,
+        });
 
-        // Methods
-        object.intrinsic_func(
-            cx,
-            cx.names.add(),
-            RuntimeFunction::PlainDateTimePrototype_add,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.subtract(),
-            RuntimeFunction::PlainDateTimePrototype_subtract,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.until(),
-            RuntimeFunction::PlainDateTimePrototype_until,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.since(),
-            RuntimeFunction::PlainDateTimePrototype_since,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.round(),
-            RuntimeFunction::PlainDateTimePrototype_round,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.equals(),
-            RuntimeFunction::PlainDateTimePrototype_equals,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_plain_date(),
-            RuntimeFunction::PlainDateTimePrototype_toPlainDate,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_plain_time(),
-            RuntimeFunction::PlainDateTimePrototype_toPlainTime,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_zoned_date_time(),
-            RuntimeFunction::PlainDateTimePrototype_toZonedDateTime,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::PlainDateTimePrototype_toString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_string(),
-            RuntimeFunction::PlainDateTimePrototype_toLocaleString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_json(),
-            RuntimeFunction::PlainDateTimePrototype_toJSON,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::PlainDateTimePrototype_valueOf,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.with(),
-            RuntimeFunction::PlainDateTimePrototype_with,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.with_plain_time(),
-            RuntimeFunction::PlainDateTimePrototype_withPlainTime,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.with_calendar(),
-            RuntimeFunction::PlainDateTimePrototype_withCalendar,
-            1,
-            realm,
-        )?;
+        builder.to_string_tag(cx.names.temporal_plain_date_time())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
@@ -3,12 +3,13 @@ use temporal_rs::{
 };
 
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Realm, Value,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
@@ -31,32 +32,22 @@ pub struct PlainMonthDayConstructor;
 impl PlainMonthDayConstructor {
     /// Temporal.PlainMonthDay Constructor (https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::PlainMonthDayConstructor_construct,
             2,
             cx.names.plain_month_day(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm
-                .get_intrinsic(Intrinsic::PlainMonthDayPrototype)
-                .into(),
-        )?;
+        builder.prototype(Intrinsic::PlainMonthDayPrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.from(),
-            RuntimeFunction::PlainMonthDayConstructor_from,
-            1,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            from PlainMonthDayConstructor_from (1),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
@@ -1,13 +1,14 @@
 use temporal_rs::options::DisplayCalendar;
 
 use crate::{
+    intrinsic_getter_methods, intrinsic_methods,
     runtime::{
         Context, EvalResult, Handle, Realm, Value,
         alloc_error::AllocResult,
         error::type_error,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
             temporal::{
                 plain_date_object::PlainDateObject,
                 plain_month_day_constructor::to_temporal_month_day,
@@ -20,7 +21,6 @@ use crate::{
             },
         },
         object_value::ObjectValue,
-        property::Property,
     },
     runtime_fn,
 };
@@ -30,95 +30,29 @@ pub struct PlainMonthDayPrototype;
 impl PlainMonthDayPrototype {
     /// Properties of the Temporal.PlainMonthDay Prototype Object (https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plainmonthday-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once PlainMonthDayConstructor has been created
 
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(
-                cx.names.temporal_plain_month_day().as_string().into(),
-                false,
-                false,
-                true,
-            ),
-        )?;
+        intrinsic_methods!(cx, builder, {
+            equals            PlainMonthDayPrototype_equals          (1),
+            to_plain_date     PlainMonthDayPrototype_toPlainDate     (1),
+            to_string         PlainMonthDayPrototype_toString        (0),
+            to_locale_string  PlainMonthDayPrototype_toLocaleString  (0),
+            to_json           PlainMonthDayPrototype_toJSON          (0),
+            value_of          PlainMonthDayPrototype_valueOf         (0),
+            with              PlainMonthDayPrototype_with            (1),
+        });
 
-        // Getters
-        object.intrinsic_getter(
-            cx,
-            cx.names.calendar_id(),
-            RuntimeFunction::PlainMonthDayPrototype_calendarId,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.month_code(),
-            RuntimeFunction::PlainMonthDayPrototype_monthCode,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.day(),
-            RuntimeFunction::PlainMonthDayPrototype_day,
-            realm,
-        )?;
+        intrinsic_getter_methods!(cx, builder, {
+            calendar_id PlainMonthDayPrototype_calendarId,
+            month_code  PlainMonthDayPrototype_monthCode,
+            day         PlainMonthDayPrototype_day,
+        });
 
-        // Methods
-        object.intrinsic_func(
-            cx,
-            cx.names.equals(),
-            RuntimeFunction::PlainMonthDayPrototype_equals,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_plain_date(),
-            RuntimeFunction::PlainMonthDayPrototype_toPlainDate,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::PlainMonthDayPrototype_toString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_string(),
-            RuntimeFunction::PlainMonthDayPrototype_toLocaleString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_json(),
-            RuntimeFunction::PlainMonthDayPrototype_toJSON,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::PlainMonthDayPrototype_valueOf,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.with(),
-            RuntimeFunction::PlainMonthDayPrototype_with,
-            1,
-            realm,
-        )?;
+        builder.to_string_tag(cx.names.temporal_plain_month_day())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
@@ -1,12 +1,13 @@
 use temporal_rs::PlainTime;
 
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Realm, Value,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
@@ -28,37 +29,23 @@ pub struct PlainTimeConstructor;
 impl PlainTimeConstructor {
     /// Temporal.PlainTime Constructor (https://tc39.es/proposal-temporal/#sec-temporal-plaintime-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::PlainTimeConstructor_construct,
             0,
             cx.names.plain_time(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::PlainTimePrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::PlainTimePrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.from(),
-            RuntimeFunction::PlainTimeConstructor_from,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.compare(),
-            RuntimeFunction::PlainTimeConstructor_compare,
-            2,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            from    PlainTimeConstructor_from    (1),
+            compare PlainTimeConstructor_compare (2),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
@@ -1,13 +1,14 @@
 use temporal_rs::options::{RoundingMode, RoundingOptions, ToStringRoundingOptions};
 
 use crate::{
+    intrinsic_getter_methods, intrinsic_methods,
     runtime::{
         Arguments, Context, EvalResult, Handle, Realm, Value,
         alloc_error::AllocResult,
         error::type_error,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
             temporal::{
                 duration_constructor::to_temporal_duration,
                 duration_object::DurationObject,
@@ -22,7 +23,6 @@ use crate::{
             },
         },
         object_value::ObjectValue,
-        property::Property,
     },
     runtime_fn,
 };
@@ -32,136 +32,36 @@ pub struct PlainTimePrototype;
 impl PlainTimePrototype {
     /// Properties of the Temporal.PlainTime Prototype Object (https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaintime-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once PlainTimeConstructor has been created
 
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.temporal_plain_time().as_string().into(), false, false, true),
-        )?;
+        intrinsic_methods!(cx, builder, {
+            add              PlainTimePrototype_add              (1),
+            subtract         PlainTimePrototype_subtract         (1),
+            with             PlainTimePrototype_with             (1),
+            until            PlainTimePrototype_until            (1),
+            since            PlainTimePrototype_since            (1),
+            round            PlainTimePrototype_round            (1),
+            equals           PlainTimePrototype_equals           (1),
+            to_string        PlainTimePrototype_toString         (0),
+            to_locale_string PlainTimePrototype_toLocaleString   (0),
+            to_json          PlainTimePrototype_toJSON           (0),
+            value_of         PlainTimePrototype_valueOf          (0),
+        });
 
-        // Getters
-        object.intrinsic_getter(
-            cx,
-            cx.names.hour(),
-            RuntimeFunction::PlainTimePrototype_hour,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.minute(),
-            RuntimeFunction::PlainTimePrototype_minute,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.second(),
-            RuntimeFunction::PlainTimePrototype_second,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.millisecond(),
-            RuntimeFunction::PlainTimePrototype_millisecond,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.microsecond(),
-            RuntimeFunction::PlainTimePrototype_microsecond,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.nanosecond(),
-            RuntimeFunction::PlainTimePrototype_nanosecond,
-            realm,
-        )?;
+        intrinsic_getter_methods!(cx, builder, {
+            hour        PlainTimePrototype_hour,
+            minute      PlainTimePrototype_minute,
+            second      PlainTimePrototype_second,
+            millisecond PlainTimePrototype_millisecond,
+            microsecond PlainTimePrototype_microsecond,
+            nanosecond  PlainTimePrototype_nanosecond,
+        });
 
-        // Methods
-        object.intrinsic_func(
-            cx,
-            cx.names.add(),
-            RuntimeFunction::PlainTimePrototype_add,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.subtract(),
-            RuntimeFunction::PlainTimePrototype_subtract,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.with(),
-            RuntimeFunction::PlainTimePrototype_with,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.until(),
-            RuntimeFunction::PlainTimePrototype_until,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.since(),
-            RuntimeFunction::PlainTimePrototype_since,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.round(),
-            RuntimeFunction::PlainTimePrototype_round,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.equals(),
-            RuntimeFunction::PlainTimePrototype_equals,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::PlainTimePrototype_toString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_string(),
-            RuntimeFunction::PlainTimePrototype_toLocaleString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_json(),
-            RuntimeFunction::PlainTimePrototype_toJSON,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::PlainTimePrototype_valueOf,
-            0,
-            realm,
-        )?;
+        builder.to_string_tag(cx.names.temporal_plain_time())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
@@ -1,12 +1,13 @@
 use temporal_rs::{PlainYearMonth, parsed_intermediates::ParsedDate, partial::PartialYearMonth};
 
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Realm, Value,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
@@ -29,39 +30,23 @@ pub struct PlainYearMonthConstructor;
 impl PlainYearMonthConstructor {
     /// Temporal.PlainYearMonth Constructor (https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::PlainYearMonthConstructor_construct,
             2,
             cx.names.plain_year_month(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm
-                .get_intrinsic(Intrinsic::PlainYearMonthPrototype)
-                .into(),
-        )?;
+        builder.prototype(Intrinsic::PlainYearMonthPrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.from(),
-            RuntimeFunction::PlainYearMonthConstructor_from,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.compare(),
-            RuntimeFunction::PlainYearMonthConstructor_compare,
-            2,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            from    PlainYearMonthConstructor_from    (1),
+            compare PlainYearMonthConstructor_compare (2),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
@@ -1,13 +1,14 @@
 use temporal_rs::options::DisplayCalendar;
 
 use crate::{
+    intrinsic_getter_methods, intrinsic_methods,
     runtime::{
         Arguments, Context, EvalResult, Handle, Realm, Value,
         alloc_error::AllocResult,
         error::type_error,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
             temporal::{
                 duration_constructor::to_temporal_duration,
                 duration_object::DurationObject,
@@ -22,7 +23,6 @@ use crate::{
             },
         },
         object_value::ObjectValue,
-        property::Property,
     },
     runtime_fn,
 };
@@ -32,165 +32,40 @@ pub struct PlainYearMonthPrototype;
 impl PlainYearMonthPrototype {
     /// Properties of the Temporal.PlainYearMonth Prototype Object (https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plainyearmonth-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once PlainYearMonthConstructor has been created
 
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(
-                cx.names.temporal_plain_year_month().as_string().into(),
-                false,
-                false,
-                true,
-            ),
-        )?;
+        intrinsic_methods!(cx, builder, {
+            add               PlainYearMonthPrototype_add             (1),
+            subtract          PlainYearMonthPrototype_subtract        (1),
+            until             PlainYearMonthPrototype_until           (1),
+            since             PlainYearMonthPrototype_since           (1),
+            equals            PlainYearMonthPrototype_equals          (1),
+            to_plain_date     PlainYearMonthPrototype_toPlainDate     (1),
+            to_string         PlainYearMonthPrototype_toString        (0),
+            to_locale_string  PlainYearMonthPrototype_toLocaleString  (0),
+            to_json           PlainYearMonthPrototype_toJSON          (0),
+            value_of          PlainYearMonthPrototype_valueOf         (0),
+            with              PlainYearMonthPrototype_with            (1),
+        });
 
-        // Getters
-        object.intrinsic_getter(
-            cx,
-            cx.names.calendar_id(),
-            RuntimeFunction::PlainYearMonthPrototype_calendarId,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.era(),
-            RuntimeFunction::PlainYearMonthPrototype_era,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.era_year(),
-            RuntimeFunction::PlainYearMonthPrototype_eraYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.year(),
-            RuntimeFunction::PlainYearMonthPrototype_year,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.month(),
-            RuntimeFunction::PlainYearMonthPrototype_month,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.month_code(),
-            RuntimeFunction::PlainYearMonthPrototype_monthCode,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.days_in_year(),
-            RuntimeFunction::PlainYearMonthPrototype_daysInYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.days_in_month(),
-            RuntimeFunction::PlainYearMonthPrototype_daysInMonth,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.months_in_year(),
-            RuntimeFunction::PlainYearMonthPrototype_monthsInYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.in_leap_year(),
-            RuntimeFunction::PlainYearMonthPrototype_inLeapYear,
-            realm,
-        )?;
+        intrinsic_getter_methods!(cx, builder, {
+            calendar_id    PlainYearMonthPrototype_calendarId,
+            era            PlainYearMonthPrototype_era,
+            era_year       PlainYearMonthPrototype_eraYear,
+            year           PlainYearMonthPrototype_year,
+            month          PlainYearMonthPrototype_month,
+            month_code     PlainYearMonthPrototype_monthCode,
+            days_in_year   PlainYearMonthPrototype_daysInYear,
+            days_in_month  PlainYearMonthPrototype_daysInMonth,
+            months_in_year PlainYearMonthPrototype_monthsInYear,
+            in_leap_year   PlainYearMonthPrototype_inLeapYear,
+        });
 
-        // Methods
-        object.intrinsic_func(
-            cx,
-            cx.names.add(),
-            RuntimeFunction::PlainYearMonthPrototype_add,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.subtract(),
-            RuntimeFunction::PlainYearMonthPrototype_subtract,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.until(),
-            RuntimeFunction::PlainYearMonthPrototype_until,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.since(),
-            RuntimeFunction::PlainYearMonthPrototype_since,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.equals(),
-            RuntimeFunction::PlainYearMonthPrototype_equals,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_plain_date(),
-            RuntimeFunction::PlainYearMonthPrototype_toPlainDate,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::PlainYearMonthPrototype_toString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_string(),
-            RuntimeFunction::PlainYearMonthPrototype_toLocaleString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_json(),
-            RuntimeFunction::PlainYearMonthPrototype_toJSON,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::PlainYearMonthPrototype_valueOf,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.with(),
-            RuntimeFunction::PlainYearMonthPrototype_with,
-            1,
-            realm,
-        )?;
+        builder.to_string_tag(cx.names.temporal_plain_year_month())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/temporal_now_object.rs
+++ b/src/js/runtime/intrinsics/temporal/temporal_now_object.rs
@@ -7,12 +7,13 @@ use temporal_rs::{
 };
 
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, EvalResult, Handle, Realm, Value,
         alloc_error::AllocResult,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
             temporal::{
                 instant_object::InstantObject,
                 plain_date_object::PlainDateObject,
@@ -23,7 +24,6 @@ use crate::{
             },
         },
         object_value::ObjectValue,
-        property::Property,
     },
     runtime_fn,
 };
@@ -33,66 +33,21 @@ pub struct TemporalNowObject;
 
 impl TemporalNowObject {
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
+
+        intrinsic_methods!(cx, builder, {
+            time_zone_id        TemporalNowObject_timeZoneId       (0),
+            instant_            TemporalNowObject_instant          (0),
+            plain_date_time_iso TemporalNowObject_plainDateTimeISO (0),
+            zoned_date_time_iso TemporalNowObject_zonedDateTimeISO (0),
+            plain_date_iso      TemporalNowObject_plainDateISO     (0),
+            plain_time_iso      TemporalNowObject_plainTimeISO     (0),
+        });
 
         // Temporal.Now [ @@toStringTag ] (https://tc39.es/proposal-temporal/#sec-temporal-now-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.temporal_now().as_string().into(), false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.temporal_now())?;
 
-        object.intrinsic_func(
-            cx,
-            cx.names.time_zone_id(),
-            RuntimeFunction::TemporalNowObject_timeZoneId,
-            0,
-            realm,
-        )?;
-
-        object.intrinsic_func(
-            cx,
-            cx.names.instant_(),
-            RuntimeFunction::TemporalNowObject_instant,
-            0,
-            realm,
-        )?;
-
-        object.intrinsic_func(
-            cx,
-            cx.names.plain_date_time_iso(),
-            RuntimeFunction::TemporalNowObject_plainDateTimeISO,
-            0,
-            realm,
-        )?;
-
-        object.intrinsic_func(
-            cx,
-            cx.names.zoned_date_time_iso(),
-            RuntimeFunction::TemporalNowObject_zonedDateTimeISO,
-            0,
-            realm,
-        )?;
-
-        object.intrinsic_func(
-            cx,
-            cx.names.plain_date_iso(),
-            RuntimeFunction::TemporalNowObject_plainDateISO,
-            0,
-            realm,
-        )?;
-
-        object.intrinsic_func(
-            cx,
-            cx.names.plain_time_iso(),
-            RuntimeFunction::TemporalNowObject_plainTimeISO,
-            0,
-            realm,
-        )?;
-
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/temporal_object.rs
+++ b/src/js/runtime/intrinsics/temporal/temporal_object.rs
@@ -1,6 +1,6 @@
 use crate::runtime::{
-    Context, Handle, Realm, alloc_error::AllocResult, intrinsics::intrinsics::Intrinsic,
-    object_value::ObjectValue, property::Property,
+    Context, Handle, Realm, alloc_error::AllocResult, intrinsic_builder::IntrinsicBuilder,
+    intrinsics::intrinsics::Intrinsic, object_value::ObjectValue,
 };
 
 /// The Temporal Object (https://tc39.es/proposal-temporal/#sec-temporal-objects)
@@ -8,61 +8,61 @@ pub struct TemporalObject;
 
 impl TemporalObject {
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
-        let now_object = realm.get_intrinsic(Intrinsic::TemporalNow);
-        object.intrinsic_data_prop(cx, cx.names.now(), now_object.as_value())?;
-
-        let duration_constructor = realm.get_intrinsic(Intrinsic::DurationConstructor);
-        object.intrinsic_data_prop(cx, cx.names.duration(), duration_constructor.as_value())?;
-
-        let instant_constructor = realm.get_intrinsic(Intrinsic::InstantConstructor);
-        object.intrinsic_data_prop(cx, cx.names.instant(), instant_constructor.as_value())?;
-
-        let plain_date_constructor = realm.get_intrinsic(Intrinsic::PlainDateConstructor);
-        object.intrinsic_data_prop(cx, cx.names.plain_date(), plain_date_constructor.as_value())?;
-
-        let plain_date_time_constructor = realm.get_intrinsic(Intrinsic::PlainDateTimeConstructor);
-        object.intrinsic_data_prop(
-            cx,
+        builder.data(cx.names.now(), realm.get_intrinsic(Intrinsic::TemporalNow).as_value())?;
+        builder.data(
+            cx.names.duration(),
+            realm
+                .get_intrinsic(Intrinsic::DurationConstructor)
+                .as_value(),
+        )?;
+        builder.data(
+            cx.names.instant(),
+            realm
+                .get_intrinsic(Intrinsic::InstantConstructor)
+                .as_value(),
+        )?;
+        builder.data(
+            cx.names.plain_date(),
+            realm
+                .get_intrinsic(Intrinsic::PlainDateConstructor)
+                .as_value(),
+        )?;
+        builder.data(
             cx.names.plain_date_time(),
-            plain_date_time_constructor.as_value(),
+            realm
+                .get_intrinsic(Intrinsic::PlainDateTimeConstructor)
+                .as_value(),
         )?;
-
-        let plain_month_day_constructor = realm.get_intrinsic(Intrinsic::PlainMonthDayConstructor);
-        object.intrinsic_data_prop(
-            cx,
+        builder.data(
             cx.names.plain_month_day(),
-            plain_month_day_constructor.as_value(),
+            realm
+                .get_intrinsic(Intrinsic::PlainMonthDayConstructor)
+                .as_value(),
         )?;
-
-        let plain_time_constructor = realm.get_intrinsic(Intrinsic::PlainTimeConstructor);
-        object.intrinsic_data_prop(cx, cx.names.plain_time(), plain_time_constructor.as_value())?;
-
-        let plain_year_month_constructor =
-            realm.get_intrinsic(Intrinsic::PlainYearMonthConstructor);
-        object.intrinsic_data_prop(
-            cx,
+        builder.data(
+            cx.names.plain_time(),
+            realm
+                .get_intrinsic(Intrinsic::PlainTimeConstructor)
+                .as_value(),
+        )?;
+        builder.data(
             cx.names.plain_year_month(),
-            plain_year_month_constructor.as_value(),
+            realm
+                .get_intrinsic(Intrinsic::PlainYearMonthConstructor)
+                .as_value(),
         )?;
-
-        let zoned_date_time_constructor = realm.get_intrinsic(Intrinsic::ZonedDateTimeConstructor);
-        object.intrinsic_data_prop(
-            cx,
+        builder.data(
             cx.names.zoned_date_time(),
-            zoned_date_time_constructor.as_value(),
+            realm
+                .get_intrinsic(Intrinsic::ZonedDateTimeConstructor)
+                .as_value(),
         )?;
 
         // Temporal [ %Symbol.toStringTag% ] (https://tc39.es/proposal-temporal/#sec-temporal-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.temporal().as_string().into(), false, false, true),
-        )?;
+        builder.to_string_tag(cx.names.temporal())?;
 
-        Ok(object)
+        builder.build()
     }
 }

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
@@ -6,12 +6,13 @@ use temporal_rs::{
 };
 
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Realm, Value,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
@@ -37,39 +38,23 @@ pub struct ZonedDateTimeConstructor;
 impl ZonedDateTimeConstructor {
     /// Temporal.ZonedDateTime Constructor (https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::ZonedDateTimeConstructor_construct,
             2,
             cx.names.zoned_date_time(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm
-                .get_intrinsic(Intrinsic::ZonedDateTimePrototype)
-                .into(),
-        )?;
+        builder.prototype(Intrinsic::ZonedDateTimePrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.compare(),
-            RuntimeFunction::ZonedDateTimeConstructor_compare,
-            2,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.from(),
-            RuntimeFunction::ZonedDateTimeConstructor_from,
-            1,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            compare ZonedDateTimeConstructor_compare (2),
+            from    ZonedDateTimeConstructor_from    (1),
+        });
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
@@ -5,15 +5,15 @@ use temporal_rs::options::{
 };
 
 use crate::{
-    must,
+    intrinsic_getter_methods, intrinsic_methods, must,
     runtime::{
         Arguments, Context, EvalResult, Handle, Realm, Value,
         abstract_operations::create_data_property_or_throw,
         alloc_error::AllocResult,
         error::type_error,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
-            rust_runtime::RuntimeFunction,
             temporal::{
                 duration_constructor::to_temporal_duration,
                 duration_object::DurationObject,
@@ -40,7 +40,6 @@ use crate::{
         },
         object_value::ObjectValue,
         ordinary_object::ordinary_object_create_without_proto,
-        property::Property,
         value::BigIntValue,
     },
     runtime_fn,
@@ -51,336 +50,67 @@ pub struct ZonedDateTimePrototype;
 impl ZonedDateTimePrototype {
     /// Properties of the Temporal.ZonedDateTime Prototype Object (https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-zoneddatetime-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once ZonedDateTimeConstructor has been created
 
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(
-                cx.names.temporal_zoned_date_time().as_string().into(),
-                false,
-                false,
-                true,
-            ),
-        )?;
+        intrinsic_methods!(cx, builder, {
+            add                      ZonedDateTimePrototype_add                   (1),
+            subtract                 ZonedDateTimePrototype_subtract              (1),
+            until                    ZonedDateTimePrototype_until                 (1),
+            since                    ZonedDateTimePrototype_since                 (1),
+            round                    ZonedDateTimePrototype_round                 (1),
+            equals                   ZonedDateTimePrototype_equals                (1),
+            to_instant               ZonedDateTimePrototype_toInstant             (0),
+            to_plain_date            ZonedDateTimePrototype_toPlainDate           (0),
+            to_plain_time            ZonedDateTimePrototype_toPlainTime           (0),
+            to_plain_date_time       ZonedDateTimePrototype_toPlainDateTime       (0),
+            to_string                ZonedDateTimePrototype_toString              (0),
+            to_locale_string         ZonedDateTimePrototype_toLocaleString        (0),
+            to_json                  ZonedDateTimePrototype_toJSON                (0),
+            value_of                 ZonedDateTimePrototype_valueOf               (0),
+            with                     ZonedDateTimePrototype_with                  (1),
+            with_plain_time          ZonedDateTimePrototype_withPlainTime         (0),
+            with_time_zone           ZonedDateTimePrototype_withTimeZone          (1),
+            with_calendar            ZonedDateTimePrototype_withCalendar          (1),
+            start_of_day             ZonedDateTimePrototype_startOfDay            (0),
+            get_time_zone_transition ZonedDateTimePrototype_getTimeZoneTransition (1),
+        });
 
-        // Getters
-        object.intrinsic_getter(
-            cx,
-            cx.names.calendar_id(),
-            RuntimeFunction::ZonedDateTimePrototype_calendarId,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.time_zone_id(),
-            RuntimeFunction::ZonedDateTimePrototype_timeZoneId,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.epoch_milliseconds(),
-            RuntimeFunction::ZonedDateTimePrototype_epochMilliseconds,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.epoch_nanoseconds(),
-            RuntimeFunction::ZonedDateTimePrototype_epochNanoseconds,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.era(),
-            RuntimeFunction::ZonedDateTimePrototype_era,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.era_year(),
-            RuntimeFunction::ZonedDateTimePrototype_eraYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.year(),
-            RuntimeFunction::ZonedDateTimePrototype_year,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.month(),
-            RuntimeFunction::ZonedDateTimePrototype_month,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.month_code(),
-            RuntimeFunction::ZonedDateTimePrototype_monthCode,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.day(),
-            RuntimeFunction::ZonedDateTimePrototype_day,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.hour(),
-            RuntimeFunction::ZonedDateTimePrototype_hour,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.minute(),
-            RuntimeFunction::ZonedDateTimePrototype_minute,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.second(),
-            RuntimeFunction::ZonedDateTimePrototype_second,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.millisecond(),
-            RuntimeFunction::ZonedDateTimePrototype_millisecond,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.microsecond(),
-            RuntimeFunction::ZonedDateTimePrototype_microsecond,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.nanosecond(),
-            RuntimeFunction::ZonedDateTimePrototype_nanosecond,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.offset(),
-            RuntimeFunction::ZonedDateTimePrototype_offset,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.offset_nanoseconds(),
-            RuntimeFunction::ZonedDateTimePrototype_offsetNanoseconds,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.day_of_week(),
-            RuntimeFunction::ZonedDateTimePrototype_dayOfWeek,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.day_of_year(),
-            RuntimeFunction::ZonedDateTimePrototype_dayOfYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.week_of_year(),
-            RuntimeFunction::ZonedDateTimePrototype_weekOfYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.year_of_week(),
-            RuntimeFunction::ZonedDateTimePrototype_yearOfWeek,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.days_in_week(),
-            RuntimeFunction::ZonedDateTimePrototype_daysInWeek,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.days_in_month(),
-            RuntimeFunction::ZonedDateTimePrototype_daysInMonth,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.days_in_year(),
-            RuntimeFunction::ZonedDateTimePrototype_daysInYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.months_in_year(),
-            RuntimeFunction::ZonedDateTimePrototype_monthsInYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.in_leap_year(),
-            RuntimeFunction::ZonedDateTimePrototype_inLeapYear,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.hours_in_day(),
-            RuntimeFunction::ZonedDateTimePrototype_hoursInDay,
-            realm,
-        )?;
+        intrinsic_getter_methods!(cx, builder, {
+            calendar_id        ZonedDateTimePrototype_calendarId,
+            time_zone_id       ZonedDateTimePrototype_timeZoneId,
+            epoch_milliseconds ZonedDateTimePrototype_epochMilliseconds,
+            epoch_nanoseconds  ZonedDateTimePrototype_epochNanoseconds,
+            era                ZonedDateTimePrototype_era,
+            era_year           ZonedDateTimePrototype_eraYear,
+            year               ZonedDateTimePrototype_year,
+            month              ZonedDateTimePrototype_month,
+            month_code         ZonedDateTimePrototype_monthCode,
+            day                ZonedDateTimePrototype_day,
+            hour               ZonedDateTimePrototype_hour,
+            minute             ZonedDateTimePrototype_minute,
+            second             ZonedDateTimePrototype_second,
+            millisecond        ZonedDateTimePrototype_millisecond,
+            microsecond        ZonedDateTimePrototype_microsecond,
+            nanosecond         ZonedDateTimePrototype_nanosecond,
+            offset             ZonedDateTimePrototype_offset,
+            offset_nanoseconds ZonedDateTimePrototype_offsetNanoseconds,
+            day_of_week        ZonedDateTimePrototype_dayOfWeek,
+            day_of_year        ZonedDateTimePrototype_dayOfYear,
+            week_of_year       ZonedDateTimePrototype_weekOfYear,
+            year_of_week       ZonedDateTimePrototype_yearOfWeek,
+            days_in_week       ZonedDateTimePrototype_daysInWeek,
+            days_in_month      ZonedDateTimePrototype_daysInMonth,
+            days_in_year       ZonedDateTimePrototype_daysInYear,
+            months_in_year     ZonedDateTimePrototype_monthsInYear,
+            in_leap_year       ZonedDateTimePrototype_inLeapYear,
+            hours_in_day       ZonedDateTimePrototype_hoursInDay,
+        });
 
-        // Methods
-        object.intrinsic_func(
-            cx,
-            cx.names.add(),
-            RuntimeFunction::ZonedDateTimePrototype_add,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.subtract(),
-            RuntimeFunction::ZonedDateTimePrototype_subtract,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.until(),
-            RuntimeFunction::ZonedDateTimePrototype_until,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.since(),
-            RuntimeFunction::ZonedDateTimePrototype_since,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.round(),
-            RuntimeFunction::ZonedDateTimePrototype_round,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.equals(),
-            RuntimeFunction::ZonedDateTimePrototype_equals,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_instant(),
-            RuntimeFunction::ZonedDateTimePrototype_toInstant,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_plain_date(),
-            RuntimeFunction::ZonedDateTimePrototype_toPlainDate,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_plain_time(),
-            RuntimeFunction::ZonedDateTimePrototype_toPlainTime,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_plain_date_time(),
-            RuntimeFunction::ZonedDateTimePrototype_toPlainDateTime,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_string(),
-            RuntimeFunction::ZonedDateTimePrototype_toString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_string(),
-            RuntimeFunction::ZonedDateTimePrototype_toLocaleString,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_json(),
-            RuntimeFunction::ZonedDateTimePrototype_toJSON,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.value_of(),
-            RuntimeFunction::ZonedDateTimePrototype_valueOf,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.with(),
-            RuntimeFunction::ZonedDateTimePrototype_with,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.with_plain_time(),
-            RuntimeFunction::ZonedDateTimePrototype_withPlainTime,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.with_time_zone(),
-            RuntimeFunction::ZonedDateTimePrototype_withTimeZone,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.with_calendar(),
-            RuntimeFunction::ZonedDateTimePrototype_withCalendar,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.start_of_day(),
-            RuntimeFunction::ZonedDateTimePrototype_startOfDay,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_time_zone_transition(),
-            RuntimeFunction::ZonedDateTimePrototype_getTimeZoneTransition,
-            1,
-            realm,
-        )?;
+        builder.to_string_tag(cx.names.temporal_zoned_date_time())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/typed_array.rs
+++ b/src/js/runtime/intrinsics/typed_array.rs
@@ -11,11 +11,11 @@ use crate::{
         Context, Handle, HeapPtr,
         abstract_operations::{get, get_method, length_of_array_like, set},
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::{range_error, type_error},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             array_buffer_constructor::{ArrayBufferObject, clone_array_buffer},
             intrinsics::Intrinsic,

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -1,13 +1,13 @@
 use crate::{
-    eval_err, must, must_a,
+    eval_err, intrinsic_methods, must, must_a,
     runtime::{
         Context, Handle, PropertyKey, Realm,
         abstract_operations::{call_object, get_method, length_of_array_like, set},
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             encodings::{
                 decode_base64, decode_hex, get_base64_alphabet_option,
@@ -38,59 +38,38 @@ pub struct TypedArrayConstructor;
 
 impl TypedArrayConstructor {
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::TypedArrayConstructor_construct,
             0,
             cx.names.typed_array(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::TypedArrayPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::TypedArrayPrototype)?;
 
-        func.intrinsic_func(
-            cx,
-            cx.names.from(),
-            RuntimeFunction::TypedArrayConstructor_from,
-            1,
-            realm,
-        )?;
-        func.intrinsic_func(
-            cx,
-            cx.names.of(),
-            RuntimeFunction::TypedArrayConstructor_of,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            from TypedArrayConstructor_from (1),
+            of   TypedArrayConstructor_of   (0),
+        });
 
         // get %TypedArray% [ @@species ] (https://tc39.es/ecma262/#sec-get-%typedarray%-%symbol.species%)
-        let species_key = cx.symbols.species();
-        func.intrinsic_getter(cx, species_key, RuntimeFunction::ReturnThis, realm)?;
+        builder.getter(cx.symbols.species(), RuntimeFunction::ReturnThis)?;
 
-        Ok(func)
+        builder.build()
     }
 
     pub fn install_uint8_array_methods(cx: Context, realm: Handle<Realm>) -> AllocResult<()> {
-        let mut constructor = realm.get_intrinsic(Intrinsic::UInt8ArrayConstructor);
-        constructor.intrinsic_func(
-            cx,
-            cx.names.from_base64(),
-            RuntimeFunction::TypedArrayConstructor_from_base64,
-            1,
-            realm,
-        )?;
-        constructor.intrinsic_func(
-            cx,
-            cx.names.from_hex(),
-            RuntimeFunction::TypedArrayConstructor_from_hex,
-            1,
-            realm,
-        )?;
+        let constructor = realm.get_intrinsic(Intrinsic::UInt8ArrayConstructor);
+        let mut builder = IntrinsicBuilder::new(cx, realm, constructor);
+
+        intrinsic_methods!(cx, builder, {
+            from_base64 TypedArrayConstructor_from_base64 (1),
+            from_hex    TypedArrayConstructor_from_hex    (1),
+        });
+
+        builder.build()?;
 
         Ok(())
     }
@@ -713,29 +692,20 @@ macro_rules! create_typed_array_constructor {
         impl $constructor {
             /// Properties of the TypedArray Constructors (https://tc39.es/ecma262/#sec-properties-of-the-typedarray-constructors)
             pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-                let mut func = BuiltinFunction::intrinsic_constructor(
+                let mut builder = IntrinsicBuilder::constructor(
                     cx,
+                    realm,
                     $construct_fn,
                     3,
                     cx.names.$rust_name(),
-                    realm,
                     Intrinsic::TypedArrayConstructor,
                 )?;
 
-                func.intrinsic_frozen_property(
-                    cx,
-                    cx.names.prototype(),
-                    realm.get_intrinsic(Intrinsic::$prototype).into(),
-                )?;
+                builder.prototype(Intrinsic::$prototype)?;
 
-                let element_size_value = cx.smi(element_size!() as u8);
-                func.intrinsic_frozen_property(
-                    cx,
-                    cx.names.bytes_per_element(),
-                    element_size_value,
-                )?;
+                builder.frozen(cx.names.bytes_per_element(), cx.smi(element_size!() as u8))?;
 
-                Ok(func)
+                builder.build()
             }
 
             $crate::runtime_fn! {

--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use num_bigint::{BigUint, Sign};
 
 use crate::{
-    eval_err, must,
+    eval_err, intrinsic_getter_methods, intrinsic_methods, must,
     runtime::{
         Context, EvalResult, Handle, PropertyKey, Realm, Value,
         abstract_operations::{
@@ -11,9 +11,9 @@ use crate::{
             length_of_array_like, set, species_constructor,
         },
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::{range_error, type_error},
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             array_buffer_constructor::clone_array_buffer,
             array_iterator::{ArrayIterator, ArrayIteratorKind},
@@ -31,7 +31,6 @@ use crate::{
         },
         object_value::ObjectValue,
         ordinary_object::ordinary_object_create,
-        property::Property,
         string_value::{FlatString, StringValue},
         to_string,
         type_utilities::{
@@ -47,309 +46,81 @@ pub struct TypedArrayPrototype;
 impl TypedArrayPrototype {
     /// Properties of the %TypedArray% Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-%typedarrayprototype%-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once TypedArrayConstructor has been created
+        intrinsic_methods!(cx, builder, {
+            at               TypedArrayPrototype_at               (1),
+            copy_within      TypedArrayPrototype_copy_within      (2),
+            entries          TypedArrayPrototype_entries          (0),
+            every            TypedArrayPrototype_every            (1),
+            fill             TypedArrayPrototype_fill             (1),
+            filter           TypedArrayPrototype_filter           (1),
+            find             TypedArrayPrototype_find             (1),
+            find_index       TypedArrayPrototype_find_index       (1),
+            find_last        TypedArrayPrototype_find_last        (1),
+            find_last_index  TypedArrayPrototype_find_last_index  (1),
+            for_each         TypedArrayPrototype_for_each         (1),
+            includes         TypedArrayPrototype_includes         (1),
+            index_of         TypedArrayPrototype_index_of         (1),
+            join             TypedArrayPrototype_join             (1),
+            keys             TypedArrayPrototype_keys             (0),
+            last_index_of    TypedArrayPrototype_last_index_of    (1),
+            map_             TypedArrayPrototype_map              (1),
+            reduce           TypedArrayPrototype_reduce           (1),
+            reduce_right     TypedArrayPrototype_reduce_right     (1),
+            reverse          TypedArrayPrototype_reverse          (0),
+            set_             TypedArrayPrototype_set              (1),
+            slice            TypedArrayPrototype_slice            (2),
+            some             TypedArrayPrototype_some             (1),
+            sort             TypedArrayPrototype_sort             (1),
+            subarray         TypedArrayPrototype_subarray         (2),
+            to_locale_string TypedArrayPrototype_to_locale_string (0),
+            to_reversed      TypedArrayPrototype_to_reversed      (0),
+            to_sorted        TypedArrayPrototype_to_sorted        (1),
+            values           TypedArrayPrototype_values           (0),
+            with             TypedArrayPrototype_with             (2),
+        });
 
-        // Create values function as it is referenced by multiple properties
-        let values_function = BuiltinFunction::create(
-            cx,
-            RuntimeFunction::TypedArrayPrototype_values,
-            0,
-            cx.names.values(),
-            realm,
-            None,
-        )?
-        .into();
+        intrinsic_getter_methods!(cx, builder, {
+            buffer      TypedArrayPrototype_buffer,
+            byte_length TypedArrayPrototype_byte_length,
+            byte_offset TypedArrayPrototype_byte_offset,
+            length      TypedArrayPrototype_length,
+        });
 
-        object.intrinsic_func(
-            cx,
-            cx.names.at(),
-            RuntimeFunction::TypedArrayPrototype_at,
-            1,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.buffer(),
-            RuntimeFunction::TypedArrayPrototype_buffer,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.byte_length(),
-            RuntimeFunction::TypedArrayPrototype_byte_length,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.byte_offset(),
-            RuntimeFunction::TypedArrayPrototype_byte_offset,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.copy_within(),
-            RuntimeFunction::TypedArrayPrototype_copy_within,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.entries(),
-            RuntimeFunction::TypedArrayPrototype_entries,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.every(),
-            RuntimeFunction::TypedArrayPrototype_every,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.fill(),
-            RuntimeFunction::TypedArrayPrototype_fill,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.filter(),
-            RuntimeFunction::TypedArrayPrototype_filter,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.find(),
-            RuntimeFunction::TypedArrayPrototype_find,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.find_index(),
-            RuntimeFunction::TypedArrayPrototype_find_index,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.find_last(),
-            RuntimeFunction::TypedArrayPrototype_find_last,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.find_last_index(),
-            RuntimeFunction::TypedArrayPrototype_find_last_index,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.for_each(),
-            RuntimeFunction::TypedArrayPrototype_for_each,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.includes(),
-            RuntimeFunction::TypedArrayPrototype_includes,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.index_of(),
-            RuntimeFunction::TypedArrayPrototype_index_of,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.join(),
-            RuntimeFunction::TypedArrayPrototype_join,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.keys(),
-            RuntimeFunction::TypedArrayPrototype_keys,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.last_index_of(),
-            RuntimeFunction::TypedArrayPrototype_last_index_of,
-            1,
-            realm,
-        )?;
-        object.intrinsic_getter(
-            cx,
-            cx.names.length(),
-            RuntimeFunction::TypedArrayPrototype_length,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.map_(),
-            RuntimeFunction::TypedArrayPrototype_map,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.reduce(),
-            RuntimeFunction::TypedArrayPrototype_reduce,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.reduce_right(),
-            RuntimeFunction::TypedArrayPrototype_reduce_right,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.reverse(),
-            RuntimeFunction::TypedArrayPrototype_reverse,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_(),
-            RuntimeFunction::TypedArrayPrototype_set,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.slice(),
-            RuntimeFunction::TypedArrayPrototype_slice,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.some(),
-            RuntimeFunction::TypedArrayPrototype_some,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.sort(),
-            RuntimeFunction::TypedArrayPrototype_sort,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.subarray(),
-            RuntimeFunction::TypedArrayPrototype_subarray,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_locale_string(),
-            RuntimeFunction::TypedArrayPrototype_to_locale_string,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_reversed(),
-            RuntimeFunction::TypedArrayPrototype_to_reversed,
-            0,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.to_sorted(),
-            RuntimeFunction::TypedArrayPrototype_to_sorted,
-            1,
-            realm,
-        )?;
         // Use Array.prototype.toString directly
-        object.intrinsic_data_prop(
-            cx,
+        builder.data(
             cx.names.to_string(),
             realm
                 .get_intrinsic(Intrinsic::ArrayPrototypeToString)
                 .into(),
         )?;
-        object.intrinsic_data_prop(cx, cx.names.values(), values_function)?;
-        object.intrinsic_func(
-            cx,
-            cx.names.with(),
-            RuntimeFunction::TypedArrayPrototype_with,
-            2,
-            realm,
-        )?;
 
         // %TypedArray%.prototype [ @@iterator ] (https://tc39.es/ecma262/#sec-%typedarray%.prototype-%symbol.iterator%)
-        let iterator_key = cx.symbols.iterator();
-        object.set_property(
-            cx,
-            iterator_key,
-            Property::data(values_function, true, false, true),
-        )?;
+        builder.alias(cx.names.values(), cx.symbols.iterator())?;
 
         // get %TypedArray%.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-%symbol.tostringtag%)
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.intrinsic_getter(
-            cx,
-            to_string_tag_key,
+        builder.getter(
+            cx.symbols.to_string_tag(),
             RuntimeFunction::TypedArrayPrototype_get_to_string_tag,
-            realm,
         )?;
 
-        Ok(object)
+        builder.build()
     }
 
     pub fn install_uint8_array_methods(cx: Context, realm: Handle<Realm>) -> AllocResult<()> {
-        let mut prototype = realm.get_intrinsic(Intrinsic::UInt8ArrayPrototype);
-        prototype.intrinsic_func(
-            cx,
-            cx.names.to_base64(),
-            RuntimeFunction::TypedArrayPrototype_to_base64,
-            0,
-            realm,
-        )?;
-        prototype.intrinsic_func(
-            cx,
-            cx.names.to_hex(),
-            RuntimeFunction::TypedArrayPrototype_to_hex,
-            0,
-            realm,
-        )?;
-        prototype.intrinsic_func(
-            cx,
-            cx.names.set_from_base64(),
-            RuntimeFunction::TypedArrayPrototype_set_from_base64,
-            1,
-            realm,
-        )?;
-        prototype.intrinsic_func(
-            cx,
-            cx.names.set_from_hex(),
-            RuntimeFunction::TypedArrayPrototype_set_from_hex,
-            1,
-            realm,
-        )?;
+        let prototype = realm.get_intrinsic(Intrinsic::UInt8ArrayPrototype);
+        let mut builder = IntrinsicBuilder::new(cx, realm, prototype);
+
+        intrinsic_methods!(cx, builder, {
+            to_base64       TypedArrayPrototype_to_base64       (0),
+            to_hex          TypedArrayPrototype_to_hex          (0),
+            set_from_base64 TypedArrayPrototype_set_from_base64 (1),
+            set_from_hex    TypedArrayPrototype_set_from_hex    (1),
+        });
+
+        builder.build()?;
 
         Ok(())
     }
@@ -1845,21 +1616,16 @@ macro_rules! create_typed_array_prototype {
         impl $prototype {
             /// Properties of the TypedArray Prototype Objects (https://tc39.es/ecma262/#sec-properties-of-typedarray-prototype-objects)
             pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-                let mut object = ObjectValue::new(
-                    cx,
-                    Some(realm.get_intrinsic(Intrinsic::TypedArrayPrototype)),
-                    true,
-                )?;
+                let mut builder =
+                    IntrinsicBuilder::object(cx, realm, Intrinsic::TypedArrayPrototype)?;
 
                 // Constructor property is added once TypedArrayConstructor has been created
-                let element_size_value = cx.smi(std::mem::size_of::<$element_type>() as u8);
-                object.intrinsic_frozen_property(
-                    cx,
+                builder.frozen(
                     cx.names.bytes_per_element(),
-                    element_size_value,
+                    cx.smi(std::mem::size_of::<$element_type>() as u8),
                 )?;
 
-                Ok(object.into())
+                builder.build()
             }
         }
     };

--- a/src/js/runtime/intrinsics/weak_map_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_map_constructor.rs
@@ -3,8 +3,8 @@ use crate::{
         Context, Handle,
         abstract_operations::{call_object, get},
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic, map_constructor::add_entries_from_iterable,
             rust_runtime::RuntimeFunction, weak_map_object::WeakMapObject,
@@ -21,22 +21,18 @@ pub struct WeakMapConstructor;
 impl WeakMapConstructor {
     /// Properties of the WeakMap Constructor (https://tc39.es/ecma262/#sec-properties-of-the-weakmap-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::WeakMapConstructor_construct,
             0,
             cx.names.weak_map(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::WeakMapPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::WeakMapPrototype)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/weak_map_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_map_prototype.rs
@@ -1,16 +1,17 @@
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Value,
         abstract_operations::call,
         alloc_error::AllocResult,
         error::type_error,
         eval_result::EvalResult,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
-            intrinsics::Intrinsic, rust_runtime::RuntimeFunction, weak_map_object::WeakMapObject,
+            intrinsics::Intrinsic, weak_map_object::WeakMapObject,
             weak_ref_constructor::can_be_held_weakly,
         },
         object_value::ObjectValue,
-        property::Property,
         realm::Realm,
         type_utilities::is_callable,
         value::ValueCollectionKey,
@@ -23,62 +24,22 @@ pub struct WeakMapPrototype;
 impl WeakMapPrototype {
     /// Properties of the WeakMap Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-weakmap-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once WeakMapConstructor has been created
-        object.intrinsic_func(
-            cx,
-            cx.names.delete(),
-            RuntimeFunction::WeakMapPrototype_delete,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get(),
-            RuntimeFunction::WeakMapPrototype_get,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_or_insert(),
-            RuntimeFunction::WeakMapPrototype_get_or_insert,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.get_or_insert_computed(),
-            RuntimeFunction::WeakMapPrototype_get_or_insert_computed,
-            2,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.has(),
-            RuntimeFunction::WeakMapPrototype_has,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.set_(),
-            RuntimeFunction::WeakMapPrototype_set,
-            2,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            delete                 WeakMapPrototype_delete                 (1),
+            get                    WeakMapPrototype_get                    (1),
+            get_or_insert          WeakMapPrototype_get_or_insert          (2),
+            get_or_insert_computed WeakMapPrototype_get_or_insert_computed (2),
+            has                    WeakMapPrototype_has                    (1),
+            set_                   WeakMapPrototype_set                    (2),
+        });
 
-        // [Symbol.toStringTag] property
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.weak_map().as_string().into(), false, false, true),
-        )?;
+        // WeakMap.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-weakmap.prototype-%symbol.tostringtag%)
+        builder.to_string_tag(cx.names.weak_map())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/weak_ref_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_ref_constructor.rs
@@ -5,11 +5,11 @@ use crate::{
     runtime::{
         Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -69,22 +69,18 @@ pub struct WeakRefConstructor;
 impl WeakRefConstructor {
     /// Properties of the WeakRef Constructor (https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::WeakRefConstructor_construct,
             1,
             cx.names.weak_ref(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::WeakRefPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::WeakRefPrototype)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/weak_ref_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_ref_prototype.rs
@@ -1,14 +1,12 @@
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Value,
         alloc_error::AllocResult,
         error::type_error,
-        intrinsics::{
-            intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
-            weak_ref_constructor::WeakRefObject,
-        },
+        intrinsic_builder::IntrinsicBuilder,
+        intrinsics::{intrinsics::Intrinsic, weak_ref_constructor::WeakRefObject},
         object_value::ObjectValue,
-        property::Property,
         realm::Realm,
     },
     runtime_fn,
@@ -19,27 +17,17 @@ pub struct WeakRefPrototype;
 impl WeakRefPrototype {
     /// Properties of the WeakRef Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once WeakRefConstructor has been created
-        object.intrinsic_func(
-            cx,
-            cx.names.deref(),
-            RuntimeFunction::WeakRefPrototype_deref,
-            0,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            deref WeakRefPrototype_deref (0),
+        });
 
-        // [Symbol.toStringTag] property
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.weak_ref().as_string().into(), false, false, true),
-        )?;
+        // WeakRef.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-weak-ref.prototype-%symbol.tostringtag%)
+        builder.to_string_tag(cx.names.weak_ref())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/weak_set_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_set_constructor.rs
@@ -3,8 +3,8 @@ use crate::{
         Context, Handle,
         abstract_operations::{call_object, get},
         alloc_error::AllocResult,
-        builtin_function::BuiltinFunction,
         error::type_error,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic, rust_runtime::RuntimeFunction, weak_set_object::WeakSetObject,
         },
@@ -21,22 +21,18 @@ pub struct WeakSetConstructor;
 impl WeakSetConstructor {
     /// Properties of the WeakSet Constructor (https://tc39.es/ecma262/#sec-properties-of-the-weakset-constructor)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut func = BuiltinFunction::intrinsic_constructor(
+        let mut builder = IntrinsicBuilder::constructor(
             cx,
+            realm,
             RuntimeFunction::WeakSetConstructor_construct,
             0,
             cx.names.weak_set(),
-            realm,
             Intrinsic::FunctionPrototype,
         )?;
 
-        func.intrinsic_frozen_property(
-            cx,
-            cx.names.prototype(),
-            realm.get_intrinsic(Intrinsic::WeakSetPrototype).into(),
-        )?;
+        builder.prototype(Intrinsic::WeakSetPrototype)?;
 
-        Ok(func)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/weak_set_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_set_prototype.rs
@@ -1,15 +1,16 @@
 use crate::{
+    intrinsic_methods,
     runtime::{
         Context, Handle, Value,
         alloc_error::AllocResult,
         error::type_error,
         eval_result::EvalResult,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
-            intrinsics::Intrinsic, rust_runtime::RuntimeFunction,
-            weak_ref_constructor::can_be_held_weakly, weak_set_object::WeakSetObject,
+            intrinsics::Intrinsic, weak_ref_constructor::can_be_held_weakly,
+            weak_set_object::WeakSetObject,
         },
         object_value::ObjectValue,
-        property::Property,
         realm::Realm,
         value::ValueCollectionKey,
     },
@@ -21,41 +22,19 @@ pub struct WeakSetPrototype;
 impl WeakSetPrototype {
     /// Properties of the WeakSet Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-weakset-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         // Constructor property is added once WeakSetConstructor has been created
-        object.intrinsic_func(
-            cx,
-            cx.names.add(),
-            RuntimeFunction::WeakSetPrototype_add,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.delete(),
-            RuntimeFunction::WeakSetPrototype_delete,
-            1,
-            realm,
-        )?;
-        object.intrinsic_func(
-            cx,
-            cx.names.has(),
-            RuntimeFunction::WeakSetPrototype_has,
-            1,
-            realm,
-        )?;
+        intrinsic_methods!(cx, builder, {
+            add    WeakSetPrototype_add    (1),
+            delete WeakSetPrototype_delete (1),
+            has    WeakSetPrototype_has    (1),
+        });
 
-        // [Symbol.toStringTag] property
-        let to_string_tag_key = cx.symbols.to_string_tag();
-        object.set_property(
-            cx,
-            to_string_tag_key,
-            Property::data(cx.names.weak_set().as_string().into(), false, false, true),
-        )?;
+        // WeakSet.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-weakset.prototype-%symbol.tostringtag%)
+        builder.to_string_tag(cx.names.weak_set())?;
 
-        Ok(object)
+        builder.build()
     }
 
     runtime_fn! {

--- a/src/js/runtime/mod.rs
+++ b/src/js/runtime/mod.rs
@@ -29,6 +29,7 @@ mod generator_object;
 pub mod global_names;
 mod heap_item_descriptor;
 mod interned_strings;
+pub mod intrinsic_builder;
 pub mod intrinsics;
 mod iterator;
 pub mod module;

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -6,15 +6,12 @@ use std::{
 use rand::Rng;
 
 use crate::{
-    handle_scope_guard,
     runtime::{
         Context, Realm,
-        accessor::Accessor,
         alloc_error::AllocResult,
         array_object::ArrayObject,
         array_properties::ArrayProperties,
         async_generator_object::AsyncGeneratorObject,
-        builtin_function::BuiltinFunction,
         bytecode::function::Closure,
         collections::{BsIndexMap, BsIndexMapField},
         error::type_error,
@@ -31,7 +28,7 @@ use crate::{
             iterator_helper_object::IteratorHelperObject, map_object::MapObject,
             number_constructor::NumberObject, object_prototype::ObjectPrototype,
             raw_json_object::RawJSONObject, regexp_constructor::RegExpObject,
-            rust_runtime::RuntimeFunction, set_object::SetObject, symbol_constructor::SymbolObject,
+            set_object::SetObject, symbol_constructor::SymbolObject,
             temporal::duration_object::DurationObject, temporal::instant_object::InstantObject,
             temporal::plain_date_object::PlainDateObject,
             temporal::plain_date_time_object::PlainDateTimeObject,
@@ -446,87 +443,6 @@ impl Handle<ObjectValue> {
         new_length: u32,
     ) -> AllocResult<bool> {
         ArrayProperties::set_len(cx, *self, new_length)
-    }
-
-    // Intrinsic creation utilities
-    pub fn intrinsic_data_prop(
-        &mut self,
-        cx: Context,
-        key: Handle<PropertyKey>,
-        value: Handle<Value>,
-    ) -> AllocResult<()> {
-        handle_scope_guard!(cx);
-
-        self.set_property(cx, key, Property::data(value, true, false, true))
-    }
-
-    pub fn intrinsic_length_prop(&mut self, cx: Context, length: i32) -> AllocResult<()> {
-        handle_scope_guard!(cx);
-
-        let length_value = cx.smi(length);
-        self.set_property(cx, cx.names.length(), Property::data(length_value, false, false, true))
-    }
-
-    pub fn intrinsic_name_prop(&mut self, mut cx: Context, name: &'static str) -> AllocResult<()> {
-        handle_scope_guard!(cx);
-
-        let name_value = cx.alloc_static_string(name)?.into();
-        self.set_property(cx, cx.names.name(), Property::data(name_value, false, false, true))
-    }
-
-    pub fn intrinsic_getter(
-        &mut self,
-        cx: Context,
-        name: Handle<PropertyKey>,
-        func: RuntimeFunction,
-        realm: Handle<Realm>,
-    ) -> AllocResult<()> {
-        handle_scope_guard!(cx);
-
-        let getter = BuiltinFunction::create(cx, func, 0, name, realm, Some("get"))?;
-        let accessor_value = Accessor::new(cx, Some(getter), None)?;
-        self.set_property(cx, name, Property::accessor(accessor_value.into(), false, true))
-    }
-
-    pub fn intrinsic_getter_and_setter(
-        &mut self,
-        cx: Context,
-        name: Handle<PropertyKey>,
-        getter: RuntimeFunction,
-        setter: RuntimeFunction,
-        realm: Handle<Realm>,
-    ) -> AllocResult<()> {
-        handle_scope_guard!(cx);
-
-        let getter = BuiltinFunction::create(cx, getter, 0, name, realm, Some("get"))?;
-        let setter = BuiltinFunction::create(cx, setter, 1, name, realm, Some("set"))?;
-        let accessor_value = Accessor::new(cx, Some(getter), Some(setter))?;
-        self.set_property(cx, name, Property::accessor(accessor_value.into(), false, true))
-    }
-
-    pub fn intrinsic_func(
-        &mut self,
-        cx: Context,
-        name: Handle<PropertyKey>,
-        func: RuntimeFunction,
-        length: u32,
-        realm: Handle<Realm>,
-    ) -> AllocResult<()> {
-        handle_scope_guard!(cx);
-
-        let func = BuiltinFunction::create(cx, func, length, name, realm, None)?.into();
-        self.intrinsic_data_prop(cx, name, func)
-    }
-
-    pub fn intrinsic_frozen_property(
-        &mut self,
-        cx: Context,
-        key: Handle<PropertyKey>,
-        value: Handle<Value>,
-    ) -> AllocResult<()> {
-        handle_scope_guard!(cx);
-
-        self.set_property(cx, key, Property::data(value, false, false, false))
     }
 }
 

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -10,6 +10,7 @@ use crate::{
         error::{syntax_parse_error, type_error},
         eval::eval::evaluate_script,
         get,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             array_buffer_constructor::ArrayBufferObject, intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
@@ -26,46 +27,31 @@ pub struct Test262Object;
 
 impl Test262Object {
     fn new(mut cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
-        let mut object =
-            ObjectValue::new(cx, Some(realm.get_intrinsic(Intrinsic::ObjectPrototype)), true)?;
+        let mut builder = IntrinsicBuilder::object(cx, realm, Intrinsic::ObjectPrototype)?;
 
         let create_realm_string = cx.alloc_static_string("createRealm")?;
         let create_realm_key = PropertyKey::string_handle(cx, create_realm_string)?;
-        object.intrinsic_func(
-            cx,
-            create_realm_key,
-            RuntimeFunction::Test262Object_create_realm,
-            0,
-            realm,
-        )?;
+        builder.method(create_realm_key, RuntimeFunction::Test262Object_create_realm, 0)?;
 
         let eval_script_string = cx.alloc_static_string("evalScript")?;
         let eval_script_key = PropertyKey::string_handle(cx, eval_script_string)?;
-        object.intrinsic_func(
-            cx,
-            eval_script_key,
-            RuntimeFunction::Test262Object_eval_script,
-            1,
-            realm,
-        )?;
+        builder.method(eval_script_key, RuntimeFunction::Test262Object_eval_script, 1)?;
 
         let global_string = cx.alloc_static_string("global")?;
         let global_key = PropertyKey::string_handle(cx, global_string)?;
-        object.intrinsic_data_prop(cx, global_key, realm.global_object().into())?;
+        builder.data(global_key, realm.global_object().into())?;
 
         let detach_array_buffer_string = cx.alloc_static_string("detachArrayBuffer")?;
         let detach_array_buffer_key = PropertyKey::string_handle(cx, detach_array_buffer_string)?;
-        object.intrinsic_func(
-            cx,
+        builder.method(
             detach_array_buffer_key,
             RuntimeFunction::Test262Object_detach_array_buffer,
             1,
-            realm,
         )?;
 
-        object.intrinsic_func(cx, cx.names.gc(), RuntimeFunction::GcObject_run, 0, realm)?;
+        builder.method(cx.names.gc(), RuntimeFunction::GcObject_run, 0)?;
 
-        Ok(object.to_handle())
+        builder.build()
     }
 
     pub fn install(mut cx: Context, realm: Handle<Realm>) -> AllocResult<()> {
@@ -73,23 +59,17 @@ impl Test262Object {
             // Create the test262 object
             let test_262_object = Test262Object::new(cx, realm)?;
 
+            let mut builder = IntrinsicBuilder::new(cx, realm, realm.global_object());
+
             // Install the "$262" property on the global object
-            realm.global_object().intrinsic_data_prop(
-                cx,
-                test_262_key(cx)?,
-                test_262_object.into(),
-            )?;
+            builder.data(test_262_key(cx)?, test_262_object.into())?;
 
             // Also install a global print function needed in tests
             let print_string = cx.alloc_static_string("print")?;
             let print_key = PropertyKey::string_handle(cx, print_string)?;
-            realm.global_object().intrinsic_func(
-                cx,
-                print_key,
-                RuntimeFunction::Test262Object_print,
-                1,
-                realm,
-            )?;
+            builder.method(print_key, RuntimeFunction::Test262Object_print, 1)?;
+
+            builder.build()?;
 
             // Install the global print log property
             must_a!(Self::set_print_log(

--- a/src/js/runtime/test_shell.rs
+++ b/src/js/runtime/test_shell.rs
@@ -17,6 +17,7 @@ use crate::{
         error::syntax_parse_error,
         eval::eval::evaluate_script,
         gc_object::GcObject,
+        intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             array_buffer_constructor::ArrayBufferObject, error_constructor::ErrorObject,
             intrinsics::Intrinsic, rust_runtime::RuntimeFunctionPtr,
@@ -123,9 +124,9 @@ impl TestShell {
         }
 
         let arguments_key = PropertyKey::string_handle(cx, cx.alloc_static_string("arguments")?)?;
-        realm
-            .global_object()
-            .intrinsic_data_prop(cx, arguments_key, array.as_value())?;
+        let mut builder = IntrinsicBuilder::new(cx, realm, realm.global_object());
+        builder.data(arguments_key, array.as_value())?;
+        builder.build()?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

There was a huge amount of boilerplate in setting up builtin objects like all intrinsic constructors, prototypes, etc. We can greatly simplify this with an `IntrinsicsBuilder` utility and some concise macros for quickly defining methods.

Net -3700 lines so there was a lot of boilerplate.

## Tests

- CI