### PR TITLE
[runtime] Refactor how heap collection types are instantiated, use traits and macros

### DIFF
--- a/src/js/runtime/array_properties.rs
+++ b/src/js/runtime/array_properties.rs
@@ -1,10 +1,10 @@
 use crate::{
-    field_offset,
+    field_offset, impl_hash_map_instance,
     runtime::{
         Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
-        collections::{BsHashMap, BsHashMapField, InlineArray},
-        gc::{HeapItem, HeapVisitor},
+        collections::{BsHashMap, BsHashMapField, HashMapInstance, InlineArray},
+        gc::{HeapItem, HeapVisitor, IsHeapItem},
         heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
         object_value::ObjectValue,
         property::{HeapProperty, Property, PropertyFlags},
@@ -35,7 +35,7 @@ impl HeapPtr<ArrayProperties> {
     }
 
     #[inline]
-    pub fn as_sparse(&self) -> HeapPtr<SparseArrayProperties> {
+    pub fn as_sparse(&self) -> HeapPtr<SparseArrayPropertiesMap> {
         self.cast()
     }
 
@@ -71,7 +71,6 @@ impl HeapPtr<ArrayProperties> {
         } else {
             let sparse_properties = self.as_sparse();
             sparse_properties
-                .map
                 .get(&array_index)
                 .map(|property| Property::from_heap(cx, property))
         }
@@ -82,7 +81,7 @@ impl HeapPtr<ArrayProperties> {
             dense_properties.set(array_index, Value::empty());
         } else {
             let mut sparse_properties = self.as_sparse();
-            sparse_properties.map.remove(&array_index);
+            sparse_properties.remove(&array_index);
         }
     }
 }
@@ -182,9 +181,12 @@ impl ArrayProperties {
             .iter_gc_unsafe()
             .filter(|value| !value.is_empty())
             .count();
-        let new_capacity = SparseArrayProperties::min_capacity_needed(num_non_empty_properties);
-        let mut sparse_properties =
-            SparseArrayProperties::new(cx, new_capacity, dense_properties.len())?;
+        let new_capacity = SparseArrayPropertiesMap::min_capacity_needed(num_non_empty_properties);
+        let mut sparse_properties = SparseArrayPropertiesMap::new_with_array_length(
+            cx,
+            new_capacity,
+            dense_properties.len(),
+        )?;
 
         // Share handle across iterations
         let mut value_handle = Handle::<Value>::empty(cx);
@@ -194,7 +196,7 @@ impl ArrayProperties {
         for (index, value) in dense_properties.iter_gc_unsafe().enumerate() {
             if !value.is_empty() {
                 value_handle.replace(value);
-                sparse_properties.map.insert_without_growing(
+                sparse_properties.insert_without_growing(
                     index as u32,
                     Property::data(value_handle, true, true, true).to_heap(),
                 );
@@ -255,7 +257,7 @@ impl ArrayProperties {
             // In sparse removal case we must first find the last non-configurable property.
             // Can use stored property directly since loop does not allocate.
             let mut last_non_configurable_index = None;
-            for (index, stored_property) in sparse_properties.map.iter_gc_unsafe() {
+            for (index, stored_property) in sparse_properties.iter_gc_unsafe() {
                 if index < new_length || index == ARRAY_LENGTH_SENTINEL_KEY {
                     continue;
                 }
@@ -277,23 +279,20 @@ impl ArrayProperties {
             //
             // Length sentinel is excluded here since it's index is u32::MAX.
             let num_properties_left = sparse_properties
-                .map
                 .iter_gc_unsafe()
                 .filter(|(index, _)| *index < new_length)
                 .count();
-            let new_capacity = SparseArrayProperties::min_capacity_needed(num_properties_left);
+            let new_capacity = SparseArrayPropertiesMap::min_capacity_needed(num_properties_left);
             let mut new_sparse_properties =
-                SparseArrayProperties::new(cx, new_capacity, new_length)?;
+                SparseArrayPropertiesMap::new_with_array_length(cx, new_capacity, new_length)?;
 
             // Create a new map with non-truncated values. Can use stored property directly since
             // loop does not allocate on managed heap as map has capacity for all properties.
             //
             // Length sentinel is excluded here since it's index is u32::MAX.
-            for (index, stored_property) in sparse_properties.map.iter_gc_unsafe() {
+            for (index, stored_property) in sparse_properties.iter_gc_unsafe() {
                 if index < new_length {
-                    new_sparse_properties
-                        .map
-                        .insert_without_growing(index, stored_property.clone());
+                    new_sparse_properties.insert_without_growing(index, stored_property.clone());
                 }
             }
 
@@ -476,52 +475,48 @@ impl Iterator for DenseArrayPropertiesGcUnsafeIter {
     }
 }
 
-#[repr(C)]
-pub struct SparseArrayProperties {
-    map: SparseMap,
-}
+impl_hash_map_instance!(SparseArrayPropertiesMap, u32, HeapProperty);
 
-type SparseMap = BsHashMap<u32, HeapProperty>;
+type InnerSparseMap = BsHashMap<u32, HeapProperty>;
 
 /// The array length is stored in the sparse map under this key, which is never a valid array index.
 const ARRAY_LENGTH_SENTINEL_KEY: u32 = u32::MAX;
 
-impl SparseArrayProperties {
+impl SparseArrayPropertiesMap {
     /// Create a sparse properties map with the given total capacity. This capacity must include a
     /// slot for the array length, which be be found with `Self::min_capacity_needed`.
-    fn new(
+    ///
+    /// This is the only SparseArrayPropertiesMap creation function that should be used.
+    fn new_with_array_length(
         cx: Context,
         capacity: usize,
         array_length: u32,
-    ) -> AllocResult<HeapPtr<SparseArrayProperties>> {
-        let map = SparseMap::new(cx, HeapItemKind::SparseArrayProperties, capacity)?;
-        let mut sparse_properties = map.cast::<SparseArrayProperties>();
+    ) -> AllocResult<HeapPtr<SparseArrayPropertiesMap>> {
+        let mut map = Self::new(cx, capacity)?;
 
-        sparse_properties.set_array_length(array_length);
+        map.set_array_length(array_length);
 
-        Ok(sparse_properties)
+        Ok(map)
     }
 
     /// Minimum map capacity needed to hold `num_properties` real entries plus the length sentinel.
     fn min_capacity_needed(num_properties: usize) -> usize {
-        SparseMap::min_capacity_needed(num_properties + 1)
+        InnerSparseMap::min_capacity_needed(num_properties + 1)
     }
 
     fn array_length(&self) -> u32 {
-        let length_value = self.map.get(&ARRAY_LENGTH_SENTINEL_KEY).unwrap().value();
+        let length_value = self.get(&ARRAY_LENGTH_SENTINEL_KEY).unwrap().value();
         length_value.as_number() as u32
     }
 
     fn set_array_length(&mut self, array_length: u32) {
         let length_property =
             HeapProperty::new(Value::number(array_length), PropertyFlags::empty());
-        self.map
-            .insert_without_growing(ARRAY_LENGTH_SENTINEL_KEY, length_property);
+        self.insert_without_growing(ARRAY_LENGTH_SENTINEL_KEY, length_property);
     }
 
     pub fn ordered_keys(&self) -> Vec<u32> {
         let mut indexes_array = self
-            .map
             .keys_gc_unsafe()
             .filter(|key| *key != ARRAY_LENGTH_SENTINEL_KEY)
             .collect::<Vec<_>>();
@@ -531,50 +526,31 @@ impl SparseArrayProperties {
     }
 }
 
-impl HeapPtr<SparseArrayProperties> {
-    pub fn sparse_map(&self) -> HeapPtr<SparseMap> {
-        self.cast()
-    }
-}
-
 struct SparseMapField(Handle<ObjectValue>);
 
-impl BsHashMapField<u32, HeapProperty> for SparseMapField {
-    fn new_map(&self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<SparseMap>> {
+impl BsHashMapField<SparseArrayPropertiesMap> for SparseMapField {
+    #[inline]
+    fn get(&self, _: Context) -> HeapPtr<SparseArrayPropertiesMap> {
+        self.0.array_properties().as_sparse()
+    }
+
+    fn set_new(
+        &mut self,
+        cx: Context,
+        capacity: usize,
+    ) -> AllocResult<HeapPtr<SparseArrayPropertiesMap>> {
         let array_length = self.0.array_properties_length();
 
         // Capacity already includes the array length sentinel, no need to adjust for it here.
-        Ok(SparseArrayProperties::new(cx, capacity, array_length)?.cast())
-    }
+        let new_map = SparseArrayPropertiesMap::new_with_array_length(cx, capacity, array_length)?;
+        self.0.set_array_properties(new_map.cast());
 
-    #[inline]
-    fn get(&self, _: Context) -> HeapPtr<SparseMap> {
-        self.0.array_properties().as_sparse().sparse_map()
-    }
-
-    #[inline]
-    fn set(&mut self, _: Context, map: HeapPtr<SparseMap>) {
-        self.0.set_array_properties(map.cast())
+        Ok(new_map)
     }
 }
 
-impl HeapItem for HeapPtr<ArrayProperties> {
-    fn byte_size(&self) -> usize {
-        if let Some(dense_array) = self.as_dense_opt() {
-            dense_array.byte_size()
-        } else {
-            self.as_sparse().byte_size()
-        }
-    }
-
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        if let Some(mut dense_array) = self.as_dense_opt() {
-            dense_array.visit_pointers(visitor)
-        } else {
-            self.as_sparse().visit_pointers(visitor)
-        }
-    }
-}
+// Only necessary so we get deref for HeapPtrs.
+impl IsHeapItem for ArrayProperties {}
 
 impl HeapItem for HeapPtr<DenseArrayProperties> {
     fn byte_size(&self) -> usize {
@@ -591,15 +567,15 @@ impl HeapItem for HeapPtr<DenseArrayProperties> {
     }
 }
 
-impl HeapItem for HeapPtr<SparseArrayProperties> {
-    fn byte_size(&self) -> usize {
-        SparseMap::calculate_size_in_bytes(self.map.capacity())
+impl SparseArrayPropertiesMap {
+    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(map.capacity())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.map.visit_pointers(visitor);
+    pub fn visit_pointers(map: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        map.visit_pointers(visitor);
 
-        for (_, property) in self.map.iter_mut_gc_unsafe() {
+        for (_, property) in map.iter_mut_gc_unsafe() {
             property.visit_pointers(visitor);
         }
     }

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -15,7 +15,7 @@ use crate::{
         error::{ErrorFormatter, FormatOptions},
         wtf_8::{Wtf8Cow, Wtf8Str, Wtf8String},
     },
-    handle_scope, must_a,
+    handle_scope, impl_vec_instance, must_a,
     parser::{
         analyze::{AnalyzedFunctionResult, AnalyzedProgramResult},
         ast::{self, AstPtr, AstStr, LabelId, ProgramKind, ResolvedScope, TaggedResolvedScope},
@@ -48,11 +48,10 @@ use crate::{
             writer::BytecodeWriter,
         },
         class_names::{ClassNames, HomeObjectLocation, Method},
-        collections::{BsVec, BsVecField},
+        collections::{BsVecField, VecInstance},
         eval::expression::generate_template_object,
-        gc::Escapable,
+        gc::{Escapable, HeapVisitor},
         global_names::GlobalNames,
-        heap_item_descriptor::HeapItemKind,
         interned_strings::InternedStrings,
         module::{
             import_attributes::ImportAttributes,
@@ -119,7 +118,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
 
         // If we are dumping bytecode then we must collect all functions
         let all_functions = if cx.options.print_bytecode {
-            Some(FunctionVecField::new_vec(cx, 4)?.to_handle())
+            Some(FunctionVec::new_initial(cx)?.to_handle())
         } else {
             None
         };
@@ -9951,20 +9950,32 @@ impl StmtCompletion {
     }
 }
 
-type FunctionVec = BsVec<HeapPtr<BytecodeFunction>>;
+impl_vec_instance!(FunctionVec, HeapPtr<BytecodeFunction>);
+
+impl FunctionVec {
+    pub fn byte_size(vec: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(vec.capacity())
+    }
+
+    pub fn visit_pointers(vec: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        vec.visit_pointers(visitor);
+
+        for function in vec.as_mut_slice() {
+            visitor.visit_pointer(function);
+        }
+    }
+}
 
 struct FunctionVecField<'a>(&'a mut Option<Handle<FunctionVec>>);
 
-impl BsVecField<HeapPtr<BytecodeFunction>> for FunctionVecField<'_> {
-    fn new_vec(cx: Context, capacity: usize) -> AllocResult<HeapPtr<FunctionVec>> {
-        BsVec::new(cx, HeapItemKind::ValueVec, capacity)
-    }
-
+impl BsVecField<FunctionVec> for FunctionVecField<'_> {
     fn get(&self) -> HeapPtr<FunctionVec> {
         **self.0.as_ref().unwrap()
     }
 
-    fn set(&mut self, vec: HeapPtr<FunctionVec>) {
-        *self.0 = Some(vec.to_handle());
+    fn set_new(&mut self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<FunctionVec>> {
+        let new_vec = FunctionVec::new(cx, capacity)?;
+        *self.0 = Some(new_vec.to_handle());
+        Ok(new_vec)
     }
 }

--- a/src/js/runtime/bytecode/source_map.rs
+++ b/src/js/runtime/bytecode/source_map.rs
@@ -4,8 +4,9 @@ use crate::{
     common::varint::decode_varint,
     parser::loc::Pos,
     runtime::{
-        Context, Handle, HeapPtr, alloc_error::AllocResult, collections::array::ByteArray,
-        heap_item_descriptor::HeapItemKind,
+        Context, Handle, HeapPtr,
+        alloc_error::AllocResult,
+        collections::{ArrayInstance, array::ByteArray},
     },
 };
 
@@ -24,7 +25,7 @@ pub struct BytecodeSourceMap;
 
 impl BytecodeSourceMap {
     pub fn new(cx: Context, source_positions: &[u8]) -> AllocResult<Handle<ByteArray>> {
-        Ok(ByteArray::new_from_slice(cx, HeapItemKind::ByteArray, source_positions)?.to_handle())
+        Ok(ByteArray::new_from_slice(cx, source_positions)?.to_handle())
     }
 
     /// The first two varints are the full source range of the function. Return them as a range.

--- a/src/js/runtime/collections/array.rs
+++ b/src/js/runtime/collections/array.rs
@@ -4,7 +4,7 @@ use crate::{
         Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::InlineArray,
-        gc::{HeapItem, HeapVisitor},
+        gc::{HeapItem, HeapVisitor, IsHeapItem},
         heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
     },
     set_uninit,
@@ -84,6 +84,11 @@ impl<T> BsArray<T> {
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         self.array.as_mut_slice()
     }
+
+    /// Visit pointers intrinsic to all Arrays. Do not visit elements as they could be of any type.
+    pub fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut self.descriptor);
+    }
 }
 
 impl<T> HeapItem for HeapPtr<BsArray<T>> {
@@ -97,62 +102,123 @@ impl<T> HeapItem for HeapPtr<BsArray<T>> {
     }
 }
 
-/// A generic array of values. Corresponds to HeapItemKind::ValueArray.
-pub type ValueArray = BsArray<Value>;
+/// An instance of a BsArray with a specific element type. This has its own object descriptor
+/// identifying the full BsArray<T>.
+pub trait ArrayInstance:
+    IsHeapItem
+    + std::ops::Deref<Target = BsArray<Self::T>>
+    + std::ops::DerefMut<Target = BsArray<Self::T>>
+{
+    type T;
 
-pub fn value_array_from_slice(
-    cx: Context,
-    slice: &[Handle<Value>],
-) -> AllocResult<HeapPtr<ValueArray>> {
-    let mut array = ValueArray::new_uninit(cx, HeapItemKind::ValueArray, slice.len())?;
+    const KIND: HeapItemKind;
 
-    for (i, value) in slice.iter().enumerate() {
-        array.as_mut_slice()[i] = **value;
+    fn new(cx: Context, capacity: usize, initial: Self::T) -> AllocResult<HeapPtr<Self>>
+    where
+        Self::T: Clone,
+    {
+        Ok(BsArray::<Self::T>::new(cx, Self::KIND, capacity, initial)?.cast())
     }
 
-    Ok(array)
-}
+    fn new_from_slice(cx: Context, slice: &[Self::T]) -> AllocResult<HeapPtr<Self>>
+    where
+        Self::T: Clone,
+    {
+        Ok(BsArray::<Self::T>::new_from_slice(cx, Self::KIND, slice)?.cast())
+    }
 
-pub fn value_array_byte_size(value_array: HeapPtr<ValueArray>) -> usize {
-    ValueArray::calculate_size_in_bytes(value_array.len())
-}
+    fn new_uninit(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
+        Ok(BsArray::<Self::T>::new_uninit(cx, Self::KIND, capacity)?.cast())
+    }
 
-pub fn value_array_visit_pointers(
-    value_array: &mut HeapPtr<ValueArray>,
-    visitor: &mut impl HeapVisitor,
-) {
-    value_array.visit_pointers(visitor);
-
-    for value in value_array.as_mut_slice() {
-        visitor.visit_value(value);
+    fn calculate_size_in_bytes(capacity: usize) -> usize {
+        BsArray::<Self::T>::calculate_size_in_bytes(capacity)
     }
 }
 
-/// A generic array of bytes. Corresponds to HeapItemKind::ByteArray.
-///
-/// Can be used for any kind of opaque byte data.
-pub type ByteArray = BsArray<u8>;
+#[macro_export]
+macro_rules! impl_array_instance {
+    ($array_type:ident, $element_type:ty) => {
+        #[repr(transparent)]
+        pub struct $array_type($crate::runtime::collections::BsArray<$element_type>);
 
-pub fn byte_array_byte_size(byte_array: HeapPtr<ByteArray>) -> usize {
-    ByteArray::calculate_size_in_bytes(byte_array.len())
+        impl $crate::runtime::collections::ArrayInstance for $array_type {
+            type T = $element_type;
+
+            const KIND: $crate::runtime::heap_item_descriptor::HeapItemKind =
+                $crate::runtime::heap_item_descriptor::HeapItemKind::$array_type;
+        }
+
+        impl $crate::runtime::gc::IsHeapItem for $array_type {}
+
+        impl std::ops::Deref for $array_type {
+            type Target = $crate::runtime::collections::BsArray<$element_type>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl std::ops::DerefMut for $array_type {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+    };
 }
 
-pub fn byte_array_visit_pointers(
-    byte_array: &mut HeapPtr<ByteArray>,
-    visitor: &mut impl HeapVisitor,
-) {
-    byte_array.visit_pointers(visitor);
+impl_array_instance!(ValueArray, Value);
+
+impl ValueArray {
+    /// A ValueArray must be created from a slice of handles.
+    ///
+    /// It is not safe to use `ValueArray::new_from_slice`.
+    pub fn new_from_handle_slice(
+        cx: Context,
+        slice: &[Handle<Value>],
+    ) -> AllocResult<HeapPtr<ValueArray>> {
+        let mut array = ValueArray::new_uninit(cx, slice.len())?;
+
+        for (i, value) in slice.iter().enumerate() {
+            array.as_mut_slice()[i] = **value;
+        }
+
+        Ok(array)
+    }
+
+    pub fn byte_size(array: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(array.len())
+    }
+
+    pub fn visit_pointers(array: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array.visit_pointers(visitor);
+
+        for value in array.as_mut_slice() {
+            visitor.visit_value(value);
+        }
+    }
 }
 
-/// A generic array of opaque 32-bit values. Corresponds to HeapItemKind::U32Array.
-///
-/// Can be used for any kind of opaque 32-bit data.
-pub type U32Array = BsArray<u32>;
+impl_array_instance!(ByteArray, u8);
 
-pub fn u32_array_byte_size(array: HeapPtr<U32Array>) -> usize {
-    U32Array::calculate_size_in_bytes(array.len())
+impl ByteArray {
+    pub fn byte_size(array: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(array.len())
+    }
+
+    pub fn visit_pointers(array: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array.visit_pointers(visitor);
+    }
 }
 
-pub fn u32_array_visit_pointers(array: &mut HeapPtr<U32Array>, visitor: &mut impl HeapVisitor) {
-    array.visit_pointers(visitor);
+impl_array_instance!(U32Array, u32);
+
+impl U32Array {
+    pub fn byte_size(array: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(array.len())
+    }
+
+    pub fn visit_pointers(array: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array.visit_pointers(visitor);
+    }
 }

--- a/src/js/runtime/collections/hash_map.rs
+++ b/src/js/runtime/collections/hash_map.rs
@@ -11,7 +11,7 @@ use crate::{
         Context, HeapPtr,
         alloc_error::AllocResult,
         collections::InlineArray,
-        gc::{HeapItem, HeapVisitor},
+        gc::{HeapVisitor, IsHeapItem},
         heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
     },
     set_uninit,
@@ -277,44 +277,118 @@ impl<K: Eq + Hash + Clone, V: Clone> BsHashMap<K, V> {
     }
 }
 
+/// An instance of a BsHashMap with a specific key and value type. This has its own object
+/// descriptor identifying the full BsHashMap<K, V>.
+pub trait HashMapInstance:
+    IsHeapItem
+    + std::ops::Deref<Target = BsHashMap<Self::K, Self::V>>
+    + std::ops::DerefMut<Target = BsHashMap<Self::K, Self::V>>
+{
+    type K: Eq + std::hash::Hash + Clone;
+    type V: Clone;
+
+    const KIND: HeapItemKind;
+
+    fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
+        Ok(BsHashMap::<Self::K, Self::V>::new(cx, Self::KIND, capacity)?.cast())
+    }
+
+    fn new_initial(cx: Context) -> AllocResult<HeapPtr<Self>> {
+        Ok(BsHashMap::<Self::K, Self::V>::new_initial(cx, Self::KIND)?.cast())
+    }
+
+    fn calculate_size_in_bytes(capacity: usize) -> usize {
+        BsHashMap::<Self::K, Self::V>::calculate_size_in_bytes(capacity)
+    }
+}
+
+#[macro_export]
+macro_rules! impl_hash_map_instance {
+    ($map_type:ident, $key_type:ty, $value_type:ty) => {
+        #[repr(transparent)]
+        pub struct $map_type($crate::runtime::collections::BsHashMap<$key_type, $value_type>);
+
+        impl $crate::runtime::collections::HashMapInstance for $map_type {
+            type K = $key_type;
+            type V = $value_type;
+
+            const KIND: $crate::runtime::heap_item_descriptor::HeapItemKind =
+                $crate::runtime::heap_item_descriptor::HeapItemKind::$map_type;
+        }
+
+        impl $crate::runtime::gc::IsHeapItem for $map_type {}
+
+        impl std::ops::Deref for $map_type {
+            type Target = $crate::runtime::collections::BsHashMap<$key_type, $value_type>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl std::ops::DerefMut for $map_type {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+    };
+}
+
+/// Prepare map for insertion of a single entry. This will grow the map and update container to
+/// point to new map if there is no room to insert another entry in the map.
+///
+/// `set_new` callback creates a new map with the given capacity and uses it from then on.
+#[inline]
+pub fn maybe_grow_for_insertion<K, V>(
+    cx: Context,
+    map: HeapPtr<BsHashMap<K, V>>,
+    mut set_new: impl FnMut(Context, usize) -> AllocResult<HeapPtr<BsHashMap<K, V>>>,
+) -> AllocResult<HeapPtr<BsHashMap<K, V>>>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    // Keep at least half of the entries empty, otherwise grow
+    let new_length = map.len() + 1;
+    let capacity = map.capacity();
+    if new_length <= capacity / 2 {
+        return Ok(map);
+    }
+
+    // Save old map behind handle before allocating
+    let old_map = map.to_handle();
+
+    // Double size leaving map 1/4 full after growing
+    let new_capacity = capacity * 2;
+    let mut new_map = set_new(cx, new_capacity)?;
+
+    // Copy all values into new map. We have already guaranteed that there is enough room in map.
+    for (key, value) in old_map.iter_gc_unsafe() {
+        new_map.insert_without_growing(key, value);
+    }
+
+    Ok(new_map)
+}
+
 /// A BsHashMap stored as the field of a heap item. Can create new maps and set the field to a
 /// new map.
-pub trait BsHashMapField<K: Eq + Hash + Clone, V: Clone> {
-    fn new_map(&self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<BsHashMap<K, V>>>;
+pub trait BsHashMapField<I: HashMapInstance> {
+    fn get(&self, cx: Context) -> HeapPtr<I>;
 
-    fn get(&self, cx: Context) -> HeapPtr<BsHashMap<K, V>>;
-
-    fn set(&mut self, cx: Context, map: HeapPtr<BsHashMap<K, V>>);
+    /// Create a new map with the given capacity and set the field to point to it.
+    /// Return the new map.
+    fn set_new(&mut self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<I>>;
 
     /// Prepare map for insertion of a single entry. This will grow the map and update container to
     /// point to new map if there is no room to insert another entry in the map.
     #[inline]
-    fn maybe_grow_for_insertion(&mut self, cx: Context) -> AllocResult<HeapPtr<BsHashMap<K, V>>> {
-        let old_map = self.get(cx);
-
-        // Keep at least half of the entries empty, otherwise grow
-        let new_length = old_map.len() + 1;
-        let capacity = old_map.capacity();
-        if new_length <= capacity / 2 {
-            return Ok(old_map);
-        }
-
-        // Save old map behind handle before allocating
-        let old_map = old_map.to_handle();
-
-        // Double size leaving map 1/4 full after growing
-        let new_capacity = capacity * 2;
-        let mut new_map = self.new_map(cx, new_capacity)?;
-
-        // Update parent reference from old child to new child map
-        self.set(cx, new_map);
-
-        // Copy all values into new map. We have already guaranteed that there is enough room in map.
-        for (key, value) in old_map.iter_gc_unsafe() {
-            new_map.insert_without_growing(key, value);
-        }
-
-        Ok(new_map)
+    fn maybe_grow_for_insertion(&mut self, cx: Context) -> AllocResult<HeapPtr<I>> {
+        Ok(maybe_grow_for_insertion(
+            cx,
+            self.get(cx).cast::<BsHashMap<I::K, I::V>>(),
+            |cx, capacity| Ok(self.set_new(cx, capacity)?.cast()),
+        )?
+        .cast())
     }
 }
 
@@ -412,12 +486,5 @@ impl<'a, K: Clone, V: Clone> Iterator for GcUnsafeKeysIterMut<'a, K, V> {
     }
 }
 
-impl<K: Eq + Hash + Clone, V: Clone> HeapItem for HeapPtr<BsHashMap<K, V>> {
-    fn byte_size(&self) -> usize {
-        BsHashMap::<K, V>::calculate_size_in_bytes(self.capacity())
-    }
-
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        BsHashMap::<K, V>::visit_pointers(self, visitor)
-    }
-}
+// Only necessary so we get deref for HeapPtrs.
+impl<K, V> IsHeapItem for BsHashMap<K, V> {}

--- a/src/js/runtime/collections/hash_set.rs
+++ b/src/js/runtime/collections/hash_set.rs
@@ -3,26 +3,31 @@ use std::hash::Hash;
 use crate::runtime::{
     Context, HeapPtr,
     alloc_error::AllocResult,
-    collections::{BsHashMap, BsHashMapField, hash_map::GcUnsafeKeysIterMut},
-    gc::{HeapItem, HeapVisitor},
+    collections::{
+        BsHashMap,
+        hash_map::{GcUnsafeKeysIterMut, maybe_grow_for_insertion},
+    },
+    gc::{HeapVisitor, IsHeapItem},
     heap_item_descriptor::HeapItemKind,
 };
 
 /// Generic flat HashSet implementation which is a simple wrapper over a HashMap with unit values.
-#[repr(C)]
-pub struct BsHashSet<T>(BsHashMap<T, ()>);
+#[repr(transparent)]
+pub struct BsHashSet<T>(InnerMap<T>);
+
+type InnerMap<T> = BsHashMap<T, ()>;
 
 impl<T: Eq + Hash + Clone> BsHashSet<T> {
     pub fn new(cx: Context, kind: HeapItemKind, capacity: usize) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsHashMap::<T, ()>::new(cx, kind, capacity)?.cast())
+        Ok(InnerMap::<T>::new(cx, kind, capacity)?.cast())
     }
 
     pub fn new_initial(cx: Context, kind: HeapItemKind) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsHashMap::<T, ()>::new_initial(cx, kind)?.cast())
+        Ok(InnerMap::<T>::new_initial(cx, kind)?.cast())
     }
 
     pub fn calculate_size_in_bytes(capacity: usize) -> usize {
-        BsHashMap::<T, ()>::calculate_size_in_bytes(capacity)
+        InnerMap::<T>::calculate_size_in_bytes(capacity)
     }
 
     /// Total number of elements in the backing array.
@@ -64,47 +69,82 @@ impl<T: Eq + Hash + Clone> BsHashSet<T> {
     }
 }
 
+/// An instance of a BsHashSet with a specific element type. This has its own object
+/// descriptor identifying the full BsHashSet<T>.
+pub trait HashSetInstance:
+    IsHeapItem
+    + std::ops::Deref<Target = BsHashSet<Self::T>>
+    + std::ops::DerefMut<Target = BsHashSet<Self::T>>
+{
+    type T: Eq + std::hash::Hash + Clone;
+
+    const KIND: HeapItemKind;
+
+    fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
+        Ok(BsHashSet::<Self::T>::new(cx, Self::KIND, capacity)?.cast())
+    }
+
+    fn new_initial(cx: Context) -> AllocResult<HeapPtr<Self>> {
+        Ok(BsHashSet::<Self::T>::new_initial(cx, Self::KIND)?.cast())
+    }
+
+    fn calculate_size_in_bytes(capacity: usize) -> usize {
+        BsHashSet::<Self::T>::calculate_size_in_bytes(capacity)
+    }
+}
+
+#[macro_export]
+macro_rules! impl_hash_set_instance {
+    ($set_type:ident, $element_type:ty) => {
+        #[repr(transparent)]
+        pub struct $set_type($crate::runtime::collections::BsHashSet<$element_type>);
+
+        impl $crate::runtime::collections::HashSetInstance for $set_type {
+            type T = $element_type;
+
+            const KIND: $crate::runtime::heap_item_descriptor::HeapItemKind =
+                $crate::runtime::heap_item_descriptor::HeapItemKind::$set_type;
+        }
+
+        impl $crate::runtime::gc::IsHeapItem for $set_type {}
+
+        impl std::ops::Deref for $set_type {
+            type Target = $crate::runtime::collections::BsHashSet<$element_type>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl std::ops::DerefMut for $set_type {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+    };
+}
+
 /// A BsHashSet stored as the field of a heap item. Can create new set and set the field to a
 /// new set.
-pub trait BsHashSetField<T: Eq + Hash + Clone>: Clone {
-    fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<BsHashSet<T>>>;
+pub trait BsHashSetField<I: HashSetInstance>: Clone {
+    fn get(&self, cx: Context) -> HeapPtr<I>;
 
-    fn get(&self, cx: Context) -> HeapPtr<BsHashSet<T>>;
-
-    fn set(&mut self, cx: Context, set: HeapPtr<BsHashSet<T>>);
+    /// Create a new set with the given capacity and set the field to point to it.
+    /// Return the new set.
+    fn set_new(&mut self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<I>>;
 
     /// Prepare set for insertion of a single element. This will grow the set and update container
     /// to point to new set if there is no room to insert another entry in the set.
     #[inline]
-    fn maybe_grow_for_insertion(&mut self, cx: Context) -> AllocResult<HeapPtr<BsHashSet<T>>> {
-        let mut map_field = HashMapField(self.clone());
-        Ok(map_field.maybe_grow_for_insertion(cx)?.cast())
+    fn maybe_grow_for_insertion(&mut self, cx: Context) -> AllocResult<HeapPtr<I>> {
+        Ok(
+            maybe_grow_for_insertion(cx, self.get(cx).cast::<InnerMap<I::T>>(), |cx, capacity| {
+                Ok(self.set_new(cx, capacity)?.cast())
+            })?
+            .cast(),
+        )
     }
 }
 
-/// Simple wrapper for HashSet that allows treating it as a map field.
-struct HashMapField<T>(T);
-
-impl<T: Eq + Hash + Clone, S: BsHashSetField<T>> BsHashMapField<T, ()> for HashMapField<S> {
-    fn new_map(&self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<BsHashMap<T, ()>>> {
-        Ok(S::new(cx, capacity)?.cast())
-    }
-
-    fn get(&self, cx: Context) -> HeapPtr<BsHashMap<T, ()>> {
-        self.0.get(cx).cast()
-    }
-
-    fn set(&mut self, cx: Context, map: HeapPtr<BsHashMap<T, ()>>) {
-        self.0.set(cx, map.cast())
-    }
-}
-
-impl<T: Eq + Hash + Clone> HeapItem for HeapPtr<BsHashSet<T>> {
-    fn byte_size(&self) -> usize {
-        BsHashSet::<T>::calculate_size_in_bytes(self.capacity())
-    }
-
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        BsHashSet::<T>::visit_pointers(self, visitor)
-    }
-}
+// Only necessary so we get deref for HeapPtrs.
+impl<T> IsHeapItem for BsHashSet<T> {}

--- a/src/js/runtime/collections/index_map.rs
+++ b/src/js/runtime/collections/index_map.rs
@@ -11,7 +11,7 @@ use crate::{
         Context, Handle, HeapPtr,
         alloc_error::AllocResult,
         collections::InlineArray,
-        gc::{HeapItem, HeapVisitor},
+        gc::{HeapVisitor, IsHeapItem},
         heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
     },
     set_uninit,
@@ -421,62 +421,155 @@ impl<K: Eq + Hash + Clone, V: Clone> Handle<BsIndexMap<K, V>> {
     }
 }
 
-/// A BsHashMap stored as the field of a heap item. Can create new maps and set the field to a
+/// An instance of a BsIndexMap with a specific key and value type. This has its own object
+/// descriptor identifying the full BsIndexMap<K, V>.
+pub trait IndexMapInstance:
+    IsHeapItem
+    + std::ops::Deref<Target = BsIndexMap<Self::K, Self::V>>
+    + std::ops::DerefMut<Target = BsIndexMap<Self::K, Self::V>>
+{
+    type K: Eq + std::hash::Hash + Clone;
+    type V: Clone;
+
+    const KIND: HeapItemKind;
+
+    const MIN_CAPACITY: usize = BsIndexMap::<Self::K, Self::V>::MIN_CAPACITY;
+
+    fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
+        Ok(BsIndexMap::<Self::K, Self::V>::new(cx, Self::KIND, capacity)?.cast())
+    }
+
+    fn calculate_size_in_bytes(capacity: usize) -> usize {
+        BsIndexMap::<Self::K, Self::V>::calculate_size_in_bytes(capacity)
+    }
+
+    fn fix_iterator_for_resized_map(
+        tombstone_map: HeapPtr<Self>,
+        next_entry_index: &mut usize,
+    ) -> HeapPtr<Self> {
+        BsIndexMap::<Self::K, Self::V>::fix_iterator_for_resized_map(
+            tombstone_map.cast(),
+            next_entry_index,
+        )
+        .cast()
+    }
+
+    fn visit_pointers_impl<H: HeapVisitor>(
+        map: HeapPtr<Self>,
+        visitor: &mut H,
+        entries_visitor: impl FnMut(HeapPtr<BsIndexMap<Self::K, Self::V>>, &mut H),
+    ) {
+        BsIndexMap::<Self::K, Self::V>::visit_pointers_impl(map.cast(), visitor, entries_visitor);
+    }
+}
+
+#[macro_export]
+macro_rules! impl_index_map_instance {
+    ($map_type:ident, $key_type:ty, $value_type:ty) => {
+        #[repr(transparent)]
+        pub struct $map_type($crate::runtime::collections::BsIndexMap<$key_type, $value_type>);
+
+        impl $crate::runtime::collections::IndexMapInstance for $map_type {
+            type K = $key_type;
+            type V = $value_type;
+
+            const KIND: $crate::runtime::heap_item_descriptor::HeapItemKind =
+                $crate::runtime::heap_item_descriptor::HeapItemKind::$map_type;
+        }
+
+        impl $crate::runtime::gc::IsHeapItem for $map_type {}
+
+        impl std::ops::Deref for $map_type {
+            type Target = $crate::runtime::collections::BsIndexMap<$key_type, $value_type>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl std::ops::DerefMut for $map_type {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+    };
+}
+
+/// Prepare map for insertion of a single entry. This will grow the map and update container to
+/// point to new map if there is no room to insert another entry in the map.
+///
+/// `set_new` callback creates a new map with the given capacity and uses it from then on.
+#[inline]
+pub fn maybe_grow_for_insertion<K, V>(
+    cx: Context,
+    map: HeapPtr<BsIndexMap<K, V>>,
+    mut set_new: impl FnMut(Context, usize) -> AllocResult<HeapPtr<BsIndexMap<K, V>>>,
+) -> AllocResult<HeapPtr<BsIndexMap<K, V>>>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    let num_entries_used = map.num_entries_used();
+    let capacity = map.capacity();
+
+    if num_entries_used < capacity {
+        return Ok(map);
+    }
+
+    // Save old map behind handle before allocating
+    let mut old_map = map.to_handle();
+
+    // Capacity jumps from 0 to min capacity
+    let new_capacity;
+    if capacity == 0 {
+        new_capacity = BsIndexMap::<K, V>::MIN_CAPACITY;
+    } else if old_map.num_deleted > (capacity / 2) {
+        // New capacity stays the same if most elements are deleted
+        new_capacity = capacity;
+    } else {
+        // Otherwise double capacity of map
+        new_capacity = capacity * 2;
+    }
+
+    // Use a new map with the given capacity
+    let mut new_map = set_new(cx, new_capacity)?;
+
+    // Copy all values into new map. We have already guaranteed that there is enough room in map.
+    for (key, value) in old_map.iter_gc_unsafe() {
+        new_map.insert_without_growing(key, value);
+    }
+
+    // Empty maps should not become tombstones since there is nowhere to put the new map pointer
+    // debug_assert!(capacity != 0);
+
+    // Mark the old map as a tombstone object that points to the new map
+    if capacity != 0 {
+        old_map.is_tombstone = true;
+        old_map.set_new_map_ptr(new_map);
+    }
+
+    Ok(new_map)
+}
+
+/// A BsIndexMap stored as the field of a heap item. Can create new maps and set the field to a
 /// new map.
-pub trait BsIndexMapField<K: Eq + Hash + Clone, V: Clone> {
-    fn new_map(&self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<BsIndexMap<K, V>>>;
+pub trait BsIndexMapField<I: IndexMapInstance> {
+    fn get(&self) -> HeapPtr<I>;
 
-    fn get(&self) -> HeapPtr<BsIndexMap<K, V>>;
-
-    fn set(&mut self, map: HeapPtr<BsIndexMap<K, V>>);
+    /// Create a new map with the given capacity and set the field to point to it.
+    /// Return the new map.
+    fn set_new(&mut self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<I>>;
 
     /// Prepare map for insertion of a single entry. This will grow the map and update container to
     /// point to new map if there is no room to insert another entry in the map.
     #[inline]
-    fn maybe_grow_for_insertion(&mut self, cx: Context) -> AllocResult<HeapPtr<BsIndexMap<K, V>>> {
-        let old_map = self.get();
-        let num_entries_used = old_map.num_entries_used();
-        let capacity = old_map.capacity();
-
-        if num_entries_used < capacity {
-            return Ok(old_map);
-        }
-
-        // Save old map behind handle before allocating
-        let mut old_map = old_map.to_handle();
-
-        // Capacity jumps from 0 to min capacity
-        let new_capacity;
-        if capacity == 0 {
-            new_capacity = BsIndexMap::<K, V>::MIN_CAPACITY;
-        } else if old_map.num_deleted > (capacity / 2) {
-            // New capacity stays the same if most elements are deleted
-            new_capacity = capacity;
-        } else {
-            // Otherwise double capacity of map
-            new_capacity = capacity * 2;
-        }
-
-        let mut new_map = self.new_map(cx, new_capacity)?;
-
-        // Update parent reference from old child to new child map
-        self.set(new_map);
-
-        // Copy all values into new map. We have already guaranteed that there is enough room in map.
-        for (key, value) in old_map.iter_gc_unsafe() {
-            new_map.insert_without_growing(key, value);
-        }
-
-        // Empty maps should not become tombstones since there is nowhere to put the new map pointer
-        // debug_assert!(capacity != 0);
-
-        // Mark the old map as a tombstone object that points to the new map
-        if capacity != 0 {
-            old_map.is_tombstone = true;
-            old_map.set_new_map_ptr(new_map);
-        }
-
-        Ok(new_map)
+    fn maybe_grow_for_insertion(&mut self, cx: Context) -> AllocResult<HeapPtr<I>> {
+        Ok(maybe_grow_for_insertion(
+            cx,
+            self.get().cast::<BsIndexMap<I::K, I::V>>(),
+            |cx, capacity| Ok(self.set_new(cx, capacity)?.cast()),
+        )?
+        .cast())
     }
 }
 
@@ -632,33 +725,25 @@ impl<K: Eq + Hash + Clone, V: Clone> Iterator for GcSafeEntriesIter<K, V> {
     }
 }
 
-impl<K: Eq + Hash + Clone, V: Clone> HeapItem for HeapPtr<BsIndexMap<K, V>> {
-    fn byte_size(&self) -> usize {
-        BsIndexMap::<K, V>::calculate_size_in_bytes(self.capacity())
-    }
-
-    /// Visit pointers intrinsic to all IndexMaps. Do not visit entries as they could be of any type.
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        Self::visit_pointers_impl(self, visitor, |_, _| ());
-    }
-}
-
-impl<K: Eq + Hash + Clone, V: Clone> HeapPtr<BsIndexMap<K, V>> {
+impl<K: Eq + Hash + Clone, V: Clone> BsIndexMap<K, V> {
     #[inline]
     pub fn visit_pointers_impl<H: HeapVisitor>(
-        &mut self,
+        mut map: HeapPtr<Self>,
         visitor: &mut H,
-        mut entries_visitor: impl FnMut(&mut Self, &mut H),
+        mut entries_visitor: impl FnMut(HeapPtr<Self>, &mut H),
     ) {
-        visitor.visit_pointer(&mut self.descriptor);
+        visitor.visit_pointer(&mut map.descriptor);
 
-        if self.is_tombstone() {
+        if map.is_tombstone() {
             // Tombstones contain the new map but entries are not still live - we only need to know
             // if the entries are occupied.
-            visitor.visit_pointer(self.get_new_map_ptr_mut());
+            visitor.visit_pointer(map.get_new_map_ptr_mut());
         } else {
             // Otherwise visit entries since they are still live.
-            entries_visitor(self, visitor);
+            entries_visitor(map, visitor);
         }
     }
 }
+
+// Only necessary so we get deref for HeapPtrs.
+impl<K, V> IsHeapItem for BsIndexMap<K, V> {}

--- a/src/js/runtime/collections/index_set.rs
+++ b/src/js/runtime/collections/index_set.rs
@@ -4,31 +4,33 @@ use crate::runtime::{
     Context, Handle, HeapPtr,
     alloc_error::AllocResult,
     collections::{
-        BsIndexMap, BsIndexMapField,
-        index_map::{GcSafeEntriesIter, GcUnsafeKeysIterMut},
+        BsIndexMap,
+        index_map::{GcSafeEntriesIter, GcUnsafeKeysIterMut, maybe_grow_for_insertion},
     },
-    gc::{HeapItem, HeapVisitor},
+    gc::{HeapVisitor, IsHeapItem},
     heap_item_descriptor::HeapItemKind,
 };
 
 /// Generic flat IndexSet implementation which is a simple wrapper over an IndexMap with unit values.
-#[repr(C)]
-pub struct BsIndexSet<T>(BsIndexMap<T, ()>);
+#[repr(transparent)]
+pub struct BsIndexSet<T>(InnerMap<T>);
+
+type InnerMap<T> = BsIndexMap<T, ()>;
 
 impl<T: Eq + Hash + Clone> BsIndexSet<T> {
     pub const MIN_CAPACITY: usize = BsIndexMap::<T, ()>::MIN_CAPACITY;
 
     pub fn new(cx: Context, kind: HeapItemKind, capacity: usize) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsIndexMap::<T, ()>::new(cx, kind, capacity)?.cast())
+        Ok(InnerMap::<T>::new(cx, kind, capacity)?.cast())
     }
 
     pub fn calculate_size_in_bytes(capacity: usize) -> usize {
-        BsIndexMap::<T, ()>::calculate_size_in_bytes(capacity)
+        InnerMap::<T>::calculate_size_in_bytes(capacity)
     }
 
     /// Create a new set whose entries are copied from the provided set.
     pub fn new_from_set(cx: Context, set: Handle<Self>) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsIndexMap::<T, ()>::new_from_map(cx, set.cast())?.cast())
+        Ok(InnerMap::<T>::new_from_map(cx, set.cast())?.cast())
     }
 
     /// Number of elements inserted in the set.
@@ -78,61 +80,113 @@ impl<T: Eq + Hash + Clone> Handle<BsIndexSet<T>> {
     }
 }
 
+/// An instance of a BsIndexSet with a specific element type. This has its own object
+/// descriptor identifying the full BsIndexSet<T>.
+pub trait IndexSetInstance:
+    IsHeapItem
+    + std::ops::Deref<Target = BsIndexSet<Self::T>>
+    + std::ops::DerefMut<Target = BsIndexSet<Self::T>>
+{
+    type T: Eq + std::hash::Hash + Clone;
+
+    const KIND: HeapItemKind;
+
+    const MIN_CAPACITY: usize = BsIndexSet::<Self::T>::MIN_CAPACITY;
+
+    fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
+        Ok(BsIndexSet::<Self::T>::new(cx, Self::KIND, capacity)?.cast())
+    }
+
+    fn new_from_set(cx: Context, set: Handle<Self>) -> AllocResult<HeapPtr<Self>> {
+        Ok(BsIndexSet::<Self::T>::new_from_set(cx, set.cast())?.cast())
+    }
+
+    fn calculate_size_in_bytes(capacity: usize) -> usize {
+        BsIndexSet::<Self::T>::calculate_size_in_bytes(capacity)
+    }
+
+    fn fix_iterator_for_resized_map(
+        tombstone_map: HeapPtr<Self>,
+        next_entry_index: &mut usize,
+    ) -> HeapPtr<Self> {
+        InnerMap::<Self::T>::fix_iterator_for_resized_map(tombstone_map.cast(), next_entry_index)
+            .cast()
+    }
+
+    fn visit_pointers_impl<H: HeapVisitor>(
+        map: HeapPtr<Self>,
+        visitor: &mut H,
+        entries_visitor: impl FnMut(HeapPtr<BsIndexSet<Self::T>>, &mut H),
+    ) {
+        BsIndexSet::<Self::T>::visit_pointers_impl(map.cast(), visitor, entries_visitor);
+    }
+}
+
+#[macro_export]
+macro_rules! impl_index_set_instance {
+    ($set_type:ident, $element_type:ty) => {
+        #[repr(transparent)]
+        pub struct $set_type($crate::runtime::collections::BsIndexSet<$element_type>);
+
+        impl $crate::runtime::collections::IndexSetInstance for $set_type {
+            type T = $element_type;
+
+            const KIND: $crate::runtime::heap_item_descriptor::HeapItemKind =
+                $crate::runtime::heap_item_descriptor::HeapItemKind::$set_type;
+        }
+
+        impl $crate::runtime::gc::IsHeapItem for $set_type {}
+
+        impl std::ops::Deref for $set_type {
+            type Target = $crate::runtime::collections::BsIndexSet<$element_type>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl std::ops::DerefMut for $set_type {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+    };
+}
+
 /// A BsIndexSet stored as the field of a heap item. Can create new set and set the field to a
 /// new set.
-pub trait BsIndexSetField<T: Eq + Hash + Clone>: Clone {
-    fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<BsIndexSet<T>>>;
+pub trait BsIndexSetField<I: IndexSetInstance>: Clone {
+    fn get(&self) -> HeapPtr<I>;
 
-    fn get(&self) -> HeapPtr<BsIndexSet<T>>;
-
-    fn set(&mut self, set: HeapPtr<BsIndexSet<T>>);
+    /// Create a new set with the given capacity and set the field to point to it.
+    /// Return the new set.
+    fn set_new(&mut self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<I>>;
 
     /// Prepare set for insertion of a single element. This will grow the set and update container
     /// to point to new set if there is no room to insert another entry in the set.
     #[inline]
-    fn maybe_grow_for_insertion(&mut self, cx: Context) -> AllocResult<HeapPtr<BsIndexSet<T>>> {
-        let mut map_field = IndexMapField(self.clone());
-        Ok(map_field.maybe_grow_for_insertion(cx)?.cast())
+    fn maybe_grow_for_insertion(&mut self, cx: Context) -> AllocResult<HeapPtr<I>> {
+        Ok(
+            maybe_grow_for_insertion(cx, self.get().cast::<InnerMap<I::T>>(), |cx, capacity| {
+                Ok(self.set_new(cx, capacity)?.cast())
+            })?
+            .cast(),
+        )
     }
 }
 
-/// Simple wrapper for IndexSet that allows treating it as a map field.
-struct IndexMapField<T>(T);
-
-impl<T: Eq + Hash + Clone, S: BsIndexSetField<T>> BsIndexMapField<T, ()> for IndexMapField<S> {
-    fn new_map(&self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<BsIndexMap<T, ()>>> {
-        Ok(S::new(cx, capacity)?.cast())
-    }
-
-    fn get(&self) -> HeapPtr<BsIndexMap<T, ()>> {
-        self.0.get().cast()
-    }
-
-    fn set(&mut self, map: HeapPtr<BsIndexMap<T, ()>>) {
-        self.0.set(map.cast())
-    }
-}
-
-impl<T: Eq + Hash + Clone> HeapItem for HeapPtr<BsIndexSet<T>> {
-    fn byte_size(&self) -> usize {
-        BsIndexSet::<T>::calculate_size_in_bytes(self.capacity())
-    }
-
-    /// Visit pointers intrinsic to all IndexSets. Do not visit entries as they could be of any type.
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.cast_mut::<BsIndexMap<T, ()>>()
-            .visit_pointers_impl(visitor, |_, _| ())
-    }
-}
-
-impl<T: Eq + Hash + Clone> HeapPtr<BsIndexSet<T>> {
+impl<T: Eq + Hash + Clone> BsIndexSet<T> {
     #[inline]
     pub fn visit_pointers_impl<H: HeapVisitor>(
-        &mut self,
+        set: HeapPtr<Self>,
         visitor: &mut H,
-        mut entries_visitor: impl FnMut(&mut Self, &mut H),
+        mut entries_visitor: impl FnMut(HeapPtr<Self>, &mut H),
     ) {
-        self.cast_mut::<BsIndexMap<T, ()>>()
-            .visit_pointers_impl(visitor, |map, visitor| entries_visitor(&mut map.cast(), visitor))
+        BsIndexMap::<T, ()>::visit_pointers_impl(set.cast(), visitor, |set, visitor| {
+            entries_visitor(set.cast(), visitor)
+        })
     }
 }
+
+// Only necessary so we get deref for HeapPtrs.
+impl<T> IsHeapItem for BsIndexSet<T> {}

--- a/src/js/runtime/collections/mod.rs
+++ b/src/js/runtime/collections/mod.rs
@@ -7,11 +7,11 @@ mod inline_array;
 pub mod vec;
 pub mod weak_vec;
 
-pub use array::BsArray;
-pub use hash_map::{BsHashMap, BsHashMapField};
-pub use hash_set::{BsHashSet, BsHashSetField};
-pub use index_map::{BsIndexMap, BsIndexMapField};
-pub use index_set::{BsIndexSet, BsIndexSetField};
+pub use array::{ArrayInstance, BsArray};
+pub use hash_map::{BsHashMap, BsHashMapField, HashMapInstance};
+pub use hash_set::{BsHashSet, BsHashSetField, HashSetInstance};
+pub use index_map::{BsIndexMap, BsIndexMapField, IndexMapInstance};
+pub use index_set::{BsIndexSet, BsIndexSetField, IndexSetInstance};
 pub use inline_array::InlineArray;
-pub use vec::{BsVec, BsVecField};
+pub use vec::{BsVec, BsVecField, VecInstance};
 pub use weak_vec::BsWeakVec;

--- a/src/js/runtime/collections/vec.rs
+++ b/src/js/runtime/collections/vec.rs
@@ -1,10 +1,10 @@
 use crate::{
     field_offset,
     runtime::{
-        Context, HeapPtr, Value,
+        Context, HeapPtr,
         alloc_error::AllocResult,
         collections::InlineArray,
-        gc::{HeapItem, HeapVisitor},
+        gc::{HeapVisitor, IsHeapItem},
         heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
     },
     set_uninit,
@@ -21,6 +21,8 @@ pub struct BsVec<T> {
 }
 
 impl<T: Clone + Copy> BsVec<T> {
+    pub const MIN_CAPACITY: usize = 4;
+
     /// Create a new BsVec with the given capacity.
     pub fn new(cx: Context, kind: HeapItemKind, capacity: usize) -> AllocResult<HeapPtr<Self>> {
         let size = Self::calculate_size_in_bytes(capacity);
@@ -72,32 +74,79 @@ impl<T: Clone + Copy> BsVec<T> {
         self.array.as_mut_slice()[len] = item;
         self.length += 1;
     }
-}
 
-impl<T: Clone + Copy> HeapItem for HeapPtr<BsVec<T>> {
-    fn byte_size(&self) -> usize {
-        BsVec::<T>::calculate_size_in_bytes(self.capacity())
-    }
-
-    /// Visit pointers intrinsic to all BsVecs. Do not visit elements as they could be of any type.
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+    /// Visit pointers intrinsic to all Vecs. Do not visit elements as they could be of any type.
+    pub fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
         visitor.visit_pointer(&mut self.descriptor);
     }
 }
 
+/// An instance of a BsVec with a specific element type. This has its own object descriptor
+/// identifying the full BsVec<T>.
+pub trait VecInstance:
+    IsHeapItem + std::ops::Deref<Target = BsVec<Self::T>> + std::ops::DerefMut<Target = BsVec<Self::T>>
+{
+    type T: Clone + Copy;
+
+    const KIND: HeapItemKind;
+
+    const MIN_CAPACITY: usize = BsVec::<Self::T>::MIN_CAPACITY;
+
+    fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
+        Ok(BsVec::<Self::T>::new(cx, Self::KIND, capacity)?.cast())
+    }
+
+    fn new_initial(cx: Context) -> AllocResult<HeapPtr<Self>> {
+        Ok(BsVec::<Self::T>::new(cx, Self::KIND, Self::MIN_CAPACITY)?.cast())
+    }
+
+    fn calculate_size_in_bytes(capacity: usize) -> usize {
+        BsVec::<Self::T>::calculate_size_in_bytes(capacity)
+    }
+}
+
+#[macro_export]
+macro_rules! impl_vec_instance {
+    ($vec_type:ident, $element_type:ty) => {
+        #[repr(transparent)]
+        pub struct $vec_type($crate::runtime::collections::BsVec<$element_type>);
+
+        impl $crate::runtime::collections::VecInstance for $vec_type {
+            type T = $element_type;
+
+            const KIND: $crate::runtime::heap_item_descriptor::HeapItemKind =
+                $crate::runtime::heap_item_descriptor::HeapItemKind::$vec_type;
+        }
+
+        impl $crate::runtime::gc::IsHeapItem for $vec_type {}
+
+        impl std::ops::Deref for $vec_type {
+            type Target = $crate::runtime::collections::BsVec<$element_type>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl std::ops::DerefMut for $vec_type {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+    };
+}
+
 /// A BsVec stored as the field of a heap item. Can create new BsVec objects and set the field to
 /// a new BsVec.
-pub trait BsVecField<T: Clone + Copy> {
-    fn new_vec(cx: Context, capacity: usize) -> AllocResult<HeapPtr<BsVec<T>>>;
+pub trait BsVecField<I: VecInstance> {
+    fn get(&self) -> HeapPtr<I>;
 
-    fn get(&self) -> HeapPtr<BsVec<T>>;
-
-    fn set(&mut self, vec: HeapPtr<BsVec<T>>);
+    fn set_new(&mut self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<I>>;
 
     /// Prepare vec for appending a single item. This will grow the vec and update container to
     /// point to new vec if there is no room to append another item to the vec.
     #[inline]
-    fn maybe_grow_for_push(&mut self, cx: Context) -> AllocResult<HeapPtr<BsVec<T>>> {
+    fn maybe_grow_for_push(&mut self, cx: Context) -> AllocResult<HeapPtr<I>> {
         let old_vec = self.get();
 
         // Check if we have room for another item in the vec
@@ -111,11 +160,8 @@ pub trait BsVecField<T: Clone + Copy> {
         let old_vec = old_vec.to_handle();
 
         // Double size of vector, starting at a length of 4
-        let new_capacity = (capacity * 2).max(4);
-        let mut new_vec = Self::new_vec(cx, new_capacity)?;
-
-        // Update parent reference from old child to new child map
-        self.set(new_vec);
+        let new_capacity = (capacity * 2).max(I::MIN_CAPACITY);
+        let mut new_vec = self.set_new(cx, new_capacity)?;
 
         // Copy all values into new vec
         new_vec.length = old_len;
@@ -125,17 +171,5 @@ pub trait BsVecField<T: Clone + Copy> {
     }
 }
 
-/// A generic vec of values. Corresponds to HeapItemKind::ValueVec.
-type ValueVec = BsVec<Value>;
-
-pub fn value_vec_byte_size(value_array: HeapPtr<ValueVec>) -> usize {
-    BsVec::<Value>::calculate_size_in_bytes(value_array.capacity())
-}
-
-pub fn value_vec_visit_pointers(value_vec: &mut HeapPtr<ValueVec>, visitor: &mut impl HeapVisitor) {
-    value_vec.visit_pointers(visitor);
-
-    for value in value_vec.as_mut_slice() {
-        visitor.visit_value(value);
-    }
-}
+// Only necessary so we get deref for HeapPtrs.
+impl<T> IsHeapItem for BsVec<T> {}

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -19,7 +19,7 @@ use crate::{
         time::{get_current_unix_time_millis, get_current_unix_time_nanos},
         wtf_8::{Wtf8Str, Wtf8String},
     },
-    eval_err, handle_scope, must_a,
+    eval_err, handle_scope, impl_hash_map_instance, must_a,
     parser::{
         ParseContext, analyze::analyze, parse_module, parse_script, print_program, source::Source,
     },
@@ -33,11 +33,10 @@ use crate::{
             generator::{BytecodeProgramGenerator, BytecodeScript},
             vm::VM,
         },
-        collections::{BsHashMap, BsHashMapField},
+        collections::{HashMapInstance, hash_map::BsHashMapField, index_map::IndexMapInstance},
         descriptor_registry::DescriptorRegistry,
         error::BsResult,
         gc::{GarbageCollector, Heap, HeapRootsDeserializer, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         interned_strings::InternedStrings,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RustRuntimeFunctionRegistry},
         module::{
@@ -104,10 +103,10 @@ pub struct ContextCell {
     pub interned_strings: InternedStrings,
 
     /// All symbols that have been registered under a specific key with `Symbol.for`.
-    global_symbol_registry: HeapPtr<GlobalSymbolRegistry>,
+    global_symbol_registry: HeapPtr<GlobalSymbolRegistryMap>,
 
     /// Cache modules by their canonical absolute path and import attributes
-    pub modules: HeapPtr<ModuleCache>,
+    pub modules: HeapPtr<ModuleCacheMap>,
 
     /// An empty named properties map to use as the initial value for named properties
     pub default_named_properties: HeapPtr<NamedPropertiesMap>,
@@ -136,8 +135,6 @@ pub struct ContextCell {
     /// Time zone provider used for Temporal operations.
     temporal_provider: CompiledTzdbProvider,
 }
-
-type GlobalSymbolRegistry = BsHashMap<HeapPtr<FlatString>, HeapPtr<SymbolValue>>;
 
 impl Context {
     fn new(options: Rc<Options>) -> AllocResult<Context> {
@@ -209,13 +206,11 @@ impl Context {
             cx.init_builtin_names()?;
             cx.init_builtin_symbols()?;
 
-            cx.global_symbol_registry =
-                GlobalSymbolRegistry::new_initial(cx, HeapItemKind::GlobalSymbolRegistryMap)?;
-            cx.modules = ModuleCache::new_initial(cx, HeapItemKind::ModuleCacheMap)?;
+            cx.global_symbol_registry = GlobalSymbolRegistryMap::new_initial(cx)?;
+            cx.modules = ModuleCacheMap::new_initial(cx)?;
 
             cx.default_array_properties = DenseArrayProperties::new(cx, 0)?.cast();
-            cx.default_named_properties =
-                NamedPropertiesMap::new(cx, HeapItemKind::ObjectNamedPropertiesMap, 0)?;
+            cx.default_named_properties = NamedPropertiesMap::new(cx, 0)?;
 
             cx.initial_realm = *Realm::new(cx)?;
 
@@ -448,7 +443,7 @@ impl Context {
         }
     }
 
-    pub fn global_symbol_registry(&self) -> HeapPtr<GlobalSymbolRegistry> {
+    pub fn global_symbol_registry(&self) -> HeapPtr<GlobalSymbolRegistryMap> {
         self.global_symbol_registry
     }
 
@@ -741,30 +736,32 @@ impl Hash for HeapModuleCacheKey {
     }
 }
 
-type ModuleCache = BsHashMap<HeapModuleCacheKey, HeapDynModule>;
+impl_hash_map_instance!(ModuleCacheMap, HeapModuleCacheKey, HeapDynModule);
 
 pub struct ModuleCacheField;
 
-impl BsHashMapField<HeapModuleCacheKey, HeapDynModule> for ModuleCacheField {
-    fn new_map(&self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<ModuleCache>> {
-        ModuleCache::new(cx, HeapItemKind::ModuleCacheMap, capacity)
-    }
-
-    fn get(&self, cx: Context) -> HeapPtr<ModuleCache> {
+impl BsHashMapField<ModuleCacheMap> for ModuleCacheField {
+    fn get(&self, cx: Context) -> HeapPtr<ModuleCacheMap> {
         cx.modules
     }
 
-    fn set(&mut self, mut cx: Context, map: HeapPtr<ModuleCache>) {
+    fn set_new(
+        &mut self,
+        mut cx: Context,
+        capacity: usize,
+    ) -> AllocResult<HeapPtr<ModuleCacheMap>> {
+        let map = ModuleCacheMap::new(cx, capacity)?;
         cx.modules = map;
+        Ok(map)
     }
 }
 
-impl ModuleCacheField {
-    pub fn byte_size(map: &HeapPtr<ModuleCache>) -> usize {
-        ModuleCache::calculate_size_in_bytes(map.capacity())
+impl ModuleCacheMap {
+    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(map: &mut HeapPtr<ModuleCache>, visitor: &mut impl HeapVisitor) {
+    pub fn visit_pointers(map: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
         map.visit_pointers(visitor);
 
         for (cache_key, module) in map.iter_mut_gc_unsafe() {
@@ -774,28 +771,32 @@ impl ModuleCacheField {
     }
 }
 
+impl_hash_map_instance!(GlobalSymbolRegistryMap, HeapPtr<FlatString>, HeapPtr<SymbolValue>);
+
 pub struct GlobalSymbolRegistryField;
 
-impl BsHashMapField<HeapPtr<FlatString>, HeapPtr<SymbolValue>> for GlobalSymbolRegistryField {
-    fn new_map(&self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<GlobalSymbolRegistry>> {
-        GlobalSymbolRegistry::new(cx, HeapItemKind::GlobalSymbolRegistryMap, capacity)
-    }
-
-    fn get(&self, cx: Context) -> HeapPtr<GlobalSymbolRegistry> {
+impl BsHashMapField<GlobalSymbolRegistryMap> for GlobalSymbolRegistryField {
+    fn get(&self, cx: Context) -> HeapPtr<GlobalSymbolRegistryMap> {
         cx.global_symbol_registry
     }
 
-    fn set(&mut self, mut cx: Context, map: HeapPtr<GlobalSymbolRegistry>) {
+    fn set_new(
+        &mut self,
+        mut cx: Context,
+        capacity: usize,
+    ) -> AllocResult<HeapPtr<GlobalSymbolRegistryMap>> {
+        let map = GlobalSymbolRegistryMap::new(cx, capacity)?;
         cx.global_symbol_registry = map;
+        Ok(map)
     }
 }
 
-impl GlobalSymbolRegistryField {
-    pub fn byte_size(map: &HeapPtr<GlobalSymbolRegistry>) -> usize {
-        GlobalSymbolRegistry::calculate_size_in_bytes(map.capacity())
+impl GlobalSymbolRegistryMap {
+    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(map: &mut HeapPtr<GlobalSymbolRegistry>, visitor: &mut impl HeapVisitor) {
+    pub fn visit_pointers(map: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
         map.visit_pointers(visitor);
 
         for (key, value) in map.iter_mut_gc_unsafe() {

--- a/src/js/runtime/descriptor_registry.rs
+++ b/src/js/runtime/descriptor_registry.rs
@@ -167,18 +167,18 @@ impl DescriptorRegistry {
         other_heap_item_descriptor!(HeapItemKind::BuiltinGenerator);
 
         other_heap_item_descriptor!(HeapItemKind::DenseArrayProperties);
-        other_heap_item_descriptor!(HeapItemKind::SparseArrayProperties);
+        other_heap_item_descriptor!(HeapItemKind::SparseArrayPropertiesMap);
 
         other_heap_item_descriptor!(HeapItemKind::CompiledRegExpObject);
 
         other_heap_item_descriptor!(HeapItemKind::BoxedValue);
 
-        other_heap_item_descriptor!(HeapItemKind::ObjectNamedPropertiesMap);
-        other_heap_item_descriptor!(HeapItemKind::MapObjectValueMap);
-        other_heap_item_descriptor!(HeapItemKind::SetObjectValueSet);
+        other_heap_item_descriptor!(HeapItemKind::NamedPropertiesMap);
+        other_heap_item_descriptor!(HeapItemKind::ValueIndexMap);
+        other_heap_item_descriptor!(HeapItemKind::ValueIndexSet);
         other_heap_item_descriptor!(HeapItemKind::ExportMap);
-        other_heap_item_descriptor!(HeapItemKind::WeakMapObjectWeakValueMap);
-        other_heap_item_descriptor!(HeapItemKind::WeakSetObjectWeakValueSet);
+        other_heap_item_descriptor!(HeapItemKind::WeakValueMap);
+        other_heap_item_descriptor!(HeapItemKind::WeakValueSet);
         other_heap_item_descriptor!(HeapItemKind::GlobalSymbolRegistryMap);
         other_heap_item_descriptor!(HeapItemKind::InternedStringsSet);
         other_heap_item_descriptor!(HeapItemKind::LexicalNamesMap);
@@ -193,7 +193,8 @@ impl DescriptorRegistry {
         other_heap_item_descriptor!(HeapItemKind::FinalizationRegistryCells);
         other_heap_item_descriptor!(HeapItemKind::GlobalScopes);
 
-        other_heap_item_descriptor!(HeapItemKind::ValueVec);
+        other_heap_item_descriptor!(HeapItemKind::FunctionVec);
+        other_heap_item_descriptor!(HeapItemKind::SourceTextModuleVec);
         other_heap_item_descriptor!(HeapItemKind::WeakVec);
 
         Ok(base_descriptors)

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -3,7 +3,7 @@ use crate::runtime::{
     accessor::Accessor,
     arguments_object::{MappedArgumentsObject, UnmappedArgumentsObject},
     array_object::ArrayObject,
-    array_properties::{DenseArrayProperties, SparseArrayProperties},
+    array_properties::{DenseArrayProperties, SparseArrayPropertiesMap},
     async_generator_object::{AsyncGeneratorObject, AsyncGeneratorRequest},
     boxed_value::BoxedValue,
     builtin_generator::BuiltinGenerator,
@@ -11,23 +11,20 @@ use crate::runtime::{
         constant_table::ConstantTable,
         exception_handlers::ExceptionHandlers,
         function::{BytecodeFunction, Closure},
+        generator::FunctionVec,
     },
     class_names::ClassNames,
     collections::{
         BsWeakVec,
-        array::{
-            byte_array_byte_size, byte_array_visit_pointers, u32_array_byte_size,
-            u32_array_visit_pointers, value_array_byte_size, value_array_visit_pointers,
-        },
-        vec::{value_vec_byte_size, value_vec_visit_pointers},
+        array::{ByteArray, U32Array, ValueArray},
     },
-    context::{GlobalSymbolRegistryField, ModuleCacheField},
+    context::{GlobalSymbolRegistryMap, ModuleCacheMap},
     for_in_iterator::ForInIterator,
     gc::{HeapPtr, HeapVisitor},
     generator_object::GeneratorObject,
     global_names::GlobalNames,
     heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
-    interned_strings::InternedStringsSetField,
+    interned_strings::InternedStringsSet,
     intrinsics::{
         array_buffer_constructor::ArrayBufferObject,
         array_iterator::ArrayIterator,
@@ -41,51 +38,48 @@ use crate::runtime::{
         iterator_constructor::WrappedValidIterator,
         iterator_helper_object::IteratorHelperObject,
         map_iterator::MapIterator,
-        map_object::{MapObject, MapObjectMapField},
+        map_object::{MapObject, ValueIndexMap},
         number_constructor::NumberObject,
         object_prototype::ObjectPrototype,
         raw_json_object::RawJSONObject,
         regexp_constructor::RegExpObject,
         regexp_string_iterator::RegExpStringIterator,
         set_iterator::SetIterator,
-        set_object::{SetObject, SetObjectSetField},
+        set_object::{SetObject, ValueIndexSet},
         string_iterator::StringIterator,
         symbol_constructor::SymbolObject,
-        temporal::duration_object::DurationObject,
-        temporal::instant_object::InstantObject,
-        temporal::plain_date_object::PlainDateObject,
-        temporal::plain_date_time_object::PlainDateTimeObject,
-        temporal::plain_month_day_object::PlainMonthDayObject,
-        temporal::plain_time_object::PlainTimeObject,
-        temporal::plain_year_month_object::PlainYearMonthObject,
-        temporal::zoned_date_time_object::ZonedDateTimeObject,
+        temporal::{
+            duration_object::DurationObject, instant_object::InstantObject,
+            plain_date_object::PlainDateObject, plain_date_time_object::PlainDateTimeObject,
+            plain_month_day_object::PlainMonthDayObject, plain_time_object::PlainTimeObject,
+            plain_year_month_object::PlainYearMonthObject,
+            zoned_date_time_object::ZonedDateTimeObject,
+        },
         typed_array::{
             BigInt64Array, BigUInt64Array, Float16Array, Float32Array, Float64Array, Int8Array,
             Int16Array, Int32Array, UInt8Array, UInt8ClampedArray, UInt16Array, UInt32Array,
         },
-        weak_map_object::{WeakMapObject, WeakMapObjectMapField},
+        weak_map_object::{WeakMapObject, WeakValueMap},
         weak_ref_constructor::WeakRefObject,
-        weak_set_object::{WeakSetObject, WeakSetObjectSetField},
+        weak_set_object::{WeakSetObject, WeakValueSet},
     },
     module::{
         import_attributes::ImportAttributes,
         module_namespace_object::ModuleNamespaceObject,
         source_text_module::{
-            ExportMapField, SourceTextModule, module_option_array_byte_size,
-            module_option_array_visit_pointers, module_request_array_byte_size,
-            module_request_array_visit_pointers,
+            ExportMap, ModuleOptionArray, ModuleRequestArray, SourceTextModule, SourceTextModuleVec,
         },
         synthetic_module::SyntheticModule,
     },
-    object_value::{NamedPropertiesMapField, ObjectValue},
+    object_value::{NamedPropertiesMap, ObjectValue},
     promise_object::{PromiseCapability, PromiseObject, PromiseReaction},
     proxy_object::ProxyObject,
-    realm::{GlobalScopes, LexicalNamesMapField},
+    realm::{GlobalScopes, LexicalNamesMap},
     regexp::compiled_regexp::CompiledRegExpObject,
     scope::Scope,
     scope_names::ScopeNames,
     source_file::SourceFile,
-    stack_trace::{stack_frame_info_array_byte_size, stack_frame_info_array_visit_pointers},
+    stack_trace::StackFrameInfoArray,
     string_object::StringObject,
     string_value::StringValue,
     value::{BigIntValue, SymbolValue},
@@ -205,38 +199,35 @@ impl HeapPtr<AnyHeapItem> {
             HeapItemKind::AsyncGeneratorRequest => self.cast::<AsyncGeneratorRequest>().byte_size(),
             HeapItemKind::BuiltinGenerator => self.cast::<BuiltinGenerator>().byte_size(),
             HeapItemKind::DenseArrayProperties => self.cast::<DenseArrayProperties>().byte_size(),
-            HeapItemKind::SparseArrayProperties => self.cast::<SparseArrayProperties>().byte_size(),
+            HeapItemKind::SparseArrayPropertiesMap => {
+                SparseArrayPropertiesMap::byte_size(self.cast())
+            }
             HeapItemKind::CompiledRegExpObject => self.cast::<CompiledRegExpObject>().byte_size(),
             HeapItemKind::BoxedValue => self.cast::<BoxedValue>().byte_size(),
-            HeapItemKind::ObjectNamedPropertiesMap => {
-                NamedPropertiesMapField::byte_size(&self.cast())
-            }
-            HeapItemKind::MapObjectValueMap => MapObjectMapField::byte_size(&self.cast()),
-            HeapItemKind::SetObjectValueSet => SetObjectSetField::byte_size(&self.cast()),
-            HeapItemKind::ExportMap => ExportMapField::byte_size(&self.cast()),
-            HeapItemKind::WeakMapObjectWeakValueMap => {
-                WeakMapObjectMapField::byte_size(&self.cast())
-            }
-            HeapItemKind::WeakSetObjectWeakValueSet => {
-                WeakSetObjectSetField::byte_size(&self.cast())
-            }
+            HeapItemKind::NamedPropertiesMap => NamedPropertiesMap::byte_size(self.cast()),
+            HeapItemKind::ValueIndexMap => ValueIndexMap::byte_size(self.cast()),
+            HeapItemKind::ValueIndexSet => ValueIndexSet::byte_size(self.cast()),
+            HeapItemKind::ExportMap => ExportMap::byte_size(self.cast()),
+            HeapItemKind::WeakValueMap => WeakValueMap::byte_size(self.cast()),
+            HeapItemKind::WeakValueSet => WeakValueSet::byte_size(self.cast()),
             HeapItemKind::GlobalSymbolRegistryMap => {
-                GlobalSymbolRegistryField::byte_size(&self.cast())
+                GlobalSymbolRegistryMap::byte_size(self.cast())
             }
-            HeapItemKind::InternedStringsSet => InternedStringsSetField::byte_size(&self.cast()),
-            HeapItemKind::LexicalNamesMap => LexicalNamesMapField::byte_size(&self.cast()),
-            HeapItemKind::ModuleCacheMap => ModuleCacheField::byte_size(&self.cast()),
-            HeapItemKind::ValueArray => value_array_byte_size(self.cast()),
-            HeapItemKind::ByteArray => byte_array_byte_size(self.cast()),
-            HeapItemKind::U32Array => u32_array_byte_size(self.cast()),
-            HeapItemKind::ModuleRequestArray => module_request_array_byte_size(self.cast()),
-            HeapItemKind::ModuleOptionArray => module_option_array_byte_size(self.cast()),
-            HeapItemKind::StackFrameInfoArray => stack_frame_info_array_byte_size(self.cast()),
+            HeapItemKind::InternedStringsSet => InternedStringsSet::byte_size(self.cast()),
+            HeapItemKind::LexicalNamesMap => LexicalNamesMap::byte_size(self.cast()),
+            HeapItemKind::ModuleCacheMap => ModuleCacheMap::byte_size(self.cast()),
+            HeapItemKind::ValueArray => ValueArray::byte_size(self.cast()),
+            HeapItemKind::ByteArray => ByteArray::byte_size(self.cast()),
+            HeapItemKind::U32Array => U32Array::byte_size(self.cast()),
+            HeapItemKind::ModuleRequestArray => ModuleRequestArray::byte_size(self.cast()),
+            HeapItemKind::ModuleOptionArray => ModuleOptionArray::byte_size(self.cast()),
+            HeapItemKind::StackFrameInfoArray => StackFrameInfoArray::byte_size(self.cast()),
             HeapItemKind::FinalizationRegistryCells => {
                 self.cast::<FinalizationRegistryCells>().byte_size()
             }
             HeapItemKind::GlobalScopes => self.cast::<GlobalScopes>().byte_size(),
-            HeapItemKind::ValueVec => value_vec_byte_size(self.cast()),
+            HeapItemKind::FunctionVec => FunctionVec::byte_size(self.cast()),
+            HeapItemKind::SourceTextModuleVec => SourceTextModuleVec::byte_size(self.cast()),
             HeapItemKind::WeakVec => self.cast::<BsWeakVec>().byte_size(),
             HeapItemKind::Last => unreachable!("No objects are created with this descriptor"),
         }
@@ -369,58 +360,53 @@ impl HeapPtr<AnyHeapItem> {
             HeapItemKind::DenseArrayProperties => {
                 self.cast::<DenseArrayProperties>().visit_pointers(visitor)
             }
-            HeapItemKind::SparseArrayProperties => {
-                self.cast::<SparseArrayProperties>().visit_pointers(visitor)
+            HeapItemKind::SparseArrayPropertiesMap => {
+                SparseArrayPropertiesMap::visit_pointers(self.cast_mut(), visitor)
             }
             HeapItemKind::CompiledRegExpObject => {
                 self.cast::<CompiledRegExpObject>().visit_pointers(visitor)
             }
             HeapItemKind::BoxedValue => self.cast::<BoxedValue>().visit_pointers(visitor),
-            HeapItemKind::ObjectNamedPropertiesMap => {
-                NamedPropertiesMapField::visit_pointers(self.cast_mut(), visitor)
+            HeapItemKind::NamedPropertiesMap => {
+                NamedPropertiesMap::visit_pointers(self.cast_mut(), visitor)
             }
-            HeapItemKind::MapObjectValueMap => {
-                MapObjectMapField::visit_pointers(self.cast_mut(), visitor)
-            }
-            HeapItemKind::SetObjectValueSet => {
-                SetObjectSetField::visit_pointers(self.cast_mut(), visitor)
-            }
-            HeapItemKind::ExportMap => ExportMapField::visit_pointers(self.cast_mut(), visitor),
-            HeapItemKind::WeakMapObjectWeakValueMap => {
-                WeakMapObjectMapField::visit_pointers(self.cast_mut(), visitor)
-            }
-            HeapItemKind::WeakSetObjectWeakValueSet => {
-                WeakSetObjectSetField::visit_pointers(self.cast_mut(), visitor)
-            }
+            HeapItemKind::ValueIndexMap => ValueIndexMap::visit_pointers(self.cast_mut(), visitor),
+            HeapItemKind::ValueIndexSet => ValueIndexSet::visit_pointers(self.cast_mut(), visitor),
+            HeapItemKind::ExportMap => ExportMap::visit_pointers(self.cast_mut(), visitor),
+            HeapItemKind::WeakValueMap => WeakValueMap::visit_pointers(self.cast_mut(), visitor),
+            HeapItemKind::WeakValueSet => WeakValueSet::visit_pointers(self.cast_mut(), visitor),
             HeapItemKind::GlobalSymbolRegistryMap => {
-                GlobalSymbolRegistryField::visit_pointers(self.cast_mut(), visitor)
+                GlobalSymbolRegistryMap::visit_pointers(self.cast_mut(), visitor)
             }
             HeapItemKind::InternedStringsSet => {
-                InternedStringsSetField::visit_pointers(self.cast_mut(), visitor)
+                InternedStringsSet::visit_pointers(self.cast_mut(), visitor)
             }
             HeapItemKind::LexicalNamesMap => {
-                LexicalNamesMapField::visit_pointers(self.cast_mut(), visitor)
+                LexicalNamesMap::visit_pointers(self.cast_mut(), visitor)
             }
             HeapItemKind::ModuleCacheMap => {
-                ModuleCacheField::visit_pointers(self.cast_mut(), visitor)
+                ModuleCacheMap::visit_pointers(self.cast_mut(), visitor)
             }
-            HeapItemKind::ValueArray => value_array_visit_pointers(self.cast_mut(), visitor),
-            HeapItemKind::ByteArray => byte_array_visit_pointers(self.cast_mut(), visitor),
-            HeapItemKind::U32Array => u32_array_visit_pointers(self.cast_mut(), visitor),
+            HeapItemKind::ValueArray => ValueArray::visit_pointers(self.cast_mut(), visitor),
+            HeapItemKind::ByteArray => ByteArray::visit_pointers(self.cast_mut(), visitor),
+            HeapItemKind::U32Array => U32Array::visit_pointers(self.cast_mut(), visitor),
             HeapItemKind::ModuleRequestArray => {
-                module_request_array_visit_pointers(self.cast_mut(), visitor)
+                ModuleRequestArray::visit_pointers(self.cast_mut(), visitor)
             }
             HeapItemKind::ModuleOptionArray => {
-                module_option_array_visit_pointers(self.cast_mut(), visitor)
+                ModuleOptionArray::visit_pointers(self.cast_mut(), visitor)
             }
             HeapItemKind::StackFrameInfoArray => {
-                stack_frame_info_array_visit_pointers(self.cast_mut(), visitor)
+                StackFrameInfoArray::visit_pointers(self.cast_mut(), visitor)
             }
             HeapItemKind::FinalizationRegistryCells => self
                 .cast::<FinalizationRegistryCells>()
                 .visit_pointers(visitor),
             HeapItemKind::GlobalScopes => self.cast::<GlobalScopes>().visit_pointers(visitor),
-            HeapItemKind::ValueVec => value_vec_visit_pointers(self.cast_mut(), visitor),
+            HeapItemKind::FunctionVec => FunctionVec::visit_pointers(self.cast_mut(), visitor),
+            HeapItemKind::SourceTextModuleVec => {
+                SourceTextModuleVec::visit_pointers(self.cast_mut(), visitor)
+            }
             HeapItemKind::WeakVec => self.cast::<BsWeakVec>().visit_pointers(visitor),
             HeapItemKind::Last => unreachable!("No objects are created with this descriptor"),
         }
@@ -438,7 +424,7 @@ impl HeapItem for HeapPtr<AnyHeapItem> {
 }
 
 /// Marker trait that denotes an object on the managed heap
-pub trait IsHeapItem {}
+pub trait IsHeapItem: Sized {}
 
 impl<T> IsHeapItem for T where HeapPtr<T>: HeapItem {}
 

--- a/src/js/runtime/heap_item_descriptor.rs
+++ b/src/js/runtime/heap_item_descriptor.rs
@@ -129,19 +129,19 @@ pub enum HeapItemKind {
     BuiltinGenerator,
 
     DenseArrayProperties,
-    SparseArrayProperties,
+    SparseArrayPropertiesMap,
 
     CompiledRegExpObject,
 
     BoxedValue,
 
     // Hash maps
-    ObjectNamedPropertiesMap,
-    MapObjectValueMap,
-    SetObjectValueSet,
+    NamedPropertiesMap,
+    ValueIndexMap,
+    ValueIndexSet,
     ExportMap,
-    WeakSetObjectWeakValueSet,
-    WeakMapObjectWeakValueMap,
+    WeakValueMap,
+    WeakValueSet,
     GlobalSymbolRegistryMap,
     InternedStringsSet,
     LexicalNamesMap,
@@ -158,7 +158,8 @@ pub enum HeapItemKind {
     GlobalScopes,
 
     // Vectors
-    ValueVec,
+    FunctionVec,
+    SourceTextModuleVec,
     WeakVec,
 
     // Numerical value is the number of kinds in the enum

--- a/src/js/runtime/interned_strings.rs
+++ b/src/js/runtime/interned_strings.rs
@@ -3,13 +3,12 @@ use hashbrown::HashMap;
 
 use crate::{
     common::wtf_8::{Wtf8Str, Wtf8String},
-    must_a,
+    impl_hash_set_instance, must_a,
     runtime::{
         Context, EvalResult, Handle, HeapPtr,
         alloc_error::AllocResult,
-        collections::{BsHashSet, BsHashSetField},
+        collections::{BsHashSetField, HashSetInstance},
         gc::HeapVisitor,
-        heap_item_descriptor::HeapItemKind,
         string_value::{FlatString, StringValue},
     },
     set_uninit,
@@ -25,12 +24,9 @@ pub struct InternedStrings {
     generator_cache: HashMap<Wtf8String, HeapPtr<FlatString>>,
 }
 
-type InternedStringsSet = BsHashSet<HeapPtr<FlatString>>;
-
 impl InternedStrings {
     pub fn init(mut cx: Context) -> AllocResult<()> {
-        let interned_strings =
-            InternedStringsSet::new_initial(cx, HeapItemKind::InternedStringsSet)?;
+        let interned_strings = InternedStringsSet::new_initial(cx)?;
 
         set_uninit!(cx.interned_strings.strings, interned_strings);
         set_uninit!(cx.interned_strings.generator_cache, HashMap::new());
@@ -148,29 +144,33 @@ impl InternedStrings {
     }
 }
 
+impl_hash_set_instance!(InternedStringsSet, HeapPtr<FlatString>);
+
 #[derive(Clone)]
 pub struct InternedStringsSetField;
 
-impl BsHashSetField<HeapPtr<FlatString>> for InternedStringsSetField {
-    fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<InternedStringsSet>> {
-        InternedStringsSet::new(cx, HeapItemKind::InternedStringsSet, capacity)
-    }
-
+impl BsHashSetField<InternedStringsSet> for InternedStringsSetField {
     fn get(&self, cx: Context) -> HeapPtr<InternedStringsSet> {
         cx.interned_strings.strings
     }
 
-    fn set(&mut self, mut cx: Context, set: HeapPtr<InternedStringsSet>) {
+    fn set_new(
+        &mut self,
+        mut cx: Context,
+        capacity: usize,
+    ) -> AllocResult<HeapPtr<InternedStringsSet>> {
+        let set = InternedStringsSet::new(cx, capacity)?;
         cx.interned_strings.strings = set;
+        Ok(set)
     }
 }
 
-impl InternedStringsSetField {
-    pub fn byte_size(set: &HeapPtr<InternedStringsSet>) -> usize {
-        InternedStringsSet::calculate_size_in_bytes(set.capacity())
+impl InternedStringsSet {
+    pub fn byte_size(set: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(set.capacity())
     }
 
-    pub fn visit_pointers(set: &mut HeapPtr<InternedStringsSet>, visitor: &mut impl HeapVisitor) {
+    pub fn visit_pointers(set: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
         set.visit_pointers(visitor);
 
         // Interned strings are weak references

--- a/src/js/runtime/intrinsics/array_buffer_constructor.rs
+++ b/src/js/runtime/intrinsics/array_buffer_constructor.rs
@@ -5,7 +5,7 @@ use crate::{
     runtime::{
         Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
-        collections::{BsArray, array::ByteArray},
+        collections::{ArrayInstance, array::ByteArray},
         error::{range_error, type_error},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
@@ -83,8 +83,7 @@ impl ArrayBufferObject {
                 Some(*data)
             } else {
                 // Otherwise allocate new zeroed data block and copy the data into it
-                let mut new_uninit =
-                    BsArray::<u8>::new_uninit(cx, HeapItemKind::ByteArray, byte_length)?;
+                let mut new_uninit = ByteArray::new_uninit(cx, byte_length)?;
 
                 // Copy data from the old to new data block
                 let copied_size = byte_length.min(data.len());
@@ -98,7 +97,7 @@ impl ArrayBufferObject {
             }
         } else {
             // Initialize data block to all zeros
-            Some(BsArray::<u8>::new(cx, HeapItemKind::ByteArray, byte_length, 0)?)
+            Some(ByteArray::new(cx, byte_length, 0)?)
         };
 
         Ok(object)

--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -4,9 +4,8 @@ use crate::{
         Context, EvalResult, Handle, Value,
         abstract_operations::{construct, species_constructor},
         alloc_error::AllocResult,
-        collections::BsArray,
+        collections::{ArrayInstance, array::ByteArray},
         error::{range_error, type_error},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             array_buffer_constructor::{
@@ -112,7 +111,7 @@ impl ArrayBufferPrototype {
         }
 
         // Create new data block with copy of old data at start
-        let mut new_data = BsArray::<u8>::new_uninit(cx, HeapItemKind::ByteArray, new_byte_length)?;
+        let mut new_data = ByteArray::new_uninit(cx, new_byte_length)?;
         let old_byte_length = array_buffer.byte_length();
 
         unsafe {

--- a/src/js/runtime/intrinsics/iterator_constructor.rs
+++ b/src/js/runtime/intrinsics/iterator_constructor.rs
@@ -4,7 +4,7 @@ use crate::{
         Context, HeapPtr, Value,
         abstract_operations::{call, call_object, get_method, ordinary_has_instance},
         alloc_error::AllocResult,
-        collections::array::value_array_from_slice,
+        collections::array::ValueArray,
         error::type_error,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
@@ -86,8 +86,10 @@ impl IteratorConstructor {
             }
         }
 
-        let iterables_array = value_array_from_slice(cx, arguments.as_slice())?.to_handle();
-        let iterator_methods_array = value_array_from_slice(cx, &iterator_methods)?.to_handle();
+        let iterables_array =
+            ValueArray::new_from_handle_slice(cx, arguments.as_slice())?.to_handle();
+        let iterator_methods_array =
+            ValueArray::new_from_handle_slice(cx, &iterator_methods)?.to_handle();
 
         Ok(IteratorHelperObject::new_concat(cx, iterables_array, iterator_methods_array)?
             .as_value())

--- a/src/js/runtime/intrinsics/map_iterator.rs
+++ b/src/js/runtime/intrinsics/map_iterator.rs
@@ -6,7 +6,7 @@ use crate::{
         Context, Handle, HeapPtr,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
-        collections::index_map::GcSafeEntriesIter,
+        collections::index_map::{GcSafeEntriesIter, IndexMapInstance},
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
@@ -14,7 +14,7 @@ use crate::{
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
-            map_object::{MapObject, ValueMap},
+            map_object::{MapObject, ValueIndexMap},
         },
         iterator::create_iter_result_object,
         object_value::ObjectValue,
@@ -30,7 +30,7 @@ use crate::{
 extend_object! {
     pub struct MapIterator {
         // Component parts of an index_map::GcSafeEntriesIter
-        map: HeapPtr<ValueMap>,
+        map: HeapPtr<ValueIndexMap>,
         next_entry_index: usize,
         kind: MapIteratorKind,
         is_done: bool,
@@ -67,14 +67,14 @@ impl MapIterator {
 
     fn get_iter(&self) -> GcSafeEntriesIter<ValueCollectionKey, Value> {
         GcSafeEntriesIter::<ValueCollectionKey, Value>::from_parts(
-            self.map.to_handle(),
+            self.map.to_handle().cast(),
             self.next_entry_index,
         )
     }
 
     fn store_iter(&mut self, iter: GcSafeEntriesIter<ValueCollectionKey, Value>) {
         let (map, next_entry_index) = iter.to_parts();
-        self.map = *map;
+        self.map = (*map).cast();
         self.next_entry_index = next_entry_index;
     }
 }
@@ -114,7 +114,7 @@ impl MapIteratorPrototype {
         // Follow tombstone objects, fixing up iterator as needed. This may be a chain of tombstone
         // objects and we need to fix up the iterator at each step.
         while map_iterator.map.is_tombstone() {
-            map_iterator.map = ValueMap::fix_iterator_for_resized_map(
+            map_iterator.map = ValueIndexMap::fix_iterator_for_resized_map(
                 map_iterator.map,
                 &mut map_iterator.next_entry_index,
             );

--- a/src/js/runtime/intrinsics/map_object.rs
+++ b/src/js/runtime/intrinsics/map_object.rs
@@ -1,11 +1,11 @@
 use std::mem::size_of;
 
 use crate::{
-    extend_object,
+    extend_object, impl_index_map_instance,
     runtime::{
         Context, EvalResult, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
-        collections::{BsIndexMap, BsIndexMapField},
+        collections::{BsIndexMap, BsIndexMapField, index_map::IndexMapInstance},
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
@@ -19,11 +19,9 @@ use crate::{
 // Map Objects (https://tc39.es/ecma262/#sec-map-objects)
 extend_object! {
     pub struct MapObject {
-        map_data: HeapPtr<ValueMap>,
+        map_data: HeapPtr<ValueIndexMap>,
     }
 }
-
-pub type ValueMap = BsIndexMap<ValueCollectionKey, Value>;
 
 impl MapObject {
     pub fn new_from_constructor(
@@ -31,8 +29,7 @@ impl MapObject {
         constructor: Handle<ObjectValue>,
     ) -> EvalResult<Handle<MapObject>> {
         // Allocate and place behind handle before allocating environment
-        let map_data =
-            ValueMap::new(cx, HeapItemKind::MapObjectValueMap, ValueMap::MIN_CAPACITY)?.to_handle();
+        let map_data = ValueIndexMap::new(cx, ValueIndexMap::MIN_CAPACITY)?.to_handle();
 
         let mut object = object_create_from_constructor::<MapObject>(
             cx,
@@ -46,8 +43,12 @@ impl MapObject {
         Ok(object.to_handle())
     }
 
-    pub fn map_data(&self) -> HeapPtr<ValueMap> {
+    pub fn map_data(&self) -> HeapPtr<ValueIndexMap> {
         self.map_data
+    }
+
+    pub fn map_data_inner(&self) -> Handle<BsIndexMap<ValueCollectionKey, Value>> {
+        self.map_data.to_handle().cast()
     }
 }
 
@@ -71,19 +72,34 @@ impl Handle<MapObject> {
     }
 }
 
-pub struct MapObjectMapField(Handle<MapObject>);
+impl_index_map_instance!(ValueIndexMap, ValueCollectionKey, Value);
 
-impl BsIndexMapField<ValueCollectionKey, Value> for MapObjectMapField {
-    fn new_map(&self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<ValueMap>> {
-        ValueMap::new(cx, HeapItemKind::MapObjectValueMap, capacity)
+impl ValueIndexMap {
+    pub fn byte_size(map: HeapPtr<ValueIndexMap>) -> usize {
+        ValueIndexMap::calculate_size_in_bytes(map.capacity())
     }
 
-    fn get(&self) -> HeapPtr<ValueMap> {
+    pub fn visit_pointers(map: &mut HeapPtr<ValueIndexMap>, visitor: &mut impl HeapVisitor) {
+        ValueIndexMap::visit_pointers_impl(*map, visitor, |mut map, visitor| {
+            for (key, value) in map.iter_mut_gc_unsafe() {
+                key.visit_pointers(visitor);
+                visitor.visit_value(value);
+            }
+        });
+    }
+}
+
+pub struct MapObjectMapField(Handle<MapObject>);
+
+impl BsIndexMapField<ValueIndexMap> for MapObjectMapField {
+    fn get(&self) -> HeapPtr<ValueIndexMap> {
         self.0.map_data
     }
 
-    fn set(&mut self, map: HeapPtr<ValueMap>) {
+    fn set_new(&mut self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<ValueIndexMap>> {
+        let map = ValueIndexMap::new(cx, capacity)?;
         self.0.map_data = map;
+        Ok(map)
     }
 }
 
@@ -95,20 +111,5 @@ impl HeapItem for HeapPtr<MapObject> {
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
         self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.map_data);
-    }
-}
-
-impl MapObjectMapField {
-    pub fn byte_size(map: &HeapPtr<ValueMap>) -> usize {
-        ValueMap::calculate_size_in_bytes(map.capacity())
-    }
-
-    pub fn visit_pointers(map: &mut HeapPtr<ValueMap>, visitor: &mut impl HeapVisitor) {
-        map.visit_pointers_impl(visitor, |map, visitor| {
-            for (key, value) in map.iter_mut_gc_unsafe() {
-                key.visit_pointers(visitor);
-                visitor.visit_value(value);
-            }
-        });
     }
 }

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -107,7 +107,7 @@ impl MapPrototype {
 
         // Must use gc and invalidation safe iteration since arbitrary code can be executed between
         // iterations.
-        for (key, value) in map.map_data().to_handle().iter_gc_safe() {
+        for (key, value) in map.map_data_inner().iter_gc_safe() {
             key_handle.replace(key.into());
             value_handle.replace(value);
 

--- a/src/js/runtime/intrinsics/set_iterator.rs
+++ b/src/js/runtime/intrinsics/set_iterator.rs
@@ -6,13 +6,16 @@ use crate::{
         Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
-        collections::{BsIndexMap, index_map::GcSafeEntriesIter},
+        collections::{BsIndexMap, IndexSetInstance, index_map::GcSafeEntriesIter},
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
-        intrinsics::{intrinsics::Intrinsic, set_object::SetObject},
+        intrinsics::{
+            intrinsics::Intrinsic,
+            set_object::{SetObject, ValueIndexSet},
+        },
         iterator::create_iter_result_object,
         object_value::ObjectValue,
         ordinary_object::object_create,
@@ -27,7 +30,7 @@ use crate::{
 extend_object! {
     pub struct SetIterator {
         // Component parts of an index_map::GcSafeEntriesIter
-        set: HeapPtr<BsIndexMap<ValueCollectionKey, ()>>,
+        set: HeapPtr<ValueIndexSet>,
         next_entry_index: usize,
         kind: SetIteratorKind,
         is_done: bool,
@@ -63,15 +66,19 @@ impl SetIterator {
 
     fn get_iter(&self) -> GcSafeEntriesIter<ValueCollectionKey, ()> {
         GcSafeEntriesIter::<ValueCollectionKey, ()>::from_parts(
-            self.set.to_handle(),
+            self.set.to_handle().cast(),
             self.next_entry_index,
         )
     }
 
     fn store_iter(&mut self, iter: GcSafeEntriesIter<ValueCollectionKey, ()>) {
         let (set, next_entry_index) = iter.to_parts();
-        self.set = *set;
+        self.set = (*set).cast();
         self.next_entry_index = next_entry_index;
+    }
+
+    fn set_inner_map(&self) -> HeapPtr<BsIndexMap<ValueCollectionKey, ()>> {
+        self.set.cast()
     }
 }
 
@@ -110,8 +117,8 @@ impl SetIteratorPrototype {
 
         // Follow tombstone objects, fixing up iterator as needed. This may be a chain of tombstone
         // objects and we need to fix up the iterator at each step.
-        while set_iterator.set.is_tombstone() {
-            set_iterator.set = BsIndexMap::fix_iterator_for_resized_map(
+        while set_iterator.set_inner_map().is_tombstone() {
+            set_iterator.set = ValueIndexSet::fix_iterator_for_resized_map(
                 set_iterator.set,
                 &mut set_iterator.next_entry_index,
             );

--- a/src/js/runtime/intrinsics/set_object.rs
+++ b/src/js/runtime/intrinsics/set_object.rs
@@ -1,11 +1,11 @@
 use std::mem::size_of;
 
 use crate::{
-    extend_object,
+    extend_object, impl_index_set_instance,
     runtime::{
         Context, EvalResult, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
-        collections::{BsIndexSet, BsIndexSetField},
+        collections::{BsIndexSet, BsIndexSetField, IndexSetInstance},
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
@@ -19,11 +19,9 @@ use crate::{
 // Set Objects (https://tc39.es/ecma262/#sec-set-objects)
 extend_object! {
     pub struct SetObject {
-        set_data: HeapPtr<ValueSet>,
+        set_data: HeapPtr<ValueIndexSet>,
     }
 }
-
-pub type ValueSet = BsIndexSet<ValueCollectionKey>;
 
 impl SetObject {
     pub fn new_from_constructor(
@@ -31,7 +29,7 @@ impl SetObject {
         constructor: Handle<ObjectValue>,
     ) -> EvalResult<Handle<SetObject>> {
         // Allocate and place behind handle before allocating object
-        let set_data = SetObjectSetField::new(cx, ValueSet::MIN_CAPACITY)?.to_handle();
+        let set_data = ValueIndexSet::new(cx, ValueIndexSet::MIN_CAPACITY)?.to_handle();
 
         let mut object = object_create_from_constructor::<SetObject>(
             cx,
@@ -46,7 +44,10 @@ impl SetObject {
     }
 
     /// Create a new SetObject with the provided set data.
-    pub fn new_from_set(cx: Context, set_data: Handle<ValueSet>) -> AllocResult<Handle<SetObject>> {
+    pub fn new_from_set(
+        cx: Context,
+        set_data: Handle<ValueIndexSet>,
+    ) -> AllocResult<Handle<SetObject>> {
         let mut object =
             object_create::<SetObject>(cx, HeapItemKind::SetObject, Intrinsic::SetPrototype)?;
 
@@ -56,13 +57,18 @@ impl SetObject {
     }
 
     #[inline]
-    pub fn set_data_ptr(&self) -> HeapPtr<ValueSet> {
+    pub fn set_data_ptr(&self) -> HeapPtr<ValueIndexSet> {
         self.set_data
     }
 
     #[inline]
-    pub fn set_data(&self) -> Handle<ValueSet> {
+    pub fn set_data(&self) -> Handle<ValueIndexSet> {
         self.set_data_ptr().to_handle()
+    }
+
+    #[inline]
+    pub fn set_data_inner(&self) -> Handle<BsIndexSet<ValueCollectionKey>> {
+        self.set_data().cast()
     }
 }
 
@@ -81,20 +87,34 @@ impl Handle<SetObject> {
     }
 }
 
+impl_index_set_instance!(ValueIndexSet, ValueCollectionKey);
+
+impl ValueIndexSet {
+    pub fn byte_size(set: HeapPtr<ValueIndexSet>) -> usize {
+        ValueIndexSet::calculate_size_in_bytes(set.capacity())
+    }
+
+    pub fn visit_pointers(set: &mut HeapPtr<ValueIndexSet>, visitor: &mut impl HeapVisitor) {
+        ValueIndexSet::visit_pointers_impl(*set, visitor, |mut set, visitor| {
+            for element in set.iter_mut_gc_unsafe() {
+                element.visit_pointers(visitor);
+            }
+        });
+    }
+}
+
 #[derive(Clone)]
 pub struct SetObjectSetField(Handle<SetObject>);
 
-impl BsIndexSetField<ValueCollectionKey> for SetObjectSetField {
-    fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<ValueSet>> {
-        ValueSet::new(cx, HeapItemKind::SetObjectValueSet, capacity)
-    }
-
-    fn get(&self) -> HeapPtr<ValueSet> {
+impl BsIndexSetField<ValueIndexSet> for SetObjectSetField {
+    fn get(&self) -> HeapPtr<ValueIndexSet> {
         self.0.set_data
     }
 
-    fn set(&mut self, set: HeapPtr<ValueSet>) {
+    fn set_new(&mut self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<ValueIndexSet>> {
+        let set = ValueIndexSet::new(cx, capacity)?;
         self.0.set_data = set;
+        Ok(set)
     }
 }
 
@@ -106,19 +126,5 @@ impl HeapItem for HeapPtr<SetObject> {
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
         self.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut self.set_data);
-    }
-}
-
-impl SetObjectSetField {
-    pub fn byte_size(set: &HeapPtr<ValueSet>) -> usize {
-        ValueSet::calculate_size_in_bytes(set.capacity())
-    }
-
-    pub fn visit_pointers(set: &mut HeapPtr<ValueSet>, visitor: &mut impl HeapVisitor) {
-        set.visit_pointers_impl(visitor, |set, visitor| {
-            for element in set.iter_mut_gc_unsafe() {
-                element.visit_pointers(visitor);
-            }
-        });
     }
 }

--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -4,7 +4,7 @@ use crate::{
         Context, Handle,
         abstract_operations::{call_object, canonicalize_keyed_collection_key},
         alloc_error::AllocResult,
-        collections::BsIndexSetField,
+        collections::IndexSetInstance,
         error::{range_error, type_error},
         eval_result::EvalResult,
         get,
@@ -13,7 +13,7 @@ use crate::{
             intrinsics::Intrinsic,
             rust_runtime::RuntimeFunction,
             set_iterator::{SetIterator, SetIteratorKind},
-            set_object::{SetObject, SetObjectSetField, ValueSet},
+            set_object::{SetObject, ValueIndexSet},
         },
         iterator::{
             IteratorHint, get_iterator, iter_iterator_method_values, iterator_close, iterator_step,
@@ -114,7 +114,7 @@ impl SetPrototype {
         let other_set_record = get_set_record(cx, other, "difference")?;
 
         // Create a copy of this set
-        let new_set_data = ValueSet::new_from_set(cx, this_set.set_data())?.to_handle();
+        let new_set_data = ValueIndexSet::new_from_set(cx, this_set.set_data())?.to_handle();
         let new_set = SetObject::new_from_set(cx, new_set_data)?;
 
         if this_set.set_data_ptr().num_entries_occupied() as f64 <= other_set_record.size {
@@ -125,7 +125,7 @@ impl SetPrototype {
             // Handle is shared between iterations
             let mut item_handle = Handle::<Value>::empty(cx);
 
-            for (item, _) in new_set.set_data().iter_gc_safe() {
+            for (item, _) in new_set.set_data_inner().iter_gc_safe() {
                 item_handle.replace(item.get());
 
                 let in_other = call_object(
@@ -193,7 +193,7 @@ impl SetPrototype {
 
         // Must use gc and invalidation safe iteration since arbitrary code can be executed between
         // iterations.
-        for (value, _) in set.set_data().iter_gc_safe() {
+        for (value, _) in set.set_data_inner().iter_gc_safe() {
             value_handle.replace(value.into());
 
             let arguments = [value_handle, value_handle, this_value];
@@ -225,7 +225,7 @@ impl SetPrototype {
         let other_set_record = get_set_record(cx, other, "intersection")?;
 
         // Create an empty set
-        let new_set_data = SetObjectSetField::new(cx, ValueSet::MIN_CAPACITY)?.to_handle();
+        let new_set_data = ValueIndexSet::new(cx, ValueIndexSet::MIN_CAPACITY)?.to_handle();
         let new_set = SetObject::new_from_set(cx, new_set_data)?;
 
         if this_set.set_data_ptr().num_entries_occupied() as f64 <= other_set_record.size {
@@ -236,7 +236,7 @@ impl SetPrototype {
             // Handle is shared between iterations
             let mut item_handle = Handle::<Value>::empty(cx);
 
-            for (item, _) in this_set.set_data().iter_gc_safe() {
+            for (item, _) in this_set.set_data_inner().iter_gc_safe() {
                 item_handle.replace(item.get());
 
                 let in_other = call_object(
@@ -296,7 +296,7 @@ impl SetPrototype {
             // Handle is shared between iterations
             let mut item_handle = Handle::<Value>::empty(cx);
 
-            for (item, _) in this_set.set_data().iter_gc_safe() {
+            for (item, _) in this_set.set_data_inner().iter_gc_safe() {
                 item_handle.replace(item.get());
 
                 let in_other = call_object(
@@ -358,7 +358,7 @@ impl SetPrototype {
         // Handle is shared between iterations
         let mut item_handle = Handle::<Value>::empty(cx);
 
-        for (item, _) in this_set.set_data().iter_gc_safe() {
+        for (item, _) in this_set.set_data_inner().iter_gc_safe() {
             item_handle.replace(item.get());
 
             let in_other = call_object(
@@ -432,7 +432,7 @@ impl SetPrototype {
         let other_set_record = get_set_record(cx, other, "symmetricDifference")?;
 
         // Create a copy of this set
-        let new_set_data = ValueSet::new_from_set(cx, this_set.set_data())?.to_handle();
+        let new_set_data = ValueIndexSet::new_from_set(cx, this_set.set_data())?.to_handle();
         let new_set = SetObject::new_from_set(cx, new_set_data)?;
 
         // Iterate through keys of other set and add or remove them from the new set to ensure that
@@ -477,7 +477,7 @@ impl SetPrototype {
         let other_set_record = get_set_record(cx, other, "union")?;
 
         // Create a copy of this set
-        let new_set_data = ValueSet::new_from_set(cx, this_set.set_data())?.to_handle();
+        let new_set_data = ValueIndexSet::new_from_set(cx, this_set.set_data())?.to_handle();
         let new_set = SetObject::new_from_set(cx, new_set_data)?;
 
         // Iterate through keys of other set and add them to the new set

--- a/src/js/runtime/intrinsics/symbol_constructor.rs
+++ b/src/js/runtime/intrinsics/symbol_constructor.rs
@@ -5,7 +5,7 @@ use crate::{
     runtime::{
         Context, Handle, HeapPtr,
         alloc_error::AllocResult,
-        collections::BsHashMapField,
+        collections::hash_map::BsHashMapField,
         error::type_error,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,

--- a/src/js/runtime/intrinsics/weak_map_object.rs
+++ b/src/js/runtime/intrinsics/weak_map_object.rs
@@ -1,11 +1,11 @@
 use std::mem::size_of;
 
 use crate::{
-    extend_object,
+    extend_object, impl_hash_map_instance,
     runtime::{
         Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
-        collections::{BsHashMap, BsHashMapField},
+        collections::{HashMapInstance, hash_map::BsHashMapField},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
@@ -28,15 +28,12 @@ extend_object! {
     }
 }
 
-type WeakValueMap = BsHashMap<ValueCollectionKey, Value>;
-
 impl WeakMapObject {
     pub fn new_from_constructor(
         cx: Context,
         constructor: Handle<ObjectValue>,
     ) -> EvalResult<Handle<WeakMapObject>> {
-        let weak_map_data =
-            WeakValueMap::new_initial(cx, HeapItemKind::WeakMapObjectWeakValueMap)?.to_handle();
+        let weak_map_data = WeakValueMap::new_initial(cx)?.to_handle();
 
         let mut object = object_create_from_constructor::<WeakMapObject>(
             cx,
@@ -83,20 +80,20 @@ impl Handle<WeakMapObject> {
     }
 }
 
+impl_hash_map_instance!(WeakValueMap, ValueCollectionKey, Value);
+
 #[derive(Clone)]
 pub struct WeakMapObjectMapField(Handle<WeakMapObject>);
 
-impl BsHashMapField<ValueCollectionKey, Value> for WeakMapObjectMapField {
-    fn new_map(&self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<WeakValueMap>> {
-        WeakValueMap::new(cx, HeapItemKind::WeakMapObjectWeakValueMap, capacity)
-    }
-
+impl BsHashMapField<WeakValueMap> for WeakMapObjectMapField {
     fn get(&self, _: Context) -> HeapPtr<WeakValueMap> {
         self.0.weak_map_data
     }
 
-    fn set(&mut self, _: Context, map: HeapPtr<WeakValueMap>) {
+    fn set_new(&mut self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<WeakValueMap>> {
+        let map = WeakValueMap::new(cx, capacity)?;
         self.0.weak_map_data = map;
+        Ok(map)
     }
 }
 
@@ -113,12 +110,12 @@ impl HeapItem for HeapPtr<WeakMapObject> {
     }
 }
 
-impl WeakMapObjectMapField {
-    pub fn byte_size(map: &HeapPtr<WeakValueMap>) -> usize {
-        WeakValueMap::calculate_size_in_bytes(map.capacity())
+impl WeakValueMap {
+    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(map: &mut HeapPtr<WeakValueMap>, visitor: &mut impl HeapVisitor) {
+    pub fn visit_pointers(map: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
         map.visit_pointers(visitor);
 
         for (key, value) in map.iter_mut_gc_unsafe() {

--- a/src/js/runtime/intrinsics/weak_set_object.rs
+++ b/src/js/runtime/intrinsics/weak_set_object.rs
@@ -1,11 +1,11 @@
 use std::mem::size_of;
 
 use crate::{
-    extend_object,
+    extend_object, impl_hash_set_instance,
     runtime::{
         Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
-        collections::{BsHashSet, BsHashSetField},
+        collections::{BsHashSetField, HashSetInstance},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::HeapItemKind,
@@ -28,15 +28,12 @@ extend_object! {
     }
 }
 
-type WeakValueSet = BsHashSet<ValueCollectionKey>;
-
 impl WeakSetObject {
     pub fn new_from_constructor(
         cx: Context,
         constructor: Handle<ObjectValue>,
     ) -> EvalResult<Handle<WeakSetObject>> {
-        let weak_set_data =
-            WeakValueSet::new_initial(cx, HeapItemKind::WeakSetObjectWeakValueSet)?.to_handle();
+        let weak_set_data = WeakValueSet::new_initial(cx)?.to_handle();
 
         let mut object = object_create_from_constructor::<WeakSetObject>(
             cx,
@@ -78,20 +75,20 @@ impl Handle<WeakSetObject> {
     }
 }
 
+impl_hash_set_instance!(WeakValueSet, ValueCollectionKey);
+
 #[derive(Clone)]
 pub struct WeakSetObjectSetField(Handle<WeakSetObject>);
 
-impl BsHashSetField<ValueCollectionKey> for WeakSetObjectSetField {
-    fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<WeakValueSet>> {
-        WeakValueSet::new(cx, HeapItemKind::WeakSetObjectWeakValueSet, capacity)
-    }
-
+impl BsHashSetField<WeakValueSet> for WeakSetObjectSetField {
     fn get(&self, _: Context) -> HeapPtr<WeakValueSet> {
         self.0.weak_set_data
     }
 
-    fn set(&mut self, _: Context, set: HeapPtr<WeakValueSet>) {
+    fn set_new(&mut self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<WeakValueSet>> {
+        let set = WeakValueSet::new(cx, capacity)?;
         self.0.weak_set_data = set;
+        Ok(set)
     }
 }
 
@@ -108,12 +105,12 @@ impl HeapItem for HeapPtr<WeakSetObject> {
     }
 }
 
-impl WeakSetObjectSetField {
-    pub fn byte_size(map: &HeapPtr<WeakValueSet>) -> usize {
-        WeakValueSet::calculate_size_in_bytes(map.capacity())
+impl WeakValueSet {
+    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(set: &mut HeapPtr<WeakValueSet>, visitor: &mut impl HeapVisitor) {
+    pub fn visit_pointers(set: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
         set.visit_pointers(visitor);
 
         for value in set.iter_mut_gc_unsafe() {

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -3,12 +3,15 @@ use std::{collections::HashSet, hash::Hash, num::NonZeroUsize};
 use indexmap_allocator_api::IndexSet;
 
 use crate::{
-    field_offset, handle_scope,
+    field_offset, handle_scope, impl_array_instance, impl_hash_map_instance, impl_vec_instance,
     runtime::{
         Context, EvalResult, Handle, HeapPtr, PropertyKey, Value,
         alloc_error::AllocResult,
         bytecode::function::BytecodeFunction,
-        collections::{BsArray, BsHashMap, BsHashMapField, BsVec, BsVecField, InlineArray},
+        collections::{
+            ArrayInstance, BsVecField, HashMapInstance, InlineArray, VecInstance,
+            hash_map::BsHashMapField,
+        },
         gc::{AnyHeapItem, HeapItem, HeapVisitor},
         heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
         module::{
@@ -79,7 +82,7 @@ pub struct SourceTextModule {
     pending_async_dependencies: usize,
     /// If this module is evaluating asynchronously, this is the list of importers of this module
     /// that will not start execution until this module has completed execution.
-    async_parent_modules: Option<HeapPtr<AsyncParentModulesVec>>,
+    async_parent_modules: Option<HeapPtr<SourceTextModuleVec>>,
     /// All import and export entries in the module.
     entries: InlineArray<ModuleEntry>,
 }
@@ -94,15 +97,6 @@ pub enum ModuleState {
     EvaluatingAsync,
     Evaluated,
 }
-
-type ModuleRequestArray = BsArray<HeapModuleRequest>;
-
-type ModuleOptionArray = BsArray<Option<HeapDynModule>>;
-
-/// Key is the name of the export.
-/// - If export is a namespace export then value is the SourceTextModule whose namespace is exported
-/// - Otherwise value is a BoxedValue which holds the exported value
-pub type ExportMap = BsHashMap<PropertyKey, HeapPtr<AnyHeapItem>>;
 
 impl SourceTextModule {
     pub const MODULE_VTABLE: *const () = extract_module_vtable::<Self>();
@@ -122,8 +116,7 @@ impl SourceTextModule {
         // from arguments, loaded modules are initialized to None.
         let num_module_requests = requested_modules.len();
         let mut heap_requested_modules =
-            BsArray::new_uninit(cx, HeapItemKind::ModuleRequestArray, num_module_requests)?
-                .to_handle();
+            ModuleRequestArray::new_uninit(cx, num_module_requests)?.to_handle();
         for (dst, src) in heap_requested_modules
             .as_mut_slice()
             .iter_mut()
@@ -132,9 +125,7 @@ impl SourceTextModule {
             *dst = src.to_heap();
         }
 
-        let loaded_modules =
-            BsArray::new(cx, HeapItemKind::ModuleOptionArray, requested_modules.len(), None)?
-                .to_handle();
+        let loaded_modules = ModuleOptionArray::new(cx, requested_modules.len(), None)?.to_handle();
 
         // Then create the uninitialized module object
         let num_entries =
@@ -314,12 +305,12 @@ impl SourceTextModule {
     }
 
     #[inline]
-    pub fn async_parent_modules_ptr(&self) -> Option<HeapPtr<AsyncParentModulesVec>> {
+    pub fn async_parent_modules_ptr(&self) -> Option<HeapPtr<SourceTextModuleVec>> {
         self.async_parent_modules
     }
 
     #[inline]
-    pub fn async_parent_modules(&self) -> Option<Handle<AsyncParentModulesVec>> {
+    pub fn async_parent_modules(&self) -> Option<Handle<SourceTextModuleVec>> {
         self.async_parent_modules_ptr()
             .map(|modules| modules.to_handle())
     }
@@ -432,7 +423,7 @@ impl Handle<SourceTextModule> {
     ) -> AllocResult<()> {
         // Lazily initialize the async parent modules vec
         if self.async_parent_modules.is_none() {
-            let async_parent_modules = BsVec::new(cx, HeapItemKind::ValueVec, 4)?;
+            let async_parent_modules = SourceTextModuleVec::new_initial(cx)?;
             self.async_parent_modules = Some(async_parent_modules);
         }
 
@@ -641,7 +632,7 @@ impl Module for Handle<SourceTextModule> {
 
         handle_scope!(cx, {
             // Lazily initialize the exports map
-            self.exports = Some(ExportMap::new(cx, HeapItemKind::ExportMap, 4)?);
+            self.exports = Some(ExportMap::new_initial(cx)?);
 
             let mut exported_names = HashSet::new();
             self.get_exported_names(cx, &mut exported_names, &mut HashSet::new());
@@ -917,59 +908,64 @@ impl DirectReExportEntry {
     }
 }
 
-pub fn module_request_array_byte_size(array: HeapPtr<ModuleRequestArray>) -> usize {
-    ModuleRequestArray::calculate_size_in_bytes(array.len())
-}
+impl_array_instance!(ModuleRequestArray, HeapModuleRequest);
 
-pub fn module_request_array_visit_pointers(
-    array: &mut HeapPtr<ModuleRequestArray>,
-    visitor: &mut impl HeapVisitor,
-) {
-    array.visit_pointers(visitor);
+impl ModuleRequestArray {
+    pub fn byte_size(array: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(array.len())
+    }
 
-    for module_request in array.as_mut_slice() {
-        module_request.visit_pointers(visitor);
+    pub fn visit_pointers(array: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array.visit_pointers(visitor);
+
+        for module_request in array.as_mut_slice() {
+            module_request.visit_pointers(visitor);
+        }
     }
 }
 
-pub fn module_option_array_byte_size(array: HeapPtr<ModuleOptionArray>) -> usize {
-    ModuleOptionArray::calculate_size_in_bytes(array.len())
-}
+impl_array_instance!(ModuleOptionArray, Option<HeapDynModule>);
 
-pub fn module_option_array_visit_pointers(
-    array: &mut HeapPtr<ModuleOptionArray>,
-    visitor: &mut impl HeapVisitor,
-) {
-    array.visit_pointers(visitor);
+impl ModuleOptionArray {
+    pub fn byte_size(array: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(array.len())
+    }
 
-    for module in array.as_mut_slice().iter_mut().flatten() {
-        module.visit_pointers(visitor);
+    pub fn visit_pointers(array: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array.visit_pointers(visitor);
+
+        for module in array.as_mut_slice().iter_mut().flatten() {
+            module.visit_pointers(visitor);
+        }
     }
 }
+
+// Key is the name of the export.
+// - If export is a namespace export then value is the SourceTextModule whose namespace is exported
+// - Otherwise value is a BoxedValue which holds the exported value
+impl_hash_map_instance!(ExportMap, PropertyKey, HeapPtr<AnyHeapItem>);
 
 #[derive(Clone)]
 pub struct ExportMapField(Handle<SourceTextModule>);
 
-impl BsHashMapField<PropertyKey, HeapPtr<AnyHeapItem>> for ExportMapField {
-    fn new_map(&self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<ExportMap>> {
-        ExportMap::new(cx, HeapItemKind::ExportMap, capacity)
-    }
-
+impl BsHashMapField<ExportMap> for ExportMapField {
     fn get(&self, _: Context) -> HeapPtr<ExportMap> {
         self.0.exports.unwrap()
     }
 
-    fn set(&mut self, _: Context, map: HeapPtr<ExportMap>) {
+    fn set_new(&mut self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<ExportMap>> {
+        let map = ExportMap::new(cx, capacity)?;
         self.0.exports = Some(map);
+        Ok(map)
     }
 }
 
-impl ExportMapField {
-    pub fn byte_size(map: &HeapPtr<ExportMap>) -> usize {
-        ExportMap::calculate_size_in_bytes(map.capacity())
+impl ExportMap {
+    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(map: &mut HeapPtr<ExportMap>, visitor: &mut impl HeapVisitor) {
+    pub fn visit_pointers(map: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
         map.visit_pointers(visitor);
 
         for (key, value) in map.iter_mut_gc_unsafe() {
@@ -979,20 +975,36 @@ impl ExportMapField {
     }
 }
 
-type AsyncParentModulesVec = BsVec<HeapPtr<SourceTextModule>>;
+impl_vec_instance!(SourceTextModuleVec, HeapPtr<SourceTextModule>);
+
+impl SourceTextModuleVec {
+    pub fn byte_size(vec: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(vec.capacity())
+    }
+
+    pub fn visit_pointers(vec: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        vec.visit_pointers(visitor);
+
+        for function in vec.as_mut_slice() {
+            visitor.visit_pointer(function);
+        }
+    }
+}
 
 struct AsyncParentModulesField(Handle<SourceTextModule>);
 
-impl BsVecField<HeapPtr<SourceTextModule>> for AsyncParentModulesField {
-    fn new_vec(cx: Context, capacity: usize) -> AllocResult<HeapPtr<AsyncParentModulesVec>> {
-        BsVec::new(cx, HeapItemKind::ValueVec, capacity)
-    }
-
-    fn get(&self) -> HeapPtr<AsyncParentModulesVec> {
+impl BsVecField<SourceTextModuleVec> for AsyncParentModulesField {
+    fn get(&self) -> HeapPtr<SourceTextModuleVec> {
         self.0.async_parent_modules.unwrap()
     }
 
-    fn set(&mut self, vec: HeapPtr<AsyncParentModulesVec>) {
-        self.0.async_parent_modules = Some(vec);
+    fn set_new(
+        &mut self,
+        cx: Context,
+        capacity: usize,
+    ) -> AllocResult<HeapPtr<SourceTextModuleVec>> {
+        let new_vec = SourceTextModuleVec::new(cx, capacity)?;
+        self.0.async_parent_modules = Some(new_vec);
+        Ok(new_vec)
     }
 }

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -6,6 +6,7 @@ use std::{
 use rand::Rng;
 
 use crate::{
+    impl_index_map_instance,
     runtime::{
         Context, Realm,
         alloc_error::AllocResult,
@@ -13,30 +14,39 @@ use crate::{
         array_properties::ArrayProperties,
         async_generator_object::AsyncGeneratorObject,
         bytecode::function::Closure,
-        collections::{BsIndexMap, BsIndexMapField},
+        collections::{BsIndexMapField, index_map::IndexMapInstance},
         error::type_error,
         eval_result::EvalResult,
         gc::{Handle, HeapInfo, HeapItem, HeapPtr, HeapVisitor},
         generator_object::GeneratorObject,
         heap_item_descriptor::HeapItemKind,
         intrinsics::{
-            array_buffer_constructor::ArrayBufferObject, bigint_constructor::BigIntObject,
-            boolean_constructor::BooleanObject, data_view_constructor::DataViewObject,
-            date_object::DateObject, error_constructor::ErrorObject,
+            array_buffer_constructor::ArrayBufferObject,
+            bigint_constructor::BigIntObject,
+            boolean_constructor::BooleanObject,
+            data_view_constructor::DataViewObject,
+            date_object::DateObject,
+            error_constructor::ErrorObject,
             finalization_registry_object::FinalizationRegistryObject,
             iterator_constructor::WrappedValidIterator,
-            iterator_helper_object::IteratorHelperObject, map_object::MapObject,
-            number_constructor::NumberObject, object_prototype::ObjectPrototype,
-            raw_json_object::RawJSONObject, regexp_constructor::RegExpObject,
-            set_object::SetObject, symbol_constructor::SymbolObject,
-            temporal::duration_object::DurationObject, temporal::instant_object::InstantObject,
-            temporal::plain_date_object::PlainDateObject,
-            temporal::plain_date_time_object::PlainDateTimeObject,
-            temporal::plain_month_day_object::PlainMonthDayObject,
-            temporal::plain_time_object::PlainTimeObject,
-            temporal::plain_year_month_object::PlainYearMonthObject,
-            temporal::zoned_date_time_object::ZonedDateTimeObject, typed_array::DynTypedArray,
-            weak_map_object::WeakMapObject, weak_ref_constructor::WeakRefObject,
+            iterator_helper_object::IteratorHelperObject,
+            map_object::MapObject,
+            number_constructor::NumberObject,
+            object_prototype::ObjectPrototype,
+            raw_json_object::RawJSONObject,
+            regexp_constructor::RegExpObject,
+            set_object::SetObject,
+            symbol_constructor::SymbolObject,
+            temporal::{
+                duration_object::DurationObject, instant_object::InstantObject,
+                plain_date_object::PlainDateObject, plain_date_time_object::PlainDateTimeObject,
+                plain_month_day_object::PlainMonthDayObject, plain_time_object::PlainTimeObject,
+                plain_year_month_object::PlainYearMonthObject,
+                zoned_date_time_object::ZonedDateTimeObject,
+            },
+            typed_array::DynTypedArray,
+            weak_map_object::WeakMapObject,
+            weak_ref_constructor::WeakRefObject,
             weak_set_object::WeakSetObject,
         },
         promise_object::PromiseObject,
@@ -71,7 +81,7 @@ macro_rules! extend_object_without_conversions {
             prototype: Option<$crate::runtime::HeapPtr<$crate::runtime::object_value::ObjectValue>>,
 
             // String and symbol properties by their property key. Includes private properties.
-            named_properties: $crate::runtime::HeapPtr<$crate::runtime::collections::BsIndexMap<$crate::runtime::property_key::PropertyKey, $crate::runtime::property::HeapProperty>>,
+            named_properties: $crate::runtime::HeapPtr<$crate::runtime::object_value::NamedPropertiesMap>,
 
             // Array index properties by their property key
             array_properties: $crate::runtime::HeapPtr<$crate::runtime::array_properties::ArrayProperties>,
@@ -647,21 +657,38 @@ pub trait VirtualObject {
     }
 }
 
-pub type NamedPropertiesMap = BsIndexMap<PropertyKey, HeapProperty>;
+impl_index_map_instance!(NamedPropertiesMap, PropertyKey, HeapProperty);
+
+impl NamedPropertiesMap {
+    pub fn byte_size(map: HeapPtr<NamedPropertiesMap>) -> usize {
+        NamedPropertiesMap::calculate_size_in_bytes(map.capacity())
+    }
+
+    pub fn visit_pointers(map: &mut HeapPtr<NamedPropertiesMap>, visitor: &mut impl HeapVisitor) {
+        NamedPropertiesMap::visit_pointers_impl(*map, visitor, |mut map, visitor| {
+            for (property_key, property) in map.iter_mut_gc_unsafe() {
+                visitor.visit_property_key(property_key);
+                property.visit_pointers(visitor);
+            }
+        });
+    }
+}
 
 pub struct NamedPropertiesMapField(Handle<ObjectValue>);
 
-impl BsIndexMapField<PropertyKey, HeapProperty> for NamedPropertiesMapField {
-    fn new_map(&self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<NamedPropertiesMap>> {
-        NamedPropertiesMap::new(cx, HeapItemKind::ObjectNamedPropertiesMap, capacity)
-    }
-
+impl BsIndexMapField<NamedPropertiesMap> for NamedPropertiesMapField {
     fn get(&self) -> HeapPtr<NamedPropertiesMap> {
         self.0.named_properties
     }
 
-    fn set(&mut self, map: HeapPtr<NamedPropertiesMap>) {
+    fn set_new(
+        &mut self,
+        cx: Context,
+        capacity: usize,
+    ) -> AllocResult<HeapPtr<NamedPropertiesMap>> {
+        let map = NamedPropertiesMap::new(cx, capacity)?;
         self.0.set_named_properties(map);
+        Ok(map)
     }
 }
 
@@ -683,21 +710,6 @@ impl HeapItem for HeapPtr<ObjectValue> {
         visitor.visit_pointer_opt(&mut self.prototype);
         visitor.visit_pointer(&mut self.named_properties);
         visitor.visit_pointer(&mut self.array_properties);
-    }
-}
-
-impl NamedPropertiesMapField {
-    pub fn byte_size(map: &HeapPtr<NamedPropertiesMap>) -> usize {
-        NamedPropertiesMap::calculate_size_in_bytes(map.capacity())
-    }
-
-    pub fn visit_pointers(map: &mut HeapPtr<NamedPropertiesMap>, visitor: &mut impl HeapVisitor) {
-        map.visit_pointers_impl(visitor, |map, visitor| {
-            for (property_key, property) in map.iter_mut_gc_unsafe() {
-                visitor.visit_property_key(property_key);
-                property.visit_pointers(visitor);
-            }
-        });
     }
 }
 

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -1,14 +1,14 @@
 use std::time::Instant;
 
 use crate::{
-    field_offset, handle_scope, must_a,
+    field_offset, handle_scope, impl_hash_map_instance, must_a,
     parser::scope_tree::REALM_SCOPE_SLOT_NAME,
     runtime::{
         Context, EvalResult, PropertyKey, Value,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         bytecode::function::Closure,
-        collections::{BsHashMap, BsHashMapField, InlineArray},
+        collections::{HashMapInstance, InlineArray, hash_map::BsHashMapField},
         error::{err_assign_constant, syntax_error},
         gc::{Handle, HeapItem, HeapPtr, HeapVisitor},
         gc_object::GcObject,
@@ -277,7 +277,7 @@ impl Handle<Realm> {
     /// function constructors, etc.
     pub fn init_global_scope(&mut self, cx: Context) -> AllocResult<()> {
         self.global_scopes = GlobalScopes::new(cx, GlobalScopes::MIN_CAPACITY)?;
-        self.lexical_names = LexicalNamesMap::new_initial(cx, HeapItemKind::LexicalNamesMap)?;
+        self.lexical_names = LexicalNamesMap::new_initial(cx)?;
 
         // All global scopes have the realm in their first slot
         let binding_names = &[InternedStrings::alloc_static_wtf8_str(
@@ -457,31 +457,29 @@ impl LexicalNameLocation {
     }
 }
 
-pub type LexicalNamesMap = BsHashMap<HeapPtr<FlatString>, LexicalNameLocation>;
+impl_hash_map_instance!(LexicalNamesMap, HeapPtr<FlatString>, LexicalNameLocation);
 
 #[derive(Clone)]
 pub struct LexicalNamesMapField(Handle<Realm>);
 
-impl BsHashMapField<HeapPtr<FlatString>, LexicalNameLocation> for LexicalNamesMapField {
-    fn new_map(&self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<LexicalNamesMap>> {
-        LexicalNamesMap::new(cx, HeapItemKind::LexicalNamesMap, capacity)
-    }
-
+impl BsHashMapField<LexicalNamesMap> for LexicalNamesMapField {
     fn get(&self, _: Context) -> HeapPtr<LexicalNamesMap> {
         self.0.lexical_names
     }
 
-    fn set(&mut self, _: Context, map: HeapPtr<LexicalNamesMap>) {
+    fn set_new(&mut self, cx: Context, capacity: usize) -> AllocResult<HeapPtr<LexicalNamesMap>> {
+        let map = LexicalNamesMap::new(cx, capacity)?;
         self.0.lexical_names = map;
+        Ok(map)
     }
 }
 
-impl LexicalNamesMapField {
-    pub fn byte_size(map: &HeapPtr<LexicalNamesMap>) -> usize {
-        LexicalNamesMap::calculate_size_in_bytes(map.capacity())
+impl LexicalNamesMap {
+    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(map: &mut HeapPtr<LexicalNamesMap>, visitor: &mut impl HeapVisitor) {
+    pub fn visit_pointers(map: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
         map.visit_pointers(visitor);
 
         for (name, _) in map.iter_mut_gc_unsafe() {

--- a/src/js/runtime/source_file.rs
+++ b/src/js/runtime/source_file.rs
@@ -4,7 +4,7 @@ use crate::{
     runtime::{
         Context, Handle, HeapPtr,
         alloc_error::AllocResult,
-        collections::{BsArray, InlineArray},
+        collections::{ArrayInstance, InlineArray, array::U32Array},
         gc::{HeapItem, HeapVisitor},
         heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
         string_value::FlatString,
@@ -20,12 +20,10 @@ pub struct SourceFile {
     /// The display name of the source file, if it is different from the path
     display_name: Option<HeapPtr<FlatString>>,
     /// Lazily generated array of line offsets for the source file
-    line_offsets: Option<HeapPtr<LineOffsetArray>>,
+    line_offsets: Option<HeapPtr<U32Array>>,
     /// Inlined source file contents as a WTF-8 string
     contents: InlineArray<u8>,
 }
-
-type LineOffsetArray = BsArray<u32>;
 
 impl SourceFile {
     #[inline]
@@ -70,7 +68,7 @@ impl SourceFile {
     }
 
     #[inline]
-    pub fn line_offsets_ptr_raw(&self) -> Option<HeapPtr<LineOffsetArray>> {
+    pub fn line_offsets_ptr_raw(&self) -> Option<HeapPtr<U32Array>> {
         self.line_offsets
     }
 
@@ -81,15 +79,14 @@ impl SourceFile {
 }
 
 impl Handle<SourceFile> {
-    pub fn line_offsets_ptr(&mut self, cx: Context) -> AllocResult<HeapPtr<LineOffsetArray>> {
+    pub fn line_offsets_ptr(&mut self, cx: Context) -> AllocResult<HeapPtr<U32Array>> {
         if let Some(line_offsets) = self.line_offsets {
             return Ok(line_offsets);
         }
 
         // Lazily generate line offsets when first requested
         let raw_line_offsets = calculate_line_offsets(self.contents_as_slice());
-        let line_offsets_object =
-            LineOffsetArray::new_from_slice(cx, HeapItemKind::U32Array, &raw_line_offsets)?;
+        let line_offsets_object = U32Array::new_from_slice(cx, &raw_line_offsets)?;
 
         self.line_offsets = Some(line_offsets_object);
 

--- a/src/js/runtime/stack_trace.rs
+++ b/src/js/runtime/stack_trace.rs
@@ -1,21 +1,16 @@
 use crate::{
-    handle_scope_guard, must_a,
+    handle_scope_guard, impl_array_instance, must_a,
     parser::loc::find_line_col_for_pos,
     runtime::{
         Context, Handle, HeapPtr,
         alloc_error::AllocResult,
         bytecode::{function::BytecodeFunction, source_map::BytecodeSourceMap},
-        collections::BsArray,
-        gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
+        collections::ArrayInstance,
+        gc::HeapVisitor,
         intrinsics::{error_constructor::CachedStackTraceInfo, rust_runtime::RuntimeFunction},
         source_file::SourceFile,
     },
 };
-
-/// An array of stack frame entries which contain the information necessary to construct a full
-/// stack trace later if desired.
-pub type StackFrameInfoArray = BsArray<HeapStackFrameInfo>;
 
 pub struct HeapStackFrameInfo {
     /// The function executing in the stack frame.
@@ -101,8 +96,7 @@ pub fn create_current_stack_frame_info(
 
     let frames = gather_current_stack_frames(cx, skip_current_frame);
 
-    let mut array =
-        StackFrameInfoArray::new_uninit(cx, HeapItemKind::StackFrameInfoArray, frames.len())?;
+    let mut array = StackFrameInfoArray::new_uninit(cx, frames.len())?;
 
     for (i, frame) in frames.iter().enumerate() {
         array.as_mut_slice()[i] = frame.to_heap();
@@ -209,17 +203,20 @@ fn prepare_for_stack_trace(
     Ok(())
 }
 
-pub fn stack_frame_info_array_byte_size(stack_frame_array: HeapPtr<StackFrameInfoArray>) -> usize {
-    StackFrameInfoArray::calculate_size_in_bytes(stack_frame_array.len())
-}
+// An array of stack frame entries which contain the information necessary to construct a full
+// stack trace later if desired.
+impl_array_instance!(StackFrameInfoArray, HeapStackFrameInfo);
 
-pub fn stack_frame_info_array_visit_pointers(
-    stack_frame_array: &mut HeapPtr<StackFrameInfoArray>,
-    visitor: &mut impl HeapVisitor,
-) {
-    stack_frame_array.visit_pointers(visitor);
+impl StackFrameInfoArray {
+    pub fn byte_size(array: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(array.len())
+    }
 
-    for stack_frame in stack_frame_array.as_mut_slice() {
-        visitor.visit_pointer(&mut stack_frame.function);
+    pub fn visit_pointers(array: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array.visit_pointers(visitor);
+
+        for stack_frame in array.as_mut_slice() {
+            visitor.visit_pointer(&mut stack_frame.function);
+        }
     }
 }

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -710,7 +710,7 @@ impl HeapItem for HeapPtr<BigIntValue> {
     }
 }
 
-/// A wrapper around values that are used as keys in ValueMap and ValueSet.
+/// A wrapper around values that are used as keys in ValueIndexMap and ValueIndexSet.
 /// Uses the SameValueZero algorithm to check equality, and hash function conforms to SameValueZero.
 #[derive(Clone, Copy)]
 pub struct ValueCollectionKey(Value);


### PR DESCRIPTION
## Summary

Refactor of how all heap collections (`BsArray, BsVec, BsHashMap, BsHashSet, BsIndexMap, BsIndexSet`) are instantiated for each set of type arguments.

We now have a direct mapping from instantiations to `HeapItemKind` variants. Each collection is now instantiated via a macro which implements a trait for that collection. Also make sure that each instantiation has its own type which have methods defined on it, and define `byte_size` and `visit_pointers` here.

## Tests

- CI