### PR TITLE
[runtime] Define central list of heap items with macro, refactoring visitors

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -9,4 +9,5 @@ struct_variant_width = 60
 
 # Unstable features, requires nightly rustfmt
 unstable_features = true
+format_macro_bodies = true
 group_imports = "StdExternalCrate"

--- a/src/js/runtime/abstract_operations.rs
+++ b/src/js/runtime/abstract_operations.rs
@@ -4,7 +4,7 @@ use crate::{
     common::numeric::MAX_SAFE_INTEGER_U64,
     must, must_a,
     runtime::{
-        Context, Value,
+        Context, HeapItemKind, Value,
         accessor::Accessor,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
@@ -14,7 +14,6 @@ use crate::{
         eval::expression::eval_instanceof_expression,
         eval_result::EvalResult,
         gc::{Handle, HeapPtr},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         iterator::iter_iterator_values,
         object_value::ObjectValue,

--- a/src/js/runtime/accessor.rs
+++ b/src/js/runtime/accessor.rs
@@ -1,9 +1,9 @@
 use crate::{
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         object_value::ObjectValue,
     },
     set_uninit,
@@ -40,14 +40,14 @@ impl Accessor {
     }
 }
 
-impl HeapItem for HeapPtr<Accessor> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for Accessor {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<Accessor>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer_opt(&mut self.get);
-        visitor.visit_pointer_opt(&mut self.set);
+    fn visit_pointers(mut accessor: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut accessor.descriptor);
+        visitor.visit_pointer_opt(&mut accessor.get);
+        visitor.visit_pointer_opt(&mut accessor.set);
     }
 }

--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -6,13 +6,12 @@ use crate::{
     extend_object, field_offset, must,
     parser::scope_tree::SHADOWED_SCOPE_SLOT_NAME,
     runtime::{
-        Context, EvalResult, HeapPtr, Value,
+        Context, EvalResult, HeapItemKind, HeapPtr, Value,
         abstract_operations::{create_data_property_or_throw, define_property_or_throw},
         alloc_error::AllocResult,
         bytecode::function::Closure,
         collections::InlineArray,
         gc::{Handle, HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         interned_strings::InternedStrings,
         intrinsics::intrinsics::Intrinsic,
         object_value::{ObjectValue, VirtualObject},
@@ -314,23 +313,25 @@ pub fn create_unmapped_arguments_object(
     Ok(object.into())
 }
 
-impl HeapItem for HeapPtr<MappedArgumentsObject> {
-    fn byte_size(&self) -> usize {
-        MappedArgumentsObject::calculate_size_in_bytes(self.mapped_parameters.len())
+impl HeapItem for MappedArgumentsObject {
+    fn byte_size(mapped_arguments_object: HeapPtr<Self>) -> usize {
+        MappedArgumentsObject::calculate_size_in_bytes(
+            mapped_arguments_object.mapped_parameters.len(),
+        )
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.scope);
+    fn visit_pointers(mut mapped_arguments_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        mapped_arguments_object.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut mapped_arguments_object.scope);
     }
 }
 
-impl HeapItem for HeapPtr<UnmappedArgumentsObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for UnmappedArgumentsObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<UnmappedArgumentsObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(unmapped_arguments_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        unmapped_arguments_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -5,13 +5,12 @@ use brimstone_macros::wrap_ordinary_object;
 use crate::{
     extend_object, must, must_a,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, Realm, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Realm, Value,
         abstract_operations::{construct, create_data_property_or_throw, get_function_realm},
         alloc_error::AllocResult,
         error::{range_error, type_error},
         gc::{HeapItem, HeapVisitor},
         get,
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{
@@ -261,12 +260,12 @@ pub fn create_array_from_list(
     Ok(array)
 }
 
-impl HeapItem for HeapPtr<ArrayObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for ArrayObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<ArrayObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(array_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/array_properties.rs
+++ b/src/js/runtime/array_properties.rs
@@ -1,11 +1,11 @@
 use crate::{
     field_offset, impl_hash_map_instance,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::{BsHashMap, BsHashMapField, HashMapInstance, InlineArray},
         gc::{HeapItem, HeapVisitor, IsHeapItem},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         object_value::ObjectValue,
         property::{HeapProperty, Property, PropertyFlags},
     },
@@ -552,28 +552,28 @@ impl BsHashMapField<SparseArrayPropertiesMap> for SparseMapField {
 // Only necessary so we get deref for HeapPtrs.
 impl IsHeapItem for ArrayProperties {}
 
-impl HeapItem for HeapPtr<DenseArrayProperties> {
-    fn byte_size(&self) -> usize {
-        DenseArrayProperties::calculate_size_in_bytes(self.capacity() as usize)
+impl HeapItem for DenseArrayProperties {
+    fn byte_size(dense_array_properties: HeapPtr<Self>) -> usize {
+        DenseArrayProperties::calculate_size_in_bytes(dense_array_properties.capacity() as usize)
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
+    fn visit_pointers(mut dense_array_properties: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut dense_array_properties.descriptor);
 
-        let len = self.len() as usize;
-        for value in &mut self.array.as_mut_slice()[..len] {
+        let len = dense_array_properties.len() as usize;
+        for value in &mut dense_array_properties.array.as_mut_slice()[..len] {
             visitor.visit_value(value);
         }
     }
 }
 
-impl SparseArrayPropertiesMap {
-    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+impl HeapItem for SparseArrayPropertiesMap {
+    fn byte_size(map: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(map: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        map.visit_pointers(visitor);
+    fn visit_pointers(mut map: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        map.visit_map_pointers(visitor);
 
         for (_, property) in map.iter_mut_gc_unsafe() {
             property.visit_pointers(visitor);

--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -1,7 +1,7 @@
 use crate::{
     completion_value, eval_err, extend_object, field_offset, must_a,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         abstract_operations::call_object,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -14,7 +14,7 @@ use crate::{
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         generator_object::{GeneratorCompletionType, GeneratorRegister, TGeneratorObject},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         intrinsics::{
             intrinsics::Intrinsic, promise_prototype::perform_promise_then,
             rust_runtime::RuntimeFunction,
@@ -485,31 +485,32 @@ pub fn async_generator_drain_queue(
     }
 }
 
-impl HeapItem for HeapPtr<AsyncGeneratorObject> {
-    fn byte_size(&self) -> usize {
-        AsyncGeneratorObject::calculate_size_in_bytes(self.stack_frame.len())
+impl HeapItem for AsyncGeneratorObject {
+    fn byte_size(async_generator_object: HeapPtr<Self>) -> usize {
+        AsyncGeneratorObject::calculate_size_in_bytes(async_generator_object.stack_frame.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer_opt(&mut self.request_queue);
+    fn visit_pointers(mut async_generator_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        async_generator_object.visit_object_pointers(visitor);
+        visitor.visit_pointer_opt(&mut async_generator_object.request_queue);
 
-        if self.state.is_suspended() {
-            let mut stack_frame = StackFrame::for_fp(self.current_fp().cast_mut());
+        if async_generator_object.state.is_suspended() {
+            let mut stack_frame =
+                StackFrame::for_fp(async_generator_object.current_fp().cast_mut());
             stack_frame.visit_simple_pointers(visitor);
         }
     }
 }
 
-impl HeapItem for HeapPtr<AsyncGeneratorRequest> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for AsyncGeneratorRequest {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         std::mem::size_of::<AsyncGeneratorRequest>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer(&mut self.capability);
-        visitor.visit_value(&mut self.completion_value);
-        visitor.visit_pointer_opt(&mut self.next);
+    fn visit_pointers(mut async_generator_request: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut async_generator_request.descriptor);
+        visitor.visit_pointer(&mut async_generator_request.capability);
+        visitor.visit_value(&mut async_generator_request.completion_value);
+        visitor.visit_pointer_opt(&mut async_generator_request.next);
     }
 }

--- a/src/js/runtime/boxed_value.rs
+++ b/src/js/runtime/boxed_value.rs
@@ -1,9 +1,9 @@
 use crate::{
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
     },
     set_uninit,
 };
@@ -34,13 +34,13 @@ impl BoxedValue {
     }
 }
 
-impl HeapItem for HeapPtr<BoxedValue> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for BoxedValue {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         std::mem::size_of::<BoxedValue>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_value(&mut self.value);
+    fn visit_pointers(mut boxed_value: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut boxed_value.descriptor);
+        visitor.visit_value(&mut boxed_value.value);
     }
 }

--- a/src/js/runtime/builtin_generator.rs
+++ b/src/js/runtime/builtin_generator.rs
@@ -1,11 +1,11 @@
 use crate::{
     if_abrupt_reject_promise,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, Realm, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Realm, Value,
         abstract_operations::call_object,
         alloc_error::AllocResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         intrinsics::array_from_async_generator::{ArrayFromAsyncGenerator, ArrayFromAsyncState},
         promise_object::{PromiseCapability, resolve},
     },
@@ -91,16 +91,16 @@ pub enum BuiltinGeneratorCompletion {
     Suspended,
     Returned(Handle<Value>),
 }
-impl HeapItem for HeapPtr<BuiltinGenerator> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for BuiltinGenerator {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         std::mem::size_of::<BuiltinGenerator>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer(&mut self.realm);
+    fn visit_pointers(mut builtin_generator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut builtin_generator.descriptor);
+        visitor.visit_pointer(&mut builtin_generator.realm);
 
-        match &mut self.state {
+        match &mut builtin_generator.state {
             BuiltinGeneratorState::ArrayFromAsync { capability, state } => {
                 visitor.visit_pointer(capability);
                 state.visit_pointers(visitor);

--- a/src/js/runtime/bytecode/constant_table.rs
+++ b/src/js/runtime/bytecode/constant_table.rs
@@ -1,12 +1,12 @@
 use crate::{
     field_offset,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::InlineArray,
         debug_print::{DebugPrint, DebugPrintMode, DebugPrinter},
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
     },
     set_uninit,
 };
@@ -121,18 +121,18 @@ impl DebugPrint for HeapPtr<ConstantTable> {
     }
 }
 
-impl HeapItem for HeapPtr<ConstantTable> {
-    fn byte_size(&self) -> usize {
-        ConstantTable::calculate_size_in_bytes(self.constants.len())
+impl HeapItem for ConstantTable {
+    fn byte_size(constant_table: HeapPtr<Self>) -> usize {
+        ConstantTable::calculate_size_in_bytes(constant_table.constants.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
+    fn visit_pointers(mut constant_table: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut constant_table.descriptor);
 
         // Only visit constants that are values, not raw offsets
-        for i in 0..self.constants.len() {
-            if self.is_value(i) {
-                let constant = self.constants.get_unchecked_mut(i);
+        for i in 0..constant_table.constants.len() {
+            if constant_table.is_value(i) {
+                let constant = constant_table.constants.get_unchecked_mut(i);
                 visitor.visit_value(constant);
             }
         }

--- a/src/js/runtime/bytecode/exception_handlers.rs
+++ b/src/js/runtime/bytecode/exception_handlers.rs
@@ -1,7 +1,7 @@
 use crate::{
     field_offset,
     runtime::{
-        Context, Handle, HeapPtr,
+        Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         bytecode::{
             generator::GenRegister,
@@ -11,7 +11,7 @@ use crate::{
         collections::InlineArray,
         debug_print::{DebugPrint, DebugPrinter},
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
     },
     set_uninit,
 };
@@ -246,12 +246,12 @@ impl DebugPrint for HeapPtr<ExceptionHandlers> {
     }
 }
 
-impl HeapItem for HeapPtr<ExceptionHandlers> {
-    fn byte_size(&self) -> usize {
-        ExceptionHandlers::calculate_size_in_bytes(self.handlers.len())
+impl HeapItem for ExceptionHandlers {
+    fn byte_size(exception_handlers: HeapPtr<Self>) -> usize {
+        ExceptionHandlers::calculate_size_in_bytes(exception_handlers.handlers.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
+    fn visit_pointers(mut exception_handlers: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut exception_handlers.descriptor);
     }
 }

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -5,7 +5,7 @@ use crate::{
     extend_object, field_offset, must_a,
     parser::loc::Pos,
     runtime::{
-        Context, Handle, HeapPtr, PropertyDescriptor, Realm,
+        Context, Handle, HeapItemKind, HeapPtr, PropertyDescriptor, Realm,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         bytecode::{
@@ -17,7 +17,7 @@ use crate::{
         debug_print::{DebugPrint, DebugPrintMode, DebugPrinter},
         function::{set_function_length, set_simple_function_name},
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunctionId},
         object_value::ObjectValue,
         ordinary_object::{
@@ -196,15 +196,15 @@ impl Handle<Closure> {
     }
 }
 
-impl HeapItem for HeapPtr<Closure> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for Closure {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<Closure>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.function);
-        visitor.visit_pointer(&mut self.scope);
+    fn visit_pointers(mut closure: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        closure.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut closure.function);
+        visitor.visit_pointer(&mut closure.scope);
     }
 }
 
@@ -515,19 +515,19 @@ pub fn dump_bytecode_function(cx: Context, func: HeapPtr<BytecodeFunction>) {
     cx.print_or_add_to_dump_buffer(&bytecode_string);
 }
 
-impl HeapItem for HeapPtr<BytecodeFunction> {
-    fn byte_size(&self) -> usize {
-        BytecodeFunction::calculate_size_in_bytes(self.bytecode.len())
+impl HeapItem for BytecodeFunction {
+    fn byte_size(bytecode_function: HeapPtr<Self>) -> usize {
+        BytecodeFunction::calculate_size_in_bytes(bytecode_function.bytecode.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
+    fn visit_pointers(mut bytecode_function: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut bytecode_function.descriptor);
 
-        visitor.visit_pointer_opt(&mut self.constant_table);
-        visitor.visit_pointer_opt(&mut self.exception_handlers);
-        visitor.visit_pointer(&mut self.realm);
-        visitor.visit_pointer_opt(&mut self.name);
-        visitor.visit_pointer_opt(&mut self.source_file);
-        visitor.visit_pointer_opt(&mut self.source_map);
+        visitor.visit_pointer_opt(&mut bytecode_function.constant_table);
+        visitor.visit_pointer_opt(&mut bytecode_function.exception_handlers);
+        visitor.visit_pointer(&mut bytecode_function.realm);
+        visitor.visit_pointer_opt(&mut bytecode_function.name);
+        visitor.visit_pointer_opt(&mut bytecode_function.source_file);
+        visitor.visit_pointer_opt(&mut bytecode_function.source_map);
     }
 }

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -50,7 +50,7 @@ use crate::{
         class_names::{ClassNames, HomeObjectLocation, Method},
         collections::{BsVecField, VecInstance},
         eval::expression::generate_template_object,
-        gc::{Escapable, HeapVisitor},
+        gc::{Escapable, HeapItem, HeapVisitor},
         global_names::GlobalNames,
         interned_strings::InternedStrings,
         module::{
@@ -535,7 +535,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
         )?;
 
         // Place the module in the first slot of its module scope
-        module_scope.set_heap_item_slot(0, module.as_heap_item());
+        module_scope.set_heap_item_slot(0, module.as_any());
 
         Ok(module)
     }
@@ -613,7 +613,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
                 if let VMLocation::ModuleScope { index, .. } = binding.vm_location().unwrap() {
                     // All exported value are boxed, which will eventually be linked to import
                     let boxed_value = BoxedValue::new(self.cx, init_value)?;
-                    module_scope.set_heap_item_slot(index, boxed_value.as_heap_item());
+                    module_scope.set_heap_item_slot(index, boxed_value.as_any());
                 } else {
                     unreachable!("expected module scope location")
                 }
@@ -949,7 +949,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
                 let mut parent_constant_table = parent_function.constant_table_ptr().unwrap();
                 parent_constant_table.set_constant(
                     constant_index as usize,
-                    Value::heap_item(emit_result.bytecode_function.as_heap_item()),
+                    Value::heap_item(emit_result.bytecode_function.as_any()),
                 );
             }
             // Patch exported function into the module scope
@@ -9952,13 +9952,13 @@ impl StmtCompletion {
 
 impl_vec_instance!(FunctionVec, HeapPtr<BytecodeFunction>);
 
-impl FunctionVec {
-    pub fn byte_size(vec: HeapPtr<Self>) -> usize {
+impl HeapItem for FunctionVec {
+    fn byte_size(vec: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(vec.capacity())
     }
 
-    pub fn visit_pointers(vec: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        vec.visit_pointers(visitor);
+    fn visit_pointers(mut vec: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        vec.visit_vec_pointers(visitor);
 
         for function in vec.as_mut_slice() {
             visitor.visit_pointer(function);

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -8,8 +8,8 @@ use crate::{
     common::numeric::Numeric,
     eval_err, handle_scope, handle_scope_guard, must,
     runtime::{
-        Arguments, Context, EvalResult, Handle, HeapPtr, PropertyDescriptor, PropertyKey, Realm,
-        Value,
+        Arguments, Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyDescriptor,
+        PropertyKey, Realm, Value,
         abstract_operations::{
             call, call_object, copy_data_properties, create_data_property_or_throw,
             define_property_or_throw, get_method, get_v, has_property, private_get, private_set,
@@ -111,7 +111,6 @@ use crate::{
         gc::{AnyHeapItem, HeapVisitor},
         generator_object::{GeneratorCompletionType, GeneratorObject, TGeneratorObject},
         get,
-        heap_item_descriptor::HeapItemKind,
         intrinsics::{
             async_generator_prototype::AsyncGeneratorPrototype,
             generator_prototype::GeneratorPrototype,
@@ -3582,7 +3581,7 @@ impl VM {
         // Allocates
         let accessor = Accessor::new(self.cx(), Some(getter), Some(setter))?;
 
-        self.write_register(dest, Value::heap_item(accessor.as_heap_item()));
+        self.write_register(dest, Value::heap_item(accessor.as_any()));
 
         Ok(())
     }
@@ -4478,7 +4477,7 @@ impl VM {
             let object = to_object(self.cx(), object)?;
             let iterator = ForInIterator::new_for_object(self.cx(), object)?;
 
-            self.write_register(dest, Value::heap_item(iterator.as_heap_item()));
+            self.write_register(dest, Value::heap_item(iterator.as_any()));
 
             Ok(())
         })

--- a/src/js/runtime/class_names.rs
+++ b/src/js/runtime/class_names.rs
@@ -1,7 +1,7 @@
 use crate::{
     field_offset, must,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, PropertyDescriptor, PropertyKey, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyDescriptor, PropertyKey, Value,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         bytecode::function::{BytecodeFunction, Closure},
@@ -10,7 +10,7 @@ use crate::{
         function::build_function_name,
         gc::{HeapItem, HeapVisitor},
         get,
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_with_optional_proto,
@@ -123,15 +123,15 @@ impl ClassNames {
     }
 }
 
-impl HeapItem for HeapPtr<ClassNames> {
-    fn byte_size(&self) -> usize {
-        ClassNames::calculate_size_in_bytes(self.methods.len())
+impl HeapItem for ClassNames {
+    fn byte_size(class_names: HeapPtr<Self>) -> usize {
+        ClassNames::calculate_size_in_bytes(class_names.methods.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
+    fn visit_pointers(mut class_names: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut class_names.descriptor);
 
-        for method in self.methods.as_mut_slice() {
+        for method in class_names.methods.as_mut_slice() {
             visitor.visit_pointer_opt(&mut method.name);
         }
     }

--- a/src/js/runtime/collections/array.rs
+++ b/src/js/runtime/collections/array.rs
@@ -1,11 +1,11 @@
 use crate::{
     field_offset,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::InlineArray,
         gc::{HeapItem, HeapVisitor, IsHeapItem},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
     },
     set_uninit,
 };
@@ -86,18 +86,7 @@ impl<T> BsArray<T> {
     }
 
     /// Visit pointers intrinsic to all Arrays. Do not visit elements as they could be of any type.
-    pub fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-    }
-}
-
-impl<T> HeapItem for HeapPtr<BsArray<T>> {
-    fn byte_size(&self) -> usize {
-        BsArray::<T>::calculate_size_in_bytes(self.len())
-    }
-
-    /// Visit pointers intrinsic to all BsArrays. Do not visit elements as they could be of any type.
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+    pub fn visit_array_pointers(&mut self, visitor: &mut impl HeapVisitor) {
         visitor.visit_pointer(&mut self.descriptor);
     }
 }
@@ -145,11 +134,8 @@ macro_rules! impl_array_instance {
         impl $crate::runtime::collections::ArrayInstance for $array_type {
             type T = $element_type;
 
-            const KIND: $crate::runtime::heap_item_descriptor::HeapItemKind =
-                $crate::runtime::heap_item_descriptor::HeapItemKind::$array_type;
+            const KIND: $crate::runtime::HeapItemKind = $crate::runtime::HeapItemKind::$array_type;
         }
-
-        impl $crate::runtime::gc::IsHeapItem for $array_type {}
 
         impl std::ops::Deref for $array_type {
             type Target = $crate::runtime::collections::BsArray<$element_type>;
@@ -185,13 +171,15 @@ impl ValueArray {
 
         Ok(array)
     }
+}
 
-    pub fn byte_size(array: HeapPtr<Self>) -> usize {
+impl HeapItem for ValueArray {
+    fn byte_size(array: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(array.len())
     }
 
-    pub fn visit_pointers(array: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        array.visit_pointers(visitor);
+    fn visit_pointers(mut array: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array.visit_array_pointers(visitor);
 
         for value in array.as_mut_slice() {
             visitor.visit_value(value);
@@ -201,24 +189,27 @@ impl ValueArray {
 
 impl_array_instance!(ByteArray, u8);
 
-impl ByteArray {
-    pub fn byte_size(array: HeapPtr<Self>) -> usize {
+impl HeapItem for ByteArray {
+    fn byte_size(array: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(array.len())
     }
 
-    pub fn visit_pointers(array: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        array.visit_pointers(visitor);
+    fn visit_pointers(mut array: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array.visit_array_pointers(visitor);
     }
 }
 
 impl_array_instance!(U32Array, u32);
 
-impl U32Array {
-    pub fn byte_size(array: HeapPtr<Self>) -> usize {
+impl HeapItem for U32Array {
+    fn byte_size(array: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(array.len())
     }
 
-    pub fn visit_pointers(array: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        array.visit_pointers(visitor);
+    fn visit_pointers(mut array: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array.visit_array_pointers(visitor);
     }
 }
+
+// Only necessary so we get deref for HeapPtrs.
+impl<T> IsHeapItem for BsArray<T> {}

--- a/src/js/runtime/collections/hash_map.rs
+++ b/src/js/runtime/collections/hash_map.rs
@@ -8,11 +8,11 @@ use std::{
 use crate::{
     field_offset,
     runtime::{
-        Context, HeapPtr,
+        Context, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         collections::InlineArray,
         gc::{HeapVisitor, IsHeapItem},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
     },
     set_uninit,
 };
@@ -158,7 +158,7 @@ impl<K: Eq + Hash + Clone, V: Clone> BsHashMap<K, V> {
     }
 
     /// Visit pointers intrinsic to all HashMaps. Do not visit entries as they could be of any type.
-    pub fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+    pub fn visit_map_pointers(&mut self, visitor: &mut impl HeapVisitor) {
         visitor.visit_pointer(&mut self.descriptor);
     }
 
@@ -312,11 +312,8 @@ macro_rules! impl_hash_map_instance {
             type K = $key_type;
             type V = $value_type;
 
-            const KIND: $crate::runtime::heap_item_descriptor::HeapItemKind =
-                $crate::runtime::heap_item_descriptor::HeapItemKind::$map_type;
+            const KIND: $crate::runtime::HeapItemKind = $crate::runtime::HeapItemKind::$map_type;
         }
-
-        impl $crate::runtime::gc::IsHeapItem for $map_type {}
 
         impl std::ops::Deref for $map_type {
             type Target = $crate::runtime::collections::BsHashMap<$key_type, $value_type>;

--- a/src/js/runtime/collections/hash_set.rs
+++ b/src/js/runtime/collections/hash_set.rs
@@ -1,14 +1,13 @@
 use std::hash::Hash;
 
 use crate::runtime::{
-    Context, HeapPtr,
+    Context, HeapItemKind, HeapPtr,
     alloc_error::AllocResult,
     collections::{
         BsHashMap,
         hash_map::{GcUnsafeKeysIterMut, maybe_grow_for_insertion},
     },
     gc::{HeapVisitor, IsHeapItem},
-    heap_item_descriptor::HeapItemKind,
 };
 
 /// Generic flat HashSet implementation which is a simple wrapper over a HashMap with unit values.
@@ -64,8 +63,8 @@ impl<T: Eq + Hash + Clone> BsHashSet<T> {
     }
 
     /// Visit pointers intrinsic to all HashSets. Do not visit entries as they could be of any type.
-    pub fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.0.visit_pointers(visitor)
+    pub fn visit_set_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+        self.0.visit_map_pointers(visitor)
     }
 }
 
@@ -102,11 +101,8 @@ macro_rules! impl_hash_set_instance {
         impl $crate::runtime::collections::HashSetInstance for $set_type {
             type T = $element_type;
 
-            const KIND: $crate::runtime::heap_item_descriptor::HeapItemKind =
-                $crate::runtime::heap_item_descriptor::HeapItemKind::$set_type;
+            const KIND: $crate::runtime::HeapItemKind = $crate::runtime::HeapItemKind::$set_type;
         }
-
-        impl $crate::runtime::gc::IsHeapItem for $set_type {}
 
         impl std::ops::Deref for $set_type {
             type Target = $crate::runtime::collections::BsHashSet<$element_type>;

--- a/src/js/runtime/collections/index_map.rs
+++ b/src/js/runtime/collections/index_map.rs
@@ -8,11 +8,11 @@ use std::{
 use crate::{
     field_offset,
     runtime::{
-        Context, Handle, HeapPtr,
+        Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         collections::InlineArray,
         gc::{HeapVisitor, IsHeapItem},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
     },
     set_uninit,
 };
@@ -473,11 +473,8 @@ macro_rules! impl_index_map_instance {
             type K = $key_type;
             type V = $value_type;
 
-            const KIND: $crate::runtime::heap_item_descriptor::HeapItemKind =
-                $crate::runtime::heap_item_descriptor::HeapItemKind::$map_type;
+            const KIND: $crate::runtime::HeapItemKind = $crate::runtime::HeapItemKind::$map_type;
         }
-
-        impl $crate::runtime::gc::IsHeapItem for $map_type {}
 
         impl std::ops::Deref for $map_type {
             type Target = $crate::runtime::collections::BsIndexMap<$key_type, $value_type>;

--- a/src/js/runtime/collections/index_set.rs
+++ b/src/js/runtime/collections/index_set.rs
@@ -1,14 +1,13 @@
 use std::hash::Hash;
 
 use crate::runtime::{
-    Context, Handle, HeapPtr,
+    Context, Handle, HeapItemKind, HeapPtr,
     alloc_error::AllocResult,
     collections::{
         BsIndexMap,
         index_map::{GcSafeEntriesIter, GcUnsafeKeysIterMut, maybe_grow_for_insertion},
     },
     gc::{HeapVisitor, IsHeapItem},
-    heap_item_descriptor::HeapItemKind,
 };
 
 /// Generic flat IndexSet implementation which is a simple wrapper over an IndexMap with unit values.
@@ -131,11 +130,8 @@ macro_rules! impl_index_set_instance {
         impl $crate::runtime::collections::IndexSetInstance for $set_type {
             type T = $element_type;
 
-            const KIND: $crate::runtime::heap_item_descriptor::HeapItemKind =
-                $crate::runtime::heap_item_descriptor::HeapItemKind::$set_type;
+            const KIND: $crate::runtime::HeapItemKind = $crate::runtime::HeapItemKind::$set_type;
         }
-
-        impl $crate::runtime::gc::IsHeapItem for $set_type {}
 
         impl std::ops::Deref for $set_type {
             type Target = $crate::runtime::collections::BsIndexSet<$element_type>;

--- a/src/js/runtime/collections/vec.rs
+++ b/src/js/runtime/collections/vec.rs
@@ -1,11 +1,11 @@
 use crate::{
     field_offset,
     runtime::{
-        Context, HeapPtr,
+        Context, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         collections::InlineArray,
         gc::{HeapVisitor, IsHeapItem},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
     },
     set_uninit,
 };
@@ -76,7 +76,7 @@ impl<T: Clone + Copy> BsVec<T> {
     }
 
     /// Visit pointers intrinsic to all Vecs. Do not visit elements as they could be of any type.
-    pub fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+    pub fn visit_vec_pointers(&mut self, visitor: &mut impl HeapVisitor) {
         visitor.visit_pointer(&mut self.descriptor);
     }
 }
@@ -114,11 +114,8 @@ macro_rules! impl_vec_instance {
         impl $crate::runtime::collections::VecInstance for $vec_type {
             type T = $element_type;
 
-            const KIND: $crate::runtime::heap_item_descriptor::HeapItemKind =
-                $crate::runtime::heap_item_descriptor::HeapItemKind::$vec_type;
+            const KIND: $crate::runtime::HeapItemKind = $crate::runtime::HeapItemKind::$vec_type;
         }
-
-        impl $crate::runtime::gc::IsHeapItem for $vec_type {}
 
         impl std::ops::Deref for $vec_type {
             type Target = $crate::runtime::collections::BsVec<$element_type>;

--- a/src/js/runtime/collections/weak_vec.rs
+++ b/src/js/runtime/collections/weak_vec.rs
@@ -1,11 +1,11 @@
 use crate::{
     field_offset,
     runtime::{
-        Context, HeapPtr, Value,
+        Context, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::InlineArray,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
     },
     set_uninit,
 };
@@ -91,14 +91,14 @@ impl BsWeakVec {
     }
 }
 
-impl HeapItem for HeapPtr<BsWeakVec> {
-    fn byte_size(&self) -> usize {
-        BsWeakVec::calculate_size_in_bytes(self.capacity())
+impl HeapItem for BsWeakVec {
+    fn byte_size(bs_weak_vec: HeapPtr<Self>) -> usize {
+        BsWeakVec::calculate_size_in_bytes(bs_weak_vec.capacity())
     }
 
     /// Visit pointers intrinsic to all BsWeakVec. Do not visit elements as they could be of any type.
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
+    fn visit_pointers(mut bs_weak_vec: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut bs_weak_vec.descriptor);
     }
 }
 

--- a/src/js/runtime/console.rs
+++ b/src/js/runtime/console.rs
@@ -5,10 +5,9 @@ use crate::{
     },
     intrinsic_methods,
     runtime::{
-        Arguments, Context, Handle, Value,
+        Arguments, Context, Handle, HeapItemKind, Value,
         alloc_error::AllocResult,
         eval_result::EvalResult,
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             error_constructor::{ErrorObject, new_heap_source_info},

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -36,7 +36,7 @@ use crate::{
         collections::{HashMapInstance, hash_map::BsHashMapField, index_map::IndexMapInstance},
         descriptor_registry::DescriptorRegistry,
         error::BsResult,
-        gc::{GarbageCollector, Heap, HeapRootsDeserializer, HeapVisitor},
+        gc::{GarbageCollector, Heap, HeapItem, HeapRootsDeserializer, HeapVisitor},
         interned_strings::InternedStrings,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RustRuntimeFunctionRegistry},
         module::{
@@ -756,13 +756,13 @@ impl BsHashMapField<ModuleCacheMap> for ModuleCacheField {
     }
 }
 
-impl ModuleCacheMap {
-    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+impl HeapItem for ModuleCacheMap {
+    fn byte_size(map: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(map: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        map.visit_pointers(visitor);
+    fn visit_pointers(mut map: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        map.visit_map_pointers(visitor);
 
         for (cache_key, module) in map.iter_mut_gc_unsafe() {
             visitor.visit_pointer_opt(&mut cache_key.attributes);
@@ -791,13 +791,13 @@ impl BsHashMapField<GlobalSymbolRegistryMap> for GlobalSymbolRegistryField {
     }
 }
 
-impl GlobalSymbolRegistryMap {
-    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+impl HeapItem for GlobalSymbolRegistryMap {
+    fn byte_size(map: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(map: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        map.visit_pointers(visitor);
+    fn visit_pointers(mut map: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        map.visit_map_pointers(visitor);
 
         for (key, value) in map.iter_mut_gc_unsafe() {
             visitor.visit_pointer(key);

--- a/src/js/runtime/debug_print.rs
+++ b/src/js/runtime/debug_print.rs
@@ -1,11 +1,10 @@
 use crate::runtime::{
-    HeapPtr,
+    HeapItemKind, HeapPtr,
     bytecode::{
         constant_table::ConstantTable, exception_handlers::ExceptionHandlers,
         function::BytecodeFunction,
     },
     gc::AnyHeapItem,
-    heap_item_descriptor::HeapItemKind,
     regexp::compiled_regexp::CompiledRegExpObject,
     string_value::StringValue,
     value::{BigIntValue, SymbolValue},

--- a/src/js/runtime/descriptor_registry.rs
+++ b/src/js/runtime/descriptor_registry.rs
@@ -1,10 +1,10 @@
 use crate::runtime::{
-    Context,
+    Context, HeapItemKind,
     alloc_error::AllocResult,
     arguments_object::MappedArgumentsObject,
     array_object::ArrayObject,
     gc::{HeapPtr, HeapVisitor},
-    heap_item_descriptor::{DescFlags, HeapItemDescriptor, HeapItemKind},
+    heap_item_descriptor::{DescFlags, HeapItemDescriptor},
     intrinsics::typed_array::{
         BigInt64Array, BigUInt64Array, Float16Array, Float32Array, Float64Array, Int8Array,
         Int16Array, Int32Array, UInt8Array, UInt8ClampedArray, UInt16Array, UInt32Array,
@@ -28,8 +28,8 @@ impl DescriptorRegistry {
     pub fn uninit() -> Self {
         let mut descriptors = vec![];
 
-        descriptors.reserve_exact(HeapItemKind::count());
-        unsafe { descriptors.set_len(HeapItemKind::count()) };
+        descriptors.reserve_exact(HeapItemKind::COUNT);
+        unsafe { descriptors.set_len(HeapItemKind::COUNT) };
 
         DescriptorRegistry { descriptors }
     }

--- a/src/js/runtime/eval/expression.rs
+++ b/src/js/runtime/eval/expression.rs
@@ -6,7 +6,7 @@ use crate::{
     must, must_a,
     parser::ast,
     runtime::{
-        Context, Handle, Realm,
+        Context, Handle, HeapItemKind, Realm,
         abstract_operations::{
             IntegrityLevel, call_object, define_property_or_throw, get_method, has_property,
             ordinary_has_instance, set_integrity_level,
@@ -16,7 +16,6 @@ use crate::{
         bytecode::generator::alloc_wtf8_str_from_source,
         error::{range_error, type_error},
         eval_result::EvalResult,
-        heap_item_descriptor::HeapItemKind,
         numeric_operations::number_exponentiate,
         object_value::ObjectValue,
         property_descriptor::PropertyDescriptor,

--- a/src/js/runtime/for_in_iterator.rs
+++ b/src/js/runtime/for_in_iterator.rs
@@ -3,11 +3,11 @@ use std::collections::HashSet;
 use crate::{
     field_offset,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, PropertyKey, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyKey, Value,
         alloc_error::AllocResult,
         collections::InlineArray,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         object_value::ObjectValue,
         string_value::StringValue,
     },
@@ -132,16 +132,16 @@ impl Handle<ForInIterator> {
     }
 }
 
-impl HeapItem for HeapPtr<ForInIterator> {
-    fn byte_size(&self) -> usize {
-        ForInIterator::calculate_size_in_bytes(self.keys.len())
+impl HeapItem for ForInIterator {
+    fn byte_size(for_in_iterator: HeapPtr<Self>) -> usize {
+        ForInIterator::calculate_size_in_bytes(for_in_iterator.keys.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer(&mut self.object);
+    fn visit_pointers(mut for_in_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut for_in_iterator.descriptor);
+        visitor.visit_pointer(&mut for_in_iterator.object);
 
-        for key in self.keys.as_mut_slice() {
+        for key in for_in_iterator.keys.as_mut_slice() {
             visitor.visit_pointer(key);
         }
     }

--- a/src/js/runtime/gc/garbage_collector.rs
+++ b/src/js/runtime/gc/garbage_collector.rs
@@ -1,10 +1,10 @@
 use std::{ops::Range, ptr::NonNull};
 
 use crate::runtime::{
-    Context, Value,
+    Context, HeapItemKind, Value,
     collections::BsWeakVec,
     gc::{AnyHeapItem, Heap, HeapItem, HeapPtr, HeapVisitor},
-    heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+    heap_item_descriptor::HeapItemDescriptor,
     interned_strings::InternedStrings,
     intrinsics::{
         finalization_registry_object::FinalizationRegistryObject, weak_map_object::WeakMapObject,
@@ -174,12 +174,13 @@ impl GarbageCollector {
         let end_ptr = self.new_permanent_space_bounds.end;
 
         while current_ptr < end_ptr {
-            let mut permanent_heap_item =
+            let permanent_heap_item =
                 HeapPtr::from_ptr(current_ptr.cast_mut()).cast::<AnyHeapItem>();
-            permanent_heap_item.visit_pointers(self);
+            AnyHeapItem::visit_pointers(permanent_heap_item, self);
 
             // Increment current pointer to point to next permanent heap item
-            let alloc_size = Heap::alloc_size_for_request_size(permanent_heap_item.byte_size());
+            let byte_size = AnyHeapItem::byte_size(permanent_heap_item);
+            let alloc_size = Heap::alloc_size_for_request_size(byte_size);
             unsafe { current_ptr = current_ptr.add(alloc_size) }
         }
     }
@@ -194,12 +195,13 @@ impl GarbageCollector {
             // with alloc pointer, meaning all live objects have been copied and pointers have
             // been fixed.
             while self.fix_ptr < self.alloc_ptr {
-                let mut new_heap_item =
+                let new_heap_item =
                     HeapPtr::from_ptr(self.fix_ptr.cast_mut()).cast::<AnyHeapItem>();
-                new_heap_item.visit_pointers(self);
+                AnyHeapItem::visit_pointers(new_heap_item, self);
 
                 // Increment fix pointer to point to next new heap item
-                let alloc_size = Heap::alloc_size_for_request_size(new_heap_item.byte_size());
+                let byte_size = AnyHeapItem::byte_size(new_heap_item);
+                let alloc_size = Heap::alloc_size_for_request_size(byte_size);
                 unsafe { self.fix_ptr = self.fix_ptr.add(alloc_size) }
             }
 
@@ -300,7 +302,7 @@ impl GarbageCollector {
     ) -> (HeapPtr<AnyHeapItem>, usize) {
         // Calculate size of heap item. Caller must ensure that there is enough space at the
         // destination to hold the moved item.
-        let alloc_size = Heap::alloc_size_for_request_size(heap_item.byte_size());
+        let alloc_size = Heap::alloc_size_for_request_size(AnyHeapItem::byte_size(*heap_item));
 
         // Copy item from old to new heap, and bump alloc_ptr to point past new allocation
         let new_heap_item = HeapPtr::from_ptr(dest_ptr.cast_mut()).cast::<AnyHeapItem>();

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -23,7 +23,7 @@ use crate::runtime::{
     gc::{HeapPtr, HeapVisitor},
     generator_object::GeneratorObject,
     global_names::GlobalNames,
-    heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+    heap_item_descriptor::HeapItemDescriptor,
     interned_strings::InternedStringsSet,
     intrinsics::{
         array_buffer_constructor::ArrayBufferObject,
@@ -87,14 +87,175 @@ use crate::runtime::{
 
 /// Trait implemented by all items stored on the heap. This includes both JS objects and non-object
 /// items like strings and descriptors.
-pub trait HeapItem {
+pub trait HeapItem: Sized {
     /// Size of this heap item in bytes. Not guaranteed to be aligned.
-    fn byte_size(&self) -> usize;
+    fn byte_size(item: HeapPtr<Self>) -> usize;
 
     /// Call the provided visit function on all pointer fields in this item. Pass a mutable
     /// reference to the fields themselves so they can be updated in copying collection.
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor);
+    fn visit_pointers(item: HeapPtr<Self>, visitor: &mut impl HeapVisitor);
 }
+
+macro_rules! unit {
+    ($x:ident) => {
+        ()
+    };
+}
+
+macro_rules! register_heap_items {
+    ($(($kind:ident, $item_name:ident),)*) => {
+        $(
+            impl HeapPtr<$item_name> {
+                #[inline]
+                pub fn as_any(&self) -> HeapPtr<AnyHeapItem> {
+                    self.cast()
+                }
+            }
+        )*
+
+        /// Type of an item in the heap. May be a JS object or non-object data stored on the heap,
+        /// e.g. descriptors and realms.
+        #[derive(Clone, Copy, Debug, PartialEq)]
+        #[repr(u8)]
+        pub enum HeapItemKind {
+            $($kind,)*
+        }
+
+        impl HeapItemKind {
+            pub const COUNT: usize = <[()]>::len(&[$(unit!($kind)),*]);
+        }
+
+        pub fn byte_size_for_kind(item: HeapPtr<AnyHeapItem>, kind: HeapItemKind) -> usize {
+            match kind {
+                $(HeapItemKind::$kind => $item_name::byte_size(item.cast()),)*
+            }
+        }
+
+        pub fn visit_pointers_for_kind(item: HeapPtr<AnyHeapItem>, visitor: &mut impl HeapVisitor, kind: HeapItemKind) {
+            match kind {
+                $(HeapItemKind::$kind => $item_name::visit_pointers(item.cast(), visitor),)*
+            }
+        }
+
+        impl HeapItem for AnyHeapItem {
+            /// Size of this heap item in bytes, dispatched based on the kind of heap item.
+            fn byte_size(any: HeapPtr<Self>) -> usize {
+                byte_size_for_kind(any, any.descriptor().kind())
+            }
+
+            /// Visit all pointer fields in this heap item, dispatched based on the kind of heap item.
+            fn visit_pointers(any: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+                visit_pointers_for_kind(any, visitor, any.descriptor().kind());
+            }
+        }
+    };
+}
+
+register_heap_items!(
+    (Descriptor, HeapItemDescriptor),
+    (OrdinaryObject, ObjectValue),
+    (Proxy, ProxyObject),
+    (BooleanObject, BooleanObject),
+    (NumberObject, NumberObject),
+    (StringObject, StringObject),
+    (SymbolObject, SymbolObject),
+    (BigIntObject, BigIntObject),
+    (ArrayObject, ArrayObject),
+    (RegExpObject, RegExpObject),
+    (ErrorObject, ErrorObject),
+    (DateObject, DateObject),
+    (SetObject, SetObject),
+    (MapObject, MapObject),
+    (WeakRefObject, WeakRefObject),
+    (WeakSetObject, WeakSetObject),
+    (WeakMapObject, WeakMapObject),
+    (FinalizationRegistryObject, FinalizationRegistryObject),
+    (RawJSONObject, RawJSONObject),
+    (MappedArgumentsObject, MappedArgumentsObject),
+    (UnmappedArgumentsObject, UnmappedArgumentsObject),
+    (Int8Array, Int8Array),
+    (UInt8Array, UInt8Array),
+    (UInt8ClampedArray, UInt8ClampedArray),
+    (Int16Array, Int16Array),
+    (UInt16Array, UInt16Array),
+    (Int32Array, Int32Array),
+    (UInt32Array, UInt32Array),
+    (BigInt64Array, BigInt64Array),
+    (BigUInt64Array, BigUInt64Array),
+    (Float16Array, Float16Array),
+    (Float32Array, Float32Array),
+    (Float64Array, Float64Array),
+    (ArrayBufferObject, ArrayBufferObject),
+    (DataViewObject, DataViewObject),
+    (DurationObject, DurationObject),
+    (InstantObject, InstantObject),
+    (PlainDateObject, PlainDateObject),
+    (PlainDateTimeObject, PlainDateTimeObject),
+    (PlainMonthDayObject, PlainMonthDayObject),
+    (PlainTimeObject, PlainTimeObject),
+    (PlainYearMonthObject, PlainYearMonthObject),
+    (ZonedDateTimeObject, ZonedDateTimeObject),
+    (ArrayIterator, ArrayIterator),
+    (StringIterator, StringIterator),
+    (SetIterator, SetIterator),
+    (MapIterator, MapIterator),
+    (RegExpStringIterator, RegExpStringIterator),
+    (ForInIterator, ForInIterator),
+    (AsyncFromSyncIterator, AsyncFromSyncIterator),
+    (WrappedValidIterator, WrappedValidIterator),
+    (IteratorHelperObject, IteratorHelperObject),
+    (ObjectPrototype, ObjectPrototype),
+    (String, StringValue),
+    (Symbol, SymbolValue),
+    (BigInt, BigIntValue),
+    (Accessor, Accessor),
+    (Promise, PromiseObject),
+    (PromiseReaction, PromiseReaction),
+    (PromiseCapability, PromiseCapability),
+    (Realm, Realm),
+    (Closure, Closure),
+    (BytecodeFunction, BytecodeFunction),
+    (ConstantTable, ConstantTable),
+    (ExceptionHandlers, ExceptionHandlers),
+    (SourceFile, SourceFile),
+    (Scope, Scope),
+    (ScopeNames, ScopeNames),
+    (GlobalNames, GlobalNames),
+    (ClassNames, ClassNames),
+    (SourceTextModule, SourceTextModule),
+    (SyntheticModule, SyntheticModule),
+    (ModuleNamespaceObject, ModuleNamespaceObject),
+    (ImportAttributes, ImportAttributes),
+    (Generator, GeneratorObject),
+    (AsyncGenerator, AsyncGeneratorObject),
+    (AsyncGeneratorRequest, AsyncGeneratorRequest),
+    (BuiltinGenerator, BuiltinGenerator),
+    (DenseArrayProperties, DenseArrayProperties),
+    (SparseArrayPropertiesMap, SparseArrayPropertiesMap),
+    (CompiledRegExpObject, CompiledRegExpObject),
+    (BoxedValue, BoxedValue),
+    (NamedPropertiesMap, NamedPropertiesMap),
+    (ValueIndexMap, ValueIndexMap),
+    (ValueIndexSet, ValueIndexSet),
+    (ExportMap, ExportMap),
+    (WeakValueMap, WeakValueMap),
+    (WeakValueSet, WeakValueSet),
+    (GlobalSymbolRegistryMap, GlobalSymbolRegistryMap),
+    (InternedStringsSet, InternedStringsSet),
+    (LexicalNamesMap, LexicalNamesMap),
+    (ModuleCacheMap, ModuleCacheMap),
+    (ValueArray, ValueArray),
+    (ByteArray, ByteArray),
+    (U32Array, U32Array),
+    (ModuleRequestArray, ModuleRequestArray),
+    (ModuleOptionArray, ModuleOptionArray),
+    (StackFrameInfoArray, StackFrameInfoArray),
+    (FinalizationRegistryCells, FinalizationRegistryCells),
+    (GlobalScopes, GlobalScopes),
+    (FunctionVec, FunctionVec),
+    (SourceTextModuleVec, SourceTextModuleVec),
+    (WeakVec, BsWeakVec),
+);
 
 /// An arbitrary heap item. Only common field between heap items is their descriptor, which can be
 /// used to determine the true type of the heap item.
@@ -113,330 +274,10 @@ impl AnyHeapItem {
     }
 }
 
-impl HeapPtr<AnyHeapItem> {
-    pub fn byte_size_for_kind(&self, kind: HeapItemKind) -> usize {
-        match kind {
-            HeapItemKind::Descriptor => self.cast::<HeapItemDescriptor>().byte_size(),
-            HeapItemKind::OrdinaryObject => self.cast::<ObjectValue>().byte_size(),
-            HeapItemKind::Proxy => self.cast::<ProxyObject>().byte_size(),
-            HeapItemKind::BooleanObject => self.cast::<BooleanObject>().byte_size(),
-            HeapItemKind::NumberObject => self.cast::<NumberObject>().byte_size(),
-            HeapItemKind::StringObject => self.cast::<StringObject>().byte_size(),
-            HeapItemKind::SymbolObject => self.cast::<SymbolObject>().byte_size(),
-            HeapItemKind::BigIntObject => self.cast::<BigIntObject>().byte_size(),
-            HeapItemKind::ArrayObject => self.cast::<ArrayObject>().byte_size(),
-            HeapItemKind::RegExpObject => self.cast::<RegExpObject>().byte_size(),
-            HeapItemKind::ErrorObject => self.cast::<ErrorObject>().byte_size(),
-            HeapItemKind::DateObject => self.cast::<DateObject>().byte_size(),
-            HeapItemKind::SetObject => self.cast::<SetObject>().byte_size(),
-            HeapItemKind::MapObject => self.cast::<MapObject>().byte_size(),
-            HeapItemKind::WeakRefObject => self.cast::<WeakRefObject>().byte_size(),
-            HeapItemKind::WeakSetObject => self.cast::<WeakSetObject>().byte_size(),
-            HeapItemKind::WeakMapObject => self.cast::<WeakMapObject>().byte_size(),
-            HeapItemKind::FinalizationRegistryObject => {
-                self.cast::<FinalizationRegistryObject>().byte_size()
-            }
-            HeapItemKind::RawJSONObject => self.cast::<RawJSONObject>().byte_size(),
-            HeapItemKind::MappedArgumentsObject => self.cast::<MappedArgumentsObject>().byte_size(),
-            HeapItemKind::UnmappedArgumentsObject => {
-                self.cast::<UnmappedArgumentsObject>().byte_size()
-            }
-            HeapItemKind::Int8Array => self.cast::<Int8Array>().byte_size(),
-            HeapItemKind::UInt8Array => self.cast::<UInt8Array>().byte_size(),
-            HeapItemKind::UInt8ClampedArray => self.cast::<UInt8ClampedArray>().byte_size(),
-            HeapItemKind::Int16Array => self.cast::<Int16Array>().byte_size(),
-            HeapItemKind::UInt16Array => self.cast::<UInt16Array>().byte_size(),
-            HeapItemKind::Int32Array => self.cast::<Int32Array>().byte_size(),
-            HeapItemKind::UInt32Array => self.cast::<UInt32Array>().byte_size(),
-            HeapItemKind::BigInt64Array => self.cast::<BigInt64Array>().byte_size(),
-            HeapItemKind::BigUInt64Array => self.cast::<BigUInt64Array>().byte_size(),
-            HeapItemKind::Float16Array => self.cast::<Float16Array>().byte_size(),
-            HeapItemKind::Float32Array => self.cast::<Float32Array>().byte_size(),
-            HeapItemKind::Float64Array => self.cast::<Float64Array>().byte_size(),
-            HeapItemKind::ArrayBufferObject => self.cast::<ArrayBufferObject>().byte_size(),
-            HeapItemKind::DataViewObject => self.cast::<DataViewObject>().byte_size(),
-            HeapItemKind::DurationObject => self.cast::<DurationObject>().byte_size(),
-            HeapItemKind::InstantObject => self.cast::<InstantObject>().byte_size(),
-            HeapItemKind::PlainDateObject => self.cast::<PlainDateObject>().byte_size(),
-            HeapItemKind::PlainDateTimeObject => self.cast::<PlainDateTimeObject>().byte_size(),
-            HeapItemKind::PlainMonthDayObject => self.cast::<PlainMonthDayObject>().byte_size(),
-            HeapItemKind::PlainTimeObject => self.cast::<PlainTimeObject>().byte_size(),
-            HeapItemKind::PlainYearMonthObject => self.cast::<PlainYearMonthObject>().byte_size(),
-            HeapItemKind::ZonedDateTimeObject => self.cast::<ZonedDateTimeObject>().byte_size(),
-            HeapItemKind::ArrayIterator => self.cast::<ArrayIterator>().byte_size(),
-            HeapItemKind::StringIterator => self.cast::<StringIterator>().byte_size(),
-            HeapItemKind::SetIterator => self.cast::<SetIterator>().byte_size(),
-            HeapItemKind::MapIterator => self.cast::<MapIterator>().byte_size(),
-            HeapItemKind::RegExpStringIterator => self.cast::<RegExpStringIterator>().byte_size(),
-            HeapItemKind::ForInIterator => self.cast::<ForInIterator>().byte_size(),
-            HeapItemKind::AsyncFromSyncIterator => self.cast::<AsyncFromSyncIterator>().byte_size(),
-            HeapItemKind::WrappedValidIterator => self.cast::<WrappedValidIterator>().byte_size(),
-            HeapItemKind::IteratorHelperObject => self.cast::<IteratorHelperObject>().byte_size(),
-            HeapItemKind::ObjectPrototype => self.cast::<ObjectPrototype>().byte_size(),
-            HeapItemKind::String => self.cast::<StringValue>().byte_size(),
-            HeapItemKind::Symbol => self.cast::<SymbolValue>().byte_size(),
-            HeapItemKind::BigInt => self.cast::<BigIntValue>().byte_size(),
-            HeapItemKind::Accessor => self.cast::<Accessor>().byte_size(),
-            HeapItemKind::Promise => self.cast::<PromiseObject>().byte_size(),
-            HeapItemKind::PromiseReaction => self.cast::<PromiseReaction>().byte_size(),
-            HeapItemKind::PromiseCapability => self.cast::<PromiseCapability>().byte_size(),
-            HeapItemKind::Realm => self.cast::<Realm>().byte_size(),
-            HeapItemKind::Closure => self.cast::<Closure>().byte_size(),
-            HeapItemKind::BytecodeFunction => self.cast::<BytecodeFunction>().byte_size(),
-            HeapItemKind::ConstantTable => self.cast::<ConstantTable>().byte_size(),
-            HeapItemKind::ExceptionHandlers => self.cast::<ExceptionHandlers>().byte_size(),
-            HeapItemKind::SourceFile => self.cast::<SourceFile>().byte_size(),
-            HeapItemKind::Scope => self.cast::<Scope>().byte_size(),
-            HeapItemKind::ScopeNames => self.cast::<ScopeNames>().byte_size(),
-            HeapItemKind::GlobalNames => self.cast::<GlobalNames>().byte_size(),
-            HeapItemKind::ClassNames => self.cast::<ClassNames>().byte_size(),
-            HeapItemKind::SourceTextModule => self.cast::<SourceTextModule>().byte_size(),
-            HeapItemKind::SyntheticModule => self.cast::<SyntheticModule>().byte_size(),
-            HeapItemKind::ModuleNamespaceObject => self.cast::<ModuleNamespaceObject>().byte_size(),
-            HeapItemKind::ImportAttributes => self.cast::<ImportAttributes>().byte_size(),
-            HeapItemKind::Generator => self.cast::<GeneratorObject>().byte_size(),
-            HeapItemKind::AsyncGenerator => self.cast::<AsyncGeneratorObject>().byte_size(),
-            HeapItemKind::AsyncGeneratorRequest => self.cast::<AsyncGeneratorRequest>().byte_size(),
-            HeapItemKind::BuiltinGenerator => self.cast::<BuiltinGenerator>().byte_size(),
-            HeapItemKind::DenseArrayProperties => self.cast::<DenseArrayProperties>().byte_size(),
-            HeapItemKind::SparseArrayPropertiesMap => {
-                SparseArrayPropertiesMap::byte_size(self.cast())
-            }
-            HeapItemKind::CompiledRegExpObject => self.cast::<CompiledRegExpObject>().byte_size(),
-            HeapItemKind::BoxedValue => self.cast::<BoxedValue>().byte_size(),
-            HeapItemKind::NamedPropertiesMap => NamedPropertiesMap::byte_size(self.cast()),
-            HeapItemKind::ValueIndexMap => ValueIndexMap::byte_size(self.cast()),
-            HeapItemKind::ValueIndexSet => ValueIndexSet::byte_size(self.cast()),
-            HeapItemKind::ExportMap => ExportMap::byte_size(self.cast()),
-            HeapItemKind::WeakValueMap => WeakValueMap::byte_size(self.cast()),
-            HeapItemKind::WeakValueSet => WeakValueSet::byte_size(self.cast()),
-            HeapItemKind::GlobalSymbolRegistryMap => {
-                GlobalSymbolRegistryMap::byte_size(self.cast())
-            }
-            HeapItemKind::InternedStringsSet => InternedStringsSet::byte_size(self.cast()),
-            HeapItemKind::LexicalNamesMap => LexicalNamesMap::byte_size(self.cast()),
-            HeapItemKind::ModuleCacheMap => ModuleCacheMap::byte_size(self.cast()),
-            HeapItemKind::ValueArray => ValueArray::byte_size(self.cast()),
-            HeapItemKind::ByteArray => ByteArray::byte_size(self.cast()),
-            HeapItemKind::U32Array => U32Array::byte_size(self.cast()),
-            HeapItemKind::ModuleRequestArray => ModuleRequestArray::byte_size(self.cast()),
-            HeapItemKind::ModuleOptionArray => ModuleOptionArray::byte_size(self.cast()),
-            HeapItemKind::StackFrameInfoArray => StackFrameInfoArray::byte_size(self.cast()),
-            HeapItemKind::FinalizationRegistryCells => {
-                self.cast::<FinalizationRegistryCells>().byte_size()
-            }
-            HeapItemKind::GlobalScopes => self.cast::<GlobalScopes>().byte_size(),
-            HeapItemKind::FunctionVec => FunctionVec::byte_size(self.cast()),
-            HeapItemKind::SourceTextModuleVec => SourceTextModuleVec::byte_size(self.cast()),
-            HeapItemKind::WeakVec => self.cast::<BsWeakVec>().byte_size(),
-            HeapItemKind::Last => unreachable!("No objects are created with this descriptor"),
-        }
-    }
-
-    pub fn visit_pointers_for_kind(&mut self, visitor: &mut impl HeapVisitor, kind: HeapItemKind) {
-        match kind {
-            HeapItemKind::Descriptor => self.cast::<HeapItemDescriptor>().visit_pointers(visitor),
-            HeapItemKind::OrdinaryObject => self.cast::<ObjectValue>().visit_pointers(visitor),
-            HeapItemKind::Proxy => self.cast::<ProxyObject>().visit_pointers(visitor),
-            HeapItemKind::BooleanObject => self.cast::<BooleanObject>().visit_pointers(visitor),
-            HeapItemKind::NumberObject => self.cast::<NumberObject>().visit_pointers(visitor),
-            HeapItemKind::StringObject => self.cast::<StringObject>().visit_pointers(visitor),
-            HeapItemKind::SymbolObject => self.cast::<SymbolObject>().visit_pointers(visitor),
-            HeapItemKind::BigIntObject => self.cast::<BigIntObject>().visit_pointers(visitor),
-            HeapItemKind::ArrayObject => self.cast::<ArrayObject>().visit_pointers(visitor),
-            HeapItemKind::RegExpObject => self.cast::<RegExpObject>().visit_pointers(visitor),
-            HeapItemKind::ErrorObject => self.cast::<ErrorObject>().visit_pointers(visitor),
-            HeapItemKind::DateObject => self.cast::<DateObject>().visit_pointers(visitor),
-            HeapItemKind::SetObject => self.cast::<SetObject>().visit_pointers(visitor),
-            HeapItemKind::MapObject => self.cast::<MapObject>().visit_pointers(visitor),
-            HeapItemKind::WeakRefObject => self.cast::<WeakRefObject>().visit_pointers(visitor),
-            HeapItemKind::WeakSetObject => self.cast::<WeakSetObject>().visit_pointers(visitor),
-            HeapItemKind::WeakMapObject => self.cast::<WeakMapObject>().visit_pointers(visitor),
-            HeapItemKind::FinalizationRegistryObject => self
-                .cast::<FinalizationRegistryObject>()
-                .visit_pointers(visitor),
-            HeapItemKind::RawJSONObject => self.cast::<RawJSONObject>().visit_pointers(visitor),
-            HeapItemKind::MappedArgumentsObject => {
-                self.cast::<MappedArgumentsObject>().visit_pointers(visitor)
-            }
-            HeapItemKind::UnmappedArgumentsObject => self
-                .cast::<UnmappedArgumentsObject>()
-                .visit_pointers(visitor),
-            HeapItemKind::Int8Array => self.cast::<Int8Array>().visit_pointers(visitor),
-            HeapItemKind::UInt8Array => self.cast::<UInt8Array>().visit_pointers(visitor),
-            HeapItemKind::UInt8ClampedArray => {
-                self.cast::<UInt8ClampedArray>().visit_pointers(visitor)
-            }
-            HeapItemKind::Int16Array => self.cast::<Int16Array>().visit_pointers(visitor),
-            HeapItemKind::UInt16Array => self.cast::<UInt16Array>().visit_pointers(visitor),
-            HeapItemKind::Int32Array => self.cast::<Int32Array>().visit_pointers(visitor),
-            HeapItemKind::UInt32Array => self.cast::<UInt32Array>().visit_pointers(visitor),
-            HeapItemKind::BigInt64Array => self.cast::<BigInt64Array>().visit_pointers(visitor),
-            HeapItemKind::BigUInt64Array => self.cast::<BigUInt64Array>().visit_pointers(visitor),
-            HeapItemKind::Float16Array => self.cast::<Float16Array>().visit_pointers(visitor),
-            HeapItemKind::Float32Array => self.cast::<Float32Array>().visit_pointers(visitor),
-            HeapItemKind::Float64Array => self.cast::<Float64Array>().visit_pointers(visitor),
-            HeapItemKind::ArrayBufferObject => {
-                self.cast::<ArrayBufferObject>().visit_pointers(visitor)
-            }
-            HeapItemKind::DataViewObject => self.cast::<DataViewObject>().visit_pointers(visitor),
-            HeapItemKind::DurationObject => self.cast::<DurationObject>().visit_pointers(visitor),
-            HeapItemKind::InstantObject => self.cast::<InstantObject>().visit_pointers(visitor),
-            HeapItemKind::PlainDateObject => self.cast::<PlainDateObject>().visit_pointers(visitor),
-            HeapItemKind::PlainDateTimeObject => {
-                self.cast::<PlainDateTimeObject>().visit_pointers(visitor)
-            }
-            HeapItemKind::PlainMonthDayObject => {
-                self.cast::<PlainMonthDayObject>().visit_pointers(visitor)
-            }
-            HeapItemKind::PlainTimeObject => self.cast::<PlainTimeObject>().visit_pointers(visitor),
-            HeapItemKind::PlainYearMonthObject => {
-                self.cast::<PlainYearMonthObject>().visit_pointers(visitor)
-            }
-            HeapItemKind::ZonedDateTimeObject => {
-                self.cast::<ZonedDateTimeObject>().visit_pointers(visitor)
-            }
-            HeapItemKind::ArrayIterator => self.cast::<ArrayIterator>().visit_pointers(visitor),
-            HeapItemKind::StringIterator => self.cast::<StringIterator>().visit_pointers(visitor),
-            HeapItemKind::SetIterator => self.cast::<SetIterator>().visit_pointers(visitor),
-            HeapItemKind::MapIterator => self.cast::<MapIterator>().visit_pointers(visitor),
-            HeapItemKind::RegExpStringIterator => {
-                self.cast::<RegExpStringIterator>().visit_pointers(visitor)
-            }
-            HeapItemKind::ForInIterator => self.cast::<ForInIterator>().visit_pointers(visitor),
-            HeapItemKind::AsyncFromSyncIterator => {
-                self.cast::<AsyncFromSyncIterator>().visit_pointers(visitor)
-            }
-            HeapItemKind::WrappedValidIterator => {
-                self.cast::<WrappedValidIterator>().visit_pointers(visitor)
-            }
-            HeapItemKind::IteratorHelperObject => {
-                self.cast::<IteratorHelperObject>().visit_pointers(visitor)
-            }
-            HeapItemKind::ObjectPrototype => self.cast::<ObjectPrototype>().visit_pointers(visitor),
-            HeapItemKind::String => self.cast::<StringValue>().visit_pointers(visitor),
-            HeapItemKind::Symbol => self.cast::<SymbolValue>().visit_pointers(visitor),
-            HeapItemKind::BigInt => self.cast::<BigIntValue>().visit_pointers(visitor),
-            HeapItemKind::Accessor => self.cast::<Accessor>().visit_pointers(visitor),
-            HeapItemKind::Promise => self.cast::<PromiseObject>().visit_pointers(visitor),
-            HeapItemKind::PromiseReaction => self.cast::<PromiseReaction>().visit_pointers(visitor),
-            HeapItemKind::PromiseCapability => {
-                self.cast::<PromiseCapability>().visit_pointers(visitor)
-            }
-            HeapItemKind::Realm => self.cast::<Realm>().visit_pointers(visitor),
-            HeapItemKind::Closure => self.cast::<Closure>().visit_pointers(visitor),
-            HeapItemKind::BytecodeFunction => {
-                self.cast::<BytecodeFunction>().visit_pointers(visitor)
-            }
-            HeapItemKind::ConstantTable => self.cast::<ConstantTable>().visit_pointers(visitor),
-            HeapItemKind::ExceptionHandlers => {
-                self.cast::<ExceptionHandlers>().visit_pointers(visitor)
-            }
-            HeapItemKind::SourceFile => self.cast::<SourceFile>().visit_pointers(visitor),
-            HeapItemKind::Scope => self.cast::<Scope>().visit_pointers(visitor),
-            HeapItemKind::ScopeNames => self.cast::<ScopeNames>().visit_pointers(visitor),
-            HeapItemKind::GlobalNames => self.cast::<GlobalNames>().visit_pointers(visitor),
-            HeapItemKind::ClassNames => self.cast::<ClassNames>().visit_pointers(visitor),
-            HeapItemKind::SourceTextModule => {
-                self.cast::<SourceTextModule>().visit_pointers(visitor)
-            }
-            HeapItemKind::SyntheticModule => self.cast::<SyntheticModule>().visit_pointers(visitor),
-            HeapItemKind::ModuleNamespaceObject => {
-                self.cast::<ModuleNamespaceObject>().visit_pointers(visitor)
-            }
-            HeapItemKind::ImportAttributes => {
-                self.cast::<ImportAttributes>().visit_pointers(visitor)
-            }
-            HeapItemKind::Generator => self.cast::<GeneratorObject>().visit_pointers(visitor),
-            HeapItemKind::AsyncGenerator => {
-                self.cast::<AsyncGeneratorObject>().visit_pointers(visitor)
-            }
-            HeapItemKind::AsyncGeneratorRequest => {
-                self.cast::<AsyncGeneratorRequest>().visit_pointers(visitor)
-            }
-            HeapItemKind::BuiltinGenerator => {
-                self.cast::<BuiltinGenerator>().visit_pointers(visitor)
-            }
-            HeapItemKind::DenseArrayProperties => {
-                self.cast::<DenseArrayProperties>().visit_pointers(visitor)
-            }
-            HeapItemKind::SparseArrayPropertiesMap => {
-                SparseArrayPropertiesMap::visit_pointers(self.cast_mut(), visitor)
-            }
-            HeapItemKind::CompiledRegExpObject => {
-                self.cast::<CompiledRegExpObject>().visit_pointers(visitor)
-            }
-            HeapItemKind::BoxedValue => self.cast::<BoxedValue>().visit_pointers(visitor),
-            HeapItemKind::NamedPropertiesMap => {
-                NamedPropertiesMap::visit_pointers(self.cast_mut(), visitor)
-            }
-            HeapItemKind::ValueIndexMap => ValueIndexMap::visit_pointers(self.cast_mut(), visitor),
-            HeapItemKind::ValueIndexSet => ValueIndexSet::visit_pointers(self.cast_mut(), visitor),
-            HeapItemKind::ExportMap => ExportMap::visit_pointers(self.cast_mut(), visitor),
-            HeapItemKind::WeakValueMap => WeakValueMap::visit_pointers(self.cast_mut(), visitor),
-            HeapItemKind::WeakValueSet => WeakValueSet::visit_pointers(self.cast_mut(), visitor),
-            HeapItemKind::GlobalSymbolRegistryMap => {
-                GlobalSymbolRegistryMap::visit_pointers(self.cast_mut(), visitor)
-            }
-            HeapItemKind::InternedStringsSet => {
-                InternedStringsSet::visit_pointers(self.cast_mut(), visitor)
-            }
-            HeapItemKind::LexicalNamesMap => {
-                LexicalNamesMap::visit_pointers(self.cast_mut(), visitor)
-            }
-            HeapItemKind::ModuleCacheMap => {
-                ModuleCacheMap::visit_pointers(self.cast_mut(), visitor)
-            }
-            HeapItemKind::ValueArray => ValueArray::visit_pointers(self.cast_mut(), visitor),
-            HeapItemKind::ByteArray => ByteArray::visit_pointers(self.cast_mut(), visitor),
-            HeapItemKind::U32Array => U32Array::visit_pointers(self.cast_mut(), visitor),
-            HeapItemKind::ModuleRequestArray => {
-                ModuleRequestArray::visit_pointers(self.cast_mut(), visitor)
-            }
-            HeapItemKind::ModuleOptionArray => {
-                ModuleOptionArray::visit_pointers(self.cast_mut(), visitor)
-            }
-            HeapItemKind::StackFrameInfoArray => {
-                StackFrameInfoArray::visit_pointers(self.cast_mut(), visitor)
-            }
-            HeapItemKind::FinalizationRegistryCells => self
-                .cast::<FinalizationRegistryCells>()
-                .visit_pointers(visitor),
-            HeapItemKind::GlobalScopes => self.cast::<GlobalScopes>().visit_pointers(visitor),
-            HeapItemKind::FunctionVec => FunctionVec::visit_pointers(self.cast_mut(), visitor),
-            HeapItemKind::SourceTextModuleVec => {
-                SourceTextModuleVec::visit_pointers(self.cast_mut(), visitor)
-            }
-            HeapItemKind::WeakVec => self.cast::<BsWeakVec>().visit_pointers(visitor),
-            HeapItemKind::Last => unreachable!("No objects are created with this descriptor"),
-        }
-    }
-}
-
-impl HeapItem for HeapPtr<AnyHeapItem> {
-    fn byte_size(&self) -> usize {
-        self.byte_size_for_kind(self.descriptor().kind())
-    }
-
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_pointers_for_kind(visitor, self.descriptor().kind());
-    }
-}
-
 /// Marker trait that denotes an object on the managed heap
 pub trait IsHeapItem: Sized {}
 
-impl<T> IsHeapItem for T where HeapPtr<T>: HeapItem {}
-
-impl<T> HeapPtr<T>
-where
-    HeapPtr<T>: HeapItem,
-{
-    #[inline]
-    pub fn as_heap_item(&self) -> HeapPtr<AnyHeapItem> {
-        self.cast()
-    }
-}
+impl<T: HeapItem> IsHeapItem for T {}
 
 /// Storage for a value whose natural alignment exceeds the 8-byte alignment of the managed heap.
 #[repr(C, packed(8))]

--- a/src/js/runtime/gc/heap_serializer.rs
+++ b/src/js/runtime/gc/heap_serializer.rs
@@ -17,7 +17,10 @@ use crate::{
     common::serialized_heap::{SerializedHeap, SerializedSemispace},
     runtime::{
         Context, Value,
-        gc::{AnyHeapItem, GcType, Heap, HeapInfo, HeapPtr, HeapVisitor},
+        gc::{
+            AnyHeapItem, GcType, Heap, HeapInfo, HeapPtr, HeapVisitor,
+            heap_item::{byte_size_for_kind, visit_pointers_for_kind},
+        },
         heap_item_descriptor::HeapItemDescriptor,
         rust_vtables::{RustVtable, get_vtable, lookup_vtable_enum},
     },
@@ -105,13 +108,13 @@ impl HeapSerializer {
             // Start of an object - cast to HeapItem and rewrite its pointers to be offsets from the
             // start of the heap.
             let item_ptr = unsafe { space_start_ptr.add(item_offset) };
-            let mut heap_item = HeapPtr::from_ptr(item_ptr).cast::<AnyHeapItem>();
+            let heap_item = HeapPtr::from_ptr(item_ptr).cast::<AnyHeapItem>();
             let kind = heap_item.descriptor().kind();
 
-            heap_item.visit_pointers_for_kind(self, kind);
+            visit_pointers_for_kind(heap_item, self, kind);
 
             // Increment fix pointer to point to next new heap item
-            item_offset += Heap::alloc_size_for_request_size(heap_item.byte_size_for_kind(kind));
+            item_offset += Heap::alloc_size_for_request_size(byte_size_for_kind(heap_item, kind));
         }
     }
 
@@ -190,11 +193,11 @@ impl HeapSpaceDeserializer {
             };
             let descriptor_kind = unsafe { (*descriptor_ptr).kind() };
 
-            let mut heap_item = HeapPtr::from_ptr(heap_item_ptr).cast::<AnyHeapItem>();
-            heap_item.visit_pointers_for_kind(&mut deserializer, descriptor_kind);
+            let heap_item = HeapPtr::from_ptr(heap_item_ptr).cast::<AnyHeapItem>();
+            visit_pointers_for_kind(heap_item, &mut deserializer, descriptor_kind);
 
             // Increment fix pointer to point to next new heap item
-            let byte_size = heap_item.byte_size_for_kind(descriptor_kind);
+            let byte_size = byte_size_for_kind(heap_item, descriptor_kind);
             item_offset += Heap::alloc_size_for_request_size(byte_size);
         }
     }

--- a/src/js/runtime/gc/mod.rs
+++ b/src/js/runtime/gc/mod.rs
@@ -12,7 +12,7 @@ pub use handle::{
     Escapable, Handle, HandleContents, HandleScope, HandleScopeGuard, ToHandleContents,
 };
 pub use heap::{Heap, HeapInfo};
-pub use heap_item::{AnyHeapItem, HeapItem, HeapUnaligned, IsHeapItem};
+pub use heap_item::{AnyHeapItem, HeapItem, HeapItemKind, HeapUnaligned, IsHeapItem};
 #[allow(unused)]
 pub use heap_serializer::{HeapRootsDeserializer, HeapSerializer};
 pub use heap_visitor::HeapVisitor;

--- a/src/js/runtime/generator_object.rs
+++ b/src/js/runtime/generator_object.rs
@@ -1,7 +1,7 @@
 use crate::{
     eval_err, extend_object, field_offset,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         bytecode::{
             ExtraWide, Register,
@@ -12,7 +12,6 @@ use crate::{
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         iterator::create_iter_result_object,
         object_value::ObjectValue,
@@ -296,16 +295,16 @@ pub fn generator_resume_abrupt(
     generate_resume_impl(cx, generator, completion_value, completion_type)
 }
 
-impl HeapItem for HeapPtr<GeneratorObject> {
-    fn byte_size(&self) -> usize {
-        GeneratorObject::calculate_size_in_bytes(self.stack_frame.len())
+impl HeapItem for GeneratorObject {
+    fn byte_size(generator_object: HeapPtr<Self>) -> usize {
+        GeneratorObject::calculate_size_in_bytes(generator_object.stack_frame.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(generator_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        generator_object.visit_object_pointers(visitor);
 
-        if self.state.is_suspended() {
-            let mut stack_frame = StackFrame::for_fp(self.current_fp().cast_mut());
+        if generator_object.state.is_suspended() {
+            let mut stack_frame = StackFrame::for_fp(generator_object.current_fp().cast_mut());
             stack_frame.visit_simple_pointers(visitor);
         }
     }

--- a/src/js/runtime/global_names.rs
+++ b/src/js/runtime/global_names.rs
@@ -3,14 +3,15 @@ use std::collections::HashSet;
 use crate::{
     field_offset,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, PropertyDescriptor, PropertyKey, Realm, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyDescriptor, PropertyKey, Realm,
+        Value,
         abstract_operations::{define_property_or_throw, has_own_property, is_extensible},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         collections::InlineArray,
         error::type_error,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         intrinsics::rust_runtime::RuntimeFunction,
         object_value::ObjectValue,
         scope_names::ScopeNames,
@@ -67,16 +68,16 @@ impl GlobalNames {
     }
 }
 
-impl HeapItem for HeapPtr<GlobalNames> {
-    fn byte_size(&self) -> usize {
-        GlobalNames::calculate_size_in_bytes(self.names.len())
+impl HeapItem for GlobalNames {
+    fn byte_size(global_names: HeapPtr<Self>) -> usize {
+        GlobalNames::calculate_size_in_bytes(global_names.names.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer(&mut self.scope_names);
+    fn visit_pointers(mut global_names: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut global_names.descriptor);
+        visitor.visit_pointer(&mut global_names.scope_names);
 
-        for name in self.names.as_mut_slice() {
+        for name in global_names.names.as_mut_slice() {
             visitor.visit_pointer(name);
         }
     }

--- a/src/js/runtime/heap_item_descriptor.rs
+++ b/src/js/runtime/heap_item_descriptor.rs
@@ -4,7 +4,7 @@ use bitflags::bitflags;
 
 use crate::{
     runtime::{
-        Context, Value,
+        Context, HeapItemKind, Value,
         alloc_error::AllocResult,
         gc::{Handle, HeapItem, HeapPtr, HeapVisitor},
         object_value::{VirtualObject, VirtualObjectVtable},
@@ -24,152 +24,6 @@ pub struct HeapItemDescriptor {
     kind: HeapItemKind,
     /// Bitflags for object
     flags: DescFlags,
-}
-
-/// Type of an item in the heap. May be a JS object or non-object data stored on the heap,
-/// e.g. descriptors and realms.
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(u8)]
-pub enum HeapItemKind {
-    // The descriptor for a descriptor
-    Descriptor,
-
-    // All objects
-    OrdinaryObject,
-    Proxy,
-
-    BooleanObject,
-    NumberObject,
-    StringObject,
-    SymbolObject,
-    BigIntObject,
-    ArrayObject,
-    RegExpObject,
-    ErrorObject,
-    DateObject,
-    SetObject,
-    MapObject,
-    WeakRefObject,
-    WeakSetObject,
-    WeakMapObject,
-    FinalizationRegistryObject,
-    RawJSONObject,
-
-    MappedArgumentsObject,
-    UnmappedArgumentsObject,
-
-    Int8Array,
-    UInt8Array,
-    UInt8ClampedArray,
-    Int16Array,
-    UInt16Array,
-    Int32Array,
-    UInt32Array,
-    BigInt64Array,
-    BigUInt64Array,
-    Float16Array,
-    Float32Array,
-    Float64Array,
-
-    ArrayBufferObject,
-    DataViewObject,
-
-    DurationObject,
-    InstantObject,
-    PlainDateObject,
-    PlainDateTimeObject,
-    PlainMonthDayObject,
-    PlainTimeObject,
-    PlainYearMonthObject,
-    ZonedDateTimeObject,
-
-    ArrayIterator,
-    StringIterator,
-    SetIterator,
-    MapIterator,
-    RegExpStringIterator,
-    ForInIterator,
-    AsyncFromSyncIterator,
-    WrappedValidIterator,
-    IteratorHelperObject,
-
-    ObjectPrototype,
-
-    // Other heap items
-    String,
-    Symbol,
-    BigInt,
-    Accessor,
-
-    Promise,
-    PromiseReaction,
-    PromiseCapability,
-
-    Realm,
-
-    Closure,
-    BytecodeFunction,
-    ConstantTable,
-    ExceptionHandlers,
-    SourceFile,
-
-    Scope,
-    ScopeNames,
-    GlobalNames,
-    ClassNames,
-
-    SourceTextModule,
-    SyntheticModule,
-    ModuleNamespaceObject,
-    ImportAttributes,
-
-    Generator,
-    AsyncGenerator,
-    AsyncGeneratorRequest,
-    BuiltinGenerator,
-
-    DenseArrayProperties,
-    SparseArrayPropertiesMap,
-
-    CompiledRegExpObject,
-
-    BoxedValue,
-
-    // Hash maps
-    NamedPropertiesMap,
-    ValueIndexMap,
-    ValueIndexSet,
-    ExportMap,
-    WeakValueMap,
-    WeakValueSet,
-    GlobalSymbolRegistryMap,
-    InternedStringsSet,
-    LexicalNamesMap,
-    ModuleCacheMap,
-
-    // Arrays
-    ValueArray,
-    ByteArray,
-    U32Array,
-    ModuleRequestArray,
-    ModuleOptionArray,
-    StackFrameInfoArray,
-    FinalizationRegistryCells,
-    GlobalScopes,
-
-    // Vectors
-    FunctionVec,
-    SourceTextModuleVec,
-    WeakVec,
-
-    // Numerical value is the number of kinds in the enum
-    Last,
-}
-
-impl HeapItemKind {
-    pub const fn count() -> usize {
-        HeapItemKind::Last as usize
-    }
 }
 
 bitflags! {
@@ -242,13 +96,13 @@ impl HeapItemDescriptor {
     }
 }
 
-impl HeapItem for HeapPtr<HeapItemDescriptor> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for HeapItemDescriptor {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<HeapItemDescriptor>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_rust_vtable_pointer(&mut self.vtable);
+    fn visit_pointers(mut heap_item_descriptor: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut heap_item_descriptor.descriptor);
+        visitor.visit_rust_vtable_pointer(&mut heap_item_descriptor.vtable);
     }
 }

--- a/src/js/runtime/interned_strings.rs
+++ b/src/js/runtime/interned_strings.rs
@@ -8,7 +8,7 @@ use crate::{
         Context, EvalResult, Handle, HeapPtr,
         alloc_error::AllocResult,
         collections::{BsHashSetField, HashSetInstance},
-        gc::HeapVisitor,
+        gc::{HeapItem, HeapVisitor},
         string_value::{FlatString, StringValue},
     },
     set_uninit,
@@ -165,13 +165,13 @@ impl BsHashSetField<InternedStringsSet> for InternedStringsSetField {
     }
 }
 
-impl InternedStringsSet {
-    pub fn byte_size(set: HeapPtr<Self>) -> usize {
+impl HeapItem for InternedStringsSet {
+    fn byte_size(set: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(set.capacity())
     }
 
-    pub fn visit_pointers(set: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        set.visit_pointers(visitor);
+    fn visit_pointers(mut set: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        set.visit_set_pointers(visitor);
 
         // Interned strings are weak references
         for string in set.iter_mut_gc_unsafe() {

--- a/src/js/runtime/intrinsics/array_buffer_constructor.rs
+++ b/src/js/runtime/intrinsics/array_buffer_constructor.rs
@@ -3,14 +3,13 @@ use std::mem::size_of;
 use crate::{
     extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::{ArrayInstance, array::ByteArray},
         error::{range_error, type_error},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         get,
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
@@ -309,13 +308,13 @@ pub fn throw_if_detached(cx: Context, array_buffer: HeapPtr<ArrayBufferObject>) 
     }
 }
 
-impl HeapItem for HeapPtr<ArrayBufferObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for ArrayBufferObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<ArrayBufferObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer_opt(&mut self.data);
+    fn visit_pointers(mut array_buffer_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array_buffer_object.visit_object_pointers(visitor);
+        visitor.visit_pointer_opt(&mut array_buffer_object.data);
     }
 }

--- a/src/js/runtime/intrinsics/array_iterator.rs
+++ b/src/js/runtime/intrinsics/array_iterator.rs
@@ -3,14 +3,13 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapPtr,
+        Context, Handle, HeapItemKind, HeapPtr,
         abstract_operations::length_of_array_like,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
@@ -164,13 +163,13 @@ impl ArrayIteratorPrototype {
     }}
 }
 
-impl HeapItem for HeapPtr<ArrayIterator> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for ArrayIterator {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<ArrayIterator>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.array);
+    fn visit_pointers(mut array_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array_iterator.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut array_iterator.array);
     }
 }

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
@@ -1,14 +1,13 @@
 use crate::{
     eval_err, extend_object, if_abrupt_reject_promise, intrinsic_methods, must,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         abstract_operations::{call_object, get_method},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::type_error_value,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic, promise_prototype::perform_promise_then,
@@ -58,15 +57,15 @@ impl AsyncFromSyncIterator {
     }
 }
 
-impl HeapItem for HeapPtr<AsyncFromSyncIterator> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for AsyncFromSyncIterator {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         std::mem::size_of::<AsyncFromSyncIterator>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.iterator);
-        visitor.visit_value(&mut self.next_method);
+    fn visit_pointers(mut async_from_sync_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        async_from_sync_iterator.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut async_from_sync_iterator.iterator);
+        visitor.visit_value(&mut async_from_sync_iterator.next_method);
     }
 }
 

--- a/src/js/runtime/intrinsics/async_generator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_generator_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     if_abrupt_reject_promise, intrinsic_methods, must,
     runtime::{
-        Context, Handle,
+        Context, Handle, HeapItemKind,
         abstract_operations::{call_object, define_property_or_throw},
         alloc_error::AllocResult,
         async_generator_object::{
@@ -11,7 +11,6 @@ use crate::{
         bytecode::function::Closure,
         eval_result::EvalResult,
         generator_object::GeneratorCompletionType,
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::intrinsics::Intrinsic,
         iterator::create_iter_result_object,

--- a/src/js/runtime/intrinsics/bigint_constructor.rs
+++ b/src/js/runtime/intrinsics/bigint_constructor.rs
@@ -6,12 +6,11 @@ use num_traits::FromPrimitive;
 use crate::{
     extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         error::{range_error, type_error},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
@@ -157,13 +156,13 @@ pub fn number_to_bigint(
     }
 }
 
-impl HeapItem for HeapPtr<BigIntObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for BigIntObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<BigIntObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.bigint_data);
+    fn visit_pointers(mut bigint_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        bigint_object.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut bigint_object.bigint_data);
     }
 }

--- a/src/js/runtime/intrinsics/boolean_constructor.rs
+++ b/src/js/runtime/intrinsics/boolean_constructor.rs
@@ -3,11 +3,10 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, HeapPtr,
+        Context, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
@@ -113,12 +112,12 @@ impl BooleanConstructor {
     }}
 }
 
-impl HeapItem for HeapPtr<BooleanObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for BooleanObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<BooleanObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(boolean_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        boolean_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/data_view_constructor.rs
+++ b/src/js/runtime/intrinsics/data_view_constructor.rs
@@ -3,12 +3,11 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, Handle, HeapPtr,
+        Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         error::{range_error, type_error},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             array_buffer_constructor::{ArrayBufferObject, throw_if_detached},
@@ -179,13 +178,13 @@ impl DataViewConstructor {
     }}
 }
 
-impl HeapItem for HeapPtr<DataViewObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for DataViewObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<DataViewObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.viewed_array_buffer);
+    fn visit_pointers(mut data_view_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        data_view_object.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut data_view_object.viewed_array_buffer);
     }
 }

--- a/src/js/runtime/intrinsics/date_object.rs
+++ b/src/js/runtime/intrinsics/date_object.rs
@@ -4,8 +4,10 @@ use crate::{
     common::math::modulo,
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, gc::HeapItem, heap_item_descriptor::HeapItemKind,
-        intrinsics::intrinsics::Intrinsic, object_value::ObjectValue,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        gc::{HeapItem, HeapVisitor},
+        intrinsics::intrinsics::Intrinsic,
+        object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
         type_utilities::to_integer_or_infinity_f64,
     },
@@ -375,12 +377,12 @@ pub fn time_clip(time: f64) -> f64 {
     to_integer_or_infinity_f64(time)
 }
 
-impl HeapItem for HeapPtr<DateObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for DateObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<DateObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl crate::runtime::gc::HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(date_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        date_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/error_constructor.rs
+++ b/src/js/runtime/intrinsics/error_constructor.rs
@@ -4,12 +4,11 @@ use crate::{
     common::error::SourceInfo,
     extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         abstract_operations::{create_non_enumerable_data_property_or_throw, get, has_property},
         alloc_error::AllocResult,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
@@ -257,15 +256,15 @@ pub fn new_heap_source_info(
     Ok(Some(SourceInfo::new(name, line, col, snippet)))
 }
 
-impl HeapItem for HeapPtr<ErrorObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for ErrorObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<ErrorObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(mut error_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        error_object.visit_object_pointers(visitor);
 
-        match &mut self.stack_trace_state {
+        match &mut error_object.stack_trace_state {
             StackTraceState::Uninitialized => {}
             StackTraceState::StackFrameInfo(stack_frame_info) => {
                 visitor.visit_pointer(stack_frame_info);

--- a/src/js/runtime/intrinsics/finalization_registry_object.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_object.rs
@@ -3,12 +3,12 @@ use std::{mem::size_of, slice};
 use crate::{
     extend_object, field_offset,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::InlineArray,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -211,30 +211,36 @@ impl FinalizationRegistryCells {
     }
 }
 
-impl HeapItem for HeapPtr<FinalizationRegistryObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for FinalizationRegistryObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<FinalizationRegistryObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.cells);
-        visitor.visit_pointer(&mut self.cleanup_callback);
+    fn visit_pointers(
+        mut finalization_registry_object: HeapPtr<Self>,
+        visitor: &mut impl HeapVisitor,
+    ) {
+        finalization_registry_object.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut finalization_registry_object.cells);
+        visitor.visit_pointer(&mut finalization_registry_object.cleanup_callback);
 
         // Intentionally do not visit next_finalization_registry
     }
 }
 
-impl HeapItem for HeapPtr<FinalizationRegistryCells> {
-    fn byte_size(&self) -> usize {
-        FinalizationRegistryCells::calculate_size_in_bytes(self.capacity())
+impl HeapItem for FinalizationRegistryCells {
+    fn byte_size(finalization_registry_cells: HeapPtr<Self>) -> usize {
+        FinalizationRegistryCells::calculate_size_in_bytes(finalization_registry_cells.capacity())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
+    fn visit_pointers(
+        mut finalization_registry_cells: HeapPtr<Self>,
+        visitor: &mut impl HeapVisitor,
+    ) {
+        visitor.visit_pointer(&mut finalization_registry_cells.descriptor);
 
-        for i in 0..self.num_cells_used() {
-            if let Some(cell) = self.cells.get_unchecked_mut(i) {
+        for i in 0..finalization_registry_cells.num_cells_used() {
+            if let Some(cell) = finalization_registry_cells.cells.get_unchecked_mut(i) {
                 visitor.visit_value(&mut cell.held_value);
 
                 visitor.visit_weak_value(&mut cell.target);

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     intrinsic_methods, must,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         abstract_operations::{
             call_object, create_list_from_array_like_arguments, has_own_property,
             ordinary_has_instance,
@@ -13,7 +13,6 @@ use crate::{
         eval_result::EvalResult,
         function::{set_function_length_maybe_infinity, set_function_name},
         get,
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,

--- a/src/js/runtime/intrinsics/generator_prototype.rs
+++ b/src/js/runtime/intrinsics/generator_prototype.rs
@@ -1,13 +1,12 @@
 use crate::{
     intrinsic_methods,
     runtime::{
-        Context, Handle, PropertyDescriptor,
+        Context, Handle, HeapItemKind, PropertyDescriptor,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         bytecode::function::Closure,
         eval_result::EvalResult,
         generator_object::{GeneratorCompletionType, generator_resume, generator_resume_abrupt},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,

--- a/src/js/runtime/intrinsics/intrinsics.rs
+++ b/src/js/runtime/intrinsics/intrinsics.rs
@@ -1,7 +1,7 @@
 use crate::{
     handle_scope, handle_scope_guard, must_a,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -10,7 +10,6 @@ use crate::{
         gc::HeapVisitor,
         get,
         global_names::create_global_declaration_instantiation_intrinsic,
-        heap_item_descriptor::HeapItemKind,
         intrinsics::{
             aggregate_error_constructor::AggregateErrorConstructor,
             aggregate_error_prototype::AggregateErrorPrototype,

--- a/src/js/runtime/intrinsics/iterator_constructor.rs
+++ b/src/js/runtime/intrinsics/iterator_constructor.rs
@@ -1,14 +1,13 @@
 use crate::{
     extend_object, intrinsic_methods,
     runtime::{
-        Context, HeapPtr, Value,
+        Context, HeapItemKind, HeapPtr, Value,
         abstract_operations::{call, call_object, get_method, ordinary_has_instance},
         alloc_error::AllocResult,
         collections::array::ValueArray,
         error::type_error,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic, iterator_helper_object::IteratorHelperObject,
@@ -146,15 +145,15 @@ impl WrappedValidIterator {
     }
 }
 
-impl HeapItem for HeapPtr<WrappedValidIterator> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for WrappedValidIterator {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<WrappedValidIterator>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.iterator);
-        visitor.visit_value(&mut self.next_method);
+    fn visit_pointers(mut wrapped_valid_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        wrapped_valid_iterator.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut wrapped_valid_iterator.iterator);
+        visitor.visit_value(&mut wrapped_valid_iterator.next_method);
     }
 }
 

--- a/src/js/runtime/intrinsics/iterator_helper_object.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_object.rs
@@ -3,14 +3,13 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
         abstract_operations::{call, call_object},
         alloc_error::AllocResult,
         collections::array::ValueArray,
         error::type_error,
         gc::{HeapItem, HeapVisitor},
         generator_object::GeneratorState,
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         iterator::{
             HeapIterator, Iterator, create_iter_result_object, get_iterator_direct,
@@ -635,19 +634,19 @@ impl Handle<IteratorHelperObject> {
     }
 }
 
-impl HeapItem for HeapPtr<IteratorHelperObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for IteratorHelperObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<IteratorHelperObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(mut iterator_helper_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        iterator_helper_object.visit_object_pointers(visitor);
 
-        if let Some(iterator) = &mut self.iterator {
+        if let Some(iterator) = &mut iterator_helper_object.iterator {
             iterator.visit_pointers(visitor);
         }
 
-        match &mut self.state {
+        match &mut iterator_helper_object.state {
             IteratorHelperState::Filter(helper) => visitor.visit_pointer(&mut helper.predicate),
             IteratorHelperState::Map(helper) => visitor.visit_pointer(&mut helper.mapper),
             IteratorHelperState::FlatMap(helper) => {

--- a/src/js/runtime/intrinsics/map_iterator.rs
+++ b/src/js/runtime/intrinsics/map_iterator.rs
@@ -3,14 +3,13 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapPtr,
+        Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         collections::index_map::{GcSafeEntriesIter, IndexMapInstance},
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
@@ -155,13 +154,13 @@ impl MapIteratorPrototype {
     }}
 }
 
-impl HeapItem for HeapPtr<MapIterator> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for MapIterator {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<MapIterator>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.map);
+    fn visit_pointers(mut map_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        map_iterator.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut map_iterator.map);
     }
 }

--- a/src/js/runtime/intrinsics/map_object.rs
+++ b/src/js/runtime/intrinsics/map_object.rs
@@ -3,11 +3,10 @@ use std::mem::size_of;
 use crate::{
     extend_object, impl_index_map_instance,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::{BsIndexMap, BsIndexMapField, index_map::IndexMapInstance},
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -74,13 +73,13 @@ impl Handle<MapObject> {
 
 impl_index_map_instance!(ValueIndexMap, ValueCollectionKey, Value);
 
-impl ValueIndexMap {
-    pub fn byte_size(map: HeapPtr<ValueIndexMap>) -> usize {
+impl HeapItem for ValueIndexMap {
+    fn byte_size(map: HeapPtr<ValueIndexMap>) -> usize {
         ValueIndexMap::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(map: &mut HeapPtr<ValueIndexMap>, visitor: &mut impl HeapVisitor) {
-        ValueIndexMap::visit_pointers_impl(*map, visitor, |mut map, visitor| {
+    fn visit_pointers(map: HeapPtr<ValueIndexMap>, visitor: &mut impl HeapVisitor) {
+        ValueIndexMap::visit_pointers_impl(map, visitor, |mut map, visitor| {
             for (key, value) in map.iter_mut_gc_unsafe() {
                 key.visit_pointers(visitor);
                 visitor.visit_value(value);
@@ -103,13 +102,13 @@ impl BsIndexMapField<ValueIndexMap> for MapObjectMapField {
     }
 }
 
-impl HeapItem for HeapPtr<MapObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for MapObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<MapObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.map_data);
+    fn visit_pointers(mut map_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        map_object.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut map_object.map_data);
     }
 }

--- a/src/js/runtime/intrinsics/number_constructor.rs
+++ b/src/js/runtime/intrinsics/number_constructor.rs
@@ -6,11 +6,10 @@ use crate::{
     common::numeric::{MAX_SAFE_INTEGER_F64, MIN_POSITIVE_SUBNORMAL_F64, MIN_SAFE_INTEGER_F64},
     extend_object, intrinsic_methods,
     runtime::{
-        Context, HeapPtr,
+        Context, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
@@ -189,12 +188,12 @@ impl NumberConstructor {
     }}
 }
 
-impl HeapItem for HeapPtr<NumberObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for NumberObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<NumberObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(number_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        number_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/object_constructor.rs
+++ b/src/js/runtime/intrinsics/object_constructor.rs
@@ -1,7 +1,7 @@
 use crate::{
     intrinsic_methods, must,
     runtime::{
-        Context, Handle, Value,
+        Context, Handle, HeapItemKind, Value,
         abstract_operations::{
             GroupByKeyCoercion, IntegrityLevel, KeyOrValue, create_data_property_or_throw,
             define_property_or_throw, enumerable_own_property_names, get, group_by,
@@ -11,7 +11,6 @@ use crate::{
         array_object::create_array_from_list,
         error::type_error,
         eval_result::EvalResult,
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic, map_constructor::add_entries_from_iterable,

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -3,12 +3,11 @@ use std::mem::size_of;
 use crate::{
     extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapPtr,
+        Context, Handle, HeapItemKind, HeapPtr,
         abstract_operations::{define_property_or_throw, get, has_own_property, invoke},
         alloc_error::AllocResult,
         error::type_error,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::rust_runtime::RuntimeFunction,
         object_value::ObjectValue,
@@ -320,12 +319,12 @@ impl ObjectPrototype {
     }}
 }
 
-impl HeapItem for HeapPtr<ObjectPrototype> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for ObjectPrototype {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<ObjectPrototype>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(object_prototype: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        object_prototype.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/raw_json_object.rs
+++ b/src/js/runtime/intrinsics/raw_json_object.rs
@@ -3,11 +3,10 @@ use std::mem::size_of;
 use crate::{
     extend_object, must_a,
     runtime::{
-        Context, HeapPtr,
+        Context, HeapItemKind, HeapPtr,
         abstract_operations::{IntegrityLevel, create_data_property_or_throw, set_integrity_level},
         alloc_error::AllocResult,
         gc::{Handle, HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         ordinary_object::object_create_with_optional_proto,
         string_value::StringValue,
     },
@@ -39,12 +38,12 @@ impl RawJSONObject {
     }
 }
 
-impl HeapItem for HeapPtr<RawJSONObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for RawJSONObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<RawJSONObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(raw_json_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        raw_json_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -23,14 +23,13 @@ use crate::{
         regexp_parser::RegExpParser,
     },
     runtime::{
-        Context, HeapPtr, PropertyDescriptor, Value,
+        Context, HeapItemKind, HeapPtr, PropertyDescriptor, Value,
         abstract_operations::{define_property_or_throw, set},
         alloc_error::AllocResult,
         error::{syntax_parse_error, type_error},
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
         get,
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
@@ -508,13 +507,13 @@ fn escape_pattern_string(
     Ok(cx.alloc_wtf8_string(&escaped_string)?.as_string())
 }
 
-impl HeapItem for HeapPtr<RegExpObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for RegExpObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<RegExpObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.compiled_regexp);
+    fn visit_pointers(mut regexp_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        regexp_object.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut regexp_object.compiled_regexp);
     }
 }

--- a/src/js/runtime/intrinsics/regexp_string_iterator.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator.rs
@@ -3,14 +3,13 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapPtr, PropertyKey, Value,
+        Context, Handle, HeapItemKind, HeapPtr, PropertyKey, Value,
         abstract_operations::set,
         alloc_error::AllocResult,
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         get,
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
@@ -146,14 +145,14 @@ impl RegExpStringIteratorPrototype {
     }}
 }
 
-impl HeapItem for HeapPtr<RegExpStringIterator> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for RegExpStringIterator {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<RegExpStringIterator>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.regexp_object);
-        visitor.visit_pointer(&mut self.target_string);
+    fn visit_pointers(mut regexp_string_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        regexp_string_iterator.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut regexp_string_iterator.regexp_object);
+        visitor.visit_pointer(&mut regexp_string_iterator.target_string);
     }
 }

--- a/src/js/runtime/intrinsics/set_iterator.rs
+++ b/src/js/runtime/intrinsics/set_iterator.rs
@@ -3,14 +3,13 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         collections::{BsIndexMap, IndexSetInstance, index_map::GcSafeEntriesIter},
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
@@ -153,13 +152,13 @@ impl SetIteratorPrototype {
     }}
 }
 
-impl HeapItem for HeapPtr<SetIterator> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for SetIterator {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<SetIterator>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.set);
+    fn visit_pointers(mut set_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        set_iterator.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut set_iterator.set);
     }
 }

--- a/src/js/runtime/intrinsics/set_object.rs
+++ b/src/js/runtime/intrinsics/set_object.rs
@@ -3,11 +3,10 @@ use std::mem::size_of;
 use crate::{
     extend_object, impl_index_set_instance,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::{BsIndexSet, BsIndexSetField, IndexSetInstance},
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::{object_create, object_create_from_constructor},
@@ -89,13 +88,13 @@ impl Handle<SetObject> {
 
 impl_index_set_instance!(ValueIndexSet, ValueCollectionKey);
 
-impl ValueIndexSet {
-    pub fn byte_size(set: HeapPtr<ValueIndexSet>) -> usize {
+impl HeapItem for ValueIndexSet {
+    fn byte_size(set: HeapPtr<ValueIndexSet>) -> usize {
         ValueIndexSet::calculate_size_in_bytes(set.capacity())
     }
 
-    pub fn visit_pointers(set: &mut HeapPtr<ValueIndexSet>, visitor: &mut impl HeapVisitor) {
-        ValueIndexSet::visit_pointers_impl(*set, visitor, |mut set, visitor| {
+    fn visit_pointers(set: HeapPtr<ValueIndexSet>, visitor: &mut impl HeapVisitor) {
+        ValueIndexSet::visit_pointers_impl(set, visitor, |mut set, visitor| {
             for element in set.iter_mut_gc_unsafe() {
                 element.visit_pointers(visitor);
             }
@@ -118,13 +117,13 @@ impl BsIndexSetField<ValueIndexSet> for SetObjectSetField {
     }
 }
 
-impl HeapItem for HeapPtr<SetObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for SetObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<SetObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.set_data);
+    fn visit_pointers(mut set_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        set_object.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut set_object.set_data);
     }
 }

--- a/src/js/runtime/intrinsics/string_iterator.rs
+++ b/src/js/runtime/intrinsics/string_iterator.rs
@@ -3,12 +3,11 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::intrinsics::Intrinsic,
         iterator::create_iter_result_object,
@@ -81,13 +80,13 @@ impl StringIteratorPrototype {
     }}
 }
 
-impl HeapItem for HeapPtr<StringIterator> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for StringIterator {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<StringIterator>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        self.iter.visit_pointers(visitor);
+    fn visit_pointers(mut string_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        string_iterator.visit_object_pointers(visitor);
+        string_iterator.iter.visit_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/symbol_constructor.rs
+++ b/src/js/runtime/intrinsics/symbol_constructor.rs
@@ -3,12 +3,11 @@ use std::mem::size_of;
 use crate::{
     extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapPtr,
+        Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         collections::hash_map::BsHashMapField,
         error::type_error,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
@@ -146,13 +145,13 @@ impl SymbolConstructor {
     }}
 }
 
-impl HeapItem for HeapPtr<SymbolObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for SymbolObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<SymbolObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.symbol_data);
+    fn visit_pointers(mut symbol_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        symbol_object.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut symbol_object.symbol_data);
     }
 }

--- a/src/js/runtime/intrinsics/temporal/duration_object.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_object.rs
@@ -3,9 +3,8 @@ use temporal_rs::Duration;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         gc::{HeapItem, HeapUnaligned, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -50,12 +49,12 @@ impl DurationObject {
     }
 }
 
-impl HeapItem for HeapPtr<DurationObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for DurationObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<DurationObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(duration_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        duration_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/temporal/instant_object.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_object.rs
@@ -3,9 +3,8 @@ use temporal_rs::Instant;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         gc::{HeapItem, HeapUnaligned, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -50,12 +49,12 @@ impl InstantObject {
     }
 }
 
-impl HeapItem for HeapPtr<InstantObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for InstantObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<InstantObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(instant_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        instant_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/temporal/plain_date_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_object.rs
@@ -3,9 +3,8 @@ use temporal_rs::PlainDate;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -48,12 +47,12 @@ impl PlainDateObject {
     }
 }
 
-impl HeapItem for HeapPtr<PlainDateObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for PlainDateObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<PlainDateObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(plain_date_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        plain_date_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_object.rs
@@ -3,9 +3,8 @@ use temporal_rs::PlainDateTime;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -48,12 +47,12 @@ impl PlainDateTimeObject {
     }
 }
 
-impl HeapItem for HeapPtr<PlainDateTimeObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for PlainDateTimeObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<PlainDateTimeObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(plain_date_time_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        plain_date_time_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_object.rs
@@ -3,9 +3,8 @@ use temporal_rs::PlainMonthDay;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -48,12 +47,12 @@ impl PlainMonthDayObject {
     }
 }
 
-impl HeapItem for HeapPtr<PlainMonthDayObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for PlainMonthDayObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<PlainMonthDayObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(plain_month_day_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        plain_month_day_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/temporal/plain_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_object.rs
@@ -3,9 +3,8 @@ use temporal_rs::PlainTime;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -48,12 +47,12 @@ impl PlainTimeObject {
     }
 }
 
-impl HeapItem for HeapPtr<PlainTimeObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for PlainTimeObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<PlainTimeObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(plain_time_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        plain_time_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_object.rs
@@ -3,9 +3,8 @@ use temporal_rs::PlainYearMonth;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -51,12 +50,12 @@ impl PlainYearMonthObject {
     }
 }
 
-impl HeapItem for HeapPtr<PlainYearMonthObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for PlainYearMonthObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<PlainYearMonthObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(plain_year_month_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        plain_year_month_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
@@ -3,9 +3,8 @@ use temporal_rs::ZonedDateTime;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         gc::{HeapItem, HeapUnaligned, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -53,12 +52,12 @@ impl ZonedDateTimeObject {
     }
 }
 
-impl HeapItem for HeapPtr<ZonedDateTimeObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for ZonedDateTimeObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<ZonedDateTimeObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(zoned_date_time_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        zoned_date_time_object.visit_object_pointers(visitor);
     }
 }

--- a/src/js/runtime/intrinsics/typed_array.rs
+++ b/src/js/runtime/intrinsics/typed_array.rs
@@ -8,13 +8,12 @@ use crate::{
     common::math::f64_to_f16,
     create_typed_array_constructor, create_typed_array_prototype, extend_object, heap_trait_object,
     runtime::{
-        Context, Handle, HeapPtr,
+        Context, Handle, HeapItemKind, HeapPtr,
         abstract_operations::{get, get_method, length_of_array_like, set},
         alloc_error::AllocResult,
         error::{range_error, type_error},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             array_buffer_constructor::{ArrayBufferObject, clone_array_buffer},

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -1072,14 +1072,14 @@ macro_rules! create_typed_array_constructor {
             }
         }
 
-        impl HeapItem for HeapPtr<$typed_array> {
-            fn byte_size(&self) -> usize {
+        impl HeapItem for $typed_array {
+            fn byte_size(_: HeapPtr<Self>) -> usize {
                 size_of::<$typed_array>()
             }
 
-            fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-                self.visit_object_pointers(visitor);
-                visitor.visit_pointer(&mut self.viewed_array_buffer);
+            fn visit_pointers(mut typed_array: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+                typed_array.visit_object_pointers(visitor);
+                visitor.visit_pointer(&mut typed_array.viewed_array_buffer);
             }
         }
     };

--- a/src/js/runtime/intrinsics/weak_map_object.rs
+++ b/src/js/runtime/intrinsics/weak_map_object.rs
@@ -3,12 +3,11 @@ use std::mem::size_of;
 use crate::{
     extend_object, impl_hash_map_instance,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::{HashMapInstance, hash_map::BsHashMapField},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -97,26 +96,26 @@ impl BsHashMapField<WeakValueMap> for WeakMapObjectMapField {
     }
 }
 
-impl HeapItem for HeapPtr<WeakMapObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for WeakMapObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<WeakMapObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.weak_map_data);
+    fn visit_pointers(mut weak_map_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        weak_map_object.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut weak_map_object.weak_map_data);
 
         // Intentionally do not visit next_weak_map
     }
 }
 
-impl WeakValueMap {
-    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+impl HeapItem for WeakValueMap {
+    fn byte_size(map: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(map: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        map.visit_pointers(visitor);
+    fn visit_pointers(mut map: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        map.visit_map_pointers(visitor);
 
         for (key, value) in map.iter_mut_gc_unsafe() {
             visitor.visit_weak_value(key.value_mut());

--- a/src/js/runtime/intrinsics/weak_ref_constructor.rs
+++ b/src/js/runtime/intrinsics/weak_ref_constructor.rs
@@ -3,12 +3,11 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
@@ -120,14 +119,14 @@ pub fn can_be_held_weakly(cx: Context, value: Value) -> bool {
     }
 }
 
-impl HeapItem for HeapPtr<WeakRefObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for WeakRefObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<WeakRefObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_weak_value(&mut self.weak_ref_target);
+    fn visit_pointers(mut weak_ref_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        weak_ref_object.visit_object_pointers(visitor);
+        visitor.visit_weak_value(&mut weak_ref_object.weak_ref_target);
 
         // Intentionally do not visit next_weak_ref
     }

--- a/src/js/runtime/intrinsics/weak_set_object.rs
+++ b/src/js/runtime/intrinsics/weak_set_object.rs
@@ -3,12 +3,11 @@ use std::mem::size_of;
 use crate::{
     extend_object, impl_hash_set_instance,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::{BsHashSetField, HashSetInstance},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
@@ -92,26 +91,26 @@ impl BsHashSetField<WeakValueSet> for WeakSetObjectSetField {
     }
 }
 
-impl HeapItem for HeapPtr<WeakSetObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for WeakSetObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<WeakSetObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.weak_set_data);
+    fn visit_pointers(mut weak_set_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        weak_set_object.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut weak_set_object.weak_set_data);
 
         // Intentionally do not visit next_weak_set
     }
 }
 
-impl WeakValueSet {
-    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+impl HeapItem for WeakValueSet {
+    fn byte_size(map: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(set: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        set.visit_pointers(visitor);
+    fn visit_pointers(mut set: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        set.visit_set_pointers(visitor);
 
         for value in set.iter_mut_gc_unsafe() {
             visitor.visit_weak_value(value.value_mut());

--- a/src/js/runtime/mod.rs
+++ b/src/js/runtime/mod.rs
@@ -62,7 +62,7 @@ pub use console::to_console_string;
 pub use context::{Context, ContextBuilder};
 pub use error::BsResult;
 pub use eval_result::EvalResult;
-pub use gc::{Handle, HeapPtr};
+pub use gc::{Handle, HeapItemKind, HeapPtr};
 pub use intrinsics::rust_runtime::Arguments;
 pub use property_descriptor::PropertyDescriptor;
 pub use property_key::PropertyKey;

--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -3,14 +3,13 @@ use std::{collections::HashMap, path::Path};
 use crate::{
     completion_value, eval_err, if_abrupt_reject_promise, must, must_a,
     runtime::{
-        Context, EvalResult, Handle, PropertyKey, Value,
+        Context, EvalResult, Handle, HeapItemKind, PropertyKey, Value,
         abstract_operations::{KeyOrValue, call_object, enumerable_own_property_names},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         context::ModuleCacheKey,
         error::type_error_value,
         get,
-        heap_item_descriptor::HeapItemKind,
         interned_strings::InternedStrings,
         intrinsics::{
             intrinsics::Intrinsic, promise_prototype::perform_promise_then,
@@ -110,7 +109,7 @@ fn set_dyn_module(
     mut function: Handle<ObjectValue>,
     value: DynModule,
 ) -> AllocResult<()> {
-    function.private_element_set(cx, cx.symbols.module().cast(), value.as_heap_item().into())
+    function.private_element_set(cx, cx.symbols.module().cast(), value.as_any().into())
 }
 
 fn get_capability(cx: Context, function: Handle<ObjectValue>) -> Handle<PromiseCapability> {

--- a/src/js/runtime/module/import_attributes.rs
+++ b/src/js/runtime/module/import_attributes.rs
@@ -1,11 +1,11 @@
 use crate::{
     field_offset,
     runtime::{
-        Context, Handle, HeapPtr,
+        Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         collections::InlineArray,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         string_value::FlatString,
     },
     set_uninit,
@@ -79,15 +79,15 @@ impl PartialEq for HeapPtr<ImportAttributes> {
 
 impl Eq for HeapPtr<ImportAttributes> {}
 
-impl HeapItem for HeapPtr<ImportAttributes> {
-    fn byte_size(&self) -> usize {
-        ImportAttributes::calculate_size_in_bytes(self.attribute_pairs.len())
+impl HeapItem for ImportAttributes {
+    fn byte_size(import_attributes: HeapPtr<Self>) -> usize {
+        ImportAttributes::calculate_size_in_bytes(import_attributes.attribute_pairs.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
+    fn visit_pointers(mut import_attributes: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut import_attributes.descriptor);
 
-        for entry in self.attribute_pairs.as_mut_slice() {
+        for entry in import_attributes.attribute_pairs.as_mut_slice() {
             visitor.visit_pointer(entry);
         }
     }

--- a/src/js/runtime/module/linker.rs
+++ b/src/js/runtime/module/linker.rs
@@ -165,7 +165,7 @@ fn initialize_environment(cx: Context, module: Handle<SourceTextModule>) -> Eval
                     } => {
                         module
                             .module_scope_ptr()
-                            .set_heap_item_slot(entry.slot_index, boxed_value.as_heap_item());
+                            .set_heap_item_slot(entry.slot_index, boxed_value.as_any());
                     }
                     // Namespace object may be stored as a module or scope value
                     ResolveExportResult::Resolved {
@@ -182,7 +182,7 @@ fn initialize_environment(cx: Context, module: Handle<SourceTextModule>) -> Eval
                         let boxed_value = BoxedValue::new(cx, namespace_object.into())?;
                         module
                             .module_scope_ptr()
-                            .set_heap_item_slot(entry.slot_index, boxed_value.as_heap_item());
+                            .set_heap_item_slot(entry.slot_index, boxed_value.as_any());
                     }
                     _ => return syntax_error(cx, "could not resolve module specifier"),
                 }

--- a/src/js/runtime/module/module.rs
+++ b/src/js/runtime/module/module.rs
@@ -75,7 +75,7 @@ pub enum ResolveExportName {
 heap_trait_object!(Module, DynModule, HeapDynModule, into_dyn_module, extract_module_vtable);
 
 impl DynModule {
-    pub fn as_heap_item(self) -> Handle<AnyHeapItem> {
+    pub fn as_any(self) -> Handle<AnyHeapItem> {
         self.data.cast()
     }
 }

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -3,12 +3,11 @@ use brimstone_macros::wrap_ordinary_object;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, PropertyDescriptor, PropertyKey, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyDescriptor, PropertyKey, Value,
         alloc_error::AllocResult,
         boxed_value::BoxedValue,
         error::reference_error,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         module::{
             module::{DynModule, HeapDynModule, Module, ModuleEnum},
             source_text_module::SourceTextModule,
@@ -311,13 +310,13 @@ impl VirtualObject for Handle<ModuleNamespaceObject> {
     }
 }
 
-impl HeapItem for HeapPtr<ModuleNamespaceObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for ModuleNamespaceObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<ModuleNamespaceObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        self.module.visit_pointers(visitor);
+    fn visit_pointers(mut module_namespace_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        module_namespace_object.visit_object_pointers(visitor);
+        module_namespace_object.module.visit_pointers(visitor);
     }
 }

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -5,7 +5,7 @@ use indexmap_allocator_api::IndexSet;
 use crate::{
     field_offset, handle_scope, impl_array_instance, impl_hash_map_instance, impl_vec_instance,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, PropertyKey, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyKey, Value,
         alloc_error::AllocResult,
         bytecode::function::BytecodeFunction,
         collections::{
@@ -13,7 +13,7 @@ use crate::{
             hash_map::BsHashMapField,
         },
         gc::{AnyHeapItem, HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         module::{
             execute::module_evaluate,
             import_attributes::ImportAttributes,
@@ -651,11 +651,11 @@ impl Module for Handle<SourceTextModule> {
                 if let ResolveExportResult::Resolved { name, module } = result {
                     match name {
                         ResolveExportName::Local { boxed_value, .. } => {
-                            boxed_value_or_module_handle.replace(boxed_value.as_heap_item());
+                            boxed_value_or_module_handle.replace(boxed_value.as_any());
                             self.insert_export(cx, key_handle, boxed_value_or_module_handle)?;
                         }
                         ResolveExportName::Namespace => {
-                            boxed_value_or_module_handle.replace(*module.as_heap_item());
+                            boxed_value_or_module_handle.replace(*module.as_any());
                             self.insert_export(cx, key_handle, boxed_value_or_module_handle)?;
                         }
                     }
@@ -673,30 +673,30 @@ impl Module for Handle<SourceTextModule> {
     }
 }
 
-impl HeapItem for HeapPtr<SourceTextModule> {
-    fn byte_size(&self) -> usize {
-        SourceTextModule::calculate_size_in_bytes(self.entries.len())
+impl HeapItem for SourceTextModule {
+    fn byte_size(source_text_module: HeapPtr<Self>) -> usize {
+        SourceTextModule::calculate_size_in_bytes(source_text_module.entries.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer(&mut self.program_function);
-        visitor.visit_pointer(&mut self.module_scope);
-        visitor.visit_pointer_opt(&mut self.import_meta);
-        visitor.visit_pointer_opt(&mut self.namespace_object);
-        visitor.visit_pointer_opt(&mut self.exports);
-        visitor.visit_pointer(&mut self.requested_modules);
-        visitor.visit_pointer(&mut self.loaded_modules);
-        visitor.visit_pointer_opt(&mut self.cycle_root);
-        visitor.visit_pointer_opt(&mut self.top_level_capability);
+    fn visit_pointers(mut source_text_module: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut source_text_module.descriptor);
+        visitor.visit_pointer(&mut source_text_module.program_function);
+        visitor.visit_pointer(&mut source_text_module.module_scope);
+        visitor.visit_pointer_opt(&mut source_text_module.import_meta);
+        visitor.visit_pointer_opt(&mut source_text_module.namespace_object);
+        visitor.visit_pointer_opt(&mut source_text_module.exports);
+        visitor.visit_pointer(&mut source_text_module.requested_modules);
+        visitor.visit_pointer(&mut source_text_module.loaded_modules);
+        visitor.visit_pointer_opt(&mut source_text_module.cycle_root);
+        visitor.visit_pointer_opt(&mut source_text_module.top_level_capability);
 
-        if let Some(error) = self.evaluation_error.as_mut() {
+        if let Some(error) = source_text_module.evaluation_error.as_mut() {
             visitor.visit_value(error);
         }
 
-        visitor.visit_pointer_opt(&mut self.async_parent_modules);
+        visitor.visit_pointer_opt(&mut source_text_module.async_parent_modules);
 
-        for entry in self.entries.as_mut_slice() {
+        for entry in source_text_module.entries.as_mut_slice() {
             match entry {
                 ModuleEntry::Import(import_entry) => {
                     import_entry.module_request.visit_pointers(visitor);
@@ -910,13 +910,13 @@ impl DirectReExportEntry {
 
 impl_array_instance!(ModuleRequestArray, HeapModuleRequest);
 
-impl ModuleRequestArray {
-    pub fn byte_size(array: HeapPtr<Self>) -> usize {
+impl HeapItem for ModuleRequestArray {
+    fn byte_size(array: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(array.len())
     }
 
-    pub fn visit_pointers(array: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        array.visit_pointers(visitor);
+    fn visit_pointers(mut array: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array.visit_array_pointers(visitor);
 
         for module_request in array.as_mut_slice() {
             module_request.visit_pointers(visitor);
@@ -926,13 +926,13 @@ impl ModuleRequestArray {
 
 impl_array_instance!(ModuleOptionArray, Option<HeapDynModule>);
 
-impl ModuleOptionArray {
-    pub fn byte_size(array: HeapPtr<Self>) -> usize {
+impl HeapItem for ModuleOptionArray {
+    fn byte_size(array: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(array.len())
     }
 
-    pub fn visit_pointers(array: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        array.visit_pointers(visitor);
+    fn visit_pointers(mut array: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array.visit_array_pointers(visitor);
 
         for module in array.as_mut_slice().iter_mut().flatten() {
             module.visit_pointers(visitor);
@@ -960,13 +960,13 @@ impl BsHashMapField<ExportMap> for ExportMapField {
     }
 }
 
-impl ExportMap {
-    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+impl HeapItem for ExportMap {
+    fn byte_size(map: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(map: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        map.visit_pointers(visitor);
+    fn visit_pointers(mut map: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        map.visit_map_pointers(visitor);
 
         for (key, value) in map.iter_mut_gc_unsafe() {
             visitor.visit_property_key(key);
@@ -977,13 +977,13 @@ impl ExportMap {
 
 impl_vec_instance!(SourceTextModuleVec, HeapPtr<SourceTextModule>);
 
-impl SourceTextModuleVec {
-    pub fn byte_size(vec: HeapPtr<Self>) -> usize {
+impl HeapItem for SourceTextModuleVec {
+    fn byte_size(vec: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(vec.capacity())
     }
 
-    pub fn visit_pointers(vec: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        vec.visit_pointers(visitor);
+    fn visit_pointers(mut vec: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        vec.visit_vec_pointers(visitor);
 
         for function in vec.as_mut_slice() {
             visitor.visit_pointer(function);

--- a/src/js/runtime/module/synthetic_module.rs
+++ b/src/js/runtime/module/synthetic_module.rs
@@ -3,12 +3,12 @@ use std::collections::HashSet;
 use crate::{
     completion_value, must_a,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, Realm, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Realm, Value,
         abstract_operations::call_object,
         alloc_error::AllocResult,
         boxed_value::BoxedValue,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         interned_strings::InternedStrings,
         intrinsics::intrinsics::Intrinsic,
         module::{
@@ -67,7 +67,7 @@ impl SyntheticModule {
         // Initialize all scope entries to undefined
         for i in 0..scope_names.len() {
             let boxed_value = BoxedValue::new(cx, cx.undefined())?;
-            module_scope.set_heap_item_slot(i, boxed_value.as_heap_item());
+            module_scope.set_heap_item_slot(i, boxed_value.as_any());
         }
 
         let mut module = cx.alloc_uninit::<SyntheticModule>()?;
@@ -221,19 +221,19 @@ impl Module for Handle<SyntheticModule> {
     }
 }
 
-impl HeapItem for HeapPtr<SyntheticModule> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for SyntheticModule {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         SyntheticModule::calculate_size_in_bytes()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
+    fn visit_pointers(mut synthetic_module: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut synthetic_module.descriptor);
 
-        match &mut self.kind {
+        match &mut synthetic_module.kind {
             SyntheticModuleKind::DefaultExport(value) => visitor.visit_value(value),
         }
 
-        visitor.visit_pointer(&mut self.module_scope);
-        visitor.visit_pointer_opt(&mut self.namespace_object);
+        visitor.visit_pointer(&mut synthetic_module.module_scope);
+        visitor.visit_pointer_opt(&mut synthetic_module.namespace_object);
     }
 }

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 use crate::{
     impl_index_map_instance,
     runtime::{
-        Context, Realm,
+        Context, HeapItemKind, Realm,
         alloc_error::AllocResult,
         array_object::ArrayObject,
         array_properties::ArrayProperties,
@@ -19,7 +19,6 @@ use crate::{
         eval_result::EvalResult,
         gc::{Handle, HeapInfo, HeapItem, HeapPtr, HeapVisitor},
         generator_object::GeneratorObject,
-        heap_item_descriptor::HeapItemKind,
         intrinsics::{
             array_buffer_constructor::ArrayBufferObject,
             bigint_constructor::BigIntObject,
@@ -176,8 +175,7 @@ macro_rules! extend_object {
         impl $(<$($generics),*>)? $crate::runtime::HeapPtr<$name $(<$($generics),*>)?> {
             #[inline]
             pub fn visit_object_pointers(&self, visitor: &mut impl $crate::runtime::gc::HeapVisitor) {
-                use $crate::runtime::gc::HeapItem;
-                self.as_object().visit_pointers(visitor);
+                $crate::runtime::object_value::ObjectValue::visit_pointers(self.as_object(), visitor);
             }
         }
     }
@@ -659,13 +657,13 @@ pub trait VirtualObject {
 
 impl_index_map_instance!(NamedPropertiesMap, PropertyKey, HeapProperty);
 
-impl NamedPropertiesMap {
-    pub fn byte_size(map: HeapPtr<NamedPropertiesMap>) -> usize {
+impl HeapItem for NamedPropertiesMap {
+    fn byte_size(map: HeapPtr<NamedPropertiesMap>) -> usize {
         NamedPropertiesMap::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(map: &mut HeapPtr<NamedPropertiesMap>, visitor: &mut impl HeapVisitor) {
-        NamedPropertiesMap::visit_pointers_impl(*map, visitor, |mut map, visitor| {
+    fn visit_pointers(map: HeapPtr<NamedPropertiesMap>, visitor: &mut impl HeapVisitor) {
+        NamedPropertiesMap::visit_pointers_impl(map, visitor, |mut map, visitor| {
             for (property_key, property) in map.iter_mut_gc_unsafe() {
                 visitor.visit_property_key(property_key);
                 property.visit_pointers(visitor);
@@ -700,16 +698,16 @@ struct ObjectTraitObject {
     vtable: *const (),
 }
 
-impl HeapItem for HeapPtr<ObjectValue> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for ObjectValue {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<ObjectValue>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer_opt(&mut self.prototype);
-        visitor.visit_pointer(&mut self.named_properties);
-        visitor.visit_pointer(&mut self.array_properties);
+    fn visit_pointers(mut object_value: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut object_value.descriptor);
+        visitor.visit_pointer_opt(&mut object_value.prototype);
+        visitor.visit_pointer(&mut object_value.named_properties);
+        visitor.visit_pointer(&mut object_value.array_properties);
     }
 }
 

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -1,13 +1,13 @@
 use crate::{
     extend_object_without_conversions, must, must_a,
     runtime::{
-        Context,
+        Context, HeapItemKind,
         abstract_operations::{call_object, create_data_property, get, get_function_realm},
         accessor::Accessor,
         alloc_error::AllocResult,
         eval_result::EvalResult,
         gc::{Handle, HeapPtr},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         intrinsics::intrinsics::Intrinsic,
         object_value::{ObjectValue, VirtualObject},
         property::Property,

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -3,14 +3,14 @@ use std::mem::size_of;
 use crate::{
     completion_value, extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         abstract_operations::{call_object, construct, get_function_realm_no_error},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         error::{type_error, type_error_value},
         gc::{AnyHeapItem, HeapItem, HeapVisitor},
         get,
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
         ordinary_object::{object_create, object_create_from_constructor},
@@ -560,15 +560,15 @@ impl PromiseCapability {
     }}
 }
 
-impl HeapItem for HeapPtr<PromiseObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for PromiseObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<PromiseObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
+    fn visit_pointers(mut promise_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        promise_object.visit_object_pointers(visitor);
 
-        match &mut self.state {
+        match &mut promise_object.state {
             PromiseState::Pending { reactions, .. } => {
                 visitor.visit_pointer_opt(reactions);
             }
@@ -579,14 +579,14 @@ impl HeapItem for HeapPtr<PromiseObject> {
     }
 }
 
-impl HeapItem for HeapPtr<PromiseReaction> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for PromiseReaction {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<PromiseReaction>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        match &mut self.handler {
+    fn visit_pointers(mut promise_reaction: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut promise_reaction.descriptor);
+        match &mut promise_reaction.handler {
             ReactionHandler::AwaitResume { suspended_generator } => {
                 visitor.visit_pointer(suspended_generator);
             }
@@ -596,19 +596,19 @@ impl HeapItem for HeapPtr<PromiseReaction> {
                 visitor.visit_pointer_opt(capability);
             }
         }
-        visitor.visit_pointer_opt(&mut self.next);
+        visitor.visit_pointer_opt(&mut promise_reaction.next);
     }
 }
 
-impl HeapItem for HeapPtr<PromiseCapability> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for PromiseCapability {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<PromiseCapability>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer_opt(&mut self.promise);
-        visitor.visit_value(&mut self.resolve);
-        visitor.visit_value(&mut self.reject);
+    fn visit_pointers(mut promise_capability: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut promise_capability.descriptor);
+        visitor.visit_pointer_opt(&mut promise_capability.promise);
+        visitor.visit_value(&mut promise_capability.resolve);
+        visitor.visit_value(&mut promise_capability.reject);
     }
 }

--- a/src/js/runtime/property_key.rs
+++ b/src/js/runtime/property_key.rs
@@ -4,10 +4,9 @@ use crate::{
     common::numeric::Numeric,
     must_a,
     runtime::{
-        Context, EvalResult, HeapPtr, Value,
+        Context, EvalResult, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         gc::{Handle, HandleContents, ToHandleContents},
-        heap_item_descriptor::HeapItemKind,
         interned_strings::InternedStrings,
         string_parsing::{StringLexer, parse_string_to_u32},
         string_value::StringValue,

--- a/src/js/runtime/proxy_object.rs
+++ b/src/js/runtime/proxy_object.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, mem::size_of};
 use crate::{
     extend_object, must,
     runtime::{
-        Context, EvalResult, Realm, Value,
+        Context, EvalResult, HeapItemKind, Realm, Value,
         abstract_operations::{
             call_object, construct, get_method, is_extensible as is_extensible_,
             length_of_array_like,
@@ -13,7 +13,6 @@ use crate::{
         error::{range_error, type_error},
         gc::{Handle, HeapItem, HeapPtr, HeapVisitor},
         get,
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{is_compatible_property_descriptor, object_create},
@@ -865,14 +864,14 @@ pub fn proxy_create(
     )?)
 }
 
-impl HeapItem for HeapPtr<ProxyObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for ProxyObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<ProxyObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer_opt(&mut self.proxy_handler);
-        visitor.visit_pointer_opt(&mut self.proxy_target);
+    fn visit_pointers(mut proxy_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        proxy_object.visit_object_pointers(visitor);
+        visitor.visit_pointer_opt(&mut proxy_object.proxy_handler);
+        visitor.visit_pointer_opt(&mut proxy_object.proxy_target);
     }
 }

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -4,7 +4,7 @@ use crate::{
     field_offset, handle_scope, impl_hash_map_instance, must_a,
     parser::scope_tree::REALM_SCOPE_SLOT_NAME,
     runtime::{
-        Context, EvalResult, PropertyKey, Value,
+        Context, EvalResult, HeapItemKind, PropertyKey, Value,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         bytecode::function::Closure,
@@ -13,7 +13,7 @@ use crate::{
         gc::{Handle, HeapItem, HeapPtr, HeapVisitor},
         gc_object::GcObject,
         global_names::has_restricted_global_property,
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         interned_strings::InternedStrings,
         intrinsics::{
             global_object::set_default_global_bindings,
@@ -250,7 +250,7 @@ impl Handle<Realm> {
         for i in 0..scope_names.len() {
             if i == 0 {
                 // The first global scope slot is always the realm
-                global_scope.set_heap_item_slot(0, self.as_heap_item());
+                global_scope.set_heap_item_slot(0, self.as_any());
             } else if scope_names
                 .get_slot_name(i)
                 .ptr_eq(&cx.names.this.as_string().as_flat())
@@ -324,18 +324,18 @@ impl Handle<Realm> {
     }
 }
 
-impl HeapItem for HeapPtr<Realm> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for Realm {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         Realm::calculate_size_in_bytes()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer(&mut self.global_object);
-        visitor.visit_pointer(&mut self.global_scopes);
-        visitor.visit_pointer(&mut self.lexical_names);
-        visitor.visit_pointer(&mut self.empty_function);
-        self.intrinsics.visit_pointers(visitor);
+    fn visit_pointers(mut realm: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut realm.descriptor);
+        visitor.visit_pointer(&mut realm.global_object);
+        visitor.visit_pointer(&mut realm.global_scopes);
+        visitor.visit_pointer(&mut realm.lexical_names);
+        visitor.visit_pointer(&mut realm.empty_function);
+        realm.intrinsics.visit_pointers(visitor);
     }
 }
 
@@ -421,16 +421,16 @@ impl GlobalScopes {
     }
 }
 
-impl HeapItem for HeapPtr<GlobalScopes> {
-    fn byte_size(&self) -> usize {
-        GlobalScopes::calculate_size_in_bytes(self.scopes.len())
+impl HeapItem for GlobalScopes {
+    fn byte_size(global_scopes: HeapPtr<Self>) -> usize {
+        GlobalScopes::calculate_size_in_bytes(global_scopes.scopes.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
+    fn visit_pointers(mut global_scopes: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut global_scopes.descriptor);
 
-        let len = self.len();
-        for scope in &mut self.scopes.as_mut_slice()[..len] {
+        let len = global_scopes.len();
+        for scope in &mut global_scopes.scopes.as_mut_slice()[..len] {
             visitor.visit_pointer(scope);
         }
     }
@@ -474,13 +474,13 @@ impl BsHashMapField<LexicalNamesMap> for LexicalNamesMapField {
     }
 }
 
-impl LexicalNamesMap {
-    pub fn byte_size(map: HeapPtr<Self>) -> usize {
+impl HeapItem for LexicalNamesMap {
+    fn byte_size(map: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(map.capacity())
     }
 
-    pub fn visit_pointers(map: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        map.visit_pointers(visitor);
+    fn visit_pointers(mut map: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        map.visit_map_pointers(visitor);
 
         for (name, _) in map.iter_mut_gc_unsafe() {
             visitor.visit_pointer(name);

--- a/src/js/runtime/regexp/compiled_regexp.rs
+++ b/src/js/runtime/regexp/compiled_regexp.rs
@@ -5,13 +5,13 @@ use crate::{
     field_offset,
     parser::regexp::{RegExp, RegExpFlags},
     runtime::{
-        Context, Handle, HeapPtr,
+        Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         bytecode::generator::alloc_wtf8_str_from_source,
         collections::InlineArray,
         debug_print::{DebugPrint, DebugPrinter},
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         regexp::{graphviz::compiled_regexp_to_dot_graph, instruction::InstructionIterator},
         string_value::{FlatString, StringValue},
     },
@@ -182,19 +182,19 @@ impl DebugPrint for HeapPtr<CompiledRegExpObject> {
     }
 }
 
-impl HeapItem for HeapPtr<CompiledRegExpObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for CompiledRegExpObject {
+    fn byte_size(compiled_regexp_object: HeapPtr<Self>) -> usize {
         CompiledRegExpObject::calculate_size_in_bytes(
-            self.instructions.len(),
-            self.num_capture_groups,
+            compiled_regexp_object.instructions.len(),
+            compiled_regexp_object.num_capture_groups,
         )
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer(&mut self.escaped_pattern_source);
+    fn visit_pointers(mut compiled_regexp_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut compiled_regexp_object.descriptor);
+        visitor.visit_pointer(&mut compiled_regexp_object.escaped_pattern_source);
 
-        for capture_group in self.capture_groups_as_slice_mut() {
+        for capture_group in compiled_regexp_object.capture_groups_as_slice_mut() {
             visitor.visit_pointer_opt(capture_group);
         }
     }

--- a/src/js/runtime/scope.rs
+++ b/src/js/runtime/scope.rs
@@ -1,7 +1,7 @@
 use crate::{
     field_offset,
     runtime::{
-        Context, EvalResult, Handle, HeapPtr, PropertyKey, Realm, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyKey, Realm, Value,
         abstract_operations::has_property,
         alloc_error::AllocResult,
         boxed_value::BoxedValue,
@@ -9,7 +9,7 @@ use crate::{
         error::{err_assign_constant, err_cannot_set_property, err_not_defined},
         gc::{AnyHeapItem, HeapItem, HeapVisitor},
         get,
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         module::source_text_module::SourceTextModule,
         object_value::ObjectValue,
         ordinary_object::ordinary_object_create,
@@ -463,18 +463,18 @@ impl Handle<Scope> {
     }
 }
 
-impl HeapItem for HeapPtr<Scope> {
-    fn byte_size(&self) -> usize {
-        Scope::calculate_size_in_bytes(self.slots.len())
+impl HeapItem for Scope {
+    fn byte_size(scope: HeapPtr<Self>) -> usize {
+        Scope::calculate_size_in_bytes(scope.slots.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer_opt(&mut self.parent);
-        visitor.visit_pointer(&mut self.scope_names);
-        visitor.visit_pointer_opt(&mut self.object);
+    fn visit_pointers(mut scope: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut scope.descriptor);
+        visitor.visit_pointer_opt(&mut scope.parent);
+        visitor.visit_pointer(&mut scope.scope_names);
+        visitor.visit_pointer_opt(&mut scope.object);
 
-        for slot in self.slots.as_mut_slice() {
+        for slot in scope.slots.as_mut_slice() {
             visitor.visit_value(slot);
         }
     }

--- a/src/js/runtime/scope_names.rs
+++ b/src/js/runtime/scope_names.rs
@@ -3,11 +3,11 @@ use bitflags::bitflags;
 use crate::{
     field_offset,
     runtime::{
-        Context, Handle, HeapPtr,
+        Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         collections::InlineArray,
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         string_value::{FlatString, StringValue},
     },
     set_uninit,
@@ -184,15 +184,15 @@ impl ScopeNames {
     }
 }
 
-impl HeapItem for HeapPtr<ScopeNames> {
-    fn byte_size(&self) -> usize {
-        ScopeNames::calculate_size_in_bytes(self.len())
+impl HeapItem for ScopeNames {
+    fn byte_size(scope_names: HeapPtr<Self>) -> usize {
+        ScopeNames::calculate_size_in_bytes(scope_names.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
+    fn visit_pointers(mut scope_names: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut scope_names.descriptor);
 
-        for name in self.names.as_mut_slice() {
+        for name in scope_names.names.as_mut_slice() {
             visitor.visit_pointer(name);
         }
     }

--- a/src/js/runtime/source_file.rs
+++ b/src/js/runtime/source_file.rs
@@ -2,11 +2,11 @@ use crate::{
     field_offset, must_a,
     parser::{loc::calculate_line_offsets, source::Source},
     runtime::{
-        Context, Handle, HeapPtr,
+        Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         collections::{ArrayInstance, InlineArray, array::U32Array},
         gc::{HeapItem, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         string_value::FlatString,
     },
     set_uninit,
@@ -109,15 +109,15 @@ impl Handle<SourceFile> {
     }
 }
 
-impl HeapItem for HeapPtr<SourceFile> {
-    fn byte_size(&self) -> usize {
-        SourceFile::calculate_size_in_bytes(self.contents.len())
+impl HeapItem for SourceFile {
+    fn byte_size(source_file: HeapPtr<Self>) -> usize {
+        SourceFile::calculate_size_in_bytes(source_file.contents.len())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer(&mut self.path);
-        visitor.visit_pointer_opt(&mut self.display_name);
-        visitor.visit_pointer_opt(&mut self.line_offsets);
+    fn visit_pointers(mut source_file: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut source_file.descriptor);
+        visitor.visit_pointer(&mut source_file.path);
+        visitor.visit_pointer_opt(&mut source_file.display_name);
+        visitor.visit_pointer_opt(&mut source_file.line_offsets);
     }
 }

--- a/src/js/runtime/stack_trace.rs
+++ b/src/js/runtime/stack_trace.rs
@@ -6,7 +6,7 @@ use crate::{
         alloc_error::AllocResult,
         bytecode::{function::BytecodeFunction, source_map::BytecodeSourceMap},
         collections::ArrayInstance,
-        gc::HeapVisitor,
+        gc::{HeapItem, HeapVisitor},
         intrinsics::{error_constructor::CachedStackTraceInfo, rust_runtime::RuntimeFunction},
         source_file::SourceFile,
     },
@@ -207,13 +207,13 @@ fn prepare_for_stack_trace(
 // stack trace later if desired.
 impl_array_instance!(StackFrameInfoArray, HeapStackFrameInfo);
 
-impl StackFrameInfoArray {
-    pub fn byte_size(array: HeapPtr<Self>) -> usize {
+impl HeapItem for StackFrameInfoArray {
+    fn byte_size(array: HeapPtr<Self>) -> usize {
         Self::calculate_size_in_bytes(array.len())
     }
 
-    pub fn visit_pointers(array: &mut HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        array.visit_pointers(visitor);
+    fn visit_pointers(mut array: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        array.visit_array_pointers(visitor);
 
         for stack_frame in array.as_mut_slice() {
             visitor.visit_pointer(&mut stack_frame.function);

--- a/src/js/runtime/string_object.rs
+++ b/src/js/runtime/string_object.rs
@@ -5,11 +5,10 @@ use brimstone_macros::wrap_ordinary_object;
 use crate::{
     extend_object,
     runtime::{
-        Context, PropertyKey,
+        Context, HeapItemKind, PropertyKey,
         alloc_error::AllocResult,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapPtr, HeapVisitor},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::intrinsics::Intrinsic,
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{
@@ -199,13 +198,13 @@ impl VirtualObject for Handle<StringObject> {
     }
 }
 
-impl HeapItem for HeapPtr<StringObject> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for StringObject {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<StringObject>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        self.visit_object_pointers(visitor);
-        visitor.visit_pointer(&mut self.string_data);
+    fn visit_pointers(mut string_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        string_object.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut string_object.string_data);
     }
 }

--- a/src/js/runtime/string_value.rs
+++ b/src/js/runtime/string_value.rs
@@ -27,12 +27,12 @@ use crate::{
     },
     field_offset, must_a,
     runtime::{
-        Context, EvalResult, Value,
+        Context, EvalResult, HeapItemKind, Value,
         alloc_error::AllocResult,
         debug_print::{DebugPrint, DebugPrinter},
         error::range_error,
         gc::{Handle, HeapInfo, HeapItem, HeapPtr, HeapVisitor},
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         object_value::ObjectValue,
     },
     set_uninit, static_assert,
@@ -1583,42 +1583,42 @@ fn map_valid_substrings(iter: UnsafeCodePointIterator, f: impl Fn(&str) -> Strin
     result
 }
 
-impl HeapItem for HeapPtr<StringValue> {
-    fn byte_size(&self) -> usize {
-        if let Some(concat_string) = self.as_concat_opt() {
-            concat_string.byte_size()
+impl HeapItem for StringValue {
+    fn byte_size(string_value: HeapPtr<Self>) -> usize {
+        if let Some(concat_string) = string_value.as_concat_opt() {
+            ConcatString::byte_size(concat_string)
         } else {
-            self.as_flat().byte_size()
+            FlatString::byte_size(string_value.as_flat())
         }
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        if let Some(mut concat_string) = self.as_concat_opt() {
-            concat_string.visit_pointers(visitor)
+    fn visit_pointers(string_value: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        if let Some(concat_string) = string_value.as_concat_opt() {
+            ConcatString::visit_pointers(concat_string, visitor)
         } else {
-            self.as_flat().visit_pointers(visitor)
+            FlatString::visit_pointers(string_value.as_flat(), visitor)
         }
     }
 }
 
-impl HeapItem for HeapPtr<ConcatString> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for ConcatString {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<ConcatString>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer(&mut self.left);
-        visitor.visit_pointer_opt(&mut self.right);
+    fn visit_pointers(mut concat_string: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut concat_string.descriptor);
+        visitor.visit_pointer(&mut concat_string.left);
+        visitor.visit_pointer_opt(&mut concat_string.right);
     }
 }
 
-impl HeapItem for HeapPtr<FlatString> {
-    fn byte_size(&self) -> usize {
-        FlatString::calculate_size_in_bytes(self.len, self.width())
+impl HeapItem for FlatString {
+    fn byte_size(flat_string: HeapPtr<Self>) -> usize {
+        FlatString::calculate_size_in_bytes(flat_string.len, flat_string.width())
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
+    fn visit_pointers(mut flat_string: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut flat_string.descriptor);
     }
 }

--- a/src/js/runtime/tasks.rs
+++ b/src/js/runtime/tasks.rs
@@ -3,13 +3,12 @@ use std::collections::VecDeque;
 use crate::{
     completion_value, eval_err, handle_scope,
     runtime::{
-        Context, EvalResult, HeapPtr, Realm, Value,
+        Context, EvalResult, HeapItemKind, HeapPtr, Realm, Value,
         abstract_operations::{call, call_object},
         async_generator_object::{AsyncGeneratorObject, async_generator_resume},
         builtin_generator::BuiltinGenerator,
         gc::{AnyHeapItem, HeapVisitor},
         generator_object::{GeneratorCompletionType, GeneratorObject},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::promise_constructor::execute_then,
         object_value::ObjectValue,
         promise_object::{PromiseCapability, PromiseObject, PromiseReactionKind},

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -12,14 +12,13 @@ use crate::{
     },
     must_a,
     runtime::{
-        Context,
+        Context, HeapItemKind,
         abstract_operations::{call_object, get, get_method},
         alloc_error::AllocResult,
         bytecode::function::Closure,
         error::{range_error, syntax_error, type_error},
         eval_result::EvalResult,
         gc::{Handle, HeapPtr},
-        heap_item_descriptor::HeapItemKind,
         intrinsics::{
             bigint_constructor::BigIntObject, boolean_constructor::BooleanObject,
             number_constructor::NumberObject, symbol_constructor::SymbolObject,

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -7,13 +7,14 @@ use crate::{
     common::numeric::Numeric,
     const_assert, field_offset,
     runtime::{
+        HeapItemKind,
         alloc_error::AllocResult,
         context::Context,
         debug_print::{DebugPrint, DebugPrinter},
         gc::{
             AnyHeapItem, Handle, HandleContents, HeapItem, HeapPtr, HeapVisitor, ToHandleContents,
         },
-        heap_item_descriptor::{HeapItemDescriptor, HeapItemKind},
+        heap_item_descriptor::HeapItemDescriptor,
         object_value::ObjectValue,
         string_value::{FlatString, StringValue},
         type_utilities::same_value_zero_non_allocating,
@@ -441,22 +442,22 @@ impl Value {
 
     #[inline]
     pub fn object(value: HeapPtr<ObjectValue>) -> Value {
-        Value::heap_item(value.as_heap_item())
+        Value::heap_item(value.as_any())
     }
 
     #[inline]
     pub fn string(value: HeapPtr<StringValue>) -> Value {
-        Value::heap_item(value.as_heap_item())
+        Value::heap_item(value.as_any())
     }
 
     #[inline]
     pub fn symbol(value: HeapPtr<SymbolValue>) -> Value {
-        Value::heap_item(value.as_heap_item())
+        Value::heap_item(value.as_any())
     }
 
     #[inline]
     pub fn bigint(value: HeapPtr<BigIntValue>) -> Value {
-        Value::heap_item(value.as_heap_item())
+        Value::heap_item(value.as_any())
     }
 
     #[inline]
@@ -628,14 +629,14 @@ impl From<Handle<SymbolValue>> for Handle<ObjectValue> {
     }
 }
 
-impl HeapItem for HeapPtr<SymbolValue> {
-    fn byte_size(&self) -> usize {
+impl HeapItem for SymbolValue {
+    fn byte_size(_: HeapPtr<Self>) -> usize {
         size_of::<SymbolValue>()
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
-        visitor.visit_pointer_opt(&mut self.description);
+    fn visit_pointers(mut symbol_value: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut symbol_value.descriptor);
+        visitor.visit_pointer_opt(&mut symbol_value.description);
     }
 }
 
@@ -700,13 +701,13 @@ impl From<Handle<BigIntValue>> for Handle<ObjectValue> {
     }
 }
 
-impl HeapItem for HeapPtr<BigIntValue> {
-    fn byte_size(&self) -> usize {
-        BigIntValue::calculate_size_in_bytes(self.len)
+impl HeapItem for BigIntValue {
+    fn byte_size(big_int_value: HeapPtr<Self>) -> usize {
+        BigIntValue::calculate_size_in_bytes(big_int_value.len)
     }
 
-    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut self.descriptor);
+    fn visit_pointers(mut big_int_value: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut big_int_value.descriptor);
     }
 }
 


### PR DESCRIPTION
## Summary

Refactor how we define heap items into a central list expanded by a macro.

- Define `HeapItemKind` off this list
- Define `byte_size` and `visit_pointers` switches off this list
- Defines `byte_size` and `visit_pointers` directly on the `T` instead of `HeapPtr<T>`. These instead are static methods which take a `HeapPtr<T>` as their first argument.
- Implicitly define mapping between `HeapItemKind` and its corresponding object. Will use this for type checks/casts in the future.
- Automatically implement `IsHeapItem` if a type implements `HeapItem`. Only one manual `impl IsHeapItem` remaining, for the generic array properties view.

## Tests

- CI