### PR TITLE
[runtime] Type checks and casting for all heap items using attached kind

### DIFF
--- a/src/js/common/macros.rs
+++ b/src/js/common/macros.rs
@@ -24,5 +24,13 @@ macro_rules! replace_expr {
 /// Count the number of arguments passed to the macro. Only use for low numbers (e.g. < 10).
 #[macro_export]
 macro_rules! count {
-    ($($tts:tt)*) => {0usize $(+ replace_expr!($tts 1usize))*};
+    ($($tts:tt)*) => {0usize $(+ $crate::replace_expr!($tts 1usize))*};
+}
+
+/// Utility macro that ignores its argument and returns a unit value.
+#[macro_export]
+macro_rules! unit {
+    ($x:ident) => {
+        ()
+    };
 }

--- a/src/js/runtime/abstract_operations.rs
+++ b/src/js/runtime/abstract_operations.rs
@@ -4,7 +4,7 @@ use crate::{
     common::numeric::MAX_SAFE_INTEGER_U64,
     must, must_a,
     runtime::{
-        Context, HeapItemKind, Value,
+        Context, Value,
         accessor::Accessor,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
@@ -478,18 +478,15 @@ pub fn get_function_realm_no_error(
     cx: Context,
     func: Handle<ObjectValue>,
 ) -> Option<HeapPtr<Realm>> {
-    let kind = func.descriptor().kind();
-
     // Bound functions are also represented as closures with the correct realm set
-    if kind == HeapItemKind::Closure {
+    if let Some(closure) = func.as_opt::<Closure>() {
         if let Some(bound_target_func) = BoundFunctionObject::get_target_if_bound_function(cx, func)
         {
             get_function_realm_no_error(cx, bound_target_func)
         } else {
-            Some(func.cast::<Closure>().function_ptr().realm_ptr())
+            Some(closure.function_ptr().realm_ptr())
         }
-    } else if kind == HeapItemKind::Proxy {
-        let proxy_object = func.cast::<ProxyObject>();
+    } else if let Some(proxy_object) = func.as_opt::<ProxyObject>() {
         if proxy_object.is_revoked() {
             return None;
         }

--- a/src/js/runtime/accessor.rs
+++ b/src/js/runtime/accessor.rs
@@ -33,9 +33,7 @@ impl Accessor {
     }
 
     pub fn from_value(value: Handle<Value>) -> Handle<Accessor> {
-        debug_assert!(
-            value.is_pointer() && value.as_pointer().descriptor().kind() == HeapItemKind::Accessor
-        );
+        debug_assert!(value.is::<Accessor>());
         value.cast::<Accessor>()
     }
 }

--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -308,10 +308,8 @@ pub fn async_generator_validate(
     cx: Context,
     generator: Handle<Value>,
 ) -> EvalResult<Handle<AsyncGeneratorObject>> {
-    if generator.is_object() {
-        if let Some(async_generator) = generator.as_object().as_async_generator() {
-            return Ok(async_generator);
-        }
+    if let Some(async_generator) = generator.as_opt::<AsyncGeneratorObject>() {
+        return Ok(async_generator);
     }
 
     type_error(cx, "expected an async generator")

--- a/src/js/runtime/bound_function_object.rs
+++ b/src/js/runtime/bound_function_object.rs
@@ -1,3 +1,5 @@
+use crate::runtime::bytecode::function::Closure;
+use crate::runtime::proxy_object::ProxyObject;
 use crate::{
     runtime::{
         Context, Handle,
@@ -28,9 +30,9 @@ impl BoundFunctionObject {
     ) -> EvalResult<Handle<ObjectValue>> {
         let prototype = target_function.get_prototype_of(cx)?;
 
-        let is_constructor = if let Some(closure) = target_function.as_closure() {
+        let is_constructor = if let Some(closure) = target_function.as_opt::<Closure>() {
             closure.function_ptr().is_constructor()
-        } else if let Some(proxy_object) = target_function.as_proxy() {
+        } else if let Some(proxy_object) = target_function.as_opt::<ProxyObject>() {
             proxy_object.is_constructor()
         } else if let Some(target_function) =
             BoundFunctionObject::get_target_if_bound_function(cx, target_function)

--- a/src/js/runtime/builtin_generator.rs
+++ b/src/js/runtime/builtin_generator.rs
@@ -1,3 +1,4 @@
+use crate::runtime::promise_object::PromiseObject;
 use crate::{
     if_abrupt_reject_promise,
     runtime::{
@@ -73,7 +74,7 @@ impl BuiltinGenerator {
         capability: Handle<PromiseCapability>,
         generator_result: EvalResult<BuiltinGeneratorCompletion>,
     ) -> EvalResult<Handle<Value>> {
-        let promise = capability.promise().as_promise().unwrap();
+        let promise = capability.promise().as_opt::<PromiseObject>().unwrap();
 
         let from_async_result = if_abrupt_reject_promise!(cx, generator_result, capability);
 

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -6,7 +6,7 @@ use std::{
 use bitflags::bitflags;
 
 use crate::{
-    count, replace_expr,
+    count,
     runtime::{
         HeapPtr,
         bytecode::{
@@ -1892,7 +1892,7 @@ define_instructions!(
         }
     }
 
-    /// Resolve a promise with a value.
+    /// Resolve a promise with a value. Promise operand must be a PromiseObject.
     ResolvePromise {
         camel_case: ResolvePromiseInstruction,
         snake_case: resolve_promise_instruction,
@@ -1902,7 +1902,7 @@ define_instructions!(
         }
     }
 
-    /// Reject a promise with a value.
+    /// Reject a promise with a value. Promise operand must be a PromiseObject.
     RejectPromise {
         camel_case: RejectPromiseInstruction,
         snake_case: reject_promise_instruction,

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -4,6 +4,7 @@ use std::{
     ops::Deref,
 };
 
+use crate::runtime::intrinsics::error_constructor::ErrorObject;
 use crate::{
     common::numeric::Numeric,
     eval_err, handle_scope, handle_scope_guard, must,
@@ -123,7 +124,7 @@ use crate::{
         module::{execute::dynamic_import, source_text_module::SourceTextModule},
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{object_create_from_constructor, ordinary_object_create},
-        promise_object::{PromiseObject, coerce_to_ordinary_promise, is_promise, resolve},
+        promise_object::{PromiseObject, coerce_to_ordinary_promise, resolve},
         property::Property,
         proxy_object::ProxyObject,
         regexp::compiled_regexp::CompiledRegExpObject,
@@ -537,7 +538,7 @@ impl VM {
                     self.set_pc_after(instr);
                     let pc_to_resume_offset = self.get_pc_offset();
 
-                    if let Some(mut generator) = generator_object.as_generator() {
+                    if let Some(mut generator) = generator_object.as_opt::<GeneratorObject>() {
                         // GeneratorYield (https://tc39.es/ecma262/#sec-generatoryield)
 
                         // Save the stack frame and PC to resume in the generator object
@@ -551,10 +552,10 @@ impl VM {
                         return_!(yield_value)
                     } else {
                         // AsyncGeneratorYield (https://tc39.es/ecma262/#sec-asyncgeneratoryield)
-                        debug_assert!(generator_object.is_async_generator());
+                        debug_assert!(generator_object.is::<AsyncGeneratorObject>());
 
                         let mut async_generator =
-                            generator_object.as_async_generator().unwrap().to_handle();
+                            generator_object.as_opt::<AsyncGeneratorObject>().unwrap().to_handle();
                         let yield_value = yield_value.to_handle(self.cx());
 
                         maybe_throw_a!(async_generator_complete_step(
@@ -614,7 +615,10 @@ impl VM {
                     let mut argument_promise =
                         maybe_throw!(coerce_to_ordinary_promise(self.cx(), argument_promise));
 
-                    if return_promise_or_generator.as_object().is_promise() {
+                    if return_promise_or_generator
+                        .as_object()
+                        .is::<PromiseObject>()
+                    {
                         // Create a new generator object that holds the stack frame's state
                         let generator = maybe_throw_a!(GeneratorObject::new_for_async_function(
                             self.cx(),
@@ -764,7 +768,7 @@ impl VM {
                     // Native errors will already contain a stack trace, but any other thrown values
                     // should save the current stack trace info so a trace can be displayed later if
                     // desired.
-                    if error_value.is_object() && error_value.as_object().is_error() {
+                    if error_value.is::<ErrorObject>() {
                         self.thrown_non_error_info = None;
                     } else {
                         self.thrown_non_error_info = Some(create_current_stack_frame_info(
@@ -1961,31 +1965,25 @@ impl VM {
     /// categorization of the callable object
     #[inline]
     fn check_value_is_callable(&mut self, value: Value) -> EvalResult<CallableObject> {
-        if value.is_pointer() {
-            let kind = value.as_pointer().descriptor().kind();
-            if kind == HeapItemKind::Closure {
-                let closure = value.as_pointer().cast::<Closure>();
+        if let Some(closure) = value.as_opt::<Closure>() {
+            // Class constructors cannot be called directly
+            if closure.function_ptr().is_class_constructor() {
+                let function_realm = closure.function_ptr().realm_ptr();
+                let error_value = TypeError::new_with_message_in_realm(
+                    self.cx(),
+                    function_realm,
+                    "cannot call class constructor",
+                )?;
 
-                // Class constructors cannot be called directly
-                if closure.function_ptr().is_class_constructor() {
-                    let function_realm = closure.function_ptr().realm_ptr();
-                    let error_value = TypeError::new_with_message_in_realm(
-                        self.cx(),
-                        function_realm,
-                        "cannot call class constructor",
-                    )?;
+                return Ok(CallableObject::Error(error_value.into()));
+            }
 
-                    return Ok(CallableObject::Error(error_value.into()));
-                }
-
-                // All other closures all callable
-                return Ok(CallableObject::Closure(closure));
-            } else if kind == HeapItemKind::Proxy {
-                // Check if proxy is callable, and if so return the attached closure
-                let proxy_object = value.as_pointer().cast::<ProxyObject>();
-                if proxy_object.is_callable() {
-                    return Ok(CallableObject::Proxy(proxy_object));
-                }
+            // All other closures all callable
+            return Ok(CallableObject::Closure(closure));
+        } else if let Some(proxy_object) = value.as_opt::<ProxyObject>() {
+            // Check if proxy is callable, and if so return the attached closure
+            if proxy_object.is_callable() {
+                return Ok(CallableObject::Proxy(proxy_object));
             }
         }
 
@@ -1996,20 +1994,15 @@ impl VM {
     /// categorization of the callable object
     #[inline]
     fn check_value_is_constructor(&self, value: Value) -> EvalResult<CallableObject> {
-        if value.is_pointer() {
-            let kind = value.as_pointer().descriptor().kind();
-            if kind == HeapItemKind::Closure {
-                // Check if closure is a constructor
-                let closure = value.as_pointer().cast::<Closure>();
-                if closure.function_ptr().is_constructor() {
-                    return Ok(CallableObject::Closure(closure));
-                }
-            } else if kind == HeapItemKind::Proxy {
-                // Check if proxy is a constructor
-                let proxy_object = value.as_pointer().cast::<ProxyObject>();
-                if proxy_object.is_constructor() {
-                    return Ok(CallableObject::Proxy(proxy_object));
-                }
+        if let Some(closure) = value.as_opt::<Closure>() {
+            // Check if closure is a constructor
+            if closure.function_ptr().is_constructor() {
+                return Ok(CallableObject::Closure(closure));
+            }
+        } else if let Some(proxy_object) = value.as_opt::<ProxyObject>() {
+            // Check if proxy is a constructor
+            if proxy_object.is_constructor() {
+                return Ok(CallableObject::Proxy(proxy_object));
             }
         }
 
@@ -3684,10 +3677,7 @@ impl VM {
             // Uncommon cases when some flags are set, e.g. for accessors or named evaluation
             if !flags.is_empty() {
                 // We only set flags when the value evaluates to a closure
-                debug_assert!(
-                    value.is_pointer()
-                        && value.as_pointer().descriptor().kind() == HeapItemKind::Closure
-                );
+                debug_assert!(value.is::<Closure>());
                 let mut closure = value.cast::<Closure>();
 
                 // Since we did not statically know the key we must perform "named evaluation" here,
@@ -4263,10 +4253,7 @@ impl VM {
     ) -> HeapPtr<BoxedValue> {
         let boxed_value = self.load_from_scope_at_depth(scope_index, parent_depth);
 
-        debug_assert!(
-            boxed_value.is_pointer()
-                && boxed_value.as_pointer().descriptor().kind() == HeapItemKind::BoxedValue
-        );
+        debug_assert!(boxed_value.is::<BoxedValue>());
 
         boxed_value.as_pointer().cast::<BoxedValue>()
     }
@@ -4691,8 +4678,8 @@ impl VM {
         let promise = self.read_register_to_handle(instr.promise());
         let value = self.read_register_to_handle(instr.value());
 
-        debug_assert!(is_promise(*promise));
-        let promise = promise.as_object().cast::<PromiseObject>();
+        // Must be called with a PromiseObject.
+        let promise = promise.as_opt::<PromiseObject>().unwrap();
 
         resolve(self.cx(), promise, value)?;
 
@@ -4706,8 +4693,8 @@ impl VM {
         let promise = self.read_register(instr.promise());
         let value = self.read_register(instr.value());
 
-        debug_assert!(is_promise(promise));
-        let mut promise = promise.as_object().cast::<PromiseObject>();
+        // Must be called with a PromiseObject.
+        let mut promise = promise.as_opt::<PromiseObject>().unwrap();
 
         promise.reject(self.cx(), value);
     }

--- a/src/js/runtime/collections/array.rs
+++ b/src/js/runtime/collections/array.rs
@@ -4,7 +4,7 @@ use crate::{
         Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::InlineArray,
-        gc::{HeapItem, HeapVisitor, IsHeapItem},
+        gc::{HeapItem, HeapVisitor, IsHeapItem, WithHeapItemKind},
         heap_item_descriptor::HeapItemDescriptor,
     },
     set_uninit,
@@ -95,12 +95,11 @@ impl<T> BsArray<T> {
 /// identifying the full BsArray<T>.
 pub trait ArrayInstance:
     IsHeapItem
+    + WithHeapItemKind
     + std::ops::Deref<Target = BsArray<Self::T>>
     + std::ops::DerefMut<Target = BsArray<Self::T>>
 {
     type T;
-
-    const KIND: HeapItemKind;
 
     fn new(cx: Context, capacity: usize, initial: Self::T) -> AllocResult<HeapPtr<Self>>
     where
@@ -133,8 +132,6 @@ macro_rules! impl_array_instance {
 
         impl $crate::runtime::collections::ArrayInstance for $array_type {
             type T = $element_type;
-
-            const KIND: $crate::runtime::HeapItemKind = $crate::runtime::HeapItemKind::$array_type;
         }
 
         impl std::ops::Deref for $array_type {

--- a/src/js/runtime/collections/hash_map.rs
+++ b/src/js/runtime/collections/hash_map.rs
@@ -11,7 +11,7 @@ use crate::{
         Context, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         collections::InlineArray,
-        gc::{HeapVisitor, IsHeapItem},
+        gc::{HeapVisitor, IsHeapItem, WithHeapItemKind},
         heap_item_descriptor::HeapItemDescriptor,
     },
     set_uninit,
@@ -281,13 +281,12 @@ impl<K: Eq + Hash + Clone, V: Clone> BsHashMap<K, V> {
 /// descriptor identifying the full BsHashMap<K, V>.
 pub trait HashMapInstance:
     IsHeapItem
+    + WithHeapItemKind
     + std::ops::Deref<Target = BsHashMap<Self::K, Self::V>>
     + std::ops::DerefMut<Target = BsHashMap<Self::K, Self::V>>
 {
     type K: Eq + std::hash::Hash + Clone;
     type V: Clone;
-
-    const KIND: HeapItemKind;
 
     fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
         Ok(BsHashMap::<Self::K, Self::V>::new(cx, Self::KIND, capacity)?.cast())
@@ -311,8 +310,6 @@ macro_rules! impl_hash_map_instance {
         impl $crate::runtime::collections::HashMapInstance for $map_type {
             type K = $key_type;
             type V = $value_type;
-
-            const KIND: $crate::runtime::HeapItemKind = $crate::runtime::HeapItemKind::$map_type;
         }
 
         impl std::ops::Deref for $map_type {

--- a/src/js/runtime/collections/hash_set.rs
+++ b/src/js/runtime/collections/hash_set.rs
@@ -7,7 +7,7 @@ use crate::runtime::{
         BsHashMap,
         hash_map::{GcUnsafeKeysIterMut, maybe_grow_for_insertion},
     },
-    gc::{HeapVisitor, IsHeapItem},
+    gc::{HeapVisitor, IsHeapItem, WithHeapItemKind},
 };
 
 /// Generic flat HashSet implementation which is a simple wrapper over a HashMap with unit values.
@@ -72,12 +72,11 @@ impl<T: Eq + Hash + Clone> BsHashSet<T> {
 /// descriptor identifying the full BsHashSet<T>.
 pub trait HashSetInstance:
     IsHeapItem
+    + WithHeapItemKind
     + std::ops::Deref<Target = BsHashSet<Self::T>>
     + std::ops::DerefMut<Target = BsHashSet<Self::T>>
 {
     type T: Eq + std::hash::Hash + Clone;
-
-    const KIND: HeapItemKind;
 
     fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
         Ok(BsHashSet::<Self::T>::new(cx, Self::KIND, capacity)?.cast())
@@ -100,8 +99,6 @@ macro_rules! impl_hash_set_instance {
 
         impl $crate::runtime::collections::HashSetInstance for $set_type {
             type T = $element_type;
-
-            const KIND: $crate::runtime::HeapItemKind = $crate::runtime::HeapItemKind::$set_type;
         }
 
         impl std::ops::Deref for $set_type {

--- a/src/js/runtime/collections/index_map.rs
+++ b/src/js/runtime/collections/index_map.rs
@@ -11,7 +11,7 @@ use crate::{
         Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         collections::InlineArray,
-        gc::{HeapVisitor, IsHeapItem},
+        gc::{HeapVisitor, IsHeapItem, WithHeapItemKind},
         heap_item_descriptor::HeapItemDescriptor,
     },
     set_uninit,
@@ -425,13 +425,12 @@ impl<K: Eq + Hash + Clone, V: Clone> Handle<BsIndexMap<K, V>> {
 /// descriptor identifying the full BsIndexMap<K, V>.
 pub trait IndexMapInstance:
     IsHeapItem
+    + WithHeapItemKind
     + std::ops::Deref<Target = BsIndexMap<Self::K, Self::V>>
     + std::ops::DerefMut<Target = BsIndexMap<Self::K, Self::V>>
 {
     type K: Eq + std::hash::Hash + Clone;
     type V: Clone;
-
-    const KIND: HeapItemKind;
 
     const MIN_CAPACITY: usize = BsIndexMap::<Self::K, Self::V>::MIN_CAPACITY;
 
@@ -472,8 +471,6 @@ macro_rules! impl_index_map_instance {
         impl $crate::runtime::collections::IndexMapInstance for $map_type {
             type K = $key_type;
             type V = $value_type;
-
-            const KIND: $crate::runtime::HeapItemKind = $crate::runtime::HeapItemKind::$map_type;
         }
 
         impl std::ops::Deref for $map_type {

--- a/src/js/runtime/collections/index_set.rs
+++ b/src/js/runtime/collections/index_set.rs
@@ -7,7 +7,7 @@ use crate::runtime::{
         BsIndexMap,
         index_map::{GcSafeEntriesIter, GcUnsafeKeysIterMut, maybe_grow_for_insertion},
     },
-    gc::{HeapVisitor, IsHeapItem},
+    gc::{HeapVisitor, IsHeapItem, WithHeapItemKind},
 };
 
 /// Generic flat IndexSet implementation which is a simple wrapper over an IndexMap with unit values.
@@ -83,12 +83,11 @@ impl<T: Eq + Hash + Clone> Handle<BsIndexSet<T>> {
 /// descriptor identifying the full BsIndexSet<T>.
 pub trait IndexSetInstance:
     IsHeapItem
+    + WithHeapItemKind
     + std::ops::Deref<Target = BsIndexSet<Self::T>>
     + std::ops::DerefMut<Target = BsIndexSet<Self::T>>
 {
     type T: Eq + std::hash::Hash + Clone;
-
-    const KIND: HeapItemKind;
 
     const MIN_CAPACITY: usize = BsIndexSet::<Self::T>::MIN_CAPACITY;
 
@@ -129,8 +128,6 @@ macro_rules! impl_index_set_instance {
 
         impl $crate::runtime::collections::IndexSetInstance for $set_type {
             type T = $element_type;
-
-            const KIND: $crate::runtime::HeapItemKind = $crate::runtime::HeapItemKind::$set_type;
         }
 
         impl std::ops::Deref for $set_type {

--- a/src/js/runtime/collections/vec.rs
+++ b/src/js/runtime/collections/vec.rs
@@ -4,7 +4,7 @@ use crate::{
         Context, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         collections::InlineArray,
-        gc::{HeapVisitor, IsHeapItem},
+        gc::{HeapVisitor, IsHeapItem, WithHeapItemKind},
         heap_item_descriptor::HeapItemDescriptor,
     },
     set_uninit,
@@ -84,11 +84,12 @@ impl<T: Clone + Copy> BsVec<T> {
 /// An instance of a BsVec with a specific element type. This has its own object descriptor
 /// identifying the full BsVec<T>.
 pub trait VecInstance:
-    IsHeapItem + std::ops::Deref<Target = BsVec<Self::T>> + std::ops::DerefMut<Target = BsVec<Self::T>>
+    IsHeapItem
+    + WithHeapItemKind
+    + std::ops::Deref<Target = BsVec<Self::T>>
+    + std::ops::DerefMut<Target = BsVec<Self::T>>
 {
     type T: Clone + Copy;
-
-    const KIND: HeapItemKind;
 
     const MIN_CAPACITY: usize = BsVec::<Self::T>::MIN_CAPACITY;
 
@@ -113,8 +114,6 @@ macro_rules! impl_vec_instance {
 
         impl $crate::runtime::collections::VecInstance for $vec_type {
             type T = $element_type;
-
-            const KIND: $crate::runtime::HeapItemKind = $crate::runtime::HeapItemKind::$vec_type;
         }
 
         impl std::ops::Deref for $vec_type {

--- a/src/js/runtime/collections/weak_vec.rs
+++ b/src/js/runtime/collections/weak_vec.rs
@@ -30,6 +30,7 @@ pub struct BsWeakVec {
 
 impl BsWeakVec {
     /// Create a new BsWeakVec with the given capacity.
+    #[allow(unused)]
     pub fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
         let size = Self::calculate_size_in_bytes(capacity);
         let mut vec = cx.alloc_uninit_with_size::<BsWeakVec>(size)?;
@@ -84,6 +85,7 @@ impl BsWeakVec {
     }
 
     /// Append an item to the BsWeakVec. Should only be called if there is room to append an item.
+    #[allow(unused)]
     pub fn push_without_growing(&mut self, item: Value) {
         let len = self.len();
         self.array.as_mut_slice()[len] = item;

--- a/src/js/runtime/console.rs
+++ b/src/js/runtime/console.rs
@@ -109,7 +109,7 @@ pub fn to_console_string(
             _ => {
                 let object = value.as_object();
 
-                if let Some(error) = object.as_error() {
+                if let Some(error) = object.as_opt::<ErrorObject>() {
                     error_to_console_string(cx, error, opts)?
                 } else if object.is_callable() {
                     "[Function]".to_owned()

--- a/src/js/runtime/error.rs
+++ b/src/js/runtime/error.rs
@@ -1,3 +1,4 @@
+use crate::runtime::intrinsics::error_constructor::ErrorObject;
 use crate::{
     common::error::{ErrorFormatter, FormatOptions},
     eval_err,
@@ -90,7 +91,7 @@ fn format_eval_error_value(
 ) -> AllocResult<String> {
     let thrown_value_string = to_console_string(cx, thrown_value, opts)?;
 
-    if thrown_value.is_object() && thrown_value.as_object().is_error() {
+    if thrown_value.is::<ErrorObject>() {
         Ok(thrown_value_string)
     } else {
         format_thrown_non_error_value(cx, thrown_value, thrown_value_string, opts)

--- a/src/js/runtime/eval_result.rs
+++ b/src/js/runtime/eval_result.rs
@@ -54,7 +54,10 @@ pub type EvalResult<T> = Result<T, EvalError>;
 #[macro_export]
 macro_rules! must {
     ($a:expr) => {{
-        use $crate::runtime::eval_result::{EvalError, EvalResult};
+        use $crate::runtime::{
+            eval_result::{EvalError, EvalResult},
+            intrinsics::error_constructor::ErrorObject,
+        };
 
         let result = $a;
         match result {
@@ -67,11 +70,9 @@ macro_rules! must {
             // A thrown value. Propagate upwards only if it is a stack overflow, otherwise fail
             // the assertion.
             Err(EvalError::Value(value)) => {
-                if value.is_object() {
-                    if let Some(error) = value.as_object().as_error() {
-                        if error.is_stack_overflow() {
-                            return Err(EvalError::Value(value.into()));
-                        }
+                if let Some(error) = value.as_opt::<ErrorObject>() {
+                    if error.is_stack_overflow() {
+                        return Err(EvalError::Value(value.into()));
                     }
                 }
 

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -1,88 +1,92 @@
-use crate::runtime::{
-    Realm,
-    accessor::Accessor,
-    arguments_object::{MappedArgumentsObject, UnmappedArgumentsObject},
-    array_object::ArrayObject,
-    array_properties::{DenseArrayProperties, SparseArrayPropertiesMap},
-    async_generator_object::{AsyncGeneratorObject, AsyncGeneratorRequest},
-    boxed_value::BoxedValue,
-    builtin_generator::BuiltinGenerator,
-    bytecode::{
-        constant_table::ConstantTable,
-        exception_handlers::ExceptionHandlers,
-        function::{BytecodeFunction, Closure},
-        generator::FunctionVec,
-    },
-    class_names::ClassNames,
-    collections::{
-        BsWeakVec,
-        array::{ByteArray, U32Array, ValueArray},
-    },
-    context::{GlobalSymbolRegistryMap, ModuleCacheMap},
-    for_in_iterator::ForInIterator,
-    gc::{HeapPtr, HeapVisitor},
-    generator_object::GeneratorObject,
-    global_names::GlobalNames,
-    heap_item_descriptor::HeapItemDescriptor,
-    interned_strings::InternedStringsSet,
-    intrinsics::{
-        array_buffer_constructor::ArrayBufferObject,
-        array_iterator::ArrayIterator,
-        async_from_sync_iterator_prototype::AsyncFromSyncIterator,
-        bigint_constructor::BigIntObject,
-        boolean_constructor::BooleanObject,
-        data_view_constructor::DataViewObject,
-        date_object::DateObject,
-        error_constructor::ErrorObject,
-        finalization_registry_object::{FinalizationRegistryCells, FinalizationRegistryObject},
-        iterator_constructor::WrappedValidIterator,
-        iterator_helper_object::IteratorHelperObject,
-        map_iterator::MapIterator,
-        map_object::{MapObject, ValueIndexMap},
-        number_constructor::NumberObject,
-        object_prototype::ObjectPrototype,
-        raw_json_object::RawJSONObject,
-        regexp_constructor::RegExpObject,
-        regexp_string_iterator::RegExpStringIterator,
-        set_iterator::SetIterator,
-        set_object::{SetObject, ValueIndexSet},
-        string_iterator::StringIterator,
-        symbol_constructor::SymbolObject,
-        temporal::{
-            duration_object::DurationObject, instant_object::InstantObject,
-            plain_date_object::PlainDateObject, plain_date_time_object::PlainDateTimeObject,
-            plain_month_day_object::PlainMonthDayObject, plain_time_object::PlainTimeObject,
-            plain_year_month_object::PlainYearMonthObject,
-            zoned_date_time_object::ZonedDateTimeObject,
+use crate::{
+    runtime::{
+        Realm,
+        accessor::Accessor,
+        arguments_object::{MappedArgumentsObject, UnmappedArgumentsObject},
+        array_object::ArrayObject,
+        array_properties::{DenseArrayProperties, SparseArrayPropertiesMap},
+        async_generator_object::{AsyncGeneratorObject, AsyncGeneratorRequest},
+        boxed_value::BoxedValue,
+        builtin_generator::BuiltinGenerator,
+        bytecode::{
+            constant_table::ConstantTable,
+            exception_handlers::ExceptionHandlers,
+            function::{BytecodeFunction, Closure},
+            generator::FunctionVec,
         },
-        typed_array::{
-            BigInt64Array, BigUInt64Array, Float16Array, Float32Array, Float64Array, Int8Array,
-            Int16Array, Int32Array, UInt8Array, UInt8ClampedArray, UInt16Array, UInt32Array,
+        class_names::ClassNames,
+        collections::{
+            BsWeakVec,
+            array::{ByteArray, U32Array, ValueArray},
         },
-        weak_map_object::{WeakMapObject, WeakValueMap},
-        weak_ref_constructor::WeakRefObject,
-        weak_set_object::{WeakSetObject, WeakValueSet},
-    },
-    module::{
-        import_attributes::ImportAttributes,
-        module_namespace_object::ModuleNamespaceObject,
-        source_text_module::{
-            ExportMap, ModuleOptionArray, ModuleRequestArray, SourceTextModule, SourceTextModuleVec,
+        context::{GlobalSymbolRegistryMap, ModuleCacheMap},
+        for_in_iterator::ForInIterator,
+        gc::{HeapPtr, HeapVisitor},
+        generator_object::GeneratorObject,
+        global_names::GlobalNames,
+        heap_item_descriptor::HeapItemDescriptor,
+        interned_strings::InternedStringsSet,
+        intrinsics::{
+            array_buffer_constructor::ArrayBufferObject,
+            array_iterator::ArrayIterator,
+            async_from_sync_iterator_prototype::AsyncFromSyncIterator,
+            bigint_constructor::BigIntObject,
+            boolean_constructor::BooleanObject,
+            data_view_constructor::DataViewObject,
+            date_object::DateObject,
+            error_constructor::ErrorObject,
+            finalization_registry_object::{FinalizationRegistryCells, FinalizationRegistryObject},
+            iterator_constructor::WrappedValidIterator,
+            iterator_helper_object::IteratorHelperObject,
+            map_iterator::MapIterator,
+            map_object::{MapObject, ValueIndexMap},
+            number_constructor::NumberObject,
+            object_prototype::ObjectPrototype,
+            raw_json_object::RawJSONObject,
+            regexp_constructor::RegExpObject,
+            regexp_string_iterator::RegExpStringIterator,
+            set_iterator::SetIterator,
+            set_object::{SetObject, ValueIndexSet},
+            string_iterator::StringIterator,
+            symbol_constructor::SymbolObject,
+            temporal::{
+                duration_object::DurationObject, instant_object::InstantObject,
+                plain_date_object::PlainDateObject, plain_date_time_object::PlainDateTimeObject,
+                plain_month_day_object::PlainMonthDayObject, plain_time_object::PlainTimeObject,
+                plain_year_month_object::PlainYearMonthObject,
+                zoned_date_time_object::ZonedDateTimeObject,
+            },
+            typed_array::{
+                BigInt64Array, BigUInt64Array, Float16Array, Float32Array, Float64Array, Int8Array,
+                Int16Array, Int32Array, UInt8Array, UInt8ClampedArray, UInt16Array, UInt32Array,
+            },
+            weak_map_object::{WeakMapObject, WeakValueMap},
+            weak_ref_constructor::WeakRefObject,
+            weak_set_object::{WeakSetObject, WeakValueSet},
         },
-        synthetic_module::SyntheticModule,
+        module::{
+            import_attributes::ImportAttributes,
+            module_namespace_object::ModuleNamespaceObject,
+            source_text_module::{
+                ExportMap, ModuleOptionArray, ModuleRequestArray, SourceTextModule,
+                SourceTextModuleVec,
+            },
+            synthetic_module::SyntheticModule,
+        },
+        object_value::{NamedPropertiesMap, ObjectValue},
+        promise_object::{PromiseCapability, PromiseObject, PromiseReaction},
+        proxy_object::ProxyObject,
+        realm::{GlobalScopes, LexicalNamesMap},
+        regexp::compiled_regexp::CompiledRegExpObject,
+        scope::Scope,
+        scope_names::ScopeNames,
+        source_file::SourceFile,
+        stack_trace::StackFrameInfoArray,
+        string_object::StringObject,
+        string_value::StringValue,
+        value::{BigIntValue, SymbolValue},
     },
-    object_value::{NamedPropertiesMap, ObjectValue},
-    promise_object::{PromiseCapability, PromiseObject, PromiseReaction},
-    proxy_object::ProxyObject,
-    realm::{GlobalScopes, LexicalNamesMap},
-    regexp::compiled_regexp::CompiledRegExpObject,
-    scope::Scope,
-    scope_names::ScopeNames,
-    source_file::SourceFile,
-    stack_trace::StackFrameInfoArray,
-    string_object::StringObject,
-    string_value::StringValue,
-    value::{BigIntValue, SymbolValue},
+    unit,
 };
 
 /// Trait implemented by all items stored on the heap. This includes both JS objects and non-object
@@ -96,20 +100,43 @@ pub trait HeapItem: Sized {
     fn visit_pointers(item: HeapPtr<Self>, visitor: &mut impl HeapVisitor);
 }
 
-macro_rules! unit {
-    ($x:ident) => {
-        ()
-    };
+/// Marker trait that denotes an object on the managed heap
+pub trait IsHeapItem: Sized {}
+
+impl<T: HeapItem> IsHeapItem for T {}
+
+pub trait WithHeapItemKind {
+    const KIND: HeapItemKind;
+}
+
+impl<T: WithHeapItemKind> HeapPtr<T> {
+    /// Whether this is a heap item of a particular type.
+    #[inline]
+    pub fn is<U: WithHeapItemKind>(&self) -> bool {
+        self.as_any().descriptor().kind() == U::KIND
+    }
+
+    /// Return this value as a heap item of a particular type, or None if it is not of that type.
+    #[inline]
+    pub fn as_opt<U: WithHeapItemKind>(&self) -> Option<HeapPtr<U>> {
+        if self.is::<U>() {
+            Some(self.cast())
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_any(&self) -> HeapPtr<AnyHeapItem> {
+        self.cast()
+    }
 }
 
 macro_rules! register_heap_items {
     ($(($kind:ident, $item_name:ident),)*) => {
         $(
-            impl HeapPtr<$item_name> {
-                #[inline]
-                pub fn as_any(&self) -> HeapPtr<AnyHeapItem> {
-                    self.cast()
-                }
+            impl WithHeapItemKind for $item_name {
+                const KIND: HeapItemKind = HeapItemKind::$kind;
             }
         )*
 
@@ -274,10 +301,23 @@ impl AnyHeapItem {
     }
 }
 
-/// Marker trait that denotes an object on the managed heap
-pub trait IsHeapItem: Sized {}
+impl HeapPtr<AnyHeapItem> {
+    /// Whether this is a heap item of a particular type.
+    #[inline]
+    pub fn is<U: WithHeapItemKind>(&self) -> bool {
+        self.descriptor().kind() == U::KIND
+    }
 
-impl<T: HeapItem> IsHeapItem for T {}
+    /// Return this value as a heap item of a particular type, or None if it is not of that type.
+    #[inline]
+    pub fn as_opt<U: WithHeapItemKind>(&self) -> Option<HeapPtr<U>> {
+        if self.is::<U>() {
+            Some(self.cast())
+        } else {
+            None
+        }
+    }
+}
 
 /// Storage for a value whose natural alignment exceeds the 8-byte alignment of the managed heap.
 #[repr(C, packed(8))]

--- a/src/js/runtime/gc/mod.rs
+++ b/src/js/runtime/gc/mod.rs
@@ -12,7 +12,9 @@ pub use handle::{
     Escapable, Handle, HandleContents, HandleScope, HandleScopeGuard, ToHandleContents,
 };
 pub use heap::{Heap, HeapInfo};
-pub use heap_item::{AnyHeapItem, HeapItem, HeapItemKind, HeapUnaligned, IsHeapItem};
+pub use heap_item::{
+    AnyHeapItem, HeapItem, HeapItemKind, HeapUnaligned, IsHeapItem, WithHeapItemKind,
+};
 #[allow(unused)]
 pub use heap_serializer::{HeapRootsDeserializer, HeapSerializer};
 pub use heap_visitor::HeapVisitor;

--- a/src/js/runtime/generator_object.rs
+++ b/src/js/runtime/generator_object.rs
@@ -208,14 +208,12 @@ fn generator_validate(
     cx: Context,
     generator: Handle<Value>,
 ) -> EvalResult<Handle<GeneratorObject>> {
-    if generator.is_object() {
-        if let Some(generator) = generator.as_object().as_generator() {
-            if generator.state == GeneratorState::Executing {
-                return type_error(cx, "generator is already executing");
-            }
-
-            return Ok(generator);
+    if let Some(generator) = generator.as_opt::<GeneratorObject>() {
+        if generator.state == GeneratorState::Executing {
+            return type_error(cx, "generator is already executing");
         }
+
+        return Ok(generator);
     }
 
     type_error(cx, "expected a generator")

--- a/src/js/runtime/intrinsics/array_buffer_constructor.rs
+++ b/src/js/runtime/intrinsics/array_buffer_constructor.rs
@@ -1,5 +1,6 @@
 use std::mem::size_of;
 
+use crate::runtime::intrinsics::data_view_constructor::DataViewObject;
 use crate::{
     extend_object, intrinsic_methods,
     runtime::{
@@ -210,7 +211,7 @@ impl ArrayBufferConstructor {
         }
 
         let object = value.as_object();
-        let is_view = object.is_data_view() || object.is_typed_array();
+        let is_view = object.is::<DataViewObject>() || object.is_typed_array();
 
         Ok(cx.bool(is_view))
     }}

--- a/src/js/runtime/intrinsics/array_buffer_prototype.rs
+++ b/src/js/runtime/intrinsics/array_buffer_prototype.rs
@@ -169,15 +169,16 @@ impl ArrayBufferPrototype {
         let new_object = construct(cx, constructor, &[new_length_value], None)?;
 
         // Check type of object returned from constructor
-        let mut new_array_buffer = if let Some(array_buffer) = new_object.as_array_buffer() {
-            array_buffer
-        } else {
-            // Includes case where constructor returns a shared array buffer
-            return type_error(
-                cx,
-                "ArrayBuffer.prototype.slice species constructor must return an ArrayBuffer",
-            );
-        };
+        let mut new_array_buffer =
+            if let Some(array_buffer) = new_object.as_opt::<ArrayBufferObject>() {
+                array_buffer
+            } else {
+                // Includes case where constructor returns a shared array buffer
+                return type_error(
+                    cx,
+                    "ArrayBuffer.prototype.slice species constructor must return an ArrayBuffer",
+                );
+            };
 
         throw_if_detached(cx, *new_array_buffer)?;
 
@@ -244,11 +245,8 @@ fn require_array_buffer(
     value: Handle<Value>,
     method_name: &str,
 ) -> EvalResult<Handle<ArrayBufferObject>> {
-    if value.is_object() {
-        let object = value.as_object();
-        if let Some(array_buffer) = object.as_array_buffer() {
-            return Ok(array_buffer);
-        }
+    if let Some(array_buffer) = value.as_opt::<ArrayBufferObject>() {
+        return Ok(array_buffer);
     }
 
     type_error(

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_prototype.rs
@@ -91,7 +91,7 @@ impl AsyncFromSyncIteratorPrototype {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
 
-        let async_iterator = this_value.as_object().cast::<AsyncFromSyncIterator>();
+        let async_iterator = this_async_from_sync_iterator(this_value);
         let sync_iterator = async_iterator.iterator();
 
         let value = if arguments.is_empty() {
@@ -120,7 +120,7 @@ impl AsyncFromSyncIteratorPrototype {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
 
-        let async_iterator = this_value.as_object().cast::<AsyncFromSyncIterator>();
+        let async_iterator = this_async_from_sync_iterator(this_value);
         let sync_iterator = async_iterator.iterator();
 
         let return_method_completion = get_method(cx, sync_iterator.into(), cx.names.return_());
@@ -171,7 +171,7 @@ impl AsyncFromSyncIteratorPrototype {
         let promise_constructor = cx.get_intrinsic(Intrinsic::PromiseConstructor);
         let capability = must!(PromiseCapability::new(cx, promise_constructor.into()));
 
-        let async_iterator = this_value.as_object().cast::<AsyncFromSyncIterator>();
+        let async_iterator = this_async_from_sync_iterator(this_value);
         let sync_iterator = async_iterator.iterator();
 
         let throw_method_completion = get_method(cx, sync_iterator.into(), cx.names.throw());
@@ -310,6 +310,12 @@ fn async_from_sync_iterator_continuation_on_reject(cx, _, arguments) {
 
     iterator_close(cx, sync_iterator, eval_err!(error))
 }}
+
+/// Methods cannot be invoked by user code, so we can guarantee type of the receiver.
+fn this_async_from_sync_iterator(value: Handle<Value>) -> Handle<AsyncFromSyncIterator> {
+    debug_assert!(value.is::<AsyncFromSyncIterator>());
+    value.cast::<AsyncFromSyncIterator>()
+}
 
 fn get_sync_iterator(cx: Context, function: Handle<ObjectValue>) -> Handle<ObjectValue> {
     function

--- a/src/js/runtime/intrinsics/bigint_prototype.rs
+++ b/src/js/runtime/intrinsics/bigint_prototype.rs
@@ -75,11 +75,8 @@ fn this_bigint_value(
         return Ok(value.as_bigint());
     }
 
-    if value.is_object() {
-        let object_value = value.as_object();
-        if object_value.is_bigint_object() {
-            return Ok(object_value.cast::<BigIntObject>().bigint_data());
-        }
+    if let Some(bigint_object) = value.as_opt::<BigIntObject>() {
+        return Ok(bigint_object.bigint_data());
     }
 
     type_error(cx, &format!("BigInt.prototype.{method_name} must be called on a BigInt"))

--- a/src/js/runtime/intrinsics/boolean_prototype.rs
+++ b/src/js/runtime/intrinsics/boolean_prototype.rs
@@ -53,11 +53,8 @@ fn this_boolean_value(cx: Context, value: Handle<Value>, method_name: &str) -> E
         return Ok(value.as_bool());
     }
 
-    if value.is_object() {
-        let object_value = value.as_object();
-        if let Some(boolean_object) = object_value.as_boolean_object() {
-            return Ok(boolean_object.boolean_data());
-        }
+    if let Some(boolean_object) = value.as_opt::<BooleanObject>() {
+        return Ok(boolean_object.boolean_data());
     }
 
     type_error(cx, &format!("Boolean.prototype.{method_name} must be called on a boolean"))

--- a/src/js/runtime/intrinsics/data_view_constructor.rs
+++ b/src/js/runtime/intrinsics/data_view_constructor.rs
@@ -102,16 +102,9 @@ impl DataViewConstructor {
         };
 
         let buffer_argument = arguments.get(cx, 0);
-        if !buffer_argument.is_object() {
+        let Some(buffer_object) = buffer_argument.as_opt::<ArrayBufferObject>() else {
             return type_error(cx, "DataView constructor first argument must be an array buffer");
-        }
-
-        let buffer_object = buffer_argument.as_object();
-        if !buffer_object.is_array_buffer() {
-            return type_error(cx, "DataView constructor first argument must be an array buffer");
-        }
-
-        let buffer_object = buffer_object.cast::<ArrayBufferObject>();
+        };
 
         let offset_arg = arguments.get(cx, 1);
         let offset = to_index(cx, offset_arg)?;

--- a/src/js/runtime/intrinsics/data_view_prototype.rs
+++ b/src/js/runtime/intrinsics/data_view_prototype.rs
@@ -375,8 +375,7 @@ fn this_data_view(
         );
     }
 
-    let object = value.as_object();
-    if let Some(data_view) = object.as_data_view() {
+    if let Some(data_view) = value.as_opt::<DataViewObject>() {
         return Ok(data_view);
     }
 

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -1251,7 +1251,7 @@ pub fn to_date_string(mut cx: Context, time_value: f64) -> EvalResult<Handle<Str
 #[inline]
 pub fn validate_date_value(value: Handle<Value>) -> Option<f64> {
     if value.is_object() {
-        if let Some(date_object) = value.as_object().as_date_object() {
+        if let Some(date_object) = value.as_opt::<DateObject>() {
             return Some(date_object.date_value());
         }
     }

--- a/src/js/runtime/intrinsics/error_constructor.rs
+++ b/src/js/runtime/intrinsics/error_constructor.rs
@@ -213,7 +213,7 @@ impl ErrorConstructor {
             return Ok(cx.bool(false));
         }
 
-        Ok(cx.bool(arg.as_object().is_error()))
+        Ok(cx.bool(arg.is::<ErrorObject>()))
     }}
 }
 

--- a/src/js/runtime/intrinsics/error_prototype.rs
+++ b/src/js/runtime/intrinsics/error_prototype.rs
@@ -74,11 +74,9 @@ impl ErrorPrototype {
     runtime_fn! {
     fn get_stack(cx, this_value, _) {
         // Check that `stack` getter was called on an error object
-        if !this_value.is_object() || !this_value.as_object().is_error() {
+        let Some(mut error) = this_value.as_opt::<ErrorObject>() else {
             return Ok(cx.undefined());
-        }
-
-        let mut error = this_value.cast::<ErrorObject>();
+        };
 
         // Stack trace starts with error message on one line
         let mut stack_trace = format_error_one_line(cx, error)?;

--- a/src/js/runtime/intrinsics/finalization_registry_prototype.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_prototype.rs
@@ -109,7 +109,7 @@ fn this_finalization_registry_value(
     method_name: &str,
 ) -> EvalResult<Handle<FinalizationRegistryObject>> {
     if value.is_object() {
-        if let Some(registry_object) = value.as_object().as_finalization_registry_object() {
+        if let Some(registry_object) = value.as_opt::<FinalizationRegistryObject>() {
             return Ok(registry_object);
         }
     }

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -185,7 +185,7 @@ impl FunctionPrototype {
         }
 
         let this_object = this_value.as_object();
-        if let Some(closure) = this_object.as_closure() {
+        if let Some(closure) = this_object.as_opt::<Closure>() {
             let function = closure.function();
 
             // First check for if the closure is a bound function

--- a/src/js/runtime/intrinsics/iterator_constructor.rs
+++ b/src/js/runtime/intrinsics/iterator_constructor.rs
@@ -203,7 +203,7 @@ fn this_wrapped_valid_iterator_object(
     method_name: &str,
 ) -> EvalResult<Handle<WrappedValidIterator>> {
     if value.is_object() {
-        if let Some(wrapper) = value.as_object().as_wrapped_valid_iterator_object() {
+        if let Some(wrapper) = value.as_opt::<WrappedValidIterator>() {
             return Ok(wrapper);
         }
     }

--- a/src/js/runtime/intrinsics/iterator_helper_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_prototype.rs
@@ -126,7 +126,7 @@ fn this_iterator_helper_object(
     method_name: &str,
 ) -> EvalResult<Handle<IteratorHelperObject>> {
     if value.is_object() {
-        if let Some(iterator_helper) = value.as_object().as_iterator_helper_object() {
+        if let Some(iterator_helper) = value.as_opt::<IteratorHelperObject>() {
             return Ok(iterator_helper);
         }
     }

--- a/src/js/runtime/intrinsics/json_object.rs
+++ b/src/js/runtime/intrinsics/json_object.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 
+use crate::runtime::intrinsics::number_constructor::NumberObject;
+use crate::runtime::string_object::StringObject;
 use crate::{
     common::{
         unicode::{CodePoint, CodeUnit, is_ascii_lowercase_alphabetic, is_decimal_digit},
@@ -55,7 +57,7 @@ impl JSONObject {
     /// JSON.isRawJSON (https://tc39.es/ecma262/#sec-json.israwjson)
     fn is_raw_json(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
-        let is_raw_json = argument.is_object() && argument.as_object().is_raw_json_object();
+        let is_raw_json = argument.is::<RawJSONObject>();
 
         Ok(cx.bool(is_raw_json))
     }}
@@ -156,18 +158,15 @@ impl JSONObject {
                         if property_keys_set.insert(property_key) {
                             property_keys.push(property_key);
                         }
-                    } else if array_element.is_object() {
+                    } else if array_element.is::<NumberObject>()
+                        || array_element.is::<StringObject>()
+                    {
                         // Property may be a number or string object
-                        let array_element_object = array_element.as_object();
-                        if array_element_object.is_number_object()
-                            || array_element_object.is_string_object()
-                        {
-                            let string = to_string(cx, array_element_object.into())?;
-                            let property_key = PropertyKey::string_handle(cx, string)?;
+                        let string = to_string(cx, array_element)?;
+                        let property_key = PropertyKey::string_handle(cx, string)?;
 
-                            if property_keys_set.insert(property_key) {
-                                property_keys.push(property_key);
-                            }
+                        if property_keys_set.insert(property_key) {
+                            property_keys.push(property_key);
                         }
                     }
                 }
@@ -180,15 +179,10 @@ impl JSONObject {
         // Convert number and string object to primitive values
         let space_arg = arguments.get(cx, 2);
 
-        let space_value = if space_arg.is_object() {
-            let space_object = space_arg.as_object();
-            if space_object.is_number_object() {
-                to_number(cx, space_object.into())?
-            } else if space_object.is_string_object() {
-                to_string(cx, space_object.into())?.into()
-            } else {
-                space_arg
-            }
+        let space_value = if space_arg.is::<NumberObject>() {
+            to_number(cx, space_arg)?
+        } else if space_arg.is::<StringObject>() {
+            to_string(cx, space_arg)?.into()
         } else {
             space_arg
         };

--- a/src/js/runtime/intrinsics/json_serializer.rs
+++ b/src/js/runtime/intrinsics/json_serializer.rs
@@ -1,3 +1,8 @@
+use crate::runtime::intrinsics::bigint_constructor::BigIntObject;
+use crate::runtime::intrinsics::boolean_constructor::BooleanObject;
+use crate::runtime::intrinsics::number_constructor::NumberObject;
+use crate::runtime::intrinsics::raw_json_object::RawJSONObject;
+use crate::runtime::string_object::StringObject;
 use crate::{
     common::{unicode::is_surrogate_code_point, wtf_8::Wtf8String},
     must,
@@ -76,30 +81,27 @@ impl JSONSerializer {
         }
 
         // Convert primitive wrapper objects to their underlying primitive value
-        if value.is_object() {
-            let value_object = value.as_object();
-            if let Some(raw_json_object) = value_object.as_raw_json_object() {
-                // Raw JSON objects have the stored `rawJSON` property used as-is. Object is frozen
-                // so we know that the `rawJSON` property will be a string, but assert it anyways
-                // for safety.
-                let raw_json = must!(get(cx, raw_json_object.as_object(), cx.names.raw_json()));
+        if let Some(raw_json_object) = value.as_opt::<RawJSONObject>() {
+            // Raw JSON objects have the stored `rawJSON` property used as-is. Object is frozen
+            // so we know that the `rawJSON` property will be a string, but assert it anyways
+            // for safety.
+            let raw_json = must!(get(cx, raw_json_object.as_object(), cx.names.raw_json()));
 
-                assert!(raw_json.is_string());
-                let raw_string = raw_json.as_string();
+            assert!(raw_json.is_string());
+            let raw_string = raw_json.as_string();
 
-                self.builder.push_wtf8_str(&raw_string.to_wtf8_string()?);
+            self.builder.push_wtf8_str(&raw_string.to_wtf8_string()?);
 
-                // We know the exact raw JSON for this entire subtree, so immediately return it
-                return Ok(true);
-            } else if value_object.is_number_object() {
-                value = to_number(cx, value)?;
-            } else if value_object.is_string_object() {
-                value = to_string(cx, value)?.into();
-            } else if let Some(boolean_object) = value_object.as_boolean_object() {
-                value = cx.bool(boolean_object.boolean_data());
-            } else if let Some(bigint_object) = value_object.as_bigint_object() {
-                value = bigint_object.bigint_data().into()
-            }
+            // We know the exact raw JSON for this entire subtree, so immediately return it
+            return Ok(true);
+        } else if value.is::<NumberObject>() {
+            value = to_number(cx, value)?;
+        } else if value.is::<StringObject>() {
+            value = to_string(cx, value)?.into();
+        } else if let Some(boolean_object) = value.as_opt::<BooleanObject>() {
+            value = cx.bool(boolean_object.boolean_data());
+        } else if let Some(bigint_object) = value.as_opt::<BigIntObject>() {
+            value = bigint_object.bigint_data().into()
         }
 
         if value.is_null() {

--- a/src/js/runtime/intrinsics/map_prototype.rs
+++ b/src/js/runtime/intrinsics/map_prototype.rs
@@ -249,7 +249,7 @@ fn this_map_value(
     method_name: &str,
 ) -> EvalResult<Handle<MapObject>> {
     if value.is_object() {
-        if let Some(map) = value.as_object().as_map_object() {
+        if let Some(map) = value.as_opt::<MapObject>() {
             return Ok(map);
         }
     }

--- a/src/js/runtime/intrinsics/number_prototype.rs
+++ b/src/js/runtime/intrinsics/number_prototype.rs
@@ -393,12 +393,9 @@ fn this_number_value(
         return Ok(value);
     }
 
-    if value.is_object() {
-        let object_value = value.as_object();
-        if let Some(number_object) = object_value.as_number_object() {
-            let number_f64 = number_object.number_data();
-            return Ok(Value::number(number_f64));
-        }
+    if let Some(number_object) = value.as_opt::<NumberObject>() {
+        let number_f64 = number_object.number_data();
+        return Ok(Value::number(number_f64));
     }
 
     type_error(cx, &format!("Number.prototype.{method_name} must be called on a number"))

--- a/src/js/runtime/intrinsics/object_prototype.rs
+++ b/src/js/runtime/intrinsics/object_prototype.rs
@@ -1,5 +1,11 @@
 use std::mem::size_of;
 
+use crate::runtime::intrinsics::boolean_constructor::BooleanObject;
+use crate::runtime::intrinsics::date_object::DateObject;
+use crate::runtime::intrinsics::error_constructor::ErrorObject;
+use crate::runtime::intrinsics::number_constructor::NumberObject;
+use crate::runtime::intrinsics::regexp_constructor::RegExpObject;
+use crate::runtime::string_object::StringObject;
 use crate::{
     extend_object, intrinsic_methods,
     runtime::{
@@ -160,17 +166,17 @@ impl ObjectPrototype {
             "Arguments"
         } else if object.is_callable() {
             "Function"
-        } else if object.is_error() {
+        } else if object.is::<ErrorObject>() {
             "Error"
-        } else if object.is_boolean_object() {
+        } else if object.is::<BooleanObject>() {
             "Boolean"
-        } else if object.is_number_object() {
+        } else if object.is::<NumberObject>() {
             "Number"
-        } else if object.is_string_object() {
+        } else if object.is::<StringObject>() {
             "String"
-        } else if object.is_date_object() {
+        } else if object.is::<DateObject>() {
             "Date"
-        } else if object.is_regexp_object() {
+        } else if object.is::<RegExpObject>() {
             "RegExp"
         } else {
             "Object"

--- a/src/js/runtime/intrinsics/promise_prototype.rs
+++ b/src/js/runtime/intrinsics/promise_prototype.rs
@@ -9,7 +9,7 @@ use crate::{
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
-        promise_object::{PromiseCapability, PromiseObject, is_promise, promise_resolve},
+        promise_object::{PromiseCapability, PromiseObject, promise_resolve},
         realm::Realm,
         type_utilities::is_callable,
     },
@@ -212,10 +212,9 @@ impl PromisePrototype {
     runtime_fn! {
     /// Promise.prototype.then (https://tc39.es/ecma262/#sec-promise.prototype.then)
     fn then(cx, this_value, arguments) {
-        if !is_promise(*this_value) {
+        let Some(promise) = this_value.as_opt::<PromiseObject>() else {
             return type_error(cx, "Promise.prototype.then must be called on a Promise");
-        }
-        let promise = this_value.as_object().cast::<PromiseObject>();
+        };
 
         let constructor = species_constructor(cx, promise.into(), Intrinsic::PromiseConstructor)?;
         let capability = PromiseCapability::new(cx, constructor.into())?;

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -276,7 +276,7 @@ impl RegExpConstructor {
 #[inline]
 pub fn as_regexp_object(value: Handle<Value>) -> Option<Handle<RegExpObject>> {
     if value.is_object() {
-        value.as_object().as_regexp_object()
+        value.as_opt::<RegExpObject>()
     } else {
         None
     }

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -512,7 +512,7 @@ impl RegExpPrototype {
     fn source(cx, this_value, _) {
         if this_value.is_object() {
             let this_object = this_value.as_object();
-            if let Some(regexp_object) = this_object.as_regexp_object() {
+            if let Some(regexp_object) = this_object.as_opt::<RegExpObject>() {
                 return Ok(regexp_object.escaped_pattern_source().as_value());
             } else if same_object_value(
                 *this_object,
@@ -754,7 +754,7 @@ fn this_regexp_object(
     method_name: &str,
 ) -> EvalResult<Handle<RegExpObject>> {
     if this_value.is_object() {
-        if let Some(regexp_object) = this_value.as_object().as_regexp_object() {
+        if let Some(regexp_object) = this_value.as_opt::<RegExpObject>() {
             return Ok(regexp_object);
         }
     }
@@ -771,7 +771,7 @@ fn regexp_has_flag(
 ) -> EvalResult<Handle<Value>> {
     if this_value.is_object() {
         let this_object = this_value.as_object();
-        if let Some(regexp_object) = this_object.as_regexp_object() {
+        if let Some(regexp_object) = this_object.as_opt::<RegExpObject>() {
             let has_flag = regexp_object.flags().contains(flag);
             return Ok(cx.bool(has_flag));
         } else if same_object_value(*this_object, cx.get_intrinsic_ptr(Intrinsic::RegExpPrototype))
@@ -808,11 +808,11 @@ pub fn regexp_exec(
         return Ok(exec_result);
     }
 
-    if !regexp_object.is_regexp_object() {
+    let Some(regexp_object) = regexp_object.as_opt::<RegExpObject>() else {
         return type_error(cx, &format!("{method_name} must be called on a RegExp"));
-    }
+    };
 
-    regexp_builtin_exec(cx, regexp_object.cast::<RegExpObject>(), string_value)
+    regexp_builtin_exec(cx, regexp_object, string_value)
 }
 
 /// RegExpBuiltinExec (https://tc39.es/ecma262/#sec-regexpbuiltinexec)

--- a/src/js/runtime/intrinsics/set_prototype.rs
+++ b/src/js/runtime/intrinsics/set_prototype.rs
@@ -514,7 +514,7 @@ fn this_set_value(
     method_name: &str,
 ) -> EvalResult<Handle<SetObject>> {
     if value.is_object() {
-        if let Some(set_object) = value.as_object().as_set_object() {
+        if let Some(set_object) = value.as_opt::<SetObject>() {
             return Ok(set_object);
         }
     }

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -1,3 +1,4 @@
+use crate::runtime::intrinsics::regexp_constructor::RegExpObject;
 use crate::{
     common::{
         icu::ICU,
@@ -425,14 +426,14 @@ impl StringPrototype {
                 let flags_string = get(cx, regexp_object, cx.names.flags())?;
                 require_object_coercible(cx, flags_string)?;
 
-                let has_global_flag = if let Some(regexp_object) = regexp_object.as_regexp_object()
-                {
-                    regexp_object.flags().is_global()
-                } else {
-                    let flags_string = to_string(cx, flags_string)?;
+                let has_global_flag =
+                    if let Some(regexp_object) = regexp_object.as_opt::<RegExpObject>() {
+                        regexp_object.flags().is_global()
+                    } else {
+                        let flags_string = to_string(cx, flags_string)?;
 
-                    flags_string_contains(flags_string, 'g' as u32)?
-                };
+                        flags_string_contains(flags_string, 'g' as u32)?
+                    };
 
                 if !has_global_flag {
                     return type_error(
@@ -1273,11 +1274,8 @@ fn this_string_value(
         return Ok(value);
     }
 
-    if value.is_object() {
-        let object_value = value.as_object();
-        if let Some(string_object) = object_value.as_string_object() {
-            return Ok(string_object.string_data().as_value());
-        }
+    if let Some(string_object) = value.as_opt::<StringObject>() {
+        return Ok(string_object.string_data().as_value());
     }
 
     type_error(cx, &format!("String.prototype.{} must be called on a string", method_name))

--- a/src/js/runtime/intrinsics/symbol_prototype.rs
+++ b/src/js/runtime/intrinsics/symbol_prototype.rs
@@ -1,3 +1,4 @@
+use crate::runtime::intrinsics::symbol_constructor::SymbolObject;
 use crate::{
     intrinsic_methods,
     runtime::{
@@ -79,11 +80,8 @@ fn this_symbol_value(
         return Ok(value);
     }
 
-    if value.is_object() {
-        let object_value = value.as_object();
-        if let Some(symbol_object) = object_value.as_symbol_object() {
-            return Ok(symbol_object.symbol_data().into());
-        }
+    if let Some(symbol_object) = value.as_opt::<SymbolObject>() {
+        return Ok(symbol_object.symbol_data().into());
     }
 
     type_error(cx, &format!("Symbol.prototype.{} must be called on a symbol", method_name))

--- a/src/js/runtime/intrinsics/temporal/duration_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_constructor.rs
@@ -129,7 +129,7 @@ pub fn to_temporal_duration(
     method_name: &str,
 ) -> EvalResult<Duration> {
     if item.is_object() {
-        if let Some(duration_object) = item.as_object().as_duration_object() {
+        if let Some(duration_object) = item.as_opt::<DurationObject>() {
             return Ok(duration_object.duration());
         }
     } else if item.is_string() {

--- a/src/js/runtime/intrinsics/temporal/duration_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_prototype.rs
@@ -404,7 +404,7 @@ fn this_duration(
     method_name: &str,
 ) -> EvalResult<Handle<DurationObject>> {
     if value.is_object() {
-        if let Some(duration) = value.as_object().as_duration_object() {
+        if let Some(duration) = value.as_opt::<DurationObject>() {
             return Ok(duration);
         }
     }

--- a/src/js/runtime/intrinsics/temporal/instant_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_constructor.rs
@@ -1,6 +1,7 @@
 use num_bigint::BigInt;
 use temporal_rs::Instant;
 
+use crate::runtime::intrinsics::temporal::zoned_date_time_object::ZonedDateTimeObject;
 use crate::{
     common::constants::NANOSECONDS_IN_ONE_MILLISECOND,
     intrinsic_methods,
@@ -148,10 +149,9 @@ pub fn to_temporal_instant(
 ) -> EvalResult<Instant> {
     if item.is_object() {
         // Check if item is a Temporal object of some kind
-        let item_object = item.as_object();
-        if let Some(instant) = item_object.as_instant_object() {
+        if let Some(instant) = item.as_opt::<InstantObject>() {
             return Ok(instant.instant());
-        } else if let Some(zoned_date_time) = item_object.as_zoned_date_time_object() {
+        } else if let Some(zoned_date_time) = item.as_opt::<ZonedDateTimeObject>() {
             return Ok(zoned_date_time.zoned_date_time().to_instant());
         }
 

--- a/src/js/runtime/intrinsics/temporal/instant_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_prototype.rs
@@ -287,7 +287,7 @@ fn this_instant(
     method_name: &str,
 ) -> EvalResult<Handle<InstantObject>> {
     if value.is_object() {
-        if let Some(instant) = value.as_object().as_instant_object() {
+        if let Some(instant) = value.as_opt::<InstantObject>() {
             return Ok(instant);
         }
     }

--- a/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
@@ -2,6 +2,8 @@ use temporal_rs::{
     PlainDate, options::Overflow, parsed_intermediates::ParsedDate, partial::PartialDate,
 };
 
+use crate::runtime::intrinsics::temporal::plain_date_time_object::PlainDateTimeObject;
+use crate::runtime::intrinsics::temporal::zoned_date_time_object::ZonedDateTimeObject;
 use crate::{
     intrinsic_methods,
     runtime::{
@@ -134,13 +136,13 @@ pub fn to_temporal_date_with_options(
     if item.is_object() {
         // Check if item is a Temporal object of some kind
         let item_object = item.as_object();
-        if let Some(plain_date) = item_object.as_plain_date_object() {
+        if let Some(plain_date) = item_object.as_opt::<PlainDateObject>() {
             validate_overflow_option(cx, options, method_name)?;
             return Ok(plain_date.date().clone());
-        } else if let Some(zoned_date_time) = item_object.as_zoned_date_time_object() {
+        } else if let Some(zoned_date_time) = item_object.as_opt::<ZonedDateTimeObject>() {
             validate_overflow_option(cx, options, method_name)?;
             return Ok(zoned_date_time.zoned_date_time().to_plain_date());
-        } else if let Some(plain_date_time) = item_object.as_plain_date_time_object() {
+        } else if let Some(plain_date_time) = item_object.as_opt::<PlainDateTimeObject>() {
             validate_overflow_option(cx, options, method_name)?;
             return Ok(plain_date_time.date_time().to_plain_date());
         }

--- a/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
@@ -521,7 +521,7 @@ fn this_plain_date(
     method_name: &str,
 ) -> EvalResult<Handle<PlainDateObject>> {
     if value.is_object() {
-        if let Some(plain_date) = value.as_object().as_plain_date_object() {
+        if let Some(plain_date) = value.as_opt::<PlainDateObject>() {
             return Ok(plain_date);
         }
     }

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
@@ -1,5 +1,7 @@
 use temporal_rs::{PlainDateTime, parsed_intermediates::ParsedDateTime, partial::PartialDateTime};
 
+use crate::runtime::intrinsics::temporal::plain_date_object::PlainDateObject;
+use crate::runtime::intrinsics::temporal::zoned_date_time_object::ZonedDateTimeObject;
 use crate::{
     intrinsic_methods,
     runtime::{
@@ -150,17 +152,17 @@ fn to_temporal_date_time_with_options(
     if item.is_object() {
         // Check if item is a Temporal object of some kind
         let item_object = item.as_object();
-        if let Some(plain_date_time) = item_object.as_plain_date_time_object() {
+        if let Some(plain_date_time) = item_object.as_opt::<PlainDateTimeObject>() {
             let options = validate_options_object(cx, options, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 
             return Ok(plain_date_time.date_time().clone());
-        } else if let Some(zoned_date_time) = item_object.as_zoned_date_time_object() {
+        } else if let Some(zoned_date_time) = item_object.as_opt::<ZonedDateTimeObject>() {
             let options = validate_options_object(cx, options, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 
             return Ok(zoned_date_time.zoned_date_time().to_plain_date_time());
-        } else if let Some(plain_date) = item_object.as_plain_date_object() {
+        } else if let Some(plain_date) = item_object.as_opt::<PlainDateObject>() {
             let options = validate_options_object(cx, options, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
@@ -646,7 +646,7 @@ fn this_plain_date_time(
     method_name: &str,
 ) -> EvalResult<Handle<PlainDateTimeObject>> {
     if value.is_object() {
-        if let Some(plain_date_time) = value.as_object().as_plain_date_time_object() {
+        if let Some(plain_date_time) = value.as_opt::<PlainDateTimeObject>() {
             return Ok(plain_date_time);
         }
     }

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
@@ -113,7 +113,7 @@ pub fn to_temporal_month_day(
     if item.is_object() {
         // Check if item is a Temporal object of some kind
         let item_object = item.as_object();
-        if let Some(plain_month_day) = item_object.as_plain_month_day_object() {
+        if let Some(plain_month_day) = item_object.as_opt::<PlainMonthDayObject>() {
             let options = validate_options_object(cx, options_arg, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
@@ -225,7 +225,7 @@ fn this_plain_month_day(
     method_name: &str,
 ) -> EvalResult<Handle<PlainMonthDayObject>> {
     if value.is_object() {
-        if let Some(plain_month_day) = value.as_object().as_plain_month_day_object() {
+        if let Some(plain_month_day) = value.as_opt::<PlainMonthDayObject>() {
             return Ok(plain_month_day);
         }
     }

--- a/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_constructor.rs
@@ -1,5 +1,7 @@
 use temporal_rs::PlainTime;
 
+use crate::runtime::intrinsics::temporal::plain_date_time_object::PlainDateTimeObject;
+use crate::runtime::intrinsics::temporal::zoned_date_time_object::ZonedDateTimeObject;
 use crate::{
     intrinsic_methods,
     runtime::{
@@ -131,18 +133,17 @@ pub fn to_temporal_time_with_options(
 ) -> EvalResult<PlainTime> {
     if item.is_object() {
         // Check if item is a Temporal object of some kind
-        let object = item.as_object();
-        if let Some(plain_time) = object.as_plain_time_object() {
+        if let Some(plain_time) = item.as_opt::<PlainTimeObject>() {
             let options = validate_options_object(cx, options_arg, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 
             return Ok(plain_time.time());
-        } else if let Some(plain_date_time) = object.as_plain_date_time_object() {
+        } else if let Some(plain_date_time) = item.as_opt::<PlainDateTimeObject>() {
             let options = validate_options_object(cx, options_arg, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 
             return Ok(plain_date_time.date_time().to_plain_time());
-        } else if let Some(zoned_date_time) = object.as_zoned_date_time_object() {
+        } else if let Some(zoned_date_time) = item.as_opt::<ZonedDateTimeObject>() {
             let options = validate_options_object(cx, options_arg, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 

--- a/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_prototype.rs
@@ -324,7 +324,7 @@ fn this_plain_time(
     method_name: &str,
 ) -> EvalResult<Handle<PlainTimeObject>> {
     if value.is_object() {
-        if let Some(time) = value.as_object().as_plain_time_object() {
+        if let Some(time) = value.as_opt::<PlainTimeObject>() {
             return Ok(time);
         }
     }

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
@@ -124,7 +124,7 @@ pub fn to_temporal_year_month(
     if item.is_object() {
         // Check if item is a Temporal object of some kind
         let item_object = item.as_object();
-        if let Some(plain_year_month) = item_object.as_plain_year_month_object() {
+        if let Some(plain_year_month) = item_object.as_opt::<PlainYearMonthObject>() {
             let options = validate_options_object(cx, options_arg, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
@@ -404,7 +404,7 @@ fn this_plain_year_month(
     method_name: &str,
 ) -> EvalResult<Handle<PlainYearMonthObject>> {
     if value.is_object() {
-        if let Some(plain_year_month) = value.as_object().as_plain_year_month_object() {
+        if let Some(plain_year_month) = value.as_opt::<PlainYearMonthObject>() {
             return Ok(plain_year_month);
         }
     }

--- a/src/js/runtime/intrinsics/temporal/utils.rs
+++ b/src/js/runtime/intrinsics/temporal/utils.rs
@@ -16,6 +16,12 @@ use temporal_rs::{
     provider::TransitionDirection,
 };
 
+use crate::runtime::intrinsics::temporal::plain_date_object::PlainDateObject;
+use crate::runtime::intrinsics::temporal::plain_date_time_object::PlainDateTimeObject;
+use crate::runtime::intrinsics::temporal::plain_month_day_object::PlainMonthDayObject;
+use crate::runtime::intrinsics::temporal::plain_time_object::PlainTimeObject;
+use crate::runtime::intrinsics::temporal::plain_year_month_object::PlainYearMonthObject;
+use crate::runtime::intrinsics::temporal::zoned_date_time_object::ZonedDateTimeObject;
 use crate::{
     must,
     runtime::{
@@ -283,11 +289,11 @@ pub fn get_relative_to_option(
 
     if option_value.is_object() {
         let option_object = option_value.as_object();
-        if let Some(plain_date) = option_object.as_plain_date_object() {
+        if let Some(plain_date) = option_object.as_opt::<PlainDateObject>() {
             return Ok(Some(RelativeTo::PlainDate(plain_date.date().clone())));
-        } else if let Some(plain_date_time) = option_object.as_plain_date_time_object() {
+        } else if let Some(plain_date_time) = option_object.as_opt::<PlainDateTimeObject>() {
             return Ok(Some(RelativeTo::PlainDate(plain_date_time.date_time().to_plain_date())));
-        } else if let Some(zoned_date_time) = option_object.as_zoned_date_time_object() {
+        } else if let Some(zoned_date_time) = option_object.as_opt::<ZonedDateTimeObject>() {
             return Ok(Some(RelativeTo::ZonedDateTime(zoned_date_time.zoned_date_time().clone())));
         }
 
@@ -464,15 +470,15 @@ pub fn get_calendar_identifier_with_iso_default(
     method_name: &str,
 ) -> EvalResult<Calendar> {
     // Use the calendar of a Temporal object
-    if let Some(date) = item_object.as_plain_date_object() {
+    if let Some(date) = item_object.as_opt::<PlainDateObject>() {
         return Ok(date.date().calendar().clone());
-    } else if let Some(date_time) = item_object.as_plain_date_time_object() {
+    } else if let Some(date_time) = item_object.as_opt::<PlainDateTimeObject>() {
         return Ok(date_time.date_time().calendar().clone());
-    } else if let Some(month_day) = item_object.as_plain_month_day_object() {
+    } else if let Some(month_day) = item_object.as_opt::<PlainMonthDayObject>() {
         return Ok(month_day.month_day().calendar().clone());
-    } else if let Some(year_month) = item_object.as_plain_year_month_object() {
+    } else if let Some(year_month) = item_object.as_opt::<PlainYearMonthObject>() {
         return Ok(year_month.year_month().calendar().clone());
-    } else if let Some(zoned_date_time) = item_object.as_zoned_date_time_object() {
+    } else if let Some(zoned_date_time) = item_object.as_opt::<ZonedDateTimeObject>() {
         return Ok(zoned_date_time.zoned_date_time().calendar().clone());
     }
 
@@ -607,7 +613,7 @@ pub fn to_time_zone_identifier(
     method_name: &str,
 ) -> EvalResult<TimeZone> {
     if value.is_object()
-        && let Some(zoned_date_time) = value.as_object().as_zoned_date_time_object()
+        && let Some(zoned_date_time) = value.as_opt::<ZonedDateTimeObject>()
     {
         return Ok(*zoned_date_time.zoned_date_time().time_zone());
     }
@@ -655,15 +661,15 @@ pub fn to_temporal_calendar_identifier(
 ) -> EvalResult<Calendar> {
     // Use the calendar of a Temporal object
     if value.is_object() {
-        if let Some(plain_date) = value.as_object().as_plain_date_object() {
+        if let Some(plain_date) = value.as_opt::<PlainDateObject>() {
             return Ok(plain_date.date().calendar().clone());
-        } else if let Some(plain_date_time) = value.as_object().as_plain_date_time_object() {
+        } else if let Some(plain_date_time) = value.as_opt::<PlainDateTimeObject>() {
             return Ok(plain_date_time.date_time().calendar().clone());
-        } else if let Some(plain_year_month) = value.as_object().as_plain_year_month_object() {
+        } else if let Some(plain_year_month) = value.as_opt::<PlainYearMonthObject>() {
             return Ok(plain_year_month.year_month().calendar().clone());
-        } else if let Some(plain_month_day) = value.as_object().as_plain_month_day_object() {
+        } else if let Some(plain_month_day) = value.as_opt::<PlainMonthDayObject>() {
             return Ok(plain_month_day.month_day().calendar().clone());
-        } else if let Some(zoned_date_time) = value.as_object().as_zoned_date_time_object() {
+        } else if let Some(zoned_date_time) = value.as_opt::<ZonedDateTimeObject>() {
             return Ok(zoned_date_time.zoned_date_time().calendar().clone());
         }
     }
@@ -694,12 +700,12 @@ pub fn is_partial_temporal_object(cx: Context, value: Handle<Value>) -> EvalResu
 
     let object = value.as_object();
 
-    if object.is_plain_date_object()
-        || object.is_plain_time_object()
-        || object.is_plain_date_time_object()
-        || object.is_zoned_date_time_object()
-        || object.is_plain_year_month_object()
-        || object.is_plain_month_day_object()
+    if object.is::<PlainDateObject>()
+        || object.is::<PlainTimeObject>()
+        || object.is::<PlainDateTimeObject>()
+        || object.is::<ZonedDateTimeObject>()
+        || object.is::<PlainYearMonthObject>()
+        || object.is::<PlainMonthDayObject>()
     {
         return Ok(false);
     }

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
@@ -150,7 +150,7 @@ pub fn to_temporal_zoned_date_time_with_options(
     if item.is_object() {
         // Check if item is another ZonedDateTime object
         let item_object = item.as_object();
-        if let Some(zdt) = item_object.as_zoned_date_time_object() {
+        if let Some(zdt) = item_object.as_opt::<ZonedDateTimeObject>() {
             validate_options(cx, options, method_name)?;
             return Ok(zdt.zoned_date_time().clone());
         }

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_prototype.rs
@@ -855,7 +855,7 @@ fn this_zoned_date_time(
     method_name: &str,
 ) -> EvalResult<Handle<ZonedDateTimeObject>> {
     if value.is_object() {
-        if let Some(zoned_date_time) = value.as_object().as_zoned_date_time_object() {
+        if let Some(zoned_date_time) = value.as_opt::<ZonedDateTimeObject>() {
             return Ok(zoned_date_time);
         }
     }

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -742,7 +742,7 @@ macro_rules! create_typed_array_constructor {
                         proto,
                         argument.as_typed_array(),
                     );
-                } else if let Some(argument) = argument.as_array_buffer() {
+                } else if let Some(argument) = argument.as_opt::<ArrayBufferObject>() {
                     let byte_offset = arguments.get(cx, 1);
                     let length = arguments.get(cx, 2);
 

--- a/src/js/runtime/intrinsics/utils.rs
+++ b/src/js/runtime/intrinsics/utils.rs
@@ -6,17 +6,11 @@ macro_rules! cast_from_value_fn {
             cx: Context,
             value: Handle<Value>,
         ) -> EvalResult<Handle<$type $(<$($generics),*>)?>> {
-            if !value.is_object() {
-                return type_error(cx, concat!("expected object of type ", $name));
+            if let Some(value) = value.as_opt::<$type>() {
+                Ok(value)
+            } else {
+                type_error(cx, concat!("expected object of type ", $name))
             }
-
-            // Check if object descriptor's kind matches the kind we are casting to
-            let object_value = value.as_object();
-            if object_value.descriptor().kind() != HeapItemKind::$type {
-                return type_error(cx, concat!("expected object of type ", $name));
-            }
-
-            Ok(object_value.cast::<$type>())
         }
     };
 }

--- a/src/js/runtime/intrinsics/weak_map_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_map_prototype.rs
@@ -169,7 +169,7 @@ fn this_weak_map_object(
     method_name: &str,
 ) -> EvalResult<Handle<WeakMapObject>> {
     if value.is_object() {
-        if let Some(weak_map_object) = value.as_object().as_weak_map_object() {
+        if let Some(weak_map_object) = value.as_opt::<WeakMapObject>() {
             return Ok(weak_map_object);
         }
     }

--- a/src/js/runtime/intrinsics/weak_ref_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_ref_prototype.rs
@@ -46,5 +46,5 @@ fn this_weak_ref_value(value: Handle<Value>) -> Option<Handle<WeakRefObject>> {
         return None;
     }
 
-    value.as_object().as_weak_ref_object()
+    value.as_opt::<WeakRefObject>()
 }

--- a/src/js/runtime/intrinsics/weak_set_prototype.rs
+++ b/src/js/runtime/intrinsics/weak_set_prototype.rs
@@ -94,7 +94,7 @@ fn this_weak_set_value(
     method_name: &str,
 ) -> EvalResult<Handle<WeakSetObject>> {
     if value.is_object() {
-        if let Some(weak_set_object) = value.as_object().as_weak_set_object() {
+        if let Some(weak_set_object) = value.as_opt::<WeakSetObject>() {
             return Ok(weak_set_object);
         }
     }

--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::Path};
 use crate::{
     completion_value, eval_err, if_abrupt_reject_promise, must, must_a,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, PropertyKey, Value,
+        Context, EvalResult, Handle, PropertyKey, Value,
         abstract_operations::{KeyOrValue, call_object, enumerable_own_property_names},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -89,18 +89,15 @@ fn get_dyn_module(cx: Context, function: Handle<ObjectValue>) -> DynModule {
     let item = function
         .private_element_find(cx, cx.symbols.module().cast())
         .unwrap()
-        .value()
-        .as_pointer();
+        .value();
 
-    debug_assert!(
-        item.descriptor().kind() == HeapItemKind::SourceTextModule
-            || item.descriptor().kind() == HeapItemKind::SyntheticModule
-    );
-
-    if item.descriptor().kind() == HeapItemKind::SourceTextModule {
-        item.cast::<SourceTextModule>().to_handle().as_dyn_module()
+    if let Some(module) = item.as_opt::<SourceTextModule>() {
+        module.to_handle().as_dyn_module()
     } else {
-        item.cast::<SyntheticModule>().to_handle().as_dyn_module()
+        item.as_opt::<SyntheticModule>()
+            .unwrap()
+            .to_handle()
+            .as_dyn_module()
     }
 }
 

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -104,25 +104,18 @@ impl HeapPtr<ModuleNamespaceObject> {
             None => return Ok(None),
         };
 
-        if heap_item.descriptor().kind() == HeapItemKind::BoxedValue {
-            let boxed_value = heap_item.cast::<BoxedValue>();
+        if let Some(boxed_value) = heap_item.as_opt::<BoxedValue>() {
             Ok(Some(boxed_value.get()))
         } else {
             // Otherwise must be a module - either a SourceTextModule or SyntheticModule - which
             // represents a namespace export of that module.
-            debug_assert!(
-                heap_item.descriptor().kind() == HeapItemKind::SourceTextModule
-                    || heap_item.descriptor().kind() == HeapItemKind::SyntheticModule
-            );
-
-            let namespace_object =
-                if heap_item.descriptor().kind() == HeapItemKind::SourceTextModule {
-                    let mut module = heap_item.cast::<SourceTextModule>().to_handle();
-                    module.get_namespace_object(cx)?
-                } else {
-                    let mut module = heap_item.cast::<SyntheticModule>().to_handle();
-                    module.get_namespace_object(cx)?
-                };
+            let namespace_object = if let Some(module) = heap_item.as_opt::<SourceTextModule>() {
+                let mut module = module.to_handle();
+                module.get_namespace_object(cx)?
+            } else {
+                let mut module = heap_item.as_opt::<SyntheticModule>().unwrap().to_handle();
+                module.get_namespace_object(cx)?
+            };
 
             Ok(Some(namespace_object.as_value()))
         }

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -10,50 +10,16 @@ use crate::{
     runtime::{
         Context, HeapItemKind, Realm,
         alloc_error::AllocResult,
-        array_object::ArrayObject,
         array_properties::ArrayProperties,
-        async_generator_object::AsyncGeneratorObject,
-        bytecode::function::Closure,
         collections::{BsIndexMapField, index_map::IndexMapInstance},
         error::type_error,
         eval_result::EvalResult,
-        gc::{Handle, HeapInfo, HeapItem, HeapPtr, HeapVisitor},
-        generator_object::GeneratorObject,
-        intrinsics::{
-            array_buffer_constructor::ArrayBufferObject,
-            bigint_constructor::BigIntObject,
-            boolean_constructor::BooleanObject,
-            data_view_constructor::DataViewObject,
-            date_object::DateObject,
-            error_constructor::ErrorObject,
-            finalization_registry_object::FinalizationRegistryObject,
-            iterator_constructor::WrappedValidIterator,
-            iterator_helper_object::IteratorHelperObject,
-            map_object::MapObject,
-            number_constructor::NumberObject,
-            object_prototype::ObjectPrototype,
-            raw_json_object::RawJSONObject,
-            regexp_constructor::RegExpObject,
-            set_object::SetObject,
-            symbol_constructor::SymbolObject,
-            temporal::{
-                duration_object::DurationObject, instant_object::InstantObject,
-                plain_date_object::PlainDateObject, plain_date_time_object::PlainDateTimeObject,
-                plain_month_day_object::PlainMonthDayObject, plain_time_object::PlainTimeObject,
-                plain_year_month_object::PlainYearMonthObject,
-                zoned_date_time_object::ZonedDateTimeObject,
-            },
-            typed_array::DynTypedArray,
-            weak_map_object::WeakMapObject,
-            weak_ref_constructor::WeakRefObject,
-            weak_set_object::WeakSetObject,
-        },
-        promise_object::PromiseObject,
+        gc::{Handle, HeapInfo, HeapItem, HeapPtr, HeapVisitor, WithHeapItemKind},
+        intrinsics::typed_array::DynTypedArray,
         property::{HeapProperty, Property},
         property_descriptor::PropertyDescriptor,
         property_key::PropertyKey,
         proxy_object::ProxyObject,
-        string_object::StringObject,
         type_utilities::is_callable_object,
         value::{SymbolValue, Value},
     },
@@ -459,7 +425,7 @@ impl Handle<ObjectValue> {
     /// The [[GetPrototypeOf]] internal method for all objects. Dispatches to type-specific
     /// implementations as necessary.
     pub fn get_prototype_of(&self, cx: Context) -> EvalResult<Option<Handle<ObjectValue>>> {
-        if let Some(proxy_object) = self.as_proxy() {
+        if let Some(proxy_object) = self.as_opt::<ProxyObject>() {
             proxy_object.get_prototype_of(cx)
         } else {
             self.ordinary_get_prototype_of()
@@ -473,7 +439,7 @@ impl Handle<ObjectValue> {
         cx: Context,
         new_prototype: Option<Handle<ObjectValue>>,
     ) -> EvalResult<bool> {
-        if let Some(mut proxy_object) = self.as_proxy() {
+        if let Some(mut proxy_object) = self.as_opt::<ProxyObject>() {
             proxy_object.set_prototype_of(cx, new_prototype)
         } else {
             self.ordinary_set_prototype_of(cx, new_prototype)
@@ -483,7 +449,7 @@ impl Handle<ObjectValue> {
     /// The [[IsExtensible]] internal method for all objects. Dispatches to type-specific
     /// implementations as necessary.
     pub fn is_extensible(&self, cx: Context) -> EvalResult<bool> {
-        if let Some(proxy_object) = self.as_proxy() {
+        if let Some(proxy_object) = self.as_opt::<ProxyObject>() {
             proxy_object.is_extensible(cx)
         } else {
             self.ordinary_is_extensible()
@@ -493,7 +459,7 @@ impl Handle<ObjectValue> {
     /// The [[PreventExtensions]] internal method for all objects. Dispatches to type-specific
     /// implementations as necessary.
     pub fn prevent_extensions(&mut self, cx: Context) -> EvalResult<bool> {
-        if let Some(mut proxy_object) = self.as_proxy() {
+        if let Some(mut proxy_object) = self.as_opt::<ProxyObject>() {
             return proxy_object.prevent_extensions(cx);
         }
 
@@ -587,6 +553,24 @@ impl Handle<ObjectValue> {
     #[inline]
     pub fn as_typed_array(&self) -> DynTypedArray {
         self.virtual_object().as_typed_array()
+    }
+}
+
+impl Handle<ObjectValue> {
+    /// Whether this is a heap item of a particular type.
+    #[inline]
+    pub fn is<T: WithHeapItemKind>(&self) -> bool {
+        self.descriptor().kind() == T::KIND
+    }
+
+    /// Return this value as a heap item of a particular type, or None if it is not of that type.
+    #[inline]
+    pub fn as_opt<T: WithHeapItemKind>(&self) -> Option<Handle<T>> {
+        if self.is::<T>() {
+            Some(self.cast())
+        } else {
+            None
+        }
     }
 }
 
@@ -710,170 +694,3 @@ impl HeapItem for ObjectValue {
         visitor.visit_pointer(&mut object_value.array_properties);
     }
 }
-
-/// Implement subtype checks and downcasts for an object subtype.
-///
-/// - `is_subtype` returns true if the object is of the given subtype.
-/// - `as_subtype` returns the object as the given subtype if it is of that subtype, otherwise None.
-macro_rules! impl_subtype_casts {
-    ($subtype:ident, $desc:expr, $is_func:ident, $as_func:ident) => {
-        impl ObjectValue {
-            #[inline]
-            pub fn $is_func(&self) -> bool {
-                self.descriptor().kind() == $desc
-            }
-        }
-
-        impl HeapPtr<ObjectValue> {
-            #[inline]
-            pub fn $as_func(&self) -> Option<HeapPtr<$subtype>> {
-                if self.$is_func() {
-                    Some(self.cast())
-                } else {
-                    None
-                }
-            }
-        }
-
-        impl Handle<ObjectValue> {
-            #[inline]
-            pub fn $as_func(&self) -> Option<Handle<$subtype>> {
-                if self.$is_func() {
-                    Some(self.cast())
-                } else {
-                    None
-                }
-            }
-        }
-    };
-}
-
-impl_subtype_casts!(ArrayObject, HeapItemKind::ArrayObject, is_array, as_array);
-impl_subtype_casts!(ErrorObject, HeapItemKind::ErrorObject, is_error, as_error);
-impl_subtype_casts!(
-    BooleanObject,
-    HeapItemKind::BooleanObject,
-    is_boolean_object,
-    as_boolean_object
-);
-impl_subtype_casts!(NumberObject, HeapItemKind::NumberObject, is_number_object, as_number_object);
-impl_subtype_casts!(StringObject, HeapItemKind::StringObject, is_string_object, as_string_object);
-impl_subtype_casts!(SymbolObject, HeapItemKind::SymbolObject, is_symbol_object, as_symbol_object);
-impl_subtype_casts!(BigIntObject, HeapItemKind::BigIntObject, is_bigint_object, as_bigint_object);
-impl_subtype_casts!(DateObject, HeapItemKind::DateObject, is_date_object, as_date_object);
-impl_subtype_casts!(RegExpObject, HeapItemKind::RegExpObject, is_regexp_object, as_regexp_object);
-impl_subtype_casts!(Closure, HeapItemKind::Closure, is_closure, as_closure);
-impl_subtype_casts!(MapObject, HeapItemKind::MapObject, is_map_object, as_map_object);
-impl_subtype_casts!(SetObject, HeapItemKind::SetObject, is_set_object, as_set_object);
-impl_subtype_casts!(
-    ArrayBufferObject,
-    HeapItemKind::ArrayBufferObject,
-    is_array_buffer,
-    as_array_buffer
-);
-impl_subtype_casts!(DataViewObject, HeapItemKind::DataViewObject, is_data_view, as_data_view);
-impl_subtype_casts!(ProxyObject, HeapItemKind::Proxy, is_proxy, as_proxy);
-impl_subtype_casts!(GeneratorObject, HeapItemKind::Generator, is_generator, as_generator);
-impl_subtype_casts!(
-    AsyncGeneratorObject,
-    HeapItemKind::AsyncGenerator,
-    is_async_generator,
-    as_async_generator
-);
-impl_subtype_casts!(PromiseObject, HeapItemKind::Promise, is_promise, as_promise);
-impl_subtype_casts!(
-    ObjectPrototype,
-    HeapItemKind::ObjectPrototype,
-    is_object_prototype,
-    as_object_prototype
-);
-impl_subtype_casts!(
-    WeakRefObject,
-    HeapItemKind::WeakRefObject,
-    is_weak_ref_object,
-    as_weak_ref_object
-);
-impl_subtype_casts!(
-    WeakSetObject,
-    HeapItemKind::WeakSetObject,
-    is_weak_set_object,
-    as_weak_set_object
-);
-impl_subtype_casts!(
-    WeakMapObject,
-    HeapItemKind::WeakMapObject,
-    is_weak_map_object,
-    as_weak_map_object
-);
-impl_subtype_casts!(
-    FinalizationRegistryObject,
-    HeapItemKind::FinalizationRegistryObject,
-    is_finalization_registry_object,
-    as_finalization_registry_object
-);
-impl_subtype_casts!(
-    DurationObject,
-    HeapItemKind::DurationObject,
-    is_duration_object,
-    as_duration_object
-);
-impl_subtype_casts!(
-    InstantObject,
-    HeapItemKind::InstantObject,
-    is_instant_object,
-    as_instant_object
-);
-impl_subtype_casts!(
-    PlainDateObject,
-    HeapItemKind::PlainDateObject,
-    is_plain_date_object,
-    as_plain_date_object
-);
-impl_subtype_casts!(
-    PlainDateTimeObject,
-    HeapItemKind::PlainDateTimeObject,
-    is_plain_date_time_object,
-    as_plain_date_time_object
-);
-impl_subtype_casts!(
-    PlainMonthDayObject,
-    HeapItemKind::PlainMonthDayObject,
-    is_plain_month_day_object,
-    as_plain_month_day_object
-);
-impl_subtype_casts!(
-    PlainTimeObject,
-    HeapItemKind::PlainTimeObject,
-    is_plain_time_object,
-    as_plain_time_object
-);
-impl_subtype_casts!(
-    PlainYearMonthObject,
-    HeapItemKind::PlainYearMonthObject,
-    is_plain_year_month_object,
-    as_plain_year_month_object
-);
-impl_subtype_casts!(
-    ZonedDateTimeObject,
-    HeapItemKind::ZonedDateTimeObject,
-    is_zoned_date_time_object,
-    as_zoned_date_time_object
-);
-impl_subtype_casts!(
-    RawJSONObject,
-    HeapItemKind::RawJSONObject,
-    is_raw_json_object,
-    as_raw_json_object
-);
-impl_subtype_casts!(
-    WrappedValidIterator,
-    HeapItemKind::WrappedValidIterator,
-    is_wrapped_valid_iterator_object,
-    as_wrapped_valid_iterator_object
-);
-impl_subtype_casts!(
-    IteratorHelperObject,
-    HeapItemKind::IteratorHelperObject,
-    is_iterator_helper_object,
-    as_iterator_helper_object
-);

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -1,3 +1,5 @@
+use crate::runtime::intrinsics::object_prototype::ObjectPrototype;
+use crate::runtime::proxy_object::ProxyObject;
 use crate::{
     extend_object_without_conversions, must, must_a,
     runtime::{
@@ -65,7 +67,7 @@ impl Handle<ObjectValue> {
         // Inlined SetImmutablePrototype (https://tc39.es/ecma262/#sec-set-immutable-prototype,)
         // currently only applies to object prototypes. If the prototypes differ, then a set
         // immutable prototype always fails.
-        if self.is_object_prototype() {
+        if self.is::<ObjectPrototype>() {
             return Ok(false);
         }
 
@@ -82,7 +84,7 @@ impl Handle<ObjectValue> {
                         return Ok(false);
                     }
 
-                    if current_proto.is_proxy() {
+                    if current_proto.is::<ProxyObject>() {
                         break;
                     } else {
                         current_prototype = must!(current_proto.get_prototype_of(cx));
@@ -168,10 +170,7 @@ pub fn ordinary_get_own_property(
         None => None,
         Some(property) => {
             let value = property.value();
-            if value.is_pointer()
-                && value.as_pointer().descriptor().kind() == HeapItemKind::Accessor
-            {
-                let accessor_value = value.as_pointer().cast::<Accessor>();
+            if let Some(accessor_value) = value.as_opt::<Accessor>() {
                 Some(PropertyDescriptor::accessor(
                     accessor_value.get.map(|f| f.to_handle()),
                     accessor_value.set.map(|f| f.to_handle()),

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -337,19 +337,6 @@ impl Handle<PromiseObject> {
     }
 }
 
-/// IsPromise (https://tc39.es/ecma262/#sec-ispromise)
-pub fn is_promise(value: Value) -> bool {
-    value.is_object() && value.as_object().is_promise()
-}
-
-pub fn as_promise(value: Handle<Value>) -> Option<Handle<PromiseObject>> {
-    if is_promise(*value) {
-        Some(value.cast())
-    } else {
-        None
-    }
-}
-
 /// Coerce a value to an ordinary promise (aka the Promise constructor). An ordinary promise is
 /// returned as-is, otherwise value is wrapped in a resolved promise.
 ///
@@ -359,7 +346,7 @@ pub fn coerce_to_ordinary_promise(
     cx: Context,
     value: Handle<Value>,
 ) -> EvalResult<Handle<PromiseObject>> {
-    if let Some(value) = as_promise(value) {
+    if let Some(value) = value.as_opt::<PromiseObject>() {
         let value_constructor = get(cx, value.into(), cx.names.constructor())?;
         let promise_constructor = cx.get_intrinsic_ptr(Intrinsic::PromiseConstructor);
         if value_constructor.is_object()
@@ -384,7 +371,7 @@ pub fn promise_resolve(
     result: Handle<Value>,
 ) -> EvalResult<Handle<ObjectValue>> {
     // If result is already a promise, return it if it was constructed with the same constructor.
-    if is_promise(*result) {
+    if result.is::<PromiseObject>() {
         let result = result.as_object();
         let value_constructor = get(cx, result, cx.names.constructor())?;
         if same_value(value_constructor, constructor)? {

--- a/src/js/runtime/property_key.rs
+++ b/src/js/runtime/property_key.rs
@@ -4,7 +4,7 @@ use crate::{
     common::numeric::Numeric,
     must_a,
     runtime::{
-        Context, EvalResult, HeapItemKind, HeapPtr, Value,
+        Context, EvalResult, HeapPtr, Value,
         alloc_error::AllocResult,
         gc::{Handle, HandleContents, ToHandleContents},
         interned_strings::InternedStrings,
@@ -204,10 +204,9 @@ impl hash::Hash for PropertyKey {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         if self.is_array_index() {
             self.as_array_index().hash(state);
-        } else if self.value.as_pointer().descriptor().kind() == HeapItemKind::String {
+        } else if let Some(string) = self.value.as_opt::<StringValue>() {
             // Strings must always be flat before they can be placed into hash tables to
             // avoid allocating in the hash function.
-            let string = self.as_string();
             debug_assert!(string.is_flat());
 
             string.as_flat().hash(state)
@@ -221,8 +220,8 @@ impl PropertyKey {
     pub fn format(&self) -> AllocResult<String> {
         if self.is_array_index() {
             Ok(format!("{}", self.as_array_index()))
-        } else if self.value.as_pointer().descriptor().kind() == HeapItemKind::String {
-            Ok(self.as_string().to_handle().format()?)
+        } else if let Some(string) = self.value.as_opt::<StringValue>() {
+            Ok(string.to_handle().format()?)
         } else {
             match self.as_symbol().description_ptr() {
                 None => Ok("Symbol()".to_owned()),

--- a/src/js/runtime/scope.rs
+++ b/src/js/runtime/scope.rs
@@ -167,10 +167,7 @@ impl Scope {
     pub fn get_module_slot(&self, index: usize) -> HeapPtr<BoxedValue> {
         let value = self.get_slot(index);
 
-        debug_assert!(
-            value.is_pointer()
-                && value.as_pointer().descriptor().kind() == HeapItemKind::BoxedValue
-        );
+        debug_assert!(value.is::<BoxedValue>());
 
         value.as_pointer().cast::<BoxedValue>()
     }
@@ -196,12 +193,7 @@ impl Scope {
     pub fn module_scope_module(&self) -> Option<HeapPtr<SourceTextModule>> {
         debug_assert!(self.kind == ScopeKind::Module);
 
-        let module = self.get_slot(0).as_pointer();
-        if module.descriptor().kind() == HeapItemKind::SourceTextModule {
-            Some(module.cast::<SourceTextModule>())
-        } else {
-            None
-        }
+        self.get_slot(0).as_opt::<SourceTextModule>()
     }
 }
 

--- a/src/js/runtime/test_262_object.rs
+++ b/src/js/runtime/test_262_object.rs
@@ -158,16 +158,9 @@ impl Test262Object {
     runtime_fn! {
     fn detach_array_buffer(cx, _, arguments) {
         let value = arguments.get(cx, 0);
-        if !value.is_object() {
+        let Some(mut array_buffer) = value.as_opt::<ArrayBufferObject>() else {
             return Ok(cx.undefined());
-        }
-
-        let object = value.as_object();
-        if !object.is_array_buffer() {
-            return Ok(cx.undefined());
-        }
-
-        let mut array_buffer = object.cast::<ArrayBufferObject>();
+        };
         array_buffer.detach();
 
         Ok(cx.undefined())

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -2,6 +2,8 @@ use std::cmp::Ordering;
 
 use num_bigint::{BigInt, ToBigInt};
 
+use crate::runtime::array_object::ArrayObject;
+use crate::runtime::intrinsics::regexp_constructor::RegExpObject;
 use crate::{
     common::{
         math::modulo,
@@ -694,12 +696,11 @@ pub fn is_array(cx: Context, value: Handle<Value>) -> EvalResult<bool> {
         return Ok(false);
     }
 
-    let object_value = value.as_object();
-    if object_value.is_array() {
+    if value.is::<ArrayObject>() {
         return Ok(true);
     }
 
-    if let Some(proxy) = object_value.as_proxy() {
+    if let Some(proxy) = value.as_opt::<ProxyObject>() {
         if proxy.is_revoked() {
             return type_error(cx, "operation attempted on revoked proxy");
         }
@@ -720,11 +721,10 @@ pub fn is_callable(value: Handle<Value>) -> bool {
 }
 
 pub fn is_callable_object(value: Handle<ObjectValue>) -> bool {
-    let kind = value.descriptor().kind();
-    if kind == HeapItemKind::Closure {
+    if value.is::<Closure>() {
         true
-    } else if kind == HeapItemKind::Proxy {
-        value.cast::<ProxyObject>().is_callable()
+    } else if let Some(proxy) = value.as_opt::<ProxyObject>() {
+        proxy.is_callable()
     } else {
         false
     }
@@ -740,11 +740,10 @@ pub fn is_constructor_value(value: Handle<Value>) -> bool {
 }
 
 pub fn is_constructor_object_value(value: Handle<ObjectValue>) -> bool {
-    let kind = value.descriptor().kind();
-    if kind == HeapItemKind::Closure {
-        value.cast::<Closure>().function_ptr().is_constructor()
-    } else if kind == HeapItemKind::Proxy {
-        value.cast::<ProxyObject>().is_constructor()
+    if let Some(closure) = value.as_opt::<Closure>() {
+        closure.function_ptr().is_constructor()
+    } else if let Some(proxy) = value.as_opt::<ProxyObject>() {
+        proxy.is_constructor()
     } else {
         false
     }
@@ -778,7 +777,7 @@ pub fn is_regexp(cx: Context, value: Handle<Value>) -> EvalResult<bool> {
         return Ok(to_boolean(*matcher));
     }
 
-    Ok(object.is_regexp_object())
+    Ok(object.is::<RegExpObject>())
 }
 
 /// SameValue (https://tc39.es/ecma262/#sec-samevalue)

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -13,6 +13,7 @@ use crate::{
         debug_print::{DebugPrint, DebugPrinter},
         gc::{
             AnyHeapItem, Handle, HandleContents, HeapItem, HeapPtr, HeapVisitor, ToHandleContents,
+            WithHeapItemKind,
         },
         heap_item_descriptor::HeapItemDescriptor,
         object_value::ObjectValue,
@@ -246,29 +247,17 @@ impl Value {
 
     #[inline]
     pub fn is_string(&self) -> bool {
-        if !self.is_pointer() {
-            return false;
-        }
-
-        self.as_pointer().descriptor().kind() == HeapItemKind::String
+        self.is::<StringValue>()
     }
 
     #[inline]
     pub fn is_symbol(&self) -> bool {
-        if !self.is_pointer() {
-            return false;
-        }
-
-        self.as_pointer().descriptor().kind() == HeapItemKind::Symbol
+        self.is::<SymbolValue>()
     }
 
     #[inline]
     pub fn is_bigint(&self) -> bool {
-        if !self.is_pointer() {
-            return false;
-        }
-
-        self.as_pointer().descriptor().kind() == HeapItemKind::BigInt
+        self.is::<BigIntValue>()
     }
 
     // Type casts
@@ -326,6 +315,22 @@ impl Value {
     #[inline]
     pub const fn as_bigint(&self) -> HeapPtr<BigIntValue> {
         HeapPtr::from_ptr(self.restore_pointer_bits())
+    }
+
+    /// Whether this is a heap item of a particular type.
+    #[inline]
+    pub fn is<T: WithHeapItemKind>(&self) -> bool {
+        self.is_pointer() && self.as_pointer().descriptor().kind() == T::KIND
+    }
+
+    /// Return this value as a heap item of a particular type, or None if it is not of that type.
+    #[inline]
+    pub fn as_opt<T: WithHeapItemKind>(&self) -> Option<HeapPtr<T>> {
+        if self.is::<T>() {
+            Some(self.as_pointer().cast())
+        } else {
+            None
+        }
     }
 
     // Constructors
@@ -477,6 +482,18 @@ impl ToHandleContents for Value {
     #[inline]
     fn to_handle_contents(value: Value) -> HandleContents {
         value.as_raw_bits() as usize
+    }
+}
+
+impl Handle<Value> {
+    /// Return this value as a heap item of a particular type, or None if it is not of that type.
+    #[inline]
+    pub fn as_opt<T: WithHeapItemKind>(&self) -> Option<Handle<T>> {
+        if self.is::<T>() {
+            Some(self.cast())
+        } else {
+            None
+        }
     }
 }
 

--- a/tests/harness/src/runner.rs
+++ b/tests/harness/src/runner.rs
@@ -20,7 +20,8 @@ use brimstone_core::{
     runtime::{
         Context, ContextBuilder, EvalResult, Handle, Value,
         bytecode::generator::BytecodeProgramGenerator, eval_result::EvalError, get,
-        test_262_object::Test262Object, to_console_string, to_string,
+        intrinsics::error_constructor::ErrorObject, test_262_object::Test262Object,
+        to_console_string, to_string,
     },
 };
 use serde_json::{self, json};
@@ -533,7 +534,7 @@ fn check_expected_completion(
                 // Check that the thrown error matches the expected error type
                 let is_expected_error = if thrown_value.is_object() {
                     let thrown_object = thrown_value.as_object();
-                    if thrown_object.is_error() {
+                    if thrown_object.is::<ErrorObject>() {
                         // Check if thrown error type has the same name as the expected error
                         match get(cx, thrown_object, cx.names.name()) {
                             Ok(name_value) if name_value.is_string() => {


### PR DESCRIPTION
## Summary

Introduce auto-implemented `is::<T>()` and `as_opt:<T>()` methods for type checks and casts of heap items. These are implemented on `Value`, `HeapPtr<ObjectValue>`, and their handles.

Use in place of the old checks/casts system that used `impl_subtype_casts`. Many callsites were simplified due to the new safe casts and their availability on `Value`.

## Tests

- CI