### PR TITLE
[runtime] Introduce RawBytesEncoding for packing bytes into an array of Values, use for temporal_rs storage

### DIFF
--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -318,19 +318,3 @@ impl HeapPtr<AnyHeapItem> {
         }
     }
 }
-
-/// Storage for a value whose natural alignment exceeds the 8-byte alignment of the managed heap.
-#[repr(C, packed(8))]
-pub struct HeapUnaligned<T>(T);
-
-impl<T> HeapUnaligned<T> {
-    #[inline]
-    pub fn new(value: T) -> Self {
-        HeapUnaligned(value)
-    }
-
-    #[inline]
-    pub fn get(&self) -> T {
-        unsafe { std::ptr::read_unaligned(&raw const self.0) }
-    }
-}

--- a/src/js/runtime/gc/mod.rs
+++ b/src/js/runtime/gc/mod.rs
@@ -12,9 +12,7 @@ pub use handle::{
     Escapable, Handle, HandleContents, HandleScope, HandleScopeGuard, ToHandleContents,
 };
 pub use heap::{Heap, HeapInfo};
-pub use heap_item::{
-    AnyHeapItem, HeapItem, HeapItemKind, HeapUnaligned, IsHeapItem, WithHeapItemKind,
-};
+pub use heap_item::{AnyHeapItem, HeapItem, HeapItemKind, IsHeapItem, WithHeapItemKind};
 #[allow(unused)]
 pub use heap_serializer::{HeapRootsDeserializer, HeapSerializer};
 pub use heap_visitor::HeapVisitor;

--- a/src/js/runtime/intrinsics/temporal/duration_object.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_object.rs
@@ -3,11 +3,12 @@ use temporal_rs::Duration;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
-        gc::{HeapItem, HeapUnaligned, HeapVisitor},
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
+        gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
+        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -15,9 +16,7 @@ use crate::{
 // Temporal.Duration Objects (https://tc39.es/proposal-temporal/#sec-temporal-duration-objects)
 extend_object! {
     pub struct DurationObject {
-        // Contains an `u128` field and so is 16-byte aligned. Must only access through the
-        // alignment wrapper.
-        duration: HeapUnaligned<Duration>,
+        duration: [Value; RawBytesEncoding::num_values::<Duration>()],
     }
 }
 
@@ -39,13 +38,13 @@ impl DurationObject {
             Intrinsic::DurationPrototype,
         )?;
 
-        set_uninit!(object.duration, HeapUnaligned::new(duration));
+        set_uninit!(object.duration, RawBytesEncoding::encode(&duration));
 
         Ok(object.to_handle())
     }
 
     pub fn duration(&self) -> Duration {
-        self.duration.get()
+        RawBytesEncoding::decode(&self.duration)
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/instant_object.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_object.rs
@@ -3,11 +3,12 @@ use temporal_rs::Instant;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
-        gc::{HeapItem, HeapUnaligned, HeapVisitor},
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
+        gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
+        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -15,9 +16,7 @@ use crate::{
 // Temporal.Instant Objects (https://tc39.es/proposal-temporal/#sec-temporal-instant-objects)
 extend_object! {
     pub struct InstantObject {
-        // Contains an `i128` field and so is 16-byte aligned. Must only access through the
-        // alignment wrapper.
-        instant: HeapUnaligned<Instant>,
+        instant: [Value; RawBytesEncoding::num_values::<Instant>()],
     }
 }
 
@@ -39,13 +38,13 @@ impl InstantObject {
             Intrinsic::InstantPrototype,
         )?;
 
-        set_uninit!(object.instant, HeapUnaligned::new(instant));
+        set_uninit!(object.instant, RawBytesEncoding::encode(&instant));
 
         Ok(object.to_handle())
     }
 
     pub fn instant(&self) -> Instant {
-        self.instant.get()
+        RawBytesEncoding::decode(&self.instant)
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
@@ -138,7 +138,7 @@ pub fn to_temporal_date_with_options(
         let item_object = item.as_object();
         if let Some(plain_date) = item_object.as_opt::<PlainDateObject>() {
             validate_overflow_option(cx, options, method_name)?;
-            return Ok(plain_date.date().clone());
+            return Ok(plain_date.date());
         } else if let Some(zoned_date_time) = item_object.as_opt::<ZonedDateTimeObject>() {
             validate_overflow_option(cx, options, method_name)?;
             return Ok(zoned_date_time.zoned_date_time().to_plain_date());

--- a/src/js/runtime/intrinsics/temporal/plain_date_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_object.rs
@@ -3,11 +3,12 @@ use temporal_rs::PlainDate;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
+        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -15,7 +16,7 @@ use crate::{
 // PlainDate Objects (https://tc39.es/proposal-temporal/#sec-temporal-plaindate-objects)
 extend_object! {
     pub struct PlainDateObject {
-        date: PlainDate,
+        date: [Value; RawBytesEncoding::num_values::<PlainDate>()],
     }
 }
 
@@ -37,13 +38,13 @@ impl PlainDateObject {
             Intrinsic::PlainDatePrototype,
         )?;
 
-        set_uninit!(object.date, date);
+        set_uninit!(object.date, RawBytesEncoding::encode(&date));
 
         Ok(object.to_handle())
     }
 
-    pub fn date(&self) -> &PlainDate {
-        &self.date
+    pub fn date(&self) -> PlainDate {
+        RawBytesEncoding::decode(&self.date)
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
@@ -324,7 +324,7 @@ impl PlainDatePrototype {
         let other_arg = arguments.get(cx, 0);
         let other_date = to_temporal_date(cx, other_arg, NAME)?;
 
-        Ok(cx.bool(this_date.date() == &other_date))
+        Ok(cx.bool(this_date.date() == other_date))
     }}
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
@@ -156,7 +156,7 @@ fn to_temporal_date_time_with_options(
             let options = validate_options_object(cx, options, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 
-            return Ok(plain_date_time.date_time().clone());
+            return Ok(plain_date_time.date_time());
         } else if let Some(zoned_date_time) = item_object.as_opt::<ZonedDateTimeObject>() {
             let options = validate_options_object(cx, options, method_name)?;
             get_overflow_option(cx, options, method_name)?;

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_object.rs
@@ -3,11 +3,12 @@ use temporal_rs::PlainDateTime;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
+        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -15,7 +16,7 @@ use crate::{
 // PlainDateTime Objects (https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-objects)
 extend_object! {
     pub struct PlainDateTimeObject {
-        date_time: PlainDateTime,
+        date_time: [Value; RawBytesEncoding::num_values::<PlainDateTime>()],
     }
 }
 
@@ -37,13 +38,13 @@ impl PlainDateTimeObject {
             Intrinsic::PlainDateTimePrototype,
         )?;
 
-        set_uninit!(object.date_time, date_time);
+        set_uninit!(object.date_time, RawBytesEncoding::encode(&date_time));
 
         Ok(object.to_handle())
     }
 
-    pub fn date_time(&self) -> &PlainDateTime {
-        &self.date_time
+    pub fn date_time(&self) -> PlainDateTime {
+        RawBytesEncoding::decode(&self.date_time)
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
@@ -443,7 +443,7 @@ impl PlainDateTimePrototype {
         let other_arg = arguments.get(cx, 0);
         let other_date_time = to_temporal_date_time(cx, other_arg, NAME)?;
 
-        Ok(cx.bool(this_date_time.date_time() == &other_date_time))
+        Ok(cx.bool(this_date_time.date_time() == other_date_time))
     }}
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
@@ -117,7 +117,7 @@ pub fn to_temporal_month_day(
             let options = validate_options_object(cx, options_arg, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 
-            return Ok(plain_month_day.month_day().clone());
+            return Ok(plain_month_day.month_day());
         }
 
         // Otherwise treat like a date-like object

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_object.rs
@@ -3,11 +3,12 @@ use temporal_rs::PlainMonthDay;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
+        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -15,7 +16,7 @@ use crate::{
 // PlainMonthDay Objects (https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-objects)
 extend_object! {
     pub struct PlainMonthDayObject {
-        month_day: PlainMonthDay,
+        month_day: [Value; RawBytesEncoding::num_values::<PlainMonthDay>()],
     }
 }
 
@@ -37,13 +38,13 @@ impl PlainMonthDayObject {
             Intrinsic::PlainMonthDayPrototype,
         )?;
 
-        set_uninit!(object.month_day, month_day);
+        set_uninit!(object.month_day, RawBytesEncoding::encode(&month_day));
 
         Ok(object.to_handle())
     }
 
-    pub fn month_day(&self) -> &PlainMonthDay {
-        &self.month_day
+    pub fn month_day(&self) -> PlainMonthDay {
+        RawBytesEncoding::decode(&self.month_day)
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
@@ -94,7 +94,7 @@ impl PlainMonthDayPrototype {
         let other_arg = arguments.get(cx, 0);
         let other_month_day = to_temporal_month_day(cx, other_arg, None, NAME)?;
 
-        Ok(cx.bool(this_month_day.month_day() == &other_month_day))
+        Ok(cx.bool(this_month_day.month_day() == other_month_day))
     }}
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_object.rs
@@ -3,11 +3,12 @@ use temporal_rs::PlainTime;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
+        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -15,7 +16,7 @@ use crate::{
 // Temporal.PlainTime Objects (https://tc39.es/proposal-temporal/#sec-temporal-plaintime-objects)
 extend_object! {
     pub struct PlainTimeObject {
-        time: PlainTime,
+        time: [Value; RawBytesEncoding::num_values::<PlainTime>()],
     }
 }
 
@@ -37,13 +38,13 @@ impl PlainTimeObject {
             Intrinsic::PlainTimePrototype,
         )?;
 
-        set_uninit!(object.time, time);
+        set_uninit!(object.time, RawBytesEncoding::encode(&time));
 
         Ok(object.to_handle())
     }
 
     pub fn time(&self) -> PlainTime {
-        self.time
+        RawBytesEncoding::decode(&self.time)
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
@@ -128,7 +128,7 @@ pub fn to_temporal_year_month(
             let options = validate_options_object(cx, options_arg, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 
-            return Ok(plain_year_month.year_month().clone());
+            return Ok(plain_year_month.year_month());
         }
 
         // Otherwise treat like a date-like object

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_object.rs
@@ -3,11 +3,12 @@ use temporal_rs::PlainYearMonth;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
+        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -15,7 +16,7 @@ use crate::{
 // PlainYearMonth Objects (https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-objects)
 extend_object! {
     pub struct PlainYearMonthObject {
-        year_month: PlainYearMonth,
+        year_month: [Value; RawBytesEncoding::num_values::<PlainYearMonth>()],
     }
 }
 
@@ -40,13 +41,13 @@ impl PlainYearMonthObject {
             Intrinsic::PlainYearMonthPrototype,
         )?;
 
-        set_uninit!(object.year_month, year_month);
+        set_uninit!(object.year_month, RawBytesEncoding::encode(&year_month));
 
         Ok(object.to_handle())
     }
 
-    pub fn year_month(&self) -> &PlainYearMonth {
-        &self.year_month
+    pub fn year_month(&self) -> PlainYearMonth {
+        RawBytesEncoding::decode(&self.year_month)
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
@@ -276,7 +276,7 @@ impl PlainYearMonthPrototype {
         let other_arg = arguments.get(cx, 0);
         let other_year_month = to_temporal_year_month(cx, other_arg, None, NAME)?;
 
-        Ok(cx.bool(this_year_month.year_month() == &other_year_month))
+        Ok(cx.bool(this_year_month.year_month() == other_year_month))
     }}
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/utils.rs
+++ b/src/js/runtime/intrinsics/temporal/utils.rs
@@ -290,11 +290,11 @@ pub fn get_relative_to_option(
     if option_value.is_object() {
         let option_object = option_value.as_object();
         if let Some(plain_date) = option_object.as_opt::<PlainDateObject>() {
-            return Ok(Some(RelativeTo::PlainDate(plain_date.date().clone())));
+            return Ok(Some(RelativeTo::PlainDate(plain_date.date())));
         } else if let Some(plain_date_time) = option_object.as_opt::<PlainDateTimeObject>() {
             return Ok(Some(RelativeTo::PlainDate(plain_date_time.date_time().to_plain_date())));
         } else if let Some(zoned_date_time) = option_object.as_opt::<ZonedDateTimeObject>() {
-            return Ok(Some(RelativeTo::ZonedDateTime(zoned_date_time.zoned_date_time().clone())));
+            return Ok(Some(RelativeTo::ZonedDateTime(zoned_date_time.zoned_date_time())));
         }
 
         // Otherwise treat as a date-like object

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
@@ -152,7 +152,7 @@ pub fn to_temporal_zoned_date_time_with_options(
         let item_object = item.as_object();
         if let Some(zdt) = item_object.as_opt::<ZonedDateTimeObject>() {
             validate_options(cx, options, method_name)?;
-            return Ok(zdt.zoned_date_time().clone());
+            return Ok(zdt.zoned_date_time());
         }
 
         // Otherwise treat like a date-like object

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
@@ -3,11 +3,12 @@ use temporal_rs::ZonedDateTime;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
-        gc::{HeapItem, HeapUnaligned, HeapVisitor},
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
+        gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
+        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -15,9 +16,7 @@ use crate::{
 // ZonedDateTime Objects (https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects)
 extend_object! {
     pub struct ZonedDateTimeObject {
-        // Contains an `i128` field and so is 16-byte aligned. Must only access through the
-        // alignment wrapper.
-        zoned_date_time: HeapUnaligned<ZonedDateTime>,
+        zoned_date_time: [Value; RawBytesEncoding::num_values::<ZonedDateTime>()],
     }
 }
 
@@ -42,13 +41,13 @@ impl ZonedDateTimeObject {
             Intrinsic::ZonedDateTimePrototype,
         )?;
 
-        set_uninit!(object.zoned_date_time, HeapUnaligned::new(zoned_date_time));
+        set_uninit!(object.zoned_date_time, RawBytesEncoding::encode(&zoned_date_time));
 
         Ok(object.to_handle())
     }
 
     pub fn zoned_date_time(&self) -> ZonedDateTime {
-        self.zoned_date_time.get()
+        RawBytesEncoding::decode(&self.zoned_date_time)
     }
 }
 

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -1,4 +1,9 @@
-use std::{hash, mem::size_of, num::NonZeroU64, ptr::copy_nonoverlapping};
+use std::{
+    hash,
+    mem::{MaybeUninit, size_of},
+    num::NonZeroU64,
+    ptr::copy_nonoverlapping,
+};
 
 use num_bigint::{BigInt, Sign};
 use rand::Rng;
@@ -725,6 +730,82 @@ impl HeapItem for BigIntValue {
 
     fn visit_pointers(mut big_int_value: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
         visitor.visit_pointer(&mut big_int_value.descriptor);
+    }
+}
+
+/// Encoding scheme for packing a sequence of raw bytes into a sequence of Values. Each Value is
+/// encoded as the EMPTY_TAG in the top 16-bits and the payload in the low 48-bits.
+pub struct RawBytesEncoding;
+
+impl RawBytesEncoding {
+    /// Number of payload bytes packed into each Value, namely the 48 bits below the 16-bit tag.
+    const PAYLOAD_BYTES_PER_VALUE: usize = (TAG_SHIFT / u8::BITS as u64) as usize;
+
+    /// Mask selecting the low 48 payload bits of a Value's raw bits.
+    const PAYLOAD_MASK: u64 = (1 << TAG_SHIFT) - 1;
+
+    /// The number of Values needed to store the raw bytes of a value of type `T`.
+    pub const fn num_values<T>() -> usize {
+        size_of::<T>().div_ceil(Self::PAYLOAD_BYTES_PER_VALUE)
+    }
+
+    /// Return the offset and length of the payload within the bytes of a value of type `T` for the
+    /// corresponding encoded Value at `value_index`.
+    #[inline]
+    fn payload_window_for_value<T>(value_index: usize) -> (usize, usize) {
+        let offset = value_index * Self::PAYLOAD_BYTES_PER_VALUE;
+        let len = (size_of::<T>() - offset).min(Self::PAYLOAD_BYTES_PER_VALUE);
+
+        (offset, len)
+    }
+
+    #[inline]
+    fn encode_payload_into_value(payload: [u8; 8]) -> Value {
+        let payload = u64::from_le_bytes(payload);
+        let raw_bits = ((EMPTY_TAG as u64) << TAG_SHIFT) | payload;
+        Value::from_raw_bits(raw_bits)
+    }
+
+    #[inline]
+    fn extract_payload_from_value(value: Value) -> [u8; 8] {
+        (value.as_raw_bits() & Self::PAYLOAD_MASK).to_le_bytes()
+    }
+
+    /// Pack the raw bytes of a value of type `T` into a sequence of Values.
+    pub fn encode<T, const N: usize>(src_value: &T) -> [Value; N] {
+        debug_assert_eq!(N, RawBytesEncoding::num_values::<T>());
+
+        let src = (src_value as *const T).cast::<u8>();
+
+        let mut values = [Value::empty(); N];
+        for (i, value) in values.iter_mut().enumerate() {
+            let mut payload_bytes = [0u8; size_of::<u64>()];
+
+            let (offset, len) = RawBytesEncoding::payload_window_for_value::<T>(i);
+            unsafe {
+                std::ptr::copy_nonoverlapping(src.add(offset), payload_bytes.as_mut_ptr(), len)
+            };
+
+            *value = RawBytesEncoding::encode_payload_into_value(payload_bytes);
+        }
+
+        values
+    }
+
+    /// Reconstruct a `T` from a sequence of Values previously produced by `RawBytesEncoding::encode`.
+    pub fn decode<T, const N: usize>(values: &[Value; N]) -> T {
+        debug_assert_eq!(N, RawBytesEncoding::num_values::<T>());
+
+        let mut result = MaybeUninit::<T>::uninit();
+        let dst = result.as_mut_ptr().cast::<u8>();
+
+        for (i, value) in values.iter().enumerate() {
+            let payload_bytes = RawBytesEncoding::extract_payload_from_value(*value);
+            let (offset, len) = RawBytesEncoding::payload_window_for_value::<T>(i);
+            unsafe { std::ptr::copy_nonoverlapping(payload_bytes.as_ptr(), dst.add(offset), len) };
+        }
+
+        unsafe { result.assume_init() }
     }
 }
 


### PR DESCRIPTION
## Summary

To eventually support inline properties on objects we will want all fields of special heap object types to be represented as standard JS `Values`. One area this is tricky is the wrapped `temporal_rs` types which are too large to fit in a single value. These are simple, flat structs internally so let's encode their raw bytes in a sequence of values and then decode these back into the `temporal_rs` type in a temporary buffer when reading.

Value encoding scheme is simply an `EMPTY_TAG` in the top 16 bits and the payload in the bottom 48 bits. So only 1/3 more size overhead for these types with simple encoding/decoding.

## Tests

-CI