### PR TITLE
[runtime] Remove rust pointers stored in the heap objects ArrayIterator and ModuleNamespaceObject

### DIFF
--- a/src/js/runtime/intrinsics/array_iterator.rs
+++ b/src/js/runtime/intrinsics/array_iterator.rs
@@ -36,7 +36,6 @@ extend_object! {
         kind: ArrayIteratorKind,
         is_done: bool,
         current_index: usize,
-        get_length: fn(cx: Context, array: Handle<ObjectValue>) -> EvalResult<u64>,
     }
 }
 
@@ -58,40 +57,16 @@ impl ArrayIterator {
             Intrinsic::ArrayIteratorPrototype,
         )?;
 
-        // Only difference between array and typed array iterators is length getter, so calculate
-        // on iterator start to avoid computing on every iteration.
-        let get_length = if array.is_typed_array() {
-            Self::get_typed_array_length
-        } else {
-            Self::get_array_like_length
-        };
-
         set_uninit!(object.array, *array);
         set_uninit!(object.is_done, false);
         set_uninit!(object.kind, kind);
         set_uninit!(object.current_index, 0);
-        set_uninit!(object.get_length, get_length);
 
         Ok(object.to_handle())
     }
 
     fn array(&self) -> Handle<ObjectValue> {
         self.array.to_handle()
-    }
-
-    fn get_typed_array_length(cx: Context, array: Handle<ObjectValue>) -> EvalResult<u64> {
-        let typed_array = array.as_typed_array();
-
-        let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
-        if is_typed_array_out_of_bounds(&typed_array_record) {
-            return type_error(cx, "typed array is out of bounds");
-        }
-
-        Ok(typed_array_length(&typed_array_record) as u64)
-    }
-
-    fn get_array_like_length(cx: Context, array: Handle<ObjectValue>) -> EvalResult<u64> {
-        length_of_array_like(cx, array)
     }
 
     cast_from_value_fn!(ArrayIterator, "Array Iterator");
@@ -125,13 +100,24 @@ impl ArrayIteratorPrototype {
         let mut array_iterator = ArrayIterator::cast_from_value(cx, this_value)?;
         let array = array_iterator.array();
 
-        // Early return if iterator is already done, before potential failure during `get_length`
+        // Early return if iterator is already done, before potential failure when checking length
         if array_iterator.is_done {
             return Ok(create_iter_result_object(cx, cx.undefined(), true)?);
         }
 
-        // Dispatches based on whether this is array or typed array
-        let length = (array_iterator.get_length)(cx, array)?;
+        // Get the length of the underlying array-like or typed array
+        let length = if array.is_typed_array() {
+            let typed_array = array.as_typed_array();
+
+            let typed_array_record = make_typed_array_with_buffer_witness_record(typed_array);
+            if is_typed_array_out_of_bounds(&typed_array_record) {
+                return type_error(cx, "typed array is out of bounds");
+            }
+
+            typed_array_length(&typed_array_record) as u64
+        } else {
+            length_of_array_like(cx, array)?
+        };
 
         let current_index = array_iterator.current_index as u64;
         if array_iterator.is_done || current_index >= length {

--- a/src/js/runtime/module/module.rs
+++ b/src/js/runtime/module/module.rs
@@ -56,6 +56,17 @@ pub enum ModuleEnum {
     Synthetic(Handle<SyntheticModule>),
 }
 
+impl ModuleEnum {
+    pub fn from_any(ptr: HeapPtr<AnyHeapItem>) -> Self {
+        if let Some(module) = ptr.as_opt::<SourceTextModule>() {
+            ModuleEnum::SourceText(module.to_handle())
+        } else {
+            let module = ptr.as_opt::<SyntheticModule>().unwrap();
+            ModuleEnum::Synthetic(module.to_handle())
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 pub enum ResolveExportResult {
     Resolved { name: ResolveExportName, module: DynModule },

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -7,9 +7,9 @@ use crate::{
         alloc_error::AllocResult,
         boxed_value::BoxedValue,
         error::reference_error,
-        gc::{HeapItem, HeapVisitor},
+        gc::{AnyHeapItem, HeapItem, HeapVisitor},
         module::{
-            module::{DynModule, HeapDynModule, Module, ModuleEnum},
+            module::{DynModule, Module, ModuleEnum},
             source_text_module::SourceTextModule,
             synthetic_module::SyntheticModule,
         },
@@ -31,7 +31,9 @@ extend_object! {
     pub struct ModuleNamespaceObject {
         // The module which the namespace object holds the exports of. Exports are actually stored
         // within the module itself and the namespace object is just a proxy to access them.
-        module: HeapDynModule,
+        //
+        // Must be either a SourceTextModule or a SyntheticModule.
+        module: HeapPtr<AnyHeapItem>,
     }
 }
 
@@ -53,7 +55,7 @@ impl ModuleNamespaceObject {
         // - [[PreventExtensions]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-preventextensions)
         object.as_object().set_is_extensible_field(false);
 
-        set_uninit!(object.module, module.to_heap());
+        set_uninit!(object.module, *module.as_any());
 
         let object = object.to_handle();
 
@@ -67,6 +69,10 @@ impl ModuleNamespaceObject {
 
         Ok(*object)
     }
+
+    fn module(&self) -> ModuleEnum {
+        ModuleEnum::from_any(self.module)
+    }
 }
 
 impl HeapPtr<ModuleNamespaceObject> {
@@ -77,7 +83,7 @@ impl HeapPtr<ModuleNamespaceObject> {
     ///
     /// Error if the export binding has not yet been initialized.
     fn lookup_export(&self, cx: Context, key: PropertyKey) -> EvalResult<Option<Value>> {
-        let value = match DynModule::from_heap(&self.module).as_enum() {
+        let value = match self.module() {
             ModuleEnum::SourceText(module) => {
                 Self::lookup_export_source_text_module(cx, module, key)?
             }
@@ -142,7 +148,7 @@ impl HeapPtr<ModuleNamespaceObject> {
 impl Handle<ModuleNamespaceObject> {
     #[inline]
     fn has_property_non_symbol(&self, cx: Context, key: Handle<PropertyKey>) -> AllocResult<bool> {
-        match DynModule::from_heap(&self.module).as_enum() {
+        match self.module() {
             // Check the exports map
             ModuleEnum::SourceText(module) => Ok(module.exports_ptr().contains_key(&key)),
             // Check the module scope names
@@ -259,7 +265,7 @@ impl VirtualObject for Handle<ModuleNamespaceObject> {
 
     /// [[OwnPropertyKeys]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-ownpropertykeys)
     fn own_property_keys(&self, cx: Context) -> EvalResult<Vec<Handle<Value>>> {
-        let mut string_keys = match DynModule::from_heap(&self.module).as_enum() {
+        let mut string_keys = match self.module() {
             ModuleEnum::SourceText(module) => {
                 // Gather all exported keys
                 let raw_keys = module
@@ -310,6 +316,6 @@ impl HeapItem for ModuleNamespaceObject {
 
     fn visit_pointers(mut module_namespace_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
         module_namespace_object.visit_object_pointers(visitor);
-        module_namespace_object.module.visit_pointers(visitor);
+        visitor.visit_pointer(&mut module_namespace_object.module);
     }
 }


### PR DESCRIPTION
## Summary

To eventually support inline properties on objects we will want all fields of special heap object types to be represented as standard JS `Values`. One type of field we must refactor are raw rust pointers (to rust functions or vtables) stored in heap objects. This includes:

- The `get_length` function pointer stored in `ArrayIterator`. We don't need this and can instead switch on the object type (typed array vs array-like) when fetching the length.
- The `DynModule` stored within `ModuleNamespaceObject`. We can instead store this as a `HeapPtr<AnyHeapItem>` and check its type at runtime to build the `ModuleEnum`.

## Tests

- CI