### PR TITLE
[runtime] Revert byte encoding of temporal objects as values

### DIFF
--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -301,3 +301,19 @@ impl AnyHeapItem {
         self.descriptor = descriptor;
     }
 }
+
+/// Storage for a value whose natural alignment exceeds the 8-byte alignment of the managed heap.
+#[repr(C, packed(8))]
+pub struct HeapUnaligned<T>(T);
+
+impl<T> HeapUnaligned<T> {
+    #[inline]
+    pub fn new(value: T) -> Self {
+        HeapUnaligned(value)
+    }
+
+    #[inline]
+    pub fn get(&self) -> T {
+        unsafe { std::ptr::read_unaligned(&raw const self.0) }
+    }
+}

--- a/src/js/runtime/gc/mod.rs
+++ b/src/js/runtime/gc/mod.rs
@@ -12,7 +12,9 @@ pub use handle::{
     Escapable, Handle, HandleContents, HandleScope, HandleScopeGuard, ToHandleContents,
 };
 pub use heap::{Heap, HeapInfo};
-pub use heap_item::{AnyHeapItem, HeapItem, HeapItemKind, IsHeapItem, WithHeapItemKind};
+pub use heap_item::{
+    AnyHeapItem, HeapItem, HeapItemKind, HeapUnaligned, IsHeapItem, WithHeapItemKind,
+};
 #[allow(unused)]
 pub use heap_serializer::{HeapRootsDeserializer, HeapSerializer};
 pub use heap_visitor::HeapVisitor;

--- a/src/js/runtime/intrinsics/temporal/duration_object.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_object.rs
@@ -3,12 +3,11 @@ use temporal_rs::Duration;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
-        gc::{HeapItem, HeapVisitor},
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        gc::{HeapItem, HeapUnaligned, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
-        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -16,7 +15,9 @@ use crate::{
 // Temporal.Duration Objects (https://tc39.es/proposal-temporal/#sec-temporal-duration-objects)
 extend_object! {
     pub struct DurationObject {
-        duration: [Value; RawBytesEncoding::num_values::<Duration>()],
+        // Contains an `u128` field and so is 16-byte aligned. Must only access through the
+        // alignment wrapper.
+        duration: HeapUnaligned<Duration>,
     }
 }
 
@@ -38,13 +39,13 @@ impl DurationObject {
             Intrinsic::DurationPrototype,
         )?;
 
-        set_uninit!(object.duration, RawBytesEncoding::encode(&duration));
+        set_uninit!(object.duration, HeapUnaligned::new(duration));
 
         Ok(object.to_handle())
     }
 
     pub fn duration(&self) -> Duration {
-        RawBytesEncoding::decode(&self.duration)
+        self.duration.get()
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/instant_object.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_object.rs
@@ -3,12 +3,11 @@ use temporal_rs::Instant;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
-        gc::{HeapItem, HeapVisitor},
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        gc::{HeapItem, HeapUnaligned, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
-        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -16,7 +15,9 @@ use crate::{
 // Temporal.Instant Objects (https://tc39.es/proposal-temporal/#sec-temporal-instant-objects)
 extend_object! {
     pub struct InstantObject {
-        instant: [Value; RawBytesEncoding::num_values::<Instant>()],
+        // Contains an `i128` field and so is 16-byte aligned. Must only access through the
+        // alignment wrapper.
+        instant: HeapUnaligned<Instant>,
     }
 }
 
@@ -38,13 +39,13 @@ impl InstantObject {
             Intrinsic::InstantPrototype,
         )?;
 
-        set_uninit!(object.instant, RawBytesEncoding::encode(&instant));
+        set_uninit!(object.instant, HeapUnaligned::new(instant));
 
         Ok(object.to_handle())
     }
 
     pub fn instant(&self) -> Instant {
-        RawBytesEncoding::decode(&self.instant)
+        self.instant.get()
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_constructor.rs
@@ -138,7 +138,7 @@ pub fn to_temporal_date_with_options(
         let item_object = item.as_object();
         if let Some(plain_date) = item_object.as_opt::<PlainDateObject>() {
             validate_overflow_option(cx, options, method_name)?;
-            return Ok(plain_date.date());
+            return Ok(plain_date.date().clone());
         } else if let Some(zoned_date_time) = item_object.as_opt::<ZonedDateTimeObject>() {
             validate_overflow_option(cx, options, method_name)?;
             return Ok(zoned_date_time.zoned_date_time().to_plain_date());

--- a/src/js/runtime/intrinsics/temporal/plain_date_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_object.rs
@@ -3,12 +3,11 @@ use temporal_rs::PlainDate;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
-        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -16,7 +15,7 @@ use crate::{
 // PlainDate Objects (https://tc39.es/proposal-temporal/#sec-temporal-plaindate-objects)
 extend_object! {
     pub struct PlainDateObject {
-        date: [Value; RawBytesEncoding::num_values::<PlainDate>()],
+        date: PlainDate,
     }
 }
 
@@ -38,13 +37,13 @@ impl PlainDateObject {
             Intrinsic::PlainDatePrototype,
         )?;
 
-        set_uninit!(object.date, RawBytesEncoding::encode(&date));
+        set_uninit!(object.date, date);
 
         Ok(object.to_handle())
     }
 
-    pub fn date(&self) -> PlainDate {
-        RawBytesEncoding::decode(&self.date)
+    pub fn date(&self) -> &PlainDate {
+        &self.date
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_prototype.rs
@@ -324,7 +324,7 @@ impl PlainDatePrototype {
         let other_arg = arguments.get(cx, 0);
         let other_date = to_temporal_date(cx, other_arg, NAME)?;
 
-        Ok(cx.bool(this_date.date() == other_date))
+        Ok(cx.bool(this_date.date() == &other_date))
     }}
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_constructor.rs
@@ -156,7 +156,7 @@ fn to_temporal_date_time_with_options(
             let options = validate_options_object(cx, options, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 
-            return Ok(plain_date_time.date_time());
+            return Ok(plain_date_time.date_time().clone());
         } else if let Some(zoned_date_time) = item_object.as_opt::<ZonedDateTimeObject>() {
             let options = validate_options_object(cx, options, method_name)?;
             get_overflow_option(cx, options, method_name)?;

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_object.rs
@@ -3,12 +3,11 @@ use temporal_rs::PlainDateTime;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
-        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -16,7 +15,7 @@ use crate::{
 // PlainDateTime Objects (https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-objects)
 extend_object! {
     pub struct PlainDateTimeObject {
-        date_time: [Value; RawBytesEncoding::num_values::<PlainDateTime>()],
+        date_time: PlainDateTime,
     }
 }
 
@@ -38,13 +37,13 @@ impl PlainDateTimeObject {
             Intrinsic::PlainDateTimePrototype,
         )?;
 
-        set_uninit!(object.date_time, RawBytesEncoding::encode(&date_time));
+        set_uninit!(object.date_time, date_time);
 
         Ok(object.to_handle())
     }
 
-    pub fn date_time(&self) -> PlainDateTime {
-        RawBytesEncoding::decode(&self.date_time)
+    pub fn date_time(&self) -> &PlainDateTime {
+        &self.date_time
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_prototype.rs
@@ -443,7 +443,7 @@ impl PlainDateTimePrototype {
         let other_arg = arguments.get(cx, 0);
         let other_date_time = to_temporal_date_time(cx, other_arg, NAME)?;
 
-        Ok(cx.bool(this_date_time.date_time() == other_date_time))
+        Ok(cx.bool(this_date_time.date_time() == &other_date_time))
     }}
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_constructor.rs
@@ -117,7 +117,7 @@ pub fn to_temporal_month_day(
             let options = validate_options_object(cx, options_arg, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 
-            return Ok(plain_month_day.month_day());
+            return Ok(plain_month_day.month_day().clone());
         }
 
         // Otherwise treat like a date-like object

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_object.rs
@@ -3,12 +3,11 @@ use temporal_rs::PlainMonthDay;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
-        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -16,7 +15,7 @@ use crate::{
 // PlainMonthDay Objects (https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-objects)
 extend_object! {
     pub struct PlainMonthDayObject {
-        month_day: [Value; RawBytesEncoding::num_values::<PlainMonthDay>()],
+        month_day: PlainMonthDay,
     }
 }
 
@@ -38,13 +37,13 @@ impl PlainMonthDayObject {
             Intrinsic::PlainMonthDayPrototype,
         )?;
 
-        set_uninit!(object.month_day, RawBytesEncoding::encode(&month_day));
+        set_uninit!(object.month_day, month_day);
 
         Ok(object.to_handle())
     }
 
-    pub fn month_day(&self) -> PlainMonthDay {
-        RawBytesEncoding::decode(&self.month_day)
+    pub fn month_day(&self) -> &PlainMonthDay {
+        &self.month_day
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_prototype.rs
@@ -94,7 +94,7 @@ impl PlainMonthDayPrototype {
         let other_arg = arguments.get(cx, 0);
         let other_month_day = to_temporal_month_day(cx, other_arg, None, NAME)?;
 
-        Ok(cx.bool(this_month_day.month_day() == other_month_day))
+        Ok(cx.bool(this_month_day.month_day() == &other_month_day))
     }}
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/plain_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_object.rs
@@ -3,12 +3,11 @@ use temporal_rs::PlainTime;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
-        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -16,7 +15,7 @@ use crate::{
 // Temporal.PlainTime Objects (https://tc39.es/proposal-temporal/#sec-temporal-plaintime-objects)
 extend_object! {
     pub struct PlainTimeObject {
-        time: [Value; RawBytesEncoding::num_values::<PlainTime>()],
+        time: PlainTime,
     }
 }
 
@@ -38,13 +37,13 @@ impl PlainTimeObject {
             Intrinsic::PlainTimePrototype,
         )?;
 
-        set_uninit!(object.time, RawBytesEncoding::encode(&time));
+        set_uninit!(object.time, time);
 
         Ok(object.to_handle())
     }
 
     pub fn time(&self) -> PlainTime {
-        RawBytesEncoding::decode(&self.time)
+        self.time
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_constructor.rs
@@ -128,7 +128,7 @@ pub fn to_temporal_year_month(
             let options = validate_options_object(cx, options_arg, method_name)?;
             get_overflow_option(cx, options, method_name)?;
 
-            return Ok(plain_year_month.year_month());
+            return Ok(plain_year_month.year_month().clone());
         }
 
         // Otherwise treat like a date-like object

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_object.rs
@@ -3,12 +3,11 @@ use temporal_rs::PlainYearMonth;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
-        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -16,7 +15,7 @@ use crate::{
 // PlainYearMonth Objects (https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-objects)
 extend_object! {
     pub struct PlainYearMonthObject {
-        year_month: [Value; RawBytesEncoding::num_values::<PlainYearMonth>()],
+        year_month: PlainYearMonth,
     }
 }
 
@@ -41,13 +40,13 @@ impl PlainYearMonthObject {
             Intrinsic::PlainYearMonthPrototype,
         )?;
 
-        set_uninit!(object.year_month, RawBytesEncoding::encode(&year_month));
+        set_uninit!(object.year_month, year_month);
 
         Ok(object.to_handle())
     }
 
-    pub fn year_month(&self) -> PlainYearMonth {
-        RawBytesEncoding::decode(&self.year_month)
+    pub fn year_month(&self) -> &PlainYearMonth {
+        &self.year_month
     }
 }
 

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_prototype.rs
@@ -276,7 +276,7 @@ impl PlainYearMonthPrototype {
         let other_arg = arguments.get(cx, 0);
         let other_year_month = to_temporal_year_month(cx, other_arg, None, NAME)?;
 
-        Ok(cx.bool(this_year_month.year_month() == other_year_month))
+        Ok(cx.bool(this_year_month.year_month() == &other_year_month))
     }}
 
     runtime_fn! {

--- a/src/js/runtime/intrinsics/temporal/utils.rs
+++ b/src/js/runtime/intrinsics/temporal/utils.rs
@@ -290,11 +290,11 @@ pub fn get_relative_to_option(
     if option_value.is_object() {
         let option_object = option_value.as_object();
         if let Some(plain_date) = option_object.as_opt::<PlainDateObject>() {
-            return Ok(Some(RelativeTo::PlainDate(plain_date.date())));
+            return Ok(Some(RelativeTo::PlainDate(plain_date.date().clone())));
         } else if let Some(plain_date_time) = option_object.as_opt::<PlainDateTimeObject>() {
             return Ok(Some(RelativeTo::PlainDate(plain_date_time.date_time().to_plain_date())));
         } else if let Some(zoned_date_time) = option_object.as_opt::<ZonedDateTimeObject>() {
-            return Ok(Some(RelativeTo::ZonedDateTime(zoned_date_time.zoned_date_time())));
+            return Ok(Some(RelativeTo::ZonedDateTime(zoned_date_time.zoned_date_time().clone())));
         }
 
         // Otherwise treat as a date-like object

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_constructor.rs
@@ -152,7 +152,7 @@ pub fn to_temporal_zoned_date_time_with_options(
         let item_object = item.as_object();
         if let Some(zdt) = item_object.as_opt::<ZonedDateTimeObject>() {
             validate_options(cx, options, method_name)?;
-            return Ok(zdt.zoned_date_time());
+            return Ok(zdt.zoned_date_time().clone());
         }
 
         // Otherwise treat like a date-like object

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
@@ -3,12 +3,11 @@ use temporal_rs::ZonedDateTime;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
-        gc::{HeapItem, HeapVisitor},
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        gc::{HeapItem, HeapUnaligned, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::object_create_from_constructor,
-        value::RawBytesEncoding,
     },
     set_uninit,
 };
@@ -16,7 +15,9 @@ use crate::{
 // ZonedDateTime Objects (https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects)
 extend_object! {
     pub struct ZonedDateTimeObject {
-        zoned_date_time: [Value; RawBytesEncoding::num_values::<ZonedDateTime>()],
+        // Contains an `i128` field and so is 16-byte aligned. Must only access through the
+        // alignment wrapper.
+        zoned_date_time: HeapUnaligned<ZonedDateTime>,
     }
 }
 
@@ -41,13 +42,13 @@ impl ZonedDateTimeObject {
             Intrinsic::ZonedDateTimePrototype,
         )?;
 
-        set_uninit!(object.zoned_date_time, RawBytesEncoding::encode(&zoned_date_time));
+        set_uninit!(object.zoned_date_time, HeapUnaligned::new(zoned_date_time));
 
         Ok(object.to_handle())
     }
 
     pub fn zoned_date_time(&self) -> ZonedDateTime {
-        RawBytesEncoding::decode(&self.zoned_date_time)
+        self.zoned_date_time.get()
     }
 }
 

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -551,8 +551,10 @@ impl From<HeapPtr<BigIntValue>> for Value {
 
 /// Encoding scheme for packing a sequence of raw bytes into a sequence of Values. Each Value is
 /// encoded as the EMPTY_TAG in the top 16-bits and the payload in the low 48-bits.
+#[allow(unused)]
 pub struct RawBytesEncoding;
 
+#[allow(unused)]
 impl RawBytesEncoding {
     /// Number of payload bytes packed into each Value, namely the 48 bits below the 16-bit tag.
     const PAYLOAD_BYTES_PER_VALUE: usize = (TAG_SHIFT / u8::BITS as u64) as usize;


### PR DESCRIPTION
## Summary

Revert https://github.com/Hans-Halverson/brimstone/pull/408 as we don't actually need it to support inline properties. Instead we can keep the simpler `HeapUnaligned` wrappers. Keep the `RawBytesEncoding` around for now though in case we need it.

## Tests

- CI