### PR TITLE
[runtime] Generator and AsyncGenerator store stack frame in separate array

### DIFF
--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -1,5 +1,5 @@
 use crate::{
-    completion_value, eval_err, extend_object, field_offset, must_a,
+    completion_value, eval_err, extend_object, must_a,
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr, Value,
         abstract_operations::call_object,
@@ -7,9 +7,9 @@ use crate::{
         builtin_function::BuiltinFunction,
         bytecode::{
             function::ClosureObject,
-            stack_frame::{StackFrame, StackSlotValue},
+            stack_frame::{StackFrame, StackFrameArray, StackSlotValue},
         },
-        collections::InlineArray,
+        collections::ArrayInstance,
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
@@ -53,7 +53,7 @@ extend_object! {
         request_queue: Option<HeapPtr<AsyncGeneratorRequest>>,
         // The stack frame of the generator, containing all args, locals, and fixed slots in
         // between.
-        stack_frame: InlineArray<StackSlotValue>,
+        stack_frame: HeapPtr<StackFrameArray>,
     }
 }
 
@@ -109,8 +109,13 @@ impl AsyncGeneratorObject {
         let prototype =
             get_prototype_from_constructor(cx, closure.into(), Intrinsic::AsyncGeneratorPrototype)?;
 
-        let size = Self::calculate_size_in_bytes(stack_frame.len());
-        let mut generator = cx.alloc_uninit_with_size::<AsyncGeneratorObject>(size)?;
+        // Stack frame slice is safe to hold across allocations only because it is a view into
+        // known roots which will be updated by the GC.
+        //
+        // For GC safety do not initialize or link the stack frame until after allocations.
+        let frame_array = StackFrameArray::new_uninit(cx, stack_frame.len())?.to_handle();
+
+        let mut generator = cx.alloc_uninit::<AsyncGeneratorObject>()?;
 
         let descriptor = cx.descriptors.get(HeapItemKind::AsyncGeneratorObject);
         object_ordinary_init(cx, generator.into(), descriptor, Some(*prototype));
@@ -120,16 +125,15 @@ impl AsyncGeneratorObject {
         set_uninit!(generator.fp_index, fp_index);
         set_uninit!(generator.completion_registers, None);
         set_uninit!(generator.request_queue, None);
-        generator.stack_frame.init_from_slice(stack_frame);
+
+        // No more allocations can occur, now safe to link and initialize the stack frame
+        set_uninit!(generator.stack_frame, *frame_array);
+        generator
+            .stack_frame
+            .as_mut_slice()
+            .copy_from_slice(stack_frame);
 
         Ok(generator)
-    }
-
-    const STACK_FRAME_OFFSET: usize = field_offset!(AsyncGeneratorObject, stack_frame);
-
-    fn calculate_size_in_bytes(num_stack_slots: usize) -> usize {
-        Self::STACK_FRAME_OFFSET
-            + InlineArray::<StackSlotValue>::calculate_size_in_bytes(num_stack_slots)
     }
 
     pub fn state(&self) -> AsyncGeneratorState {
@@ -141,7 +145,7 @@ impl AsyncGeneratorObject {
     }
 
     fn current_fp(&self) -> *const StackSlotValue {
-        unsafe { self.stack_frame.data_ptr().add(self.fp_index) }
+        unsafe { self.stack_frame.as_slice().as_ptr().add(self.fp_index) }
     }
 
     /// Return the realm for the suspended function in this generator.
@@ -484,14 +488,16 @@ pub fn async_generator_drain_queue(
 }
 
 impl HeapItem for AsyncGeneratorObject {
-    fn byte_size(async_generator_object: HeapPtr<Self>) -> usize {
-        AsyncGeneratorObject::calculate_size_in_bytes(async_generator_object.stack_frame.len())
+    fn byte_size(_: HeapPtr<Self>) -> usize {
+        std::mem::size_of::<AsyncGeneratorObject>()
     }
 
     fn visit_pointers(mut async_generator_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
         async_generator_object.visit_object_pointers(visitor);
         visitor.visit_pointer_opt(&mut async_generator_object.request_queue);
+        visitor.visit_pointer(&mut async_generator_object.stack_frame);
 
+        // Visit the separate stack frame array if it is live
         if async_generator_object.state.is_suspended() {
             let mut stack_frame =
                 StackFrame::for_fp(async_generator_object.current_fp().cast_mut());

--- a/src/js/runtime/bytecode/stack_frame.rs
+++ b/src/js/runtime/bytecode/stack_frame.rs
@@ -1,9 +1,11 @@
 use crate::{
     common::constants::MEGABYTE_BYTES,
+    impl_array_instance,
     runtime::{
         HeapPtr, Value,
         bytecode::{constant_table::ConstantTable, function::ClosureObject},
-        gc::HeapVisitor,
+        collections::ArrayInstance,
+        gc::{HeapItem, HeapVisitor},
         scope::Scope,
     },
 };
@@ -326,3 +328,18 @@ const ARGC_SLOT_INDEX: usize = 6;
 pub const RECEIVER_SLOT_INDEX: usize = 7;
 
 pub const FIRST_ARGUMENT_SLOT_INDEX: usize = 8;
+
+// An array of opaque stack slot values. Can not be interpreted on its own, we need to know the FP
+// in order to know the layout of the stack frame.
+impl_array_instance!(StackFrameArray, StackSlotValue);
+
+impl HeapItem for StackFrameArray {
+    fn byte_size(array: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(array.len())
+    }
+
+    fn visit_pointers(mut array: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        // Stack slots are opaque and the owner is responsible for interpreting and visiting them
+        array.visit_array_pointers(visitor);
+    }
+}

--- a/src/js/runtime/descriptor_registry.rs
+++ b/src/js/runtime/descriptor_registry.rs
@@ -231,6 +231,7 @@ impl DescriptorRegistry {
         other_heap_item_descriptor!(HeapItemKind::ModuleRequestArray);
         other_heap_item_descriptor!(HeapItemKind::ModuleOptionArray);
         other_heap_item_descriptor!(HeapItemKind::StackFrameInfoArray);
+        other_heap_item_descriptor!(HeapItemKind::StackFrameArray);
         other_heap_item_descriptor!(HeapItemKind::FinalizationRegistryCells);
         other_heap_item_descriptor!(HeapItemKind::GlobalScopes);
 

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -13,6 +13,7 @@ use crate::{
             exception_handlers::ExceptionHandlers,
             function::{BytecodeFunction, ClosureObject},
             generator::FunctionVec,
+            stack_frame::StackFrameArray,
         },
         class_names::ClassNames,
         collections::{
@@ -278,6 +279,7 @@ register_heap_items!(
     (ModuleRequestArray),
     (ModuleOptionArray),
     (StackFrameInfoArray),
+    (StackFrameArray),
     (FinalizationRegistryCells),
     (GlobalScopes),
     (FunctionVec),

--- a/src/js/runtime/generator_object.rs
+++ b/src/js/runtime/generator_object.rs
@@ -1,14 +1,14 @@
 use crate::{
-    eval_err, extend_object, field_offset,
+    eval_err, extend_object,
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         bytecode::{
             ExtraWide, Register,
             function::ClosureObject,
-            stack_frame::{StackFrame, StackSlotValue},
+            stack_frame::{StackFrame, StackFrameArray, StackSlotValue},
         },
-        collections::InlineArray,
+        collections::ArrayInstance,
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
@@ -44,7 +44,7 @@ extend_object! {
         completion_registers: Option<(GeneratorRegister, GeneratorRegister)>,
         // The stack frame of the generator, containing all args, locals, and fixed slots in
         // between.
-        stack_frame: InlineArray<StackSlotValue>,
+        stack_frame: HeapPtr<StackFrameArray>,
     }
 }
 
@@ -110,8 +110,13 @@ impl GeneratorObject {
         completion_registers: Option<(GeneratorRegister, GeneratorRegister)>,
         stack_frame: &[StackSlotValue],
     ) -> AllocResult<HeapPtr<GeneratorObject>> {
-        let size = Self::calculate_size_in_bytes(stack_frame.len());
-        let mut generator = cx.alloc_uninit_with_size::<GeneratorObject>(size)?;
+        // Stack frame slice is safe to hold across allocations only because it is a view into
+        // known roots which will be updated by the GC.
+        //
+        // For GC safety do not initialize or link the stack frame until after allocations.
+        let frame_array = StackFrameArray::new_uninit(cx, stack_frame.len())?.to_handle();
+
+        let mut generator = cx.alloc_uninit::<GeneratorObject>()?;
 
         let descriptor = cx.descriptors.get(HeapItemKind::GeneratorObject);
         object_ordinary_init(cx, generator.into(), descriptor, prototype.map(|p| *p));
@@ -120,7 +125,13 @@ impl GeneratorObject {
         set_uninit!(generator.pc_to_resume_offset, pc_to_resume_offset);
         set_uninit!(generator.fp_index, fp_index);
         set_uninit!(generator.completion_registers, completion_registers);
-        generator.stack_frame.init_from_slice(stack_frame);
+
+        // No more allocations can occur, now safe to link and initialize the stack frame
+        set_uninit!(generator.stack_frame, *frame_array);
+        generator
+            .stack_frame
+            .as_mut_slice()
+            .copy_from_slice(stack_frame);
 
         Ok(generator)
     }
@@ -148,15 +159,8 @@ impl GeneratorObject {
         Self::new(cx, None, pc_to_resume_offset, fp_index, Some(completion_registers), stack_frame)
     }
 
-    const STACK_FRAME_OFFSET: usize = field_offset!(GeneratorObject, stack_frame);
-
-    fn calculate_size_in_bytes(num_stack_slots: usize) -> usize {
-        Self::STACK_FRAME_OFFSET
-            + InlineArray::<StackSlotValue>::calculate_size_in_bytes(num_stack_slots)
-    }
-
     fn current_fp(&self) -> *const StackSlotValue {
-        unsafe { self.stack_frame.data_ptr().add(self.fp_index) }
+        unsafe { self.stack_frame.as_slice().as_ptr().add(self.fp_index) }
     }
 
     pub fn suspend(
@@ -294,13 +298,15 @@ pub fn generator_resume_abrupt(
 }
 
 impl HeapItem for GeneratorObject {
-    fn byte_size(generator_object: HeapPtr<Self>) -> usize {
-        GeneratorObject::calculate_size_in_bytes(generator_object.stack_frame.len())
+    fn byte_size(_: HeapPtr<Self>) -> usize {
+        size_of::<GeneratorObject>()
     }
 
     fn visit_pointers(mut generator_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
         generator_object.visit_object_pointers(visitor);
+        visitor.visit_pointer(&mut generator_object.stack_frame);
 
+        // Visit the separate stack frame array if it is live
         if generator_object.state.is_suspended() {
             let mut stack_frame = StackFrame::for_fp(generator_object.current_fp().cast_mut());
             stack_frame.visit_simple_pointers(visitor);


### PR DESCRIPTION
## Summary

To eventually support inline properties on objects we want the native fields to have a fixed size. Two exceptions are `GeneratorObject` and `AsyncGeneratorObject` which store the stack frame inline.

Instead let's break the stack frame out into a separate `StackFrameArray` heap item. We must take care to initialize it properly for GC safety since its contents are opaque and can only be interpreted as a field of another heap item.

## Tests

- CI