### PR TITLE
[runtime] MappedArgumentsObject uses efficient value-sized bitmap instead of inline array

### DIFF
--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -3,21 +3,21 @@ use std::mem::size_of;
 use brimstone_macros::wrap_ordinary_object;
 
 use crate::{
-    extend_object, field_offset, must,
+    extend_object, must,
     parser::scope_tree::SHADOWED_SCOPE_SLOT_NAME,
     runtime::{
         Context, EvalResult, HeapItemKind, HeapPtr, Value,
         abstract_operations::{create_data_property_or_throw, define_property_or_throw},
         alloc_error::AllocResult,
+        bitmap::ValueBitmap,
         bytecode::function::ClosureObject,
-        collections::InlineArray,
         gc::{Handle, HeapItem, HeapVisitor},
         interned_strings::InternedStrings,
         intrinsics::intrinsics::Intrinsic,
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{
-            object_create, object_create_with_size, ordinary_define_own_property, ordinary_delete,
-            ordinary_get, ordinary_get_own_property, ordinary_set,
+            object_create, ordinary_define_own_property, ordinary_delete, ordinary_get,
+            ordinary_get_own_property, ordinary_set,
         },
         property_descriptor::PropertyDescriptor,
         property_key::PropertyKey,
@@ -48,16 +48,16 @@ impl UnmappedArgumentsObject {
 // A mapped arguments exotic argument used in the bytecode VM. Contains a reference to the scope
 // where the arguments are stored so that they can be referenced directly.
 //
-// Only some parameters are mapped, and this can change dynamically due to user action. Keep an
-// inline array of booleans noting which parameters are mapped to the scope.
+// Only some parameters are mapped, and this can change dynamically due to user action. Stored as
+// a bitmap.
 //
 // Arguments Exotic Objects (https://tc39.es/ecma262/#sec-arguments-exotic-objects)
 extend_object! {
     pub struct MappedArgumentsObject {
         // Scope where the arguments are stored.
         scope: HeapPtr<Scope>,
-        // Whether each parameter is mapped to the value in the scope.
-        mapped_parameters: InlineArray<bool>,
+        // Bitmap of which parameters are mapped to the scope.
+        mapped_parameters: Value,
     }
 }
 
@@ -73,27 +73,26 @@ impl MappedArgumentsObject {
     ) -> EvalResult<Handle<MappedArgumentsObject>> {
         let shadowed_name = InternedStrings::alloc_static_wtf8_str(cx, &SHADOWED_SCOPE_SLOT_NAME)?;
 
-        let size = Self::calculate_size_in_bytes(num_parameters);
-        let mut object = object_create_with_size::<MappedArgumentsObject>(
+        let mut object = object_create::<MappedArgumentsObject>(
             cx,
-            size,
             HeapItemKind::MappedArgumentsObject,
             Intrinsic::ObjectPrototype,
         )?;
 
         set_uninit!(object.scope, *scope);
+        // Placeholder before the bitmap is created
+        set_uninit!(object.mapped_parameters, Value::smi(0));
+
+        let mut object = object.to_handle();
 
         // A parameter is mapped if it has not been shadowed, which we know due to the special
-        // shadowed scope slot name.
-        let scope_names = scope.scope_names_ptr();
-
-        object.mapped_parameters.init_with_uninit(num_parameters);
-        for i in 0..num_parameters {
-            let is_mapped = !scope_names.get_slot_name(i).ptr_eq(&*shadowed_name);
-            object.mapped_parameters.as_mut_slice()[i] = is_mapped;
-        }
-
-        let object = object.to_handle();
+        // shadowed scope slot name. May allocate.
+        object.mapped_parameters = ValueBitmap::new(cx, num_parameters, |i| {
+            !scope
+                .scope_names_ptr()
+                .get_slot_name(i)
+                .ptr_eq(&*shadowed_name)
+        })?;
 
         Self::init_properties(cx, object, callee, arguments)?;
 
@@ -133,22 +132,14 @@ impl MappedArgumentsObject {
         Ok(())
     }
 
-    const MAPPED_PARAMETERS_OFFSET: usize = field_offset!(MappedArgumentsObject, mapped_parameters);
-
-    fn calculate_size_in_bytes(len: usize) -> usize {
-        Self::MAPPED_PARAMETERS_OFFSET + InlineArray::<bool>::calculate_size_in_bytes(len)
-    }
-
     /// If this key corresponds to the index of a mapped parameter, return the index in the scope
     /// where that argument is stored.
     #[inline]
     fn get_mapped_scope_index_for_key(&self, key: Handle<PropertyKey>) -> Option<usize> {
         if key.is_array_index() {
             let key_index = key.as_array_index() as usize;
-            if key_index < self.mapped_parameters.len() {
-                if *self.mapped_parameters.get_unchecked(key_index) {
-                    return Some(key_index);
-                }
+            if ValueBitmap::from_value(self.mapped_parameters).get(key_index) {
+                return Some(key_index);
             }
         }
 
@@ -156,7 +147,7 @@ impl MappedArgumentsObject {
     }
 
     fn unmap_argument(&mut self, index: usize) {
-        self.mapped_parameters.as_mut_slice()[index] = false;
+        self.mapped_parameters = ValueBitmap::from_value(self.mapped_parameters).clear(index);
     }
 
     fn get_mapped_argument(&self, cx: Context, index: usize) -> Handle<Value> {
@@ -314,15 +305,14 @@ pub fn create_unmapped_arguments_object(
 }
 
 impl HeapItem for MappedArgumentsObject {
-    fn byte_size(mapped_arguments_object: HeapPtr<Self>) -> usize {
-        MappedArgumentsObject::calculate_size_in_bytes(
-            mapped_arguments_object.mapped_parameters.len(),
-        )
+    fn byte_size(_: HeapPtr<Self>) -> usize {
+        size_of::<MappedArgumentsObject>()
     }
 
     fn visit_pointers(mut mapped_arguments_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
         mapped_arguments_object.visit_object_pointers(visitor);
         visitor.visit_pointer(&mut mapped_arguments_object.scope);
+        visitor.visit_value(&mut mapped_arguments_object.mapped_parameters);
     }
 }
 

--- a/src/js/runtime/bitmap.rs
+++ b/src/js/runtime/bitmap.rs
@@ -1,0 +1,143 @@
+use crate::runtime::{
+    Context, EvalResult, Value,
+    collections::{ArrayInstance, array::ByteArray},
+    value::Smi,
+};
+
+/// A trait for types that can be used as a bitmap.
+trait Bitmap {
+    /// Get the value of the bit at `index`, returning false if the index is out of bounds.
+    fn get_bit(&self, index: usize) -> bool;
+
+    /// Set the bit at `index`. Noop if the index is out of bounds.
+    fn set_bit(&mut self, index: usize);
+
+    /// Clear the bit at `index`. Noop if the index is out of bounds.
+    fn clear_bit(&mut self, index: usize);
+}
+
+impl Bitmap for u32 {
+    fn get_bit(&self, index: usize) -> bool {
+        if index >= u32::BITS as usize {
+            return false;
+        }
+
+        *self & (1 << index) != 0
+    }
+
+    fn set_bit(&mut self, index: usize) {
+        if index >= u32::BITS as usize {
+            return;
+        }
+
+        *self |= 1 << index;
+    }
+
+    fn clear_bit(&mut self, index: usize) {
+        if index >= u32::BITS as usize {
+            return;
+        }
+
+        *self &= !(1 << index);
+    }
+}
+
+impl Bitmap for [u8] {
+    fn get_bit(&self, index: usize) -> bool {
+        let byte_index = index / 8;
+        if byte_index >= self.len() {
+            return false;
+        }
+
+        self[byte_index] & (1 << (index % 8)) != 0
+    }
+
+    fn set_bit(&mut self, index: usize) {
+        let byte_index = index / 8;
+        if byte_index >= self.len() {
+            return;
+        }
+
+        self[byte_index] |= 1 << (index % 8);
+    }
+
+    fn clear_bit(&mut self, index: usize) {
+        let byte_index = index / 8;
+        if byte_index >= self.len() {
+            return;
+        }
+
+        self[byte_index] &= !(1 << (index % 8));
+    }
+}
+
+/// A bitmap stored in a Value. Bits are stored inline in a smi if there is enough room, otherwise
+/// in a heap ByteArray.
+///
+/// Supports any size of bitmap but does not resize after creation.
+#[derive(Clone, Copy)]
+pub struct ValueBitmap(Value);
+
+impl ValueBitmap {
+    /// Max number of bits that fit in the inline smi representation.
+    const INLINE_BITS: usize = Smi::BITS as usize;
+
+    pub fn from_value(value: Value) -> Self {
+        Self(value)
+    }
+
+    /// Create a bitmap of the given length with a callback that determines if the i'th bit is set.
+    pub fn new(
+        cx: Context,
+        len: usize,
+        mut is_set: impl FnMut(usize) -> bool,
+    ) -> EvalResult<Value> {
+        if len > Self::INLINE_BITS {
+            let mut bytes = ByteArray::new(cx, len.div_ceil(8), 0)?.to_handle();
+            for i in 0..len {
+                if is_set(i) {
+                    bytes.as_mut_slice().set_bit(i);
+                }
+            }
+
+            Ok(Value::heap_item((*bytes).cast()))
+        } else {
+            let mut bits = 0u32;
+            for i in 0..len {
+                if is_set(i) {
+                    bits.set_bit(i);
+                }
+            }
+
+            Ok(Value::raw_smi(bits.cast_signed()))
+        }
+    }
+
+    /// Whether the bit at `index` is set. Returns false if the index is out of bounds.
+    #[inline]
+    pub fn get(self, index: usize) -> bool {
+        if self.0.is_smi() {
+            (self.0.as_smi() as u32).get_bit(index)
+        } else {
+            let bytes = self.0.as_pointer().cast::<ByteArray>();
+            bytes.as_slice().get_bit(index)
+        }
+    }
+
+    /// Clear the bit at `index`, returning the backing value to store back (either the updated
+    /// smi bitmap or the same heap pointer to a modified ByteArray).
+    ///
+    /// Noop if the index is out of bounds.
+    #[inline]
+    pub fn clear(self, index: usize) -> Value {
+        if self.0.is_smi() {
+            let mut bits = self.0.as_smi() as u32;
+            bits.clear_bit(index);
+            Value::raw_smi(bits.cast_signed())
+        } else {
+            let mut bytes = self.0.as_pointer().cast::<ByteArray>();
+            bytes.as_mut_slice().clear_bit(index);
+            self.0
+        }
+    }
+}

--- a/src/js/runtime/mod.rs
+++ b/src/js/runtime/mod.rs
@@ -7,6 +7,7 @@ mod array_object;
 mod array_properties;
 mod async_generator_object;
 mod bigint_value;
+mod bitmap;
 mod bound_function_object;
 mod boxed_value;
 pub mod builtin_function;

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -119,6 +119,8 @@ const SMI_MAX: f64 = i32::MAX as f64;
 const SMI_MIN: f64 = i32::MIN as f64;
 const SMI_ZERO: u64 = Value::raw_smi(0).as_raw_bits();
 
+pub type Smi = i32;
+
 impl Value {
     #[inline]
     pub const fn from_raw_bits(raw_bits: u64) -> Value {

--- a/tests/integration/language/function/mapped_arguments_bounds_check.js
+++ b/tests/integration/language/function/mapped_arguments_bounds_check.js
@@ -1,0 +1,35 @@
+/*---
+description: ^
+  Reading and writing beyond the bounds of a mapped arguments object should not read or write mapped
+  parameters.
+---*/
+
+// Reading and writing past end of a small number of arguments (inline bitmap)
+function smallRead(a, b) {
+  return arguments[32];
+}
+assert.sameValue(smallRead(1, 2), undefined);
+
+function smallWrite(a, b) {
+  arguments[32] = 99;
+  return arguments[32];
+}
+assert.sameValue(smallWrite(1, 2), 99);
+
+// Reading and writing past end of a large number of arguments (heap allocated bitmap)
+function largeRead(
+  a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,
+  a26,a27,a28,a29,a30,a31,a32,a33,a34,
+) {
+  return arguments[100];
+}
+assert.sameValue(largeRead(), undefined);
+
+function largeWrite(
+  a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,
+  a26,a27,a28,a29,a30,a31,a32,a33,a34,
+) {
+  arguments[100] = 99;
+  return arguments[100];
+}
+assert.sameValue(largeWrite(), 99);


### PR DESCRIPTION
## Summary

To eventually support inline properties on objects we want the native fields to have a fixed size. The only remaining violation of this is the inline bool array in `MappedArgumentsObject`.

We can store this in a separate fixed array. However let's do better: this is bitmap data so let's try to store it inline in the space of a single value, falling back to separate storage only if necessary. For ease of encoding we store the bitmap as a smi so it only supports up to size 32. We create a `ValueBitmap` that implements this pretty cleanly.

## Tests

- CI
- Added integration test for reading/writing past end of arguments array both for inline and separate array bitmaps