### PR TITLE
[runtime] Support doc comments on extend_object structs and fields

### DIFF
--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -28,9 +28,10 @@ use crate::{
     set_uninit,
 };
 
-// An unmapped arguments object that is identical to an ordinary object, but has an arguments object
-// descriptor. This emulates an ordinary object with a [[ParameterMap]] slot described in spec.
 extend_object! {
+    /// An unmapped arguments object that is identical to an ordinary object, but has an arguments
+    /// object descriptor. This emulates an ordinary object with a [[ParameterMap]] slot described
+    /// in spec.
     pub struct UnmappedArgumentsObject {}
 }
 
@@ -45,18 +46,18 @@ impl UnmappedArgumentsObject {
     }
 }
 
-// A mapped arguments exotic argument used in the bytecode VM. Contains a reference to the scope
-// where the arguments are stored so that they can be referenced directly.
-//
-// Only some parameters are mapped, and this can change dynamically due to user action. Stored as
-// a bitmap.
-//
-// Arguments Exotic Objects (https://tc39.es/ecma262/#sec-arguments-exotic-objects)
 extend_object! {
+    /// A mapped arguments exotic argument used in the bytecode VM. Contains a reference to the
+    /// scope where the arguments are stored so that they can be referenced directly.
+    ///
+    /// Only some parameters are mapped, and this can change dynamically due to user action. Stored
+    /// as a bitmap.
+    ///
+    /// Arguments Exotic Objects (https://tc39.es/ecma262/#sec-arguments-exotic-objects)
     pub struct MappedArgumentsObject {
-        // Scope where the arguments are stored.
+        /// Scope where the arguments are stored.
         scope: HeapPtr<Scope>,
-        // Bitmap of which parameters are mapped to the scope.
+        /// Bitmap of which parameters are mapped to the scope.
         mapped_parameters: Value,
     }
 }

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -26,11 +26,11 @@ use crate::{
     set_uninit,
 };
 
-// Array Exotic Objects (https://tc39.es/ecma262/#sec-array-exotic-objects)
 extend_object! {
+    /// Array Exotic Objects (https://tc39.es/ecma262/#sec-array-exotic-objects)
     pub struct ArrayObject {
-        // Length property is backed by length of object's ArrayProperties. There is no explicit
-        // property descriptor stored, so attributes here.
+        /// Length property is backed by length of object's ArrayProperties. There is no explicit
+        /// property descriptor stored, so attributes here.
         is_length_writable: bool,
     }
 }

--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -28,31 +28,32 @@ use crate::{
     runtime_fn, set_uninit,
 };
 
-// An async generator object represents the state of an async generator function. It holds the
-// saved stack frame of the generator function, which is restored when the generator is resumed.
-//
-// Also holds a queue of promises which represent requests to resume the async generator.
 extend_object! {
+    /// An async generator object represents the state of an async generator function. It holds the
+    /// saved stack frame of the generator function, which is restored when the generator is
+    /// resumed.
+    ///
+    /// Also holds a queue of promises which represent requests to resume the async generator.
     pub struct AsyncGeneratorObject {
-        // The current state of the generator - may be executing, suspended, awaiting return, or
-        // completed.
+        /// The current state of the generator - may be executing, suspended, awaiting return, or
+        /// completed.
         state: AsyncGeneratorState,
-        // Address of the next instruction to execute when this generator is resumed.
-        // Stored as a byte offset into the BytecodeFunction.
+        /// Address of the next instruction to execute when this generator is resumed.
+        /// Stored as a byte offset into the BytecodeFunction.
         pc_to_resume_offset: usize,
-        // Index of the frame pointer in the stack frame.
+        /// Index of the frame pointer in the stack frame.
         fp_index: usize,
-        // Registers for the completion operands to return when the generator is resumed. The value
-        // is written to the first register and the completion type is written to the second
-        // register.
-        //
-        // Value is from AsyncGenerator.prototype.{next, return, throw}.
+        /// Registers for the completion operands to return when the generator is resumed. The value
+        /// is written to the first register and the completion type is written to the second
+        /// register.
+        ///
+        /// Value is from AsyncGenerator.prototype.{next, return, throw}.
         completion_registers: Option<(GeneratorRegister, GeneratorRegister)>,
-        // A queue of requests to resume the async generator. Forms a singly linked list, where the
-        // head is the next request that should be consumed.
+        /// A queue of requests to resume the async generator. Forms a singly linked list, where the
+        /// head is the next request that should be consumed.
         request_queue: Option<HeapPtr<AsyncGeneratorRequest>>,
-        // The stack frame of the generator, containing all args, locals, and fixed slots in
-        // between.
+        /// The stack frame of the generator, containing all args, locals, and fixed slots in
+        /// between.
         stack_frame: HeapPtr<StackFrameArray>,
     }
 }

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -31,9 +31,9 @@ use crate::{
     set_uninit,
 };
 
-// A closure is a pair of a function and its scope. Represents the instantiation of a function's
-// bytecode "template" in a particular scope, and is the callable object.
 extend_object! {
+    /// A closure is a pair of a function and its scope. Represents the instantiation of a
+    /// function's bytecode "template" in a particular scope, and is the callable object.
     pub struct ClosureObject {
         function: HeapPtr<BytecodeFunction>,
         scope: HeapPtr<Scope>,

--- a/src/js/runtime/generator_object.rs
+++ b/src/js/runtime/generator_object.rs
@@ -24,26 +24,26 @@ use crate::{
 /// that all sizes of registers can be handled.
 pub type GeneratorRegister = Register<ExtraWide>;
 
-// A generator object represents the state of a generator function. It holds the saved stack frame
-// of the generator function, which is restored when the generator is resumed.
 extend_object! {
+    /// A generator object represents the state of a generator function. It holds the saved stack
+    /// frame of the generator function, which is restored when the generator is resumed.
     pub struct GeneratorObject {
-        // The current state of the generator - may be executing, suspended, or completed.
+        /// The current state of the generator - may be executing, suspended, or completed.
         state: GeneratorState,
-        // Address of the next instruction to execute when this generator is resumed.
-        // Stored as a byte offset into the BytecodeFunction.
+        /// Address of the next instruction to execute when this generator is resumed.
+        /// Stored as a byte offset into the BytecodeFunction.
         pc_to_resume_offset: usize,
-        // Index of the frame pointer in the stack frame.
+        /// Index of the frame pointer in the stack frame.
         fp_index: usize,
-        // Registers for the completion operands to return when the generator is resumed. The value
-        // is written to the first register and the completion type is written to the second
-        // register.
-        //
-        // For a generator the value is from Generator.prototype.{next, return, throw}.
-        // For an async function the value is from resolve or reject.
+        /// Registers for the completion operands to return when the generator is resumed. The value
+        /// is written to the first register and the completion type is written to the second
+        /// register.
+        ///
+        /// For a generator the value is from Generator.prototype.{next, return, throw}.
+        /// For an async function the value is from resolve or reject.
         completion_registers: Option<(GeneratorRegister, GeneratorRegister)>,
-        // The stack frame of the generator, containing all args, locals, and fixed slots in
-        // between.
+        /// The stack frame of the generator, containing all args, locals, and fixed slots in
+        /// between.
         stack_frame: HeapPtr<StackFrameArray>,
     }
 }

--- a/src/js/runtime/intrinsics/array_buffer_object.rs
+++ b/src/js/runtime/intrinsics/array_buffer_object.rs
@@ -18,15 +18,15 @@ use crate::{
 // 4GB max array buffer size
 const MAX_ARRAY_BUFFER_SIZE: usize = 1 << 32;
 
-// ArrayBuffer Objects (https://tc39.es/ecma262/#sec-arraybuffer-objects)
 extend_object! {
+    /// ArrayBuffer Objects (https://tc39.es/ecma262/#sec-arraybuffer-objects)
     pub struct ArrayBufferObject {
-        // Byte length of the array buffer. Stored separately from data as data might be detached
+        /// Byte length of the array buffer. Stored separately from data as data might be detached
         byte_length: usize,
-        // Maximum byte length that the array buffer can grow to. Fixed length if no max is set.
+        /// Maximum byte length that the array buffer can grow to. Fixed length if no max is set.
         max_byte_length: Option<usize>,
-        // Data block containing array buffer's binary data. Detached array buffers represented as
-        // a null data pointer.
+        /// Data block containing array buffer's binary data. Detached array buffers represented as
+        /// a null data pointer.
         data: Option<HeapPtr<ByteArray>>,
     }
 }

--- a/src/js/runtime/intrinsics/array_iterator_object.rs
+++ b/src/js/runtime/intrinsics/array_iterator_object.rs
@@ -29,8 +29,8 @@ use crate::{
     runtime_fn, set_uninit,
 };
 
-// Array Iterator Objects (https://tc39.es/ecma262/#sec-array-iterator-objects)
 extend_object! {
+    /// Array Iterator Objects (https://tc39.es/ecma262/#sec-array-iterator-objects)
     pub struct ArrayIteratorObject {
         array: HeapPtr<ObjectValue>,
         kind: ArrayIteratorKind,

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_object.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_object.rs
@@ -12,8 +12,8 @@ use crate::{
     set_uninit,
 };
 
-// Async-from-Sync Iterator Objects (https://tc39.es/ecma262/#sec-async-from-sync-iterator-objects)
 extend_object! {
+    /// Async-from-Sync Iterator Objects (https://tc39.es/ecma262/#sec-async-from-sync-iterator-objects)
     pub struct AsyncFromSyncIteratorObject {
         iterator: HeapPtr<ObjectValue>,
         next_method: Value,

--- a/src/js/runtime/intrinsics/bigint_object.rs
+++ b/src/js/runtime/intrinsics/bigint_object.rs
@@ -12,10 +12,10 @@ use crate::{
     set_uninit,
 };
 
-// BigInt Objects (https://tc39.es/ecma262/#sec-bigint-objects)
 extend_object! {
+    /// BigInt Objects (https://tc39.es/ecma262/#sec-bigint-objects)
     pub struct BigIntObject {
-        // The BigInt value wrapped by this object
+        /// The BigInt value wrapped by this object
         bigint_data: HeapPtr<BigIntValue>,
     }
 }

--- a/src/js/runtime/intrinsics/boolean_object.rs
+++ b/src/js/runtime/intrinsics/boolean_object.rs
@@ -16,10 +16,10 @@ use crate::{
     set_uninit,
 };
 
-// Boolean Objects (https://tc39.es/ecma262/#sec-boolean-objects)
 extend_object! {
+    /// Boolean Objects (https://tc39.es/ecma262/#sec-boolean-objects)
     pub struct BooleanObject {
-        // The boolean value wrapped by this object
+        /// The boolean value wrapped by this object
         boolean_data: bool,
     }
 }

--- a/src/js/runtime/intrinsics/data_view_object.rs
+++ b/src/js/runtime/intrinsics/data_view_object.rs
@@ -12,11 +12,11 @@ use crate::{
     },
 };
 
-// DataView Objects (https://tc39.es/ecma262/#sec-dataview-objects)
 extend_object! {
+    /// DataView Objects (https://tc39.es/ecma262/#sec-dataview-objects)
     pub struct DataViewObject {
         viewed_array_buffer: HeapPtr<ArrayBufferObject>,
-        // Byte length of the DataView. None represents a value of AUTO.
+        /// Byte length of the DataView. None represents a value of AUTO.
         byte_length: Option<usize>,
         byte_offset: usize,
     }

--- a/src/js/runtime/intrinsics/date_object.rs
+++ b/src/js/runtime/intrinsics/date_object.rs
@@ -14,11 +14,11 @@ use crate::{
     set_uninit,
 };
 
-// Date Objects (https://tc39.es/ecma262/#sec-date-objects)
 extend_object! {
+    /// Date Objects (https://tc39.es/ecma262/#sec-date-objects)
     pub struct DateObject {
-        // The instant in time (as milliseconds since the Unix epoch). May also be NaN to represent
-        // no specific instant.
+        /// The instant in time (as milliseconds since the Unix epoch). May also be NaN to represent
+        /// no specific instant.
         date_value: f64,
     }
 }

--- a/src/js/runtime/intrinsics/error_object.rs
+++ b/src/js/runtime/intrinsics/error_object.rs
@@ -22,10 +22,10 @@ use crate::{
 
 extend_object! {
     pub struct ErrorObject {
-        // Cached stack trace, or the minimal information cached to lazily generate the stack trace
-        // when first accessed.
+        /// Cached stack trace, or the minimal information cached to lazily generate the stack trace
+        /// when first accessed.
         stack_trace_state: StackTraceState,
-        // Whether this is a stack overflow error.
+        /// Whether this is a stack overflow error.
         is_stack_overflow: bool,
     }
 }

--- a/src/js/runtime/intrinsics/finalization_registry_object.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_object.rs
@@ -17,15 +17,15 @@ use crate::{
     set_uninit,
 };
 
-// FinalizationRegistry Objects (https://tc39.es/ecma262/#sec-finalization-registry-objects)
 extend_object! {
+    /// FinalizationRegistry Objects (https://tc39.es/ecma262/#sec-finalization-registry-objects)
     pub struct FinalizationRegistryObject {
-        // Cells in the finalization registry
+        /// Cells in the finalization registry
         cells: HeapPtr<FinalizationRegistryCells>,
-        // Function to be called when values are garbage collected
+        /// Function to be called when values are garbage collected
         cleanup_callback: HeapPtr<ObjectValue>,
-        // Holds the address of the next finalization registry that has been visited during garbage
-        // collection. Unused outside of garbage collection.
+        /// Holds the address of the next finalization registry that has been visited during garbage
+        /// collection. Unused outside of garbage collection.
         next_finalization_registry: Option<HeapPtr<FinalizationRegistryObject>>,
     }
 }

--- a/src/js/runtime/intrinsics/iterator_helper_object.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_object.rs
@@ -22,15 +22,15 @@ use crate::{
     set_uninit,
 };
 
-// Iterator Helper Objects (https://tc39.es/ecma262/#sec-iterator-helper-objects)
 extend_object! {
+    /// Iterator Helper Objects (https://tc39.es/ecma262/#sec-iterator-helper-objects)
     pub struct IteratorHelperObject {
-        // The [[UnderlyingIterator]] internal slot. This is always non-empty except for in `concat`
-        // helpers before `next` has been called the first time.
+        /// The [[UnderlyingIterator]] internal slot. This is always non-empty except for in
+        /// `concat` helpers before `next` has been called the first time.
         iterator: Option<HeapIterator>,
-        // The current state of the iterator, when treated as a generator.
+        /// The current state of the iterator, when treated as a generator.
         generator_state: GeneratorState,
-        // The type and captured values of the iterator helper.
+        /// The type and captured values of the iterator helper.
         state: IteratorHelperState,
     }
 }

--- a/src/js/runtime/intrinsics/map_iterator_object.rs
+++ b/src/js/runtime/intrinsics/map_iterator_object.rs
@@ -25,10 +25,10 @@ use crate::{
     runtime_fn, set_uninit,
 };
 
-// Map Iterator Objects (https://tc39.es/ecma262/#sec-map-iterator-objects)
 extend_object! {
+    /// Map Iterator Objects (https://tc39.es/ecma262/#sec-map-iterator-objects)
     pub struct MapIteratorObject {
-        // Component parts of an index_map::GcSafeEntriesIter
+        /// Component parts of an index_map::GcSafeEntriesIter
         map: HeapPtr<ValueIndexMap>,
         next_entry_index: usize,
         kind: MapIteratorKind,

--- a/src/js/runtime/intrinsics/map_object.rs
+++ b/src/js/runtime/intrinsics/map_object.rs
@@ -15,8 +15,8 @@ use crate::{
     set_uninit,
 };
 
-// Map Objects (https://tc39.es/ecma262/#sec-map-objects)
 extend_object! {
+    /// Map Objects (https://tc39.es/ecma262/#sec-map-objects)
     pub struct MapObject {
         map_data: HeapPtr<ValueIndexMap>,
     }

--- a/src/js/runtime/intrinsics/number_object.rs
+++ b/src/js/runtime/intrinsics/number_object.rs
@@ -16,10 +16,10 @@ use crate::{
     set_uninit,
 };
 
-// Number Objects (https://tc39.es/ecma262/#sec-number-objects)
 extend_object! {
+    /// Number Objects (https://tc39.es/ecma262/#sec-number-objects)
     pub struct NumberObject {
-        // The number value wrapped by this object
+        /// The number value wrapped by this object
         number_data: f64,
     }
 }

--- a/src/js/runtime/intrinsics/regexp_object.rs
+++ b/src/js/runtime/intrinsics/regexp_object.rs
@@ -18,8 +18,8 @@ use crate::{
     set_uninit,
 };
 
-// RegExp (Regular Expression) Objects (https://tc39.es/ecma262/#sec-regexp-regular-expression-objects)
 extend_object! {
+    /// RegExp (Regular Expression) Objects (https://tc39.es/ecma262/#sec-regexp-regular-expression-objects)
     pub struct RegExpObject {
         compiled_regexp: HeapPtr<CompiledRegExp>,
     }

--- a/src/js/runtime/intrinsics/regexp_string_iterator_object.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator_object.rs
@@ -27,8 +27,8 @@ use crate::{
     runtime_fn, set_uninit,
 };
 
-// RegExp String Iterator Objects (https://tc39.es/ecma262/#sec-regexp-string-iterator-objects)
 extend_object! {
+    /// RegExp String Iterator Objects (https://tc39.es/ecma262/#sec-regexp-string-iterator-objects)
     pub struct RegExpStringIteratorObject {
         regexp_object: HeapPtr<ObjectValue>,
         target_string: HeapPtr<StringValue>,

--- a/src/js/runtime/intrinsics/set_iterator_object.rs
+++ b/src/js/runtime/intrinsics/set_iterator_object.rs
@@ -25,10 +25,10 @@ use crate::{
     runtime_fn, set_uninit,
 };
 
-// Set Iterator Objects (https://tc39.es/ecma262/#sec-set-iterator-objects)
 extend_object! {
+    /// Set Iterator Objects (https://tc39.es/ecma262/#sec-set-iterator-objects)
     pub struct SetIteratorObject {
-        // Component parts of an index_map::GcSafeEntriesIter
+        /// Component parts of an index_map::GcSafeEntriesIter
         set: HeapPtr<ValueIndexSet>,
         next_entry_index: usize,
         kind: SetIteratorKind,

--- a/src/js/runtime/intrinsics/set_object.rs
+++ b/src/js/runtime/intrinsics/set_object.rs
@@ -15,8 +15,8 @@ use crate::{
     set_uninit,
 };
 
-// Set Objects (https://tc39.es/ecma262/#sec-set-objects)
 extend_object! {
+    /// Set Objects (https://tc39.es/ecma262/#sec-set-objects)
     pub struct SetObject {
         set_data: HeapPtr<ValueIndexSet>,
     }

--- a/src/js/runtime/intrinsics/string_iterator_object.rs
+++ b/src/js/runtime/intrinsics/string_iterator_object.rs
@@ -20,8 +20,8 @@ use crate::{
     runtime_fn, set_uninit,
 };
 
-// String Iterator Objects (https://tc39.es/ecma262/#sec-string-iterator-objects)
 extend_object! {
+    /// String Iterator Objects (https://tc39.es/ecma262/#sec-string-iterator-objects)
     pub struct StringIteratorObject {
         iter: SafeCodePointIterator,
     }

--- a/src/js/runtime/intrinsics/symbol_object.rs
+++ b/src/js/runtime/intrinsics/symbol_object.rs
@@ -12,10 +12,10 @@ use crate::{
     set_uninit,
 };
 
-// Symbol Objects (https://tc39.es/ecma262/#sec-symbol-objects)
 extend_object! {
+    /// Symbol Objects (https://tc39.es/ecma262/#sec-symbol-objects)
     pub struct SymbolObject {
-        // The symbol value wrapped by this object
+        /// The symbol value wrapped by this object
         symbol_data: HeapPtr<SymbolValue>,
     }
 }

--- a/src/js/runtime/intrinsics/temporal/duration_object.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_object.rs
@@ -12,11 +12,11 @@ use crate::{
     set_uninit,
 };
 
-// Temporal.Duration Objects (https://tc39.es/proposal-temporal/#sec-temporal-duration-objects)
 extend_object! {
+    /// Temporal.Duration Objects (https://tc39.es/proposal-temporal/#sec-temporal-duration-objects)
     pub struct DurationObject {
-        // Contains an `u128` field and so is 16-byte aligned. Must only access through the
-        // alignment wrapper.
+        /// Contains an `u128` field and so is 16-byte aligned. Must only access through the
+        /// alignment wrapper.
         duration: HeapUnaligned<Duration>,
     }
 }

--- a/src/js/runtime/intrinsics/temporal/instant_object.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_object.rs
@@ -12,11 +12,11 @@ use crate::{
     set_uninit,
 };
 
-// Temporal.Instant Objects (https://tc39.es/proposal-temporal/#sec-temporal-instant-objects)
 extend_object! {
+    /// Temporal.Instant Objects (https://tc39.es/proposal-temporal/#sec-temporal-instant-objects)
     pub struct InstantObject {
-        // Contains an `i128` field and so is 16-byte aligned. Must only access through the
-        // alignment wrapper.
+        /// Contains an `i128` field and so is 16-byte aligned. Must only access through the
+        /// alignment wrapper.
         instant: HeapUnaligned<Instant>,
     }
 }

--- a/src/js/runtime/intrinsics/temporal/plain_date_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_object.rs
@@ -12,8 +12,8 @@ use crate::{
     set_uninit,
 };
 
-// PlainDate Objects (https://tc39.es/proposal-temporal/#sec-temporal-plaindate-objects)
 extend_object! {
+    /// PlainDate Objects (https://tc39.es/proposal-temporal/#sec-temporal-plaindate-objects)
     pub struct PlainDateObject {
         date: PlainDate,
     }

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_object.rs
@@ -12,8 +12,8 @@ use crate::{
     set_uninit,
 };
 
-// PlainDateTime Objects (https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-objects)
 extend_object! {
+    /// PlainDateTime Objects (https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-objects)
     pub struct PlainDateTimeObject {
         date_time: PlainDateTime,
     }

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_object.rs
@@ -12,8 +12,8 @@ use crate::{
     set_uninit,
 };
 
-// PlainMonthDay Objects (https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-objects)
 extend_object! {
+    /// PlainMonthDay Objects (https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-objects)
     pub struct PlainMonthDayObject {
         month_day: PlainMonthDay,
     }

--- a/src/js/runtime/intrinsics/temporal/plain_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_object.rs
@@ -12,8 +12,8 @@ use crate::{
     set_uninit,
 };
 
-// Temporal.PlainTime Objects (https://tc39.es/proposal-temporal/#sec-temporal-plaintime-objects)
 extend_object! {
+    /// Temporal.PlainTime Objects (https://tc39.es/proposal-temporal/#sec-temporal-plaintime-objects)
     pub struct PlainTimeObject {
         time: PlainTime,
     }

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_object.rs
@@ -12,8 +12,8 @@ use crate::{
     set_uninit,
 };
 
-// PlainYearMonth Objects (https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-objects)
 extend_object! {
+    /// PlainYearMonth Objects (https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-objects)
     pub struct PlainYearMonthObject {
         year_month: PlainYearMonth,
     }

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
@@ -12,11 +12,11 @@ use crate::{
     set_uninit,
 };
 
-// ZonedDateTime Objects (https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects)
 extend_object! {
+    /// ZonedDateTime Objects (https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects)
     pub struct ZonedDateTimeObject {
-        // Contains an `i128` field and so is 16-byte aligned. Must only access through the
-        // alignment wrapper.
+        /// Contains an `i128` field and so is 16-byte aligned. Must only access through the
+        /// alignment wrapper.
         zoned_date_time: HeapUnaligned<ZonedDateTime>,
     }
 }

--- a/src/js/runtime/intrinsics/weak_map_object.rs
+++ b/src/js/runtime/intrinsics/weak_map_object.rs
@@ -16,13 +16,13 @@ use crate::{
     set_uninit,
 };
 
-// WeakMap Objects (https://tc39.es/ecma262/#sec-weakmap-objects)
 extend_object! {
+    /// WeakMap Objects (https://tc39.es/ecma262/#sec-weakmap-objects)
     pub struct WeakMapObject {
-        // Map of weakly held keys to values. Can only hold object and symbols as keys.
+        /// Map of weakly held keys to values. Can only hold object and symbols as keys.
         weak_map_data: HeapPtr<WeakValueMap>,
-        // Holds the address of the next weak map that has been visited during garbage collection.
-        // Unused outside of garbage collection.
+        /// Holds the address of the next weak map that has been visited during garbage collection.
+        /// Unused outside of garbage collection.
         next_weak_map: Option<HeapPtr<WeakMapObject>>,
     }
 }

--- a/src/js/runtime/intrinsics/weak_ref_object.rs
+++ b/src/js/runtime/intrinsics/weak_ref_object.rs
@@ -13,13 +13,13 @@ use crate::{
     set_uninit,
 };
 
-// WeakRef Objects (https://tc39.es/ecma262/#sec-weak-ref-objects)
 extend_object! {
+    /// WeakRef Objects (https://tc39.es/ecma262/#sec-weak-ref-objects)
     pub struct WeakRefObject {
-        // Weakly held reference to a value. Can only be an object, symbol, or undefined.
+        /// Weakly held reference to a value. Can only be an object, symbol, or undefined.
         weak_ref_target: Value,
-        // Holds the address of the next weak ref that has been visited during garbage collection.
-        // Unused outside of garbage collection.
+        /// Holds the address of the next weak ref that has been visited during garbage collection.
+        /// Unused outside of garbage collection.
         next_weak_ref: Option<HeapPtr<WeakRefObject>>,
     }
 }

--- a/src/js/runtime/intrinsics/weak_set_object.rs
+++ b/src/js/runtime/intrinsics/weak_set_object.rs
@@ -16,13 +16,13 @@ use crate::{
     set_uninit,
 };
 
-// WeakSet Objects (https://tc39.es/ecma262/#sec-weakset-objects)
 extend_object! {
+    /// WeakSet Objects (https://tc39.es/ecma262/#sec-weakset-objects)
     pub struct WeakSetObject {
-        // Set of weakly held references to values. Can only hold object and symbols.
+        /// Set of weakly held references to values. Can only hold object and symbols.
         weak_set_data: HeapPtr<WeakValueSet>,
-        // Holds the address of the next weak set that has been visited during garbage collection.
-        // Unused outside of garbage collection.
+        /// Holds the address of the next weak set that has been visited during garbage collection.
+        /// Unused outside of garbage collection.
         next_weak_set: Option<HeapPtr<WeakSetObject>>,
     }
 }

--- a/src/js/runtime/intrinsics/wrapped_valid_iterator_object.rs
+++ b/src/js/runtime/intrinsics/wrapped_valid_iterator_object.rs
@@ -13,8 +13,8 @@ use crate::{
     set_uninit,
 };
 
-// A WrappedValidIteratorObject wraps an iterator object and its next method.
 extend_object! {
+    /// A WrappedValidIteratorObject wraps an iterator object and its next method.
     pub struct WrappedValidIteratorObject {
         iterator: HeapPtr<ObjectValue>,
         next_method: Value,

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -26,13 +26,13 @@ use crate::{
     set_uninit,
 };
 
-// Module Namespace Exotic Objects (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects)
 extend_object! {
+    /// Module Namespace Exotic Objects (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects)
     pub struct ModuleNamespaceObject {
-        // The module which the namespace object holds the exports of. Exports are actually stored
-        // within the module itself and the namespace object is just a proxy to access them.
-        //
-        // Must be either a SourceTextModule or a SyntheticModule.
+        /// The module which the namespace object holds the exports of. Exports are actually stored
+        /// within the module itself and the namespace object is just a proxy to access them.
+        ///
+        /// Must be either a SourceTextModule or a SyntheticModule.
         module: HeapPtr<AnyHeapItem>,
     }
 }

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -29,10 +29,11 @@ use crate::{
 // Safe to apply to root ObjectValue, since it avoids self-referencing conversions.
 #[macro_export]
 macro_rules! extend_object_without_conversions {
-    ($vis:vis struct $name:ident $(<$($generics:tt),*>)? {
-        $($field_vis:vis $field_name:ident: $field_type:ty,)*
+    ($(#[$struct_meta:meta])* $vis:vis struct $name:ident $(<$($generics:tt),*>)? {
+        $($(#[$field_meta:meta])* $field_vis:vis $field_name:ident: $field_type:ty,)*
     }) => {
         #[repr(C)]
+        $(#[$struct_meta])*
         $vis struct $name $(<$($generics),*>)? {
             // All objects start with object vtable
             descriptor: $crate::runtime::HeapPtr<$crate::runtime::heap_item_descriptor::HeapItemDescriptor>,
@@ -55,7 +56,7 @@ macro_rules! extend_object_without_conversions {
             hash_code: Option<std::num::NonZeroU32>,
 
             // Child fields
-            $($field_vis $field_name: $field_type,)*
+            $($(#[$field_meta])* $field_vis $field_name: $field_type,)*
         }
 
         impl $(<$($generics),*>)? $name $(<$($generics),*>)? {
@@ -114,12 +115,13 @@ macro_rules! extend_object_without_conversions {
 // all objects except the root object.
 #[macro_export]
 macro_rules! extend_object {
-    ($vis:vis struct $name:ident $(<$($generics:tt),*>)? {
-        $($field_vis:vis $field_name:ident: $field_type:ty,)*
+    ($(#[$struct_meta:meta])* $vis:vis struct $name:ident $(<$($generics:tt),*>)? {
+        $($(#[$field_meta:meta])* $field_vis:vis $field_name:ident: $field_type:ty,)*
     }) => {
         $crate::extend_object_without_conversions! {
+            $(#[$struct_meta])*
             $vis struct $name $(<$($generics),*>)? {
-                $($field_vis $field_name: $field_type,)*
+                $($(#[$field_meta])* $field_vis $field_name: $field_type,)*
             }
         }
 

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -20,9 +20,10 @@ use crate::{
     },
 };
 
-// An ordinary object is used to create the vtable for a generic object. Must be a separate type
-// from ObjectValue so that the same methods can appear on ObjectValue but perform dynamic dispatch.
 extend_object! {
+    /// An ordinary object is used to create the vtable for a generic object. Must be a separate
+    /// type from ObjectValue so that the same methods can appear on ObjectValue but perform dynamic
+    /// dispatch.
     pub struct OrdinaryObject {}
 }
 

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -20,8 +20,8 @@ use crate::{
     runtime_fn, set_uninit,
 };
 
-// Properties of Promise Instances (https://tc39.es/ecma262/#sec-properties-of-promise-instances)
 extend_object! {
+    /// Properties of Promise Instances (https://tc39.es/ecma262/#sec-properties-of-promise-instances)
     pub struct PromiseObject {
         state: PromiseState,
     }

--- a/src/js/runtime/proxy_object.rs
+++ b/src/js/runtime/proxy_object.rs
@@ -29,8 +29,8 @@ use crate::{
     set_uninit,
 };
 
-// Proxy Object (https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots)
 extend_object! {
+    /// Proxy Object (https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots)
     pub struct ProxyObject {
         proxy_handler: Option<HeapPtr<ObjectValue>>,
         proxy_target: Option<HeapPtr<ObjectValue>>,

--- a/src/js/runtime/string_object.rs
+++ b/src/js/runtime/string_object.rs
@@ -27,10 +27,10 @@ use crate::{
     set_uninit,
 };
 
-// String Exotic Objects (https://tc39.es/ecma262/#sec-string-exotic-objects)
 extend_object! {
+    /// String Exotic Objects (https://tc39.es/ecma262/#sec-string-exotic-objects)
     pub struct StringObject {
-        // The string value wrapped by this object
+        /// The string value wrapped by this object
         string_data: HeapPtr<StringValue>,
     }
 }


### PR DESCRIPTION
## Summary

Let's fix doc comments within `extend_object!` definitions to be properly supported in the macro. This applies to doc comments both on the overall struct and each individual field.

## Tests

- CI