### PR TITLE
[runtime] Heap collections parameterized by header type allowing storing extra data, use for sparse array properties and weak vector types

### DIFF
--- a/src/js/runtime/array_properties.rs
+++ b/src/js/runtime/array_properties.rs
@@ -3,10 +3,10 @@ use crate::{
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
-        collections::{BsHashMap, BsHashMapField, HashMapInstance, InlineArray},
+        collections::{BsHashMapField, HashMapInstance, InlineArray},
         gc::{HeapItem, HeapVisitor, IsHeapItem},
         object_value::ObjectValue,
-        property::{HeapProperty, Property, PropertyFlags},
+        property::{HeapProperty, Property},
         shape::Shape,
     },
     set_uninit,
@@ -258,7 +258,7 @@ impl ArrayProperties {
             // Can use stored property directly since loop does not allocate.
             let mut last_non_configurable_index = None;
             for (index, stored_property) in sparse_properties.iter_gc_unsafe() {
-                if index < new_length || index == ARRAY_LENGTH_SENTINEL_KEY {
+                if index < new_length {
                     continue;
                 }
                 if !stored_property.is_configurable() {
@@ -276,8 +276,6 @@ impl ArrayProperties {
 
             // Calculate number of properties that will be kept so that we can create new map with
             // appropriate size.
-            //
-            // Length sentinel is excluded here since it's index is u32::MAX.
             let num_properties_left = sparse_properties
                 .iter_gc_unsafe()
                 .filter(|(index, _)| *index < new_length)
@@ -288,8 +286,6 @@ impl ArrayProperties {
 
             // Create a new map with non-truncated values. Can use stored property directly since
             // loop does not allocate on managed heap as map has capacity for all properties.
-            //
-            // Length sentinel is excluded here since it's index is u32::MAX.
             for (index, stored_property) in sparse_properties.iter_gc_unsafe() {
                 if index < new_length {
                     new_sparse_properties.insert_without_growing(index, stored_property.clone());
@@ -475,16 +471,20 @@ impl Iterator for DenseArrayPropertiesGcUnsafeIter {
     }
 }
 
-impl_hash_map_instance!(SparseArrayPropertiesMap, u32, HeapProperty);
+impl_hash_map_instance!(
+    SparseArrayPropertiesMap,
+    u32,
+    HeapProperty,
+    SparseArrayPropertiesExtraStorage
+);
 
-type InnerSparseMap = BsHashMap<u32, HeapProperty>;
-
-/// The array length is stored in the sparse map under this key, which is never a valid array index.
-const ARRAY_LENGTH_SENTINEL_KEY: u32 = u32::MAX;
+/// Extra header data for a sparse properties map, storing the length of the array.
+pub struct SparseArrayPropertiesExtraStorage {
+    array_length: u32,
+}
 
 impl SparseArrayPropertiesMap {
-    /// Create a sparse properties map with the given total capacity. This capacity must include a
-    /// slot for the array length, which be be found with `Self::min_capacity_needed`.
+    /// Create a sparse properties map with the given capacity and array length.
     ///
     /// This is the only SparseArrayPropertiesMap creation function that should be used.
     fn new_with_array_length(
@@ -499,27 +499,16 @@ impl SparseArrayPropertiesMap {
         Ok(map)
     }
 
-    /// Minimum map capacity needed to hold `num_properties` real entries plus the length sentinel.
-    fn min_capacity_needed(num_properties: usize) -> usize {
-        InnerSparseMap::min_capacity_needed(num_properties + 1)
-    }
-
     fn array_length(&self) -> u32 {
-        let length_value = self.get(&ARRAY_LENGTH_SENTINEL_KEY).unwrap().value();
-        length_value.as_number() as u32
+        self.extra_data().array_length
     }
 
     fn set_array_length(&mut self, array_length: u32) {
-        let length_property =
-            HeapProperty::new(Value::number(array_length), PropertyFlags::empty());
-        self.insert_without_growing(ARRAY_LENGTH_SENTINEL_KEY, length_property);
+        self.extra_data_mut().array_length = array_length;
     }
 
     pub fn ordered_keys(&self) -> Vec<u32> {
-        let mut indexes_array = self
-            .keys_gc_unsafe()
-            .filter(|key| *key != ARRAY_LENGTH_SENTINEL_KEY)
-            .collect::<Vec<_>>();
+        let mut indexes_array = self.keys_gc_unsafe().collect::<Vec<_>>();
         indexes_array.sort();
 
         indexes_array
@@ -541,7 +530,6 @@ impl BsHashMapField<SparseArrayPropertiesMap> for SparseMapField {
     ) -> AllocResult<HeapPtr<SparseArrayPropertiesMap>> {
         let array_length = self.0.array_properties_length();
 
-        // Capacity already includes the array length sentinel, no need to adjust for it here.
         let new_map = SparseArrayPropertiesMap::new_with_array_length(cx, capacity, array_length)?;
         self.0.set_array_properties(new_map.cast());
 

--- a/src/js/runtime/collections/hash_map.rs
+++ b/src/js/runtime/collections/hash_map.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use crate::{
-    field_offset,
     runtime::{
         Context, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
@@ -18,9 +17,13 @@ use crate::{
 };
 
 /// Generic flat HashMap implementation using quadratic probing.
+///
+/// May store extra data of type `H` in the header. Caller is responsible for initializing.
 #[repr(C)]
-pub struct BsHashMap<K, V> {
+pub struct BsHashMap<K, V, H = ()> {
     shape: HeapPtr<Shape>,
+    // Extra data stored in the header, if any
+    extra_data: H,
     // Number of kv pairs inserted in the map
     len: usize,
     // Inline array of entries which may be empty, occupied, or deleted. Total capacity must be
@@ -43,15 +46,13 @@ struct KVPair<K, V> {
     value: V,
 }
 
-const ENTRIES_BYTE_OFFSET: usize = field_offset!(BsHashMap<String, String>, entries);
-
-impl<K: Eq + Hash + Clone, V: Clone> BsHashMap<K, V> {
+impl<K: Eq + Hash + Clone, V: Clone, H> BsHashMap<K, V, H> {
     pub const MIN_CAPACITY: usize = 4;
 
     pub fn new(cx: Context, kind: HeapItemKind, capacity: usize) -> AllocResult<HeapPtr<Self>> {
         // Size of a dense array with the given capacity, in bytes
         let size = Self::calculate_size_in_bytes(capacity);
-        let mut hash_map = cx.alloc_uninit_with_size::<BsHashMap<K, V>>(size)?;
+        let mut hash_map = cx.alloc_uninit_with_size::<BsHashMap<K, V, H>>(size)?;
 
         hash_map.init(cx, kind, capacity);
 
@@ -61,6 +62,8 @@ impl<K: Eq + Hash + Clone, V: Clone> BsHashMap<K, V> {
     pub fn init(&mut self, cx: Context, kind: HeapItemKind, capacity: usize) {
         set_uninit!(self.shape, cx.shapes.get(kind));
         set_uninit!(self.len, 0);
+
+        // Note that extra data is uninitialized, caller must initialize it if needed
 
         // Initialize entries array to empty
         self.entries.init_with(capacity, Entry::Empty);
@@ -82,9 +85,22 @@ impl<K: Eq + Hash + Clone, V: Clone> BsHashMap<K, V> {
         self.entries.len()
     }
 
+    /// The extra data stored in the header, if any.
+    #[inline]
+    pub fn extra_data(&self) -> &H {
+        &self.extra_data
+    }
+
+    /// The extra data stored in the header, if any.
+    #[inline]
+    pub fn extra_data_mut(&mut self) -> &mut H {
+        &mut self.extra_data
+    }
+
     #[inline]
     pub fn calculate_size_in_bytes(capacity: usize) -> usize {
-        ENTRIES_BYTE_OFFSET + InlineArray::<Entry<K, V>>::calculate_size_in_bytes(capacity)
+        std::mem::offset_of!(Self, entries)
+            + InlineArray::<Entry<K, V>>::calculate_size_in_bytes(capacity)
     }
 
     /// Return the minimum capacity needed to fit the given number of elements.
@@ -282,38 +298,50 @@ impl<K: Eq + Hash + Clone, V: Clone> BsHashMap<K, V> {
 pub trait HashMapInstance:
     IsHeapItem
     + WithHeapItemKind
-    + std::ops::Deref<Target = BsHashMap<Self::K, Self::V>>
-    + std::ops::DerefMut<Target = BsHashMap<Self::K, Self::V>>
+    + std::ops::Deref<Target = BsHashMap<Self::K, Self::V, Self::H>>
+    + std::ops::DerefMut<Target = BsHashMap<Self::K, Self::V, Self::H>>
 {
     type K: Eq + std::hash::Hash + Clone;
     type V: Clone;
+    type H;
 
     fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsHashMap::<Self::K, Self::V>::new(cx, Self::KIND, capacity)?.cast())
+        Ok(BsHashMap::<Self::K, Self::V, Self::H>::new(cx, Self::KIND, capacity)?.cast())
     }
 
     fn new_initial(cx: Context) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsHashMap::<Self::K, Self::V>::new_initial(cx, Self::KIND)?.cast())
+        Ok(BsHashMap::<Self::K, Self::V, Self::H>::new_initial(cx, Self::KIND)?.cast())
     }
 
     fn calculate_size_in_bytes(capacity: usize) -> usize {
-        BsHashMap::<Self::K, Self::V>::calculate_size_in_bytes(capacity)
+        BsHashMap::<Self::K, Self::V, Self::H>::calculate_size_in_bytes(capacity)
+    }
+
+    fn min_capacity_needed(num_elements: usize) -> usize {
+        BsHashMap::<Self::K, Self::V, Self::H>::min_capacity_needed(num_elements)
     }
 }
 
 #[macro_export]
 macro_rules! impl_hash_map_instance {
     ($map_type:ident, $key_type:ty, $value_type:ty) => {
+        $crate::impl_hash_map_instance!($map_type, $key_type, $value_type, ());
+    };
+    ($map_type:ident, $key_type:ty, $value_type:ty, $extra_data_type:ty) => {
         #[repr(transparent)]
-        pub struct $map_type($crate::runtime::collections::BsHashMap<$key_type, $value_type>);
+        pub struct $map_type(
+            $crate::runtime::collections::BsHashMap<$key_type, $value_type, $extra_data_type>,
+        );
 
         impl $crate::runtime::collections::HashMapInstance for $map_type {
             type K = $key_type;
             type V = $value_type;
+            type H = $extra_data_type;
         }
 
         impl std::ops::Deref for $map_type {
-            type Target = $crate::runtime::collections::BsHashMap<$key_type, $value_type>;
+            type Target =
+                $crate::runtime::collections::BsHashMap<$key_type, $value_type, $extra_data_type>;
 
             fn deref(&self) -> &Self::Target {
                 &self.0
@@ -333,11 +361,11 @@ macro_rules! impl_hash_map_instance {
 ///
 /// `set_new` callback creates a new map with the given capacity and uses it from then on.
 #[inline]
-pub fn maybe_grow_for_insertion<K, V>(
+pub fn maybe_grow_for_insertion<K, V, H>(
     cx: Context,
-    map: HeapPtr<BsHashMap<K, V>>,
-    mut set_new: impl FnMut(Context, usize) -> AllocResult<HeapPtr<BsHashMap<K, V>>>,
-) -> AllocResult<HeapPtr<BsHashMap<K, V>>>
+    map: HeapPtr<BsHashMap<K, V, H>>,
+    mut set_new: impl FnMut(Context, usize) -> AllocResult<HeapPtr<BsHashMap<K, V, H>>>,
+) -> AllocResult<HeapPtr<BsHashMap<K, V, H>>>
 where
     K: Eq + Hash + Clone,
     V: Clone,
@@ -379,7 +407,7 @@ pub trait BsHashMapField<I: HashMapInstance> {
     fn maybe_grow_for_insertion(&mut self, cx: Context) -> AllocResult<HeapPtr<I>> {
         Ok(maybe_grow_for_insertion(
             cx,
-            self.get(cx).cast::<BsHashMap<I::K, I::V>>(),
+            self.get(cx).cast::<BsHashMap<I::K, I::V, I::H>>(),
             |cx, capacity| Ok(self.set_new(cx, capacity)?.cast()),
         )?
         .cast())
@@ -481,4 +509,4 @@ impl<'a, K: Clone, V: Clone> Iterator for GcUnsafeKeysIterMut<'a, K, V> {
 }
 
 // Only necessary so we get deref for HeapPtrs.
-impl<K, V> IsHeapItem for BsHashMap<K, V> {}
+impl<K, V, H> IsHeapItem for BsHashMap<K, V, H> {}

--- a/src/js/runtime/collections/vec.rs
+++ b/src/js/runtime/collections/vec.rs
@@ -1,5 +1,4 @@
 use crate::{
-    field_offset,
     runtime::{
         Context, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
@@ -11,35 +10,39 @@ use crate::{
 };
 
 /// A growable array of values.
+///
+/// May store extra data of type `H` in the header. Caller is responsible for initializing.
 #[repr(C)]
-pub struct BsVec<T> {
+pub struct BsVec<T, H = ()> {
     shape: HeapPtr<Shape>,
+    /// Extra data stored in the header, if any.
+    extra_data: H,
     /// The number of elements stored in the array.
     length: usize,
     /// The array along with its capacity, which is always a power of 2.
     array: InlineArray<T>,
 }
 
-impl<T: Clone + Copy> BsVec<T> {
+impl<T: Clone + Copy, H> BsVec<T, H> {
     pub const MIN_CAPACITY: usize = 4;
 
     /// Create a new BsVec with the given capacity.
     pub fn new(cx: Context, kind: HeapItemKind, capacity: usize) -> AllocResult<HeapPtr<Self>> {
         let size = Self::calculate_size_in_bytes(capacity);
-        let mut vec = cx.alloc_uninit_with_size::<BsVec<T>>(size)?;
+        let mut vec = cx.alloc_uninit_with_size::<BsVec<T, H>>(size)?;
 
         set_uninit!(vec.shape, cx.shapes.get(kind));
         set_uninit!(vec.length, 0);
         vec.array.init_with_uninit(capacity);
 
+        // Note that extra data is uninitialized, caller must initialize it if needed.
+
         Ok(vec)
     }
 
-    const ARRAY_FIELD_OFFSET: usize = field_offset!(BsVec<u8>, array);
-
     #[inline]
     fn calculate_size_in_bytes(capacity: usize) -> usize {
-        Self::ARRAY_FIELD_OFFSET + InlineArray::<T>::calculate_size_in_bytes(capacity)
+        std::mem::offset_of!(Self, array) + InlineArray::<T>::calculate_size_in_bytes(capacity)
     }
 
     #[inline]
@@ -55,6 +58,18 @@ impl<T: Clone + Copy> BsVec<T> {
     #[inline]
     pub fn capacity(&self) -> usize {
         self.array.len()
+    }
+
+    /// The extra data stored in the header, if any.
+    #[inline]
+    pub fn extra_data(&self) -> &H {
+        &self.extra_data
+    }
+
+    /// The extra data stored in the header, if any.
+    #[inline]
+    pub fn extra_data_mut(&mut self) -> &mut H {
+        &mut self.extra_data
     }
 
     #[inline]
@@ -86,38 +101,43 @@ impl<T: Clone + Copy> BsVec<T> {
 pub trait VecInstance:
     IsHeapItem
     + WithHeapItemKind
-    + std::ops::Deref<Target = BsVec<Self::T>>
-    + std::ops::DerefMut<Target = BsVec<Self::T>>
+    + std::ops::Deref<Target = BsVec<Self::T, Self::H>>
+    + std::ops::DerefMut<Target = BsVec<Self::T, Self::H>>
 {
     type T: Clone + Copy;
+    type H;
 
-    const MIN_CAPACITY: usize = BsVec::<Self::T>::MIN_CAPACITY;
+    const MIN_CAPACITY: usize = BsVec::<Self::T, Self::H>::MIN_CAPACITY;
 
     fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsVec::<Self::T>::new(cx, Self::KIND, capacity)?.cast())
+        Ok(BsVec::<Self::T, Self::H>::new(cx, Self::KIND, capacity)?.cast())
     }
 
     fn new_initial(cx: Context) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsVec::<Self::T>::new(cx, Self::KIND, Self::MIN_CAPACITY)?.cast())
+        Ok(BsVec::<Self::T, Self::H>::new(cx, Self::KIND, Self::MIN_CAPACITY)?.cast())
     }
 
     fn calculate_size_in_bytes(capacity: usize) -> usize {
-        BsVec::<Self::T>::calculate_size_in_bytes(capacity)
+        BsVec::<Self::T, Self::H>::calculate_size_in_bytes(capacity)
     }
 }
 
 #[macro_export]
 macro_rules! impl_vec_instance {
     ($vec_type:ident, $element_type:ty) => {
+        $crate::impl_vec_instance!($vec_type, $element_type, ());
+    };
+    ($vec_type:ident, $element_type:ty, $extra_data_type:ty) => {
         #[repr(transparent)]
-        pub struct $vec_type($crate::runtime::collections::BsVec<$element_type>);
+        pub struct $vec_type($crate::runtime::collections::BsVec<$element_type, $extra_data_type>);
 
         impl $crate::runtime::collections::VecInstance for $vec_type {
             type T = $element_type;
+            type H = $extra_data_type;
         }
 
         impl std::ops::Deref for $vec_type {
-            type Target = $crate::runtime::collections::BsVec<$element_type>;
+            type Target = $crate::runtime::collections::BsVec<$element_type, $extra_data_type>;
 
             fn deref(&self) -> &Self::Target {
                 &self.0
@@ -168,4 +188,4 @@ pub trait BsVecField<I: VecInstance> {
 }
 
 // Only necessary so we get deref for HeapPtrs.
-impl<T> IsHeapItem for BsVec<T> {}
+impl<T, H> IsHeapItem for BsVec<T, H> {}

--- a/src/js/runtime/collections/weak_vec.rs
+++ b/src/js/runtime/collections/weak_vec.rs
@@ -1,146 +1,58 @@
 use crate::{
-    field_offset,
+    impl_vec_instance,
     runtime::{
-        Context, HeapItemKind, HeapPtr, Value,
+        Context, HeapPtr, Value,
         alloc_error::AllocResult,
-        collections::InlineArray,
+        collections::VecInstance,
         gc::{HeapItem, HeapVisitor},
-        shape::Shape,
     },
     set_uninit,
 };
 
-/// A growable array of weakly held values.
-///
-/// Garbage collector is aware of this type and compresses it in place during collection.
-///
-/// The intrusive `next_weak_vec` list used by the collector lives on the holder of the vec, not on
-/// the vec itself.
-#[repr(C)]
-pub struct WeakValueVec {
-    shape: HeapPtr<Shape>,
-    /// The number of elements stored in the array.
-    length: usize,
-    // Holds the address of the next weak list that has been visited during garbage collection.
-    // Unused outside of garbage collection.
+// A growable array of weakly held values.
+//
+// Garbage collector is aware of this type and compresses it in place during collection.
+impl_vec_instance!(WeakValueVec, Value, WeakValueVecExtraStorage);
+
+/// Extra header data for a weak value vec, storing the intrusive list of weak vecs for GC.
+pub struct WeakValueVecExtraStorage {
+    /// Holds the address of the next weak vec that has been visited during garbage collection.
+    /// Unused outside of garbage collection.
     next_weak_vec: Option<HeapPtr<WeakValueVec>>,
-    /// The array along with its capacity, which is always a power of 2.
-    array: InlineArray<Value>,
 }
 
 impl WeakValueVec {
     /// Create a new WeakValueVec with the given capacity.
+    ///
+    /// This is the only WeakValueVec creation function that should be used.
     #[allow(unused)]
     pub fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
-        let size = Self::calculate_size_in_bytes(capacity);
-        let mut vec = cx.alloc_uninit_with_size::<WeakValueVec>(size)?;
+        let mut vec = <Self as VecInstance>::new(cx, capacity)?;
 
-        set_uninit!(vec.shape, cx.shapes.get(HeapItemKind::WeakValueVec));
-        set_uninit!(vec.length, 0);
-        set_uninit!(vec.next_weak_vec, None);
-        vec.array.init_with_uninit(capacity);
+        set_uninit!(vec.extra_data_mut().next_weak_vec, None);
 
         Ok(vec)
     }
 
-    const ARRAY_FIELD_OFFSET: usize = field_offset!(WeakValueVec, array);
-
-    #[inline]
-    fn calculate_size_in_bytes(capacity: usize) -> usize {
-        Self::ARRAY_FIELD_OFFSET + InlineArray::<Value>::calculate_size_in_bytes(capacity)
-    }
-
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.length
-    }
-
-    #[inline]
-    pub fn set_len(&mut self, len: usize) {
-        self.length = len;
-    }
-
-    #[inline]
-    pub fn capacity(&self) -> usize {
-        self.array.len()
-    }
-
     pub fn next_weak_vec(&self) -> Option<HeapPtr<WeakValueVec>> {
-        self.next_weak_vec
+        self.extra_data().next_weak_vec
     }
 
     pub fn set_next_weak_vec(&mut self, next_weak_vec: Option<HeapPtr<WeakValueVec>>) {
-        self.next_weak_vec = next_weak_vec;
-    }
-
-    #[inline]
-    pub fn as_slice(&self) -> &[Value] {
-        &self.array.as_slice()[..self.len()]
-    }
-
-    #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [Value] {
-        let len = self.len();
-        &mut self.array.as_mut_slice()[..len]
-    }
-
-    /// Append an item to the WeakValueVec. Should only be called if there is room to append an item.
-    #[allow(unused)]
-    pub fn push_without_growing(&mut self, item: Value) {
-        let len = self.len();
-        self.array.as_mut_slice()[len] = item;
-        self.length += 1;
+        self.extra_data_mut().next_weak_vec = next_weak_vec;
     }
 }
 
 impl HeapItem for WeakValueVec {
-    fn byte_size(bs_weak_vec: HeapPtr<Self>) -> usize {
-        WeakValueVec::calculate_size_in_bytes(bs_weak_vec.capacity())
+    fn byte_size(weak_vec: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(weak_vec.capacity())
     }
 
-    /// Visit pointers intrinsic to all WeakValueVec. Do not visit elements as they could be of any type.
-    fn visit_pointers(mut bs_weak_vec: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
-        visitor.visit_pointer(&mut bs_weak_vec.shape);
-    }
-}
+    fn visit_pointers(mut weak_vec: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        weak_vec.visit_vec_pointers(visitor);
 
-/// A WeakValueVec stored as the field of a heap item. Can create new WeakValueVec objects and set the
-/// field to a new WeakValueVec.
-#[allow(unused)]
-pub trait WeakValueVecField {
-    fn new_vec(cx: Context, capacity: usize) -> AllocResult<HeapPtr<WeakValueVec>>;
-
-    fn get(&self) -> HeapPtr<WeakValueVec>;
-
-    fn set(&mut self, vec: HeapPtr<WeakValueVec>);
-
-    /// Prepare vec for appending a single item. This will grow the vec and update container to
-    /// point to new vec if there is no room to append another item to the vec.
-    #[inline]
-    fn maybe_grow_for_push(&mut self, cx: Context) -> AllocResult<HeapPtr<WeakValueVec>> {
-        let old_vec = self.get();
-
-        // Check if we have room for another item in the vec
-        let old_len = old_vec.len();
-        let capacity = old_vec.capacity();
-        if old_len < capacity {
-            return Ok(old_vec);
+        for weak_value in weak_vec.as_mut_slice() {
+            visitor.visit_weak_value(weak_value);
         }
-
-        // Save old vec behind handle before allocating
-        let old_vec = old_vec.to_handle();
-
-        // Double size of vector, starting at a length of 4
-        let new_capacity = (capacity * 2).max(4);
-        let mut new_vec = Self::new_vec(cx, new_capacity)?;
-
-        // Update parent reference from old child to new child map
-        self.set(new_vec);
-
-        // Copy all values into new vec
-        new_vec.length = old_len;
-        new_vec.as_mut_slice().copy_from_slice(old_vec.as_slice());
-
-        Ok(new_vec)
     }
 }


### PR DESCRIPTION
## Summary

Let's improve some of our heap collections to be parameterized by a header type, allowing extra data to be stored inline. This is then used to define `SparseArrayPropertiesMap` as a `BsHashMap` and `WeakVec` as a `BsVec`, each storing an extra field inline (the array length and intrusive GC weak list respectively).

- New type parameter is optional and defaults to `()`
- Sparse property map length scheme is now much simpler since we don't have to store it under a sentinel key in the map

## Tests

- CI