### PR TITLE
[runtime] Misc GC improvements: consolidate weak ref checks, ephemeron processing, and heap traversal

### DIFF
--- a/src/js/runtime/gc/garbage_collector.rs
+++ b/src/js/runtime/gc/garbage_collector.rs
@@ -3,7 +3,10 @@ use std::{ops::Range, ptr::NonNull};
 use crate::runtime::{
     Context, HeapItemKind, Value,
     collections::WeakValueVec,
-    gc::{AnyHeapItem, Heap, HeapItem, HeapPtr, HeapVisitor},
+    gc::{
+        AnyHeapItem, Heap, HeapItem, HeapPtr, HeapVisitor,
+        heap_item::{for_each_heap_item, visit_pointers_for_kind},
+    },
     interned_strings::InternedStrings,
     intrinsics::{
         finalization_registry_object::FinalizationRegistryObject, weak_map_object::WeakMapObject,
@@ -170,19 +173,11 @@ impl GarbageCollector {
     /// The permanent heap may contain pointers into the semispaces if a permanent heap item was
     /// mutated.
     fn visit_permanent_heap_roots(&mut self) {
-        let mut current_ptr = self.new_permanent_space_bounds.start;
-        let end_ptr = self.new_permanent_space_bounds.end;
-
-        while current_ptr < end_ptr {
-            let permanent_heap_item =
-                HeapPtr::from_ptr(current_ptr.cast_mut()).cast::<AnyHeapItem>();
-            AnyHeapItem::visit_pointers(permanent_heap_item, self);
-
-            // Increment current pointer to point to next permanent heap item
-            let byte_size = AnyHeapItem::byte_size(permanent_heap_item);
-            let alloc_size = Heap::alloc_size_for_request_size(byte_size);
-            unsafe { current_ptr = current_ptr.add(alloc_size) }
-        }
+        for_each_heap_item(self.new_permanent_space_bounds.clone(), |item| {
+            let kind = item.shape().kind();
+            visit_pointers_for_kind(item, self, kind);
+            kind
+        });
     }
 
     /// Move all remaining live items from the from-heap to the to-heap, fixing pointers to point to
@@ -207,8 +202,10 @@ impl GarbageCollector {
 
             // Visit ephemeron values that are known to be live due to live keys. Keep iterating
             // until fixpoint where no new live keys are found.
-            if !self.visit_live_weak_map_entries() && !self.visit_live_finalization_registry_cells()
-            {
+            let found_live_weak_map_value = self.visit_live_weak_map_entries();
+            let found_live_unregister_token = self.visit_live_finalization_registry_cells();
+
+            if !found_live_weak_map_value && !found_live_unregister_token {
                 break;
             }
         }
@@ -216,23 +213,17 @@ impl GarbageCollector {
 
     /// Move the entire contents of the permanent heap from the old bounds to the new bounds.
     fn move_permanent_heap(&self) {
-        let old_permanent_bounds = self.old_permanent_space_bounds.clone();
-        let new_permanent_bounds = self.new_permanent_space_bounds.clone();
+        let mut dest_ptr = self.new_permanent_space_bounds.start;
 
-        let mut current_ptr = old_permanent_bounds.start;
-        let mut dest_ptr = new_permanent_bounds.start;
-
-        while current_ptr < old_permanent_bounds.end {
-            // Move the old permanent heap item to the new permanent heap
-            let mut heap_item = HeapPtr::from_ptr(current_ptr.cast_mut()).cast::<AnyHeapItem>();
-            let (_, alloc_size) = Self::move_heap_item(&mut heap_item, &mut dest_ptr);
-
-            // Increment pointer to point to next old permanent heap item
-            current_ptr = unsafe { current_ptr.add(alloc_size) }
-        }
+        for_each_heap_item(self.old_permanent_space_bounds.clone(), |mut item| {
+            // Read the kind before the shape is overwritten with a forwarding pointer
+            let kind = item.shape().kind();
+            Self::move_heap_item(&mut item, &mut dest_ptr);
+            kind
+        });
 
         // Entire old permanent heap should have been copied 1:1 to the new permanent heap
-        debug_assert!(dest_ptr == new_permanent_bounds.end);
+        debug_assert!(dest_ptr == self.new_permanent_space_bounds.end);
     }
 
     #[inline]
@@ -265,7 +256,7 @@ impl GarbageCollector {
 
         // Move the heap item to the to-space. We are guaranteed to have enough space in the
         // to-space since all allocations fit into the from-space.
-        let (new_heap_item, _) = Self::move_heap_item(heap_item, &mut self.alloc_ptr);
+        let new_heap_item = Self::move_heap_item(heap_item, &mut self.alloc_ptr);
 
         // Rewrite pointer to old heap item to instead point to new heap item
         *heap_item = new_heap_item;
@@ -296,12 +287,12 @@ impl GarbageCollector {
     /// old heap item. Updates the destination address to point to the next heap-item-aligned
     /// address after the new heap item.
     ///
-    /// Return the new heap item and the allocation size for the heap item.
+    /// Return the new heap item.
     #[inline]
     fn move_heap_item(
         heap_item: &mut HeapPtr<AnyHeapItem>,
         dest_ptr: &mut *const u8,
-    ) -> (HeapPtr<AnyHeapItem>, usize) {
+    ) -> HeapPtr<AnyHeapItem> {
         // Calculate size of heap item. Caller must ensure that there is enough space at the
         // destination to hold the moved item.
         let alloc_size = Heap::alloc_size_for_request_size(AnyHeapItem::byte_size(*heap_item));
@@ -324,7 +315,7 @@ impl GarbageCollector {
         // Bump the `dest_ptr` to point to the next aligned address after the new heap item
         unsafe { *dest_ptr = dest_ptr.add(alloc_size) };
 
-        (new_heap_item, alloc_size)
+        new_heap_item
     }
 
     #[inline]
@@ -383,6 +374,24 @@ impl GarbageCollector {
         self.finalization_registry_list = Some(finalization_registry);
     }
 
+    /// Resolve a weak pointer to a heap item, determining whether the target is live along with its
+    /// current (possibly moved-to) location.
+    ///
+    /// Must only be called after all live items have been moved. A target in a moved space is
+    /// live iff it left behind a forwarding pointer, and a target anywhere else (e.g. in the
+    /// permanent space) was never moved and is always live.
+    #[inline]
+    fn resolve_weak(&self, target: HeapPtr<AnyHeapItem>) -> WeakResolution {
+        if !self.is_in_moved_space(target.as_ptr().cast()) {
+            return WeakResolution::Live(target);
+        }
+
+        match decode_forwarding_pointer(target.shape()) {
+            Some(new_location) => WeakResolution::Live(new_location),
+            None => WeakResolution::Dead,
+        }
+    }
+
     fn prune_weak_reference_and_handle_finalizers(&mut self, cx: Context) {
         // Prune interned strings that are no longer referenced
         self.prune_weak_interned_strings(cx);
@@ -401,59 +410,47 @@ impl GarbageCollector {
         // Walk all live weak refs in the list
         let mut next_weak_ref = self.weak_ref_list;
         while let Some(mut weak_ref) = next_weak_ref {
-            let target = weak_ref.weak_ref_target();
             next_weak_ref = weak_ref.next_weak_ref();
 
             // Target may have already been cleared to undefined by a prior GC
+            let target = weak_ref.weak_ref_target();
             if !target.is_pointer() {
                 continue;
             }
 
-            let target_ptr = target.as_pointer().as_ptr().cast();
-
-            if !self.is_in_moved_space(target_ptr) {
-                continue;
-            }
-
-            let target_shape = target.as_pointer().shape();
-
-            // Target is known to be live if it has already moved (and left a forwarding pointer)
-            if let Some(forwarding_ptr) = decode_forwarding_pointer(target_shape) {
-                weak_ref.set_weak_ref_target(Value::heap_item(forwarding_ptr));
-            } else {
-                // Otherwise target was garbage collected so reset target to undefined
-                weak_ref.set_weak_ref_target(Value::undefined());
+            match self.resolve_weak(target.as_pointer()) {
+                // Live references are updated to point to the new location
+                WeakResolution::Live(target) => {
+                    weak_ref.set_weak_ref_target(Value::heap_item(target))
+                }
+                // Target was garbage collected so reset target to undefined
+                WeakResolution::Dead => weak_ref.set_weak_ref_target(Value::undefined()),
             }
         }
     }
 
-    // Visit live weak sets and check if their targets are still live. Should only be called after
+    // Visit live weak sets and check if their values are still live. Should only be called after
     // liveness of all items has been determined.
     fn fix_weak_sets(&mut self) {
         // Walk all live weak sets in the list
         let mut next_weak_set = self.weak_set_list;
         while let Some(weak_set) = next_weak_set {
+            next_weak_set = weak_set.next_weak_set();
+
             for weak_ref in weak_set.weak_set_data().iter_mut_gc_unsafe() {
-                let weak_ref_value = weak_ref.value_mut();
+                let value = weak_ref.value_mut();
+                debug_assert!(value.is_pointer());
 
-                debug_assert!(weak_ref_value.is_pointer());
-                let weak_ref_value_ptr = weak_ref_value.as_pointer().as_ptr().cast();
-
-                if self.is_in_moved_space(weak_ref_value_ptr) {
-                    let weak_ref_shape = weak_ref_value.as_pointer().shape();
-
-                    // Value is known to be live if it has already moved (and left a forwarding pointer)
-                    if let Some(forwarding_ptr) = decode_forwarding_pointer(weak_ref_shape) {
-                        *weak_ref_value = Value::heap_item(forwarding_ptr);
-                    } else {
-                        // Otherwise value was garbage collected so remove value from set.
-                        // It is safe to remove during iteration for a BsHashSet.
+                match self.resolve_weak(value.as_pointer()) {
+                    // Live references are updated to point to the new location
+                    WeakResolution::Live(new_location) => *value = Value::heap_item(new_location),
+                    // Value was garbage collected so remove value from set. It is safe to remove
+                    // during iteration for a BsHashSet.
+                    WeakResolution::Dead => {
                         weak_set.weak_set_data().remove(weak_ref);
                     }
                 }
             }
-
-            next_weak_set = weak_set.next_weak_set();
         }
     }
 
@@ -463,158 +460,133 @@ impl GarbageCollector {
         // Walk all live weak maps in the list
         let mut next_weak_map = self.weak_map_list;
         while let Some(weak_map) = next_weak_map {
+            next_weak_map = weak_map.next_weak_map();
+
             for (weak_key, _) in weak_map.weak_map_data().iter_mut_gc_unsafe() {
-                let weak_key_value = weak_key.value_mut();
+                let key = weak_key.value_mut();
+                debug_assert!(key.is_pointer());
 
-                debug_assert!(weak_key_value.is_pointer());
-                let weak_key_ptr = weak_key_value.as_pointer().as_ptr().cast();
-
-                // Check if key was not live. If not, key should be garbage collected so remove
-                // entry from map. It is safe to remove during iteration for a BsHashMap.
-                if self.is_in_moved_space(weak_key_ptr) {
+                // Key was garbage collected so remove entry from map. It is safe to remove during
+                // iteration for a BsHashMap.
+                if let WeakResolution::Dead = self.resolve_weak(key.as_pointer()) {
                     weak_map.weak_map_data().remove(weak_key);
                 }
-            }
 
-            next_weak_map = weak_map.next_weak_map();
+                // Note that live keys and values were already updated to point to their new
+                // locations when ephemerons were processed.
+            }
         }
     }
 
     // Visit live weak maps and check if their keys are still live. Visit the values associated with
-    // all live keys. Return whether any new live keys were found.
+    // all live keys. Return whether any new live values were found.
     fn visit_live_weak_map_entries(&mut self) -> bool {
         // Walk all live weak maps in the list
         let mut next_weak_map = self.weak_map_list;
         let mut found_new_live_value = false;
 
         while let Some(weak_map) = next_weak_map {
-            for (weak_key, value) in weak_map.weak_map_data().iter_mut_gc_unsafe() {
-                let weak_key_value = weak_key.value_mut();
-
-                debug_assert!(weak_key_value.is_pointer());
-                let weak_key_ptr = weak_key_value.as_pointer().as_ptr().cast();
-
-                // Check if key has not yet been visited and moved to the to-space
-                if self.is_in_moved_space(weak_key_ptr) {
-                    let weak_key_shape = weak_key_value.as_pointer().shape();
-
-                    // Key is known to be live if it has already moved and left a forwarding
-                    // pointer. Visit the value associated with the key since we now know it is
-                    // live. Also update key to point into to-space so we can tell it is visited.
-                    if let Some(forwarding_ptr) = decode_forwarding_pointer(weak_key_shape) {
-                        *weak_key_value = Value::heap_item(forwarding_ptr);
-                        found_new_live_value = true;
-                        self.visit_value(value);
-                    }
-                } else if self.is_in_old_permanent_space(weak_key_ptr) {
-                    // Check if key was in the permanent space. If so its value is live and will
-                    // always be visited.
-                    //
-                    // Note that we only need to visit the value if it is a pointer. Make sure to
-                    // only count this as a new live value if it was not already moved.
-                    if value.is_pointer()
-                        && self.is_in_moved_space(value.as_pointer().as_ptr().cast())
-                    {
-                        let value_shape = value.as_pointer().shape();
-                        if decode_forwarding_pointer(value_shape).is_none() {
-                            found_new_live_value = true;
-                        }
-
-                        self.visit_value(value);
-                    }
-                }
-            }
-
             next_weak_map = weak_map.next_weak_map();
+            for (weak_key, value) in weak_map.weak_map_data().iter_mut_gc_unsafe() {
+                found_new_live_value |= self.visit_ephemeron(weak_key.value_mut(), Some(value));
+            }
         }
 
         found_new_live_value
     }
 
-    // Finalization registries are effectively a WeakMap from target value to unregister tokens.
-    // Visit live finalization registries and check if their cells are still live. Visit the
-    // weakly held unregister tokens in each cell where the target is live. Return whether any newly
-    // live unregister tokens were found.
+    // Finalization registries are effectively a WeakMap from target value to unregister token.
+    // Visit live finalization registries and check if their cells' targets are still live. Visit
+    // the weakly held unregister token in each cell where the target is live. Return whether any
+    // newly live unregister tokens were found.
     fn visit_live_finalization_registry_cells(&mut self) -> bool {
         // Walk all live weak maps in the list
         let mut next_finalization_registry = self.finalization_registry_list;
         let mut found_new_live_unregister_token = false;
 
         while let Some(finalization_registry) = next_finalization_registry {
-            for cell in finalization_registry.cells().iter_mut_gc_unsafe().flatten() {
-                let target_value = cell.target;
-
-                debug_assert!(target_value.is_pointer());
-                let target_ptr = target_value.as_pointer().as_ptr().cast();
-
-                // Check if key has not yet been visited and moved
-                if self.is_in_moved_space(target_ptr) {
-                    let target_shape = target_value.as_pointer().shape();
-
-                    // Target is known to be live if it has already moved and left a forwarding
-                    // pointer. Visit the unregister key associated with the target since we now
-                    // know it is live. Also update target to point into to-space so we can tell it
-                    // is visited.
-                    if let Some(forwarding_ptr) = decode_forwarding_pointer(target_shape) {
-                        cell.target = Value::heap_item(forwarding_ptr);
-
-                        if let Some(ref mut unregister_token) = cell.unregister_token {
-                            found_new_live_unregister_token = true;
-                            self.visit_value(unregister_token);
-                        }
-                    }
-                } else if self.is_in_old_permanent_space(target_ptr) {
-                    // Check if target was in the permanent space. If so its unregister token is
-                    // live and will always be visited.
-                    //
-                    // Note that we only need to visit the token if it is a pointer. Make sure
-                    // to only count this as a new live token if it was not already moved.
-                    if let Some(ref mut unregister_token) = cell.unregister_token {
-                        if unregister_token.is_pointer()
-                            && self.is_in_moved_space(unregister_token.as_pointer().as_ptr().cast())
-                        {
-                            let token_shape = unregister_token.as_pointer().shape();
-                            if decode_forwarding_pointer(token_shape).is_none() {
-                                found_new_live_unregister_token = true;
-                            }
-
-                            self.visit_value(unregister_token);
-                        }
-                    }
-                }
-            }
-
             next_finalization_registry = finalization_registry.next_finalization_registry();
+
+            for cell in finalization_registry.cells().iter_mut_gc_unsafe().flatten() {
+                found_new_live_unregister_token |=
+                    self.visit_ephemeron(&mut cell.target, cell.unregister_token.as_mut());
+            }
         }
 
         found_new_live_unregister_token
     }
 
+    /// Visit a single ephemeron - a weak key and an optional dependent value that is only live
+    /// if the key is live.
+    ///
+    /// If the key is newly discovered to be live then update the key to point to its new location
+    /// and visit the value. Keys in the permanent space are always live so their values are always
+    /// visited.
+    ///
+    /// Return whether a dependent value was newly discovered to be live.
+    fn visit_ephemeron(&mut self, key: &mut Value, value: Option<&mut Value>) -> bool {
+        debug_assert!(key.is_pointer());
+        let key_ptr = key.as_pointer().as_ptr().cast();
+
+        // Check if key has not yet been visited and moved to the to-space
+        if self.is_in_moved_space(key_ptr) {
+            // Key is known to be live if it has already moved and left a forwarding pointer.
+            // Visit the value associated with the key since we now know it is live. Also update
+            // key to point into to-space so we can tell it is visited.
+            if let Some(forwarding_ptr) = decode_forwarding_pointer(key.as_pointer().shape()) {
+                *key = Value::heap_item(forwarding_ptr);
+
+                if let Some(value) = value {
+                    self.visit_value(value);
+                    return true;
+                }
+            }
+        } else if self.is_in_old_permanent_space(key_ptr) {
+            // Key was in the permanent space so it is always live and its value is always visited.
+            //
+            // Note that we only need to visit the value if it is a pointer. Make sure to only
+            // count this as a new live value if it was not already moved.
+            if let Some(value) = value {
+                if value.is_pointer() && self.is_in_moved_space(value.as_pointer().as_ptr().cast())
+                {
+                    let is_newly_live =
+                        decode_forwarding_pointer(value.as_pointer().shape()).is_none();
+                    self.visit_value(value);
+                    return is_newly_live;
+                }
+            }
+        }
+
+        false
+    }
+
+    // Visit live finalization registries and check if their cells' targets are still live. Should
+    // only be called after liveness of all items has been determined.
     fn fix_finalization_registries(&mut self, mut cx: Context) {
         // Walk all live finalization registries in the list
         let mut next_finalization_registry = self.finalization_registry_list;
         while let Some(finalization_registry) = next_finalization_registry {
+            next_finalization_registry = finalization_registry.next_finalization_registry();
+
             for cell_opt in finalization_registry.cells().iter_mut_gc_unsafe() {
                 if let Some(cell) = cell_opt {
                     debug_assert!(cell.target.is_pointer());
-                    let target_ptr = cell.target.as_pointer().as_ptr().cast();
 
-                    // Check if target has already been visited and moved. If not, target should be
-                    // garbage collected so remove cell from registry.
-                    if self.is_in_moved_space(target_ptr) {
-                        // Enqueue cleanup callback, passing in the held value
+                    // Target was garbage collected so enqueue the cleanup callback, passing in
+                    // the held value, then remove the cell from the registry.
+                    if let WeakResolution::Dead = self.resolve_weak(cell.target.as_pointer()) {
                         cx.task_queue().enqueue_callback_1_task(
                             finalization_registry.cleanup_callback().into(),
                             cell.held_value,
                         );
 
-                        // Then remove cell from registry
                         finalization_registry.cells().remove_cell(cell_opt);
                     }
+
+                    // Note that live targets were already updated to point to their new locations
+                    // when ephemerons were processed.
                 }
             }
-
-            next_finalization_registry = finalization_registry.next_finalization_registry();
         }
     }
 
@@ -623,8 +595,9 @@ impl GarbageCollector {
         // Walk all live weak vecs in the list
         let mut next_weak_vec = self.weak_vec_list;
         while let Some(weak_vec) = next_weak_vec {
-            self.compress_weak_vec(weak_vec);
             next_weak_vec = weak_vec.next_weak_vec();
+
+            self.compress_weak_vec(weak_vec);
         }
     }
 
@@ -640,16 +613,9 @@ impl GarbageCollector {
             let element = weak_vec.as_mut_slice()[index];
 
             let kept_element = if element.is_pointer() {
-                let element_ptr = element.as_pointer().as_ptr().cast::<u8>();
-                if self.is_in_moved_space(element_ptr) {
-                    let element_shape = element.as_pointer().shape();
-
-                    // Element is known to be live if it has already moved (and left a forwarding
-                    // pointer)
-                    decode_forwarding_pointer(element_shape).map(Value::heap_item)
-                } else {
-                    // Pointer is not from a GC'd space
-                    Some(element)
+                match self.resolve_weak(element.as_pointer()) {
+                    WeakResolution::Live(new_location) => Some(Value::heap_item(new_location)),
+                    WeakResolution::Dead => None,
                 }
             } else {
                 // Non-pointer values are never GC'd
@@ -666,41 +632,30 @@ impl GarbageCollector {
     }
 
     fn prune_weak_interned_strings(&mut self, cx: Context) {
-        // First check interned strings set
+        // First check interned strings set. It is safe to remove during iteration for a BsHashSet.
         let mut string_set = InternedStrings::strings(cx);
         for string_ref in string_set.clone().iter_mut_gc_unsafe() {
-            let string_shape = string_ref.shape();
-
-            if self.is_in_moved_space(string_ref.as_ptr().cast()) {
-                // String is known to be live if it has already moved (and left a forwarding pointer)
-                if let Some(forwarding_ptr) = decode_forwarding_pointer(string_shape) {
-                    *string_ref = forwarding_ptr.cast::<FlatString>();
-                } else {
-                    // Otherwise string was garbage collected so remove string from set.
-                    // It is safe to remove during iteration for a BsHashSet.
-                    string_set.remove(string_ref);
-                }
+            if !self.resolve_weak_interned_string(string_ref) {
+                string_set.remove(string_ref);
             }
         }
 
         // Then check values of interned strings map
         let mut cloned_cx = cx;
         let string_map = cloned_cx.interned_strings.generator_cache_mut();
-        string_map.retain(|_, string_ref| {
-            let string_shape = string_ref.shape();
+        string_map.retain(|_, string_ref| self.resolve_weak_interned_string(string_ref));
+    }
 
-            if self.is_in_moved_space(string_ref.as_ptr().cast()) {
-                // String is known to be live if it has already moved (and left a forwarding pointer)
-                if let Some(forwarding_ptr) = decode_forwarding_pointer(string_shape) {
-                    *string_ref = forwarding_ptr.cast::<FlatString>();
-                } else {
-                    // Otherwise string was garbage collected so remove string from map
-                    return false;
-                }
+    /// Resolve a weak reference to an interned string in place. Return whether the string is
+    /// still live.
+    fn resolve_weak_interned_string(&self, string_ref: &mut HeapPtr<FlatString>) -> bool {
+        match self.resolve_weak(string_ref.as_any()) {
+            WeakResolution::Live(new_location) => {
+                *string_ref = new_location.cast();
+                true
             }
-
-            true
-        });
+            WeakResolution::Dead => false,
+        }
     }
 }
 
@@ -708,6 +663,14 @@ impl HeapVisitor for GarbageCollector {
     fn visit(&mut self, ptr: &mut HeapPtr<AnyHeapItem>) {
         self.copy_or_fix_pointer(ptr);
     }
+}
+
+/// The result of resolving a weak pointer once liveness of all items is known.
+enum WeakResolution {
+    /// The target is live, at this possibly-new location.
+    Live(HeapPtr<AnyHeapItem>),
+    /// The target was garbage collected.
+    Dead,
 }
 
 // The first item in each heap item is a pointer, is either:

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use crate::{
     runtime::{
         BigIntValue, Realm, SymbolValue,
@@ -22,7 +24,7 @@ use crate::{
         },
         context::{GlobalSymbolRegistryMap, ModuleCacheMap},
         for_in_iterator::ForInIterator,
-        gc::{HeapPtr, HeapVisitor},
+        gc::{Heap, HeapPtr, HeapVisitor},
         generator_object::GeneratorObject,
         global_names::GlobalNames,
         interned_strings::InternedStringsSet,
@@ -317,5 +319,23 @@ impl<T> HeapUnaligned<T> {
     #[inline]
     pub fn get(&self) -> T {
         unsafe { std::ptr::read_unaligned(&raw const self.0) }
+    }
+}
+
+/// Call a function on each heap item in a contiguous, fully-allocated range of the heap.
+///
+/// The function must return the kind of each visited heap item.
+pub fn for_each_heap_item(
+    space: Range<*const u8>,
+    mut f: impl FnMut(HeapPtr<AnyHeapItem>) -> HeapItemKind,
+) {
+    let mut current_ptr = space.start;
+    while current_ptr < space.end {
+        let item = HeapPtr::from_ptr(current_ptr.cast_mut()).cast::<AnyHeapItem>();
+        let kind = f(item);
+
+        // Increment pointer to the next heap item (accounting for alignment)
+        let alloc_size = Heap::alloc_size_for_request_size(byte_size_for_kind(item, kind));
+        current_ptr = unsafe { current_ptr.add(alloc_size) };
     }
 }

--- a/src/js/runtime/gc/heap_serializer.rs
+++ b/src/js/runtime/gc/heap_serializer.rs
@@ -19,7 +19,7 @@ use crate::{
         Context, Value,
         gc::{
             AnyHeapItem, GcType, Heap, HeapInfo, HeapPtr, HeapVisitor,
-            heap_item::{byte_size_for_kind, visit_pointers_for_kind},
+            heap_item::{for_each_heap_item, visit_pointers_for_kind},
         },
         rust_vtables::{RustVtable, get_vtable, lookup_vtable_enum},
         shape::Shape,
@@ -100,22 +100,14 @@ impl HeapSerializer {
             Space::Current => &mut self.current_space,
         };
 
-        let space_len = space.len();
-        let space_start_ptr = space.as_mut_ptr();
+        let bounds = space.as_mut_ptr_range();
 
-        let mut item_offset = 0;
-        while item_offset < space_len {
-            // Start of an object - cast to HeapItem and rewrite its pointers to be offsets from the
-            // start of the heap.
-            let item_ptr = unsafe { space_start_ptr.add(item_offset) };
-            let heap_item = HeapPtr::from_ptr(item_ptr).cast::<AnyHeapItem>();
-            let kind = heap_item.shape().kind();
-
-            visit_pointers_for_kind(heap_item, self, kind);
-
-            // Increment fix pointer to point to next new heap item
-            item_offset += Heap::alloc_size_for_request_size(byte_size_for_kind(heap_item, kind));
-        }
+        for_each_heap_item(bounds.start.cast_const()..bounds.end.cast_const(), |item| {
+            // Read the kind before the shape pointer is rewritten to an offset
+            let kind = item.shape().kind();
+            visit_pointers_for_kind(item, self, kind);
+            kind
+        });
     }
 
     pub fn as_serialized(&self) -> SerializedHeap<'_> {
@@ -178,23 +170,17 @@ impl HeapSpaceDeserializer {
     pub fn deserialize(cx: Context, bytes: &mut [u8], extra_offset: usize) {
         let mut deserializer = Self::new(cx, extra_offset);
 
-        let mut item_offset = 0;
-        while item_offset < bytes.len() {
-            // Start of an object is a shape pointer, encoded as an offset;
-            let heap_item_ptr = unsafe { bytes.as_mut_ptr().add(item_offset) };
+        let bounds = bytes.as_mut_ptr_range();
 
-            // Decode the shape and read its kind
-            let shape_offset = unsafe { *heap_item_ptr.cast::<usize>() };
+        for_each_heap_item(bounds.start.cast_const()..bounds.end.cast_const(), |item| {
+            // The item's shape pointer is encoded as an offset, so decode it to read the kind
+            let shape_offset = item.shape().as_ptr() as usize;
             let shape_ptr = unsafe { deserializer.base.add(shape_offset).cast::<Shape>() };
-            let shape_kind = unsafe { (*shape_ptr).kind() };
+            let kind = unsafe { (*shape_ptr).kind() };
 
-            let heap_item = HeapPtr::from_ptr(heap_item_ptr).cast::<AnyHeapItem>();
-            visit_pointers_for_kind(heap_item, &mut deserializer, shape_kind);
-
-            // Increment fix pointer to point to next new heap item
-            let byte_size = byte_size_for_kind(heap_item, shape_kind);
-            item_offset += Heap::alloc_size_for_request_size(byte_size);
-        }
+            visit_pointers_for_kind(item, &mut deserializer, kind);
+            kind
+        });
     }
 }
 


### PR DESCRIPTION
## Summary

Misc improvements to the GC, all reducing deduplication and making the existing algorithms clearer.

- Consolidate most heap traversal to a `for_each_heap_item` over a heap range
- Consolidate weak pointer checks into `resolve_weak`
- Consolidate ephemeron processing into `visit_ephemeron`
- Don't short circuit while visiting ephemerons - always visit all weak maps and finalization registries

## Tests

- CI