### PR TITLE
[runtime] BsHashMap and BsHashSet provide an entries iterator that allows removal, use in weak map/set GC

### DIFF
--- a/src/js/runtime/collections/hash_map.rs
+++ b/src/js/runtime/collections/hash_map.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Borrow,
+    cell::Cell,
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
     slice,
@@ -171,6 +172,16 @@ impl<K: Eq + Hash + Clone, V: Clone, H> BsHashMap<K, V, H> {
     /// are no allocations between construction and use.
     pub fn keys_mut_gc_unsafe(&mut self) -> GcUnsafeKeysIterMut<'_, K, V> {
         GcUnsafeKeysIterMut(self.entries.as_mut_slice().iter_mut())
+    }
+
+    /// Return an iterator over the entries of the map, where each entry allows modifying the key
+    /// and value or removing the entry in place. Iterator is not GC-safe, so make sure there are
+    /// no allocations between construction and use.
+    pub fn iter_entries_mut_gc_unsafe(&mut self) -> GcUnsafeEntryMutIter<'_, K, V> {
+        GcUnsafeEntryMutIter {
+            iter: self.entries.as_mut_slice().iter_mut(),
+            len: Cell::from_mut(&mut self.len),
+        }
     }
 
     /// Visit pointers intrinsic to all HashMaps. Do not visit entries as they could be of any type.
@@ -420,6 +431,63 @@ impl<K, V> Entry<K, V> {
             kv_pair
         } else {
             unreachable!()
+        }
+    }
+
+    fn as_occupied_mut(&mut self) -> &mut KVPair<K, V> {
+        if let Entry::Occupied(kv_pair) = self {
+            kv_pair
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+/// An occupied entry in a map, which allows modifying the key and value or removing the entry
+/// in place.
+pub struct GcUnsafeEntryMut<'a, K, V> {
+    entry: &'a mut Entry<K, V>,
+    len: &'a Cell<usize>,
+}
+
+impl<K, V> GcUnsafeEntryMut<'_, K, V> {
+    #[inline]
+    pub fn key_mut(&mut self) -> &mut K {
+        &mut self.entry.as_occupied_mut().key
+    }
+
+    #[inline]
+    pub fn value_mut(&mut self) -> &mut V {
+        &mut self.entry.as_occupied_mut().value
+    }
+
+    /// Remove this entry from the map in place. It is safe to remove entries while iterating.
+    #[inline]
+    pub fn remove(self) {
+        *self.entry = Entry::Deleted;
+        self.len.set(self.len.get() - 1);
+    }
+}
+
+pub struct GcUnsafeEntryMutIter<'a, K, V> {
+    iter: slice::IterMut<'a, Entry<K, V>>,
+    len: &'a Cell<usize>,
+}
+
+impl<'a, K, V> Iterator for GcUnsafeEntryMutIter<'a, K, V> {
+    type Item = GcUnsafeEntryMut<'a, K, V>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.iter.next() {
+                Some(entry @ Entry::Occupied(_)) => {
+                    return Some(GcUnsafeEntryMut { entry, len: self.len });
+                }
+                Some(_) => {}
+                // Reached the end of the entries array
+                None => return None,
+            }
         }
     }
 }

--- a/src/js/runtime/collections/hash_set.rs
+++ b/src/js/runtime/collections/hash_set.rs
@@ -5,7 +5,7 @@ use crate::runtime::{
     alloc_error::AllocResult,
     collections::{
         BsHashMap,
-        hash_map::{GcUnsafeKeysIterMut, maybe_grow_for_insertion},
+        hash_map::{GcUnsafeEntryMutIter, GcUnsafeKeysIterMut, maybe_grow_for_insertion},
     },
     gc::{HeapVisitor, IsHeapItem, WithHeapItemKind},
 };
@@ -60,6 +60,13 @@ impl<T: Eq + Hash + Clone> BsHashSet<T> {
     /// are no allocations between construction and use.
     pub fn iter_mut_gc_unsafe(&mut self) -> GcUnsafeKeysIterMut<'_, T, ()> {
         self.0.keys_mut_gc_unsafe()
+    }
+
+    /// Return an iterator over the entries of the set, where each entry allows modifying the
+    /// element or removing the entry in place. Iterator is not GC-safe, so make sure there are
+    /// no allocations between construction and use.
+    pub fn iter_entries_mut_gc_unsafe(&mut self) -> GcUnsafeEntryMutIter<'_, T, ()> {
+        self.0.iter_entries_mut_gc_unsafe()
     }
 
     /// Visit pointers intrinsic to all HashSets. Do not visit entries as they could be of any type.

--- a/src/js/runtime/gc/garbage_collector.rs
+++ b/src/js/runtime/gc/garbage_collector.rs
@@ -437,18 +437,15 @@ impl GarbageCollector {
         while let Some(weak_set) = next_weak_set {
             next_weak_set = weak_set.next_weak_set();
 
-            for weak_ref in weak_set.weak_set_data().iter_mut_gc_unsafe() {
-                let value = weak_ref.value_mut();
+            for mut entry in weak_set.weak_set_data().iter_entries_mut_gc_unsafe() {
+                let value = entry.key_mut().value_mut();
                 debug_assert!(value.is_pointer());
 
                 match self.resolve_weak(value.as_pointer()) {
                     // Live references are updated to point to the new location
                     WeakResolution::Live(new_location) => *value = Value::heap_item(new_location),
-                    // Value was garbage collected so remove value from set. It is safe to remove
-                    // during iteration for a BsHashSet.
-                    WeakResolution::Dead => {
-                        weak_set.weak_set_data().remove(weak_ref);
-                    }
+                    // Value was garbage collected so remove the entry from the set
+                    WeakResolution::Dead => entry.remove(),
                 }
             }
         }
@@ -462,14 +459,13 @@ impl GarbageCollector {
         while let Some(weak_map) = next_weak_map {
             next_weak_map = weak_map.next_weak_map();
 
-            for (weak_key, _) in weak_map.weak_map_data().iter_mut_gc_unsafe() {
-                let key = weak_key.value_mut();
+            for mut entry in weak_map.weak_map_data().iter_entries_mut_gc_unsafe() {
+                let key = entry.key_mut().value_mut();
                 debug_assert!(key.is_pointer());
 
-                // Key was garbage collected so remove entry from map. It is safe to remove during
-                // iteration for a BsHashMap.
+                // Key was garbage collected so remove the entry from the map
                 if let WeakResolution::Dead = self.resolve_weak(key.as_pointer()) {
-                    weak_map.weak_map_data().remove(weak_key);
+                    entry.remove();
                 }
 
                 // Note that live keys and values were already updated to point to their new
@@ -632,11 +628,11 @@ impl GarbageCollector {
     }
 
     fn prune_weak_interned_strings(&mut self, cx: Context) {
-        // First check interned strings set. It is safe to remove during iteration for a BsHashSet.
+        // First remove dead strings from the set of interned strings
         let mut string_set = InternedStrings::strings(cx);
-        for string_ref in string_set.clone().iter_mut_gc_unsafe() {
-            if !self.resolve_weak_interned_string(string_ref) {
-                string_set.remove(string_ref);
+        for mut entry in string_set.iter_entries_mut_gc_unsafe() {
+            if !self.resolve_weak_interned_string(entry.key_mut()) {
+                entry.remove();
             }
         }
 


### PR DESCRIPTION
## Summary

We were previously sometimes calling the `remove` method on a `BsHash{Map,Set}` while iterating over it. This was occurring while pruning dead entries from weak maps, weak sets, and weak interned strings.

Instead let's provide an iterator over mutable entries that explicitly supports removal.

## Tests

- CI