### PR TITLE
[runtime] PropertyFlags store an IS_ACCESSOR bit

### DIFF
--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -154,7 +154,8 @@ pub fn ordinary_get_own_property(
         None => None,
         Some(property) => {
             let value = property.value();
-            if let Some(accessor_value) = value.as_opt::<Accessor>() {
+            if property.is_accessor() {
+                let accessor_value = Accessor::from_value(value);
                 Some(PropertyDescriptor::accessor(
                     accessor_value.get.map(|f| f.to_handle()),
                     accessor_value.set.map(|f| f.to_handle()),
@@ -283,9 +284,12 @@ pub fn validate_and_apply_property_descriptor(
                 if desc.is_data_descriptor() {
                     property.set_value(cx.undefined());
                     property.set_is_writable(false);
+                    property.set_is_accessor(false);
                 } else {
                     let accessor_value = Accessor::new(cx, None, None)?;
                     property.set_value(accessor_value.into());
+                    property.set_is_writable(false);
+                    property.set_is_accessor(true);
                 }
 
                 // Set modified property on object

--- a/src/js/runtime/property.rs
+++ b/src/js/runtime/property.rs
@@ -35,9 +35,10 @@ bitflags! {
         const IS_WRITABLE = 1 << 0;
         const IS_ENUMERABLE = 1 << 1;
         const IS_CONFIGURABLE = 1 << 2;
-        const IS_PRIVATE_FIELD = 1 << 3;
-        const IS_PRIVATE_METHOD = 1 << 4;
-        const IS_PRIVATE_ACCESSOR = 1 << 5;
+        const IS_ACCESSOR = 1 << 3;
+        const IS_PRIVATE_FIELD = 1 << 4;
+        const IS_PRIVATE_METHOD = 1 << 5;
+        const IS_PRIVATE_ACCESSOR = 1 << 6;
     }
 }
 
@@ -86,7 +87,7 @@ impl Property {
         is_enumerable: bool,
         is_configurable: bool,
     ) -> Property {
-        let mut flags = PropertyFlags::empty();
+        let mut flags = PropertyFlags::IS_ACCESSOR;
 
         if is_enumerable {
             flags |= PropertyFlags::IS_ENUMERABLE;
@@ -114,7 +115,7 @@ impl Property {
         let accessor_value = Accessor::new(cx, Some(getter), None)?;
         Ok(Property {
             value: accessor_value.into(),
-            flags: PropertyFlags::IS_PRIVATE_ACCESSOR,
+            flags: PropertyFlags::IS_PRIVATE_ACCESSOR | PropertyFlags::IS_ACCESSOR,
         })
     }
 
@@ -122,14 +123,14 @@ impl Property {
         let accessor_value = Accessor::new(cx, None, Some(setter))?;
         Ok(Property {
             value: accessor_value.into(),
-            flags: PropertyFlags::IS_PRIVATE_ACCESSOR,
+            flags: PropertyFlags::IS_PRIVATE_ACCESSOR | PropertyFlags::IS_ACCESSOR,
         })
     }
 
     pub fn private_accessor(accessor: Handle<Accessor>) -> Property {
         Property {
             value: accessor.into(),
-            flags: PropertyFlags::IS_PRIVATE_ACCESSOR,
+            flags: PropertyFlags::IS_PRIVATE_ACCESSOR | PropertyFlags::IS_ACCESSOR,
         }
     }
 
@@ -165,6 +166,10 @@ impl Property {
         self.flags.contains(PropertyFlags::IS_PRIVATE_ACCESSOR)
     }
 
+    pub fn is_accessor(&self) -> bool {
+        self.flags.contains(PropertyFlags::IS_ACCESSOR)
+    }
+
     pub fn is_allowed_as_dense_array_property(&self) -> bool {
         self.flags.contains(DENSE_ARRAY_PROPERTY_FLAGS)
     }
@@ -194,6 +199,14 @@ impl Property {
             self.flags.insert(PropertyFlags::IS_WRITABLE)
         } else {
             self.flags.remove(PropertyFlags::IS_WRITABLE)
+        }
+    }
+
+    pub fn set_is_accessor(&mut self, is_accessor: bool) {
+        if is_accessor {
+            self.flags.insert(PropertyFlags::IS_ACCESSOR)
+        } else {
+            self.flags.remove(PropertyFlags::IS_ACCESSOR)
         }
     }
 


### PR DESCRIPTION
## Summary

Let's add an `IS_ACCESSOR` bit into `PropertyFlags` instead of relying on loading the property value itself and checking whether it is an `Accessor`. Encoding whether a property is a data vs accessor property directly into the flags means we will now properly transition when data <-> accessor changes occur.

While here let's also make sure to clear the writable flag if a property changes from data -> accessor. This way all accessor properties are guaranteed to have a cleared writable flag so they will follow the same transitions.

## Tests

- CI