### PR TITLE
[runtime] Add first cache: GetNamedPropertyCache

### DIFF
--- a/src/js/runtime/abstract_operations.rs
+++ b/src/js/runtime/abstract_operations.rs
@@ -546,7 +546,7 @@ pub fn private_get(
         return Ok(property.value());
     }
 
-    let accessor = Accessor::from_value(property.value());
+    let accessor = Accessor::from_value_handle(property.value());
     match accessor.get {
         None => type_error(cx, "cannot access private field or method"),
         Some(getter) => {
@@ -575,7 +575,7 @@ pub fn private_set(
         type_error(cx, "cannot assign to private method")
     } else {
         // Property is a private accessor
-        let accessor = Accessor::from_value(property.value());
+        let accessor = Accessor::from_value_handle(property.value());
         match accessor.set {
             None => type_error(cx, "cannot set getter-only private property"),
             Some(setter) => {

--- a/src/js/runtime/accessor.rs
+++ b/src/js/runtime/accessor.rs
@@ -32,7 +32,12 @@ impl Accessor {
         Ok(accessor.to_handle())
     }
 
-    pub fn from_value(value: Handle<Value>) -> Handle<Accessor> {
+    pub fn from_value(value: Value) -> HeapPtr<Accessor> {
+        debug_assert!(value.is::<Accessor>());
+        value.as_pointer().cast::<Accessor>()
+    }
+
+    pub fn from_value_handle(value: Handle<Value>) -> Handle<Accessor> {
         debug_assert!(value.is::<Accessor>());
         value.cast::<Accessor>()
     }

--- a/src/js/runtime/bytecode/cache.rs
+++ b/src/js/runtime/bytecode/cache.rs
@@ -1,0 +1,244 @@
+use crate::runtime::{
+    Context, Handle, HeapItemKind, HeapPtr, PropertyKey, Value,
+    accessor::Accessor,
+    alloc_error::AllocResult,
+    gc::HeapVisitor,
+    object_value::ObjectValue,
+    shape::{Shape, ValidityGuard},
+    transitions::PropertyLocation,
+};
+
+/// A generic cache with multiple specific cache types.
+///
+/// Note that caches currently hold onto cached heap items strongly.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum Cache {
+    /// A cache that has not yet been used. This is the initial value when a cache is allocated.
+    Uninitialized,
+    /// Caching has failed and is no longer occurring (e.g. due to too many types).
+    Failed,
+    GetNamedProperty(GetNamedPropertyCache),
+}
+
+impl Cache {
+    #[inline]
+    pub fn get_named_property(cache: Option<GetNamedPropertyCache>) -> Self {
+        match cache {
+            Some(cache) => Self::GetNamedProperty(cache),
+            None => Self::Failed,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum GetNamedPropertyCache {
+    /// Property is found at this location on the receiver object itself.
+    Own {
+        shape: HeapPtr<Shape>,
+        location: PropertyLocation,
+        is_accessor: bool,
+    },
+    /// Property is found at this location on a prototype object in the receiver's prototype chain.
+    Proto {
+        shape: HeapPtr<Shape>,
+        guard: ValidityGuard,
+        proto: HeapPtr<ObjectValue>,
+        location: PropertyLocation,
+        is_accessor: bool,
+    },
+    /// Property was not found on the receiver or anywhere in its prototype chain. The guard is only
+    /// set if the receiver has a prototype.
+    NotFound { shape: HeapPtr<Shape>, guard: Option<ValidityGuard> },
+}
+
+pub enum GetNamedPropertyCacheResult {
+    /// Data property was found with this value.
+    Data(Value),
+    /// Accessor property was found with this getter function.
+    Accessor(HeapPtr<ObjectValue>),
+    /// Shape was the same but the validity guard was invalid.
+    InvalidGuard,
+    /// A different shape was encountered than the one cached.
+    DifferentShape,
+}
+
+impl GetNamedPropertyCache {
+    /// Match the cache against a receiver object and return the cached property if it is still
+    /// valid. If the cache is invalid, returns a result indicating why it is invalid.
+    pub fn try_match(&self, receiver: HeapPtr<ObjectValue>) -> GetNamedPropertyCacheResult {
+        match *self {
+            Self::Own { shape, location, is_accessor } if shape.ptr_eq(&receiver.shape_ptr()) => {
+                let value = receiver.lookup_location_unchecked(location);
+                if is_accessor {
+                    let accessor = Accessor::from_value(value);
+                    if let Some(getter) = accessor.get {
+                        GetNamedPropertyCacheResult::Accessor(getter)
+                    } else {
+                        // Setter only property
+                        GetNamedPropertyCacheResult::Data(Value::undefined())
+                    }
+                } else {
+                    GetNamedPropertyCacheResult::Data(value)
+                }
+            }
+            Self::Proto { shape, guard, proto, location, is_accessor }
+                if shape.ptr_eq(&receiver.shape_ptr()) =>
+            {
+                if guard.is_valid() {
+                    let value = proto.lookup_location_unchecked(location);
+                    if is_accessor {
+                        let accessor = Accessor::from_value(value);
+                        if let Some(getter) = accessor.get {
+                            GetNamedPropertyCacheResult::Accessor(getter)
+                        } else {
+                            // Setter only property
+                            GetNamedPropertyCacheResult::Data(Value::undefined())
+                        }
+                    } else {
+                        GetNamedPropertyCacheResult::Data(value)
+                    }
+                } else {
+                    GetNamedPropertyCacheResult::InvalidGuard
+                }
+            }
+            Self::NotFound { shape, guard } if shape.ptr_eq(&receiver.shape_ptr()) => {
+                if guard.is_none() || matches!(guard, Some(guard) if guard.is_valid()) {
+                    GetNamedPropertyCacheResult::Data(Value::undefined())
+                } else {
+                    GetNamedPropertyCacheResult::InvalidGuard
+                }
+            }
+            _ => GetNamedPropertyCacheResult::DifferentShape,
+        }
+    }
+
+    /// Fill the cache if possible for accessing a property key on a receiver object.
+    ///
+    /// Returns None if the property access is not cacheable.
+    pub fn fill(
+        cx: Context,
+        mut receiver: Handle<ObjectValue>,
+        key: Handle<PropertyKey>,
+    ) -> AllocResult<Option<GetNamedPropertyCache>> {
+        if !Self::is_cacheable_property(cx, *receiver, *key) {
+            return Ok(None);
+        }
+
+        // First check for an own property
+        let shape = receiver.shape_ptr();
+        if let Some(def) = shape.lookup_own_property(*key) {
+            return Ok(Some(Self::Own {
+                shape,
+                location: def.location,
+                is_accessor: def.attributes.is_accessor(),
+            }));
+        }
+
+        // Walk the prototype chain looking for the property. Does not allocate.
+        let mut next_proto = shape.prototype_ptr();
+        while let Some(proto) = next_proto {
+            let proto_shape = proto.shape_ptr();
+
+            // Cannot cache exotic object behavior
+            if Self::has_exotic_property_access(cx, proto, *key) {
+                return Ok(None);
+            }
+
+            if proto_shape.is_map_mode() {
+                // Properties stored on map mode objects cannot be cached
+                let map = proto.named_properties_map_opt().unwrap();
+                if map.contains_key(&key) {
+                    return Ok(None);
+                }
+            } else if let Some(def) = proto_shape.lookup_own_property(*key) {
+                // Property is stored in the prototype object's array
+                let proto = proto.to_handle();
+                let location = def.location;
+                let is_accessor = def.attributes.is_accessor();
+
+                // May allocate
+                let guard = receiver.request_validity_guard(cx)?.unwrap();
+
+                return Ok(Some(Self::Proto {
+                    shape: receiver.shape_ptr(),
+                    guard,
+                    proto: *proto,
+                    location,
+                    is_accessor,
+                }));
+            }
+
+            next_proto = proto_shape.prototype_ptr();
+        }
+
+        // May allocate
+        let guard = receiver.request_validity_guard(cx)?;
+
+        Ok(Some(Self::NotFound { shape: receiver.shape_ptr(), guard }))
+    }
+
+    /// Whether a named property access on this object can be cached at all.
+    fn is_cacheable_property(cx: Context, object: HeapPtr<ObjectValue>, key: PropertyKey) -> bool {
+        if key.is_array_index() {
+            return false;
+        }
+
+        // Shapes that are not part of the transition tree
+        let shape = object.shape_ptr();
+        if shape.is_map_mode() || shape.is_prototype_object() {
+            return false;
+        }
+
+        !Self::has_exotic_property_access(cx, object, key)
+    }
+
+    /// Whether named property access on this object has exotic vs ordinary behavior.
+    fn has_exotic_property_access(
+        cx: Context,
+        object: HeapPtr<ObjectValue>,
+        key: PropertyKey,
+    ) -> bool {
+        match object.shape_ptr().kind() {
+            // Exotic objects with special behavior for named property access
+            HeapItemKind::ProxyObject
+            | HeapItemKind::StringObject
+            | HeapItemKind::ModuleNamespaceObject
+            | HeapItemKind::MappedArgumentsObject => true,
+            // Arrays only intercept named access to their length property
+            HeapItemKind::ArrayObject => key == *cx.names.length(),
+            // Typed arrays intercept canonical numeric keys which we don't detect here, so reject
+            _ if object.is_typed_array() => true,
+            _ => false,
+        }
+    }
+
+    fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+        match self {
+            Self::Own { shape, .. } => {
+                visitor.visit_pointer(shape);
+            }
+            Self::Proto { shape, guard, proto, .. } => {
+                visitor.visit_pointer(shape);
+                guard.visit_pointers(visitor);
+                visitor.visit_pointer(proto);
+            }
+            Self::NotFound { shape, guard } => {
+                visitor.visit_pointer(shape);
+
+                if let Some(guard) = guard {
+                    guard.visit_pointers(visitor);
+                }
+            }
+        }
+    }
+}
+
+impl Cache {
+    pub fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+        match self {
+            Self::Uninitialized | Self::Failed => {}
+            Self::GetNamedProperty(cache) => cache.visit_pointers(visitor),
+        }
+    }
+}

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -2,18 +2,18 @@ use std::{mem::size_of, ops::Range};
 
 use crate::{
     common::graphviz::DotGraphBuilder,
-    extend_object, field_offset, must_a,
+    extend_object, field_offset, impl_array_instance, must_a,
     parser::loc::Pos,
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr, PropertyDescriptor, Realm,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         bytecode::{
-            constant_table::ConstantTable, exception_handlers::ExceptionHandlers,
+            cache::Cache, constant_table::ConstantTable, exception_handlers::ExceptionHandlers,
             graphviz::bytecode_function_to_dot_graph, instruction::debug_format_instructions,
             source_map::BytecodeSourceMap,
         },
-        collections::{InlineArray, array::ByteArray},
+        collections::{ArrayInstance, InlineArray, array::ByteArray},
         debug_print::{DebugPrint, DebugPrintMode, DebugPrinter},
         function::{set_function_length, set_simple_function_name},
         gc::{HeapItem, HeapVisitor},
@@ -226,6 +226,8 @@ pub struct BytecodeFunction {
     constant_table: Option<HeapPtr<ConstantTable>>,
     /// Exception handlers in this function.
     exception_handlers: Option<HeapPtr<ExceptionHandlers>>,
+    /// Array of all caches needed by the function, or None if the function needs no caches.
+    caches: Option<HeapPtr<CacheArray>>,
     /// The realm this function was defined in.
     realm: HeapPtr<Realm>,
     /// Number of local registers (and temporaries) needed by the function.
@@ -271,6 +273,7 @@ impl BytecodeFunction {
         bytecode: Vec<u8>,
         constant_table: Option<Handle<ConstantTable>>,
         exception_handlers: Option<Handle<ExceptionHandlers>>,
+        caches: Option<Handle<CacheArray>>,
         realm: Handle<Realm>,
         num_registers: u32,
         num_parameters: u32,
@@ -292,6 +295,7 @@ impl BytecodeFunction {
         set_uninit!(object.shape, cx.shapes.get(HeapItemKind::BytecodeFunction));
         set_uninit!(object.constant_table, constant_table.map(|c| *c));
         set_uninit!(object.exception_handlers, exception_handlers.map(|h| *h));
+        set_uninit!(object.caches, caches.map(|c| *c));
         set_uninit!(object.realm, *realm);
         set_uninit!(object.num_registers, num_registers);
         set_uninit!(object.num_parameters, num_parameters);
@@ -334,6 +338,7 @@ impl BytecodeFunction {
         set_uninit!(object.shape, cx.shapes.get(HeapItemKind::BytecodeFunction));
         set_uninit!(object.constant_table, None);
         set_uninit!(object.exception_handlers, None);
+        set_uninit!(object.caches, None);
         set_uninit!(object.realm, *realm);
         set_uninit!(object.num_registers, num_registers);
         set_uninit!(object.num_parameters, 0);
@@ -373,6 +378,11 @@ impl BytecodeFunction {
     #[inline]
     pub fn exception_handlers_ptr(&self) -> Option<HeapPtr<ExceptionHandlers>> {
         self.exception_handlers
+    }
+
+    #[inline]
+    pub fn caches_ptr(&self) -> Option<HeapPtr<CacheArray>> {
+        self.caches
     }
 
     #[inline]
@@ -523,6 +533,44 @@ pub fn dump_bytecode_function(cx: Context, func: HeapPtr<BytecodeFunction>) {
     cx.print_or_add_to_dump_buffer(&bytecode_string);
 }
 
+impl_array_instance!(CacheArray, Cache);
+
+impl CacheArray {
+    pub fn new(cx: Context, num_caches: u32) -> AllocResult<Option<Handle<Self>>> {
+        if num_caches == 0 {
+            return Ok(None);
+        }
+
+        let caches = <Self as ArrayInstance>::new(cx, num_caches as usize, Cache::Uninitialized)?;
+
+        Ok(Some(caches.to_handle()))
+    }
+
+    #[inline]
+    pub fn get(&self, index: usize) -> Cache {
+        self.as_slice()[index]
+    }
+
+    #[inline]
+    pub fn set(&mut self, index: usize, cache: Cache) {
+        self.as_mut_slice()[index] = cache;
+    }
+}
+
+impl HeapItem for CacheArray {
+    fn byte_size(caches: HeapPtr<Self>) -> usize {
+        Self::calculate_size_in_bytes(caches.len())
+    }
+
+    fn visit_pointers(mut caches: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
+        caches.visit_array_pointers(visitor);
+
+        for cache in caches.as_mut_slice() {
+            cache.visit_pointers(visitor);
+        }
+    }
+}
+
 impl HeapItem for BytecodeFunction {
     fn byte_size(bytecode_function: HeapPtr<Self>) -> usize {
         BytecodeFunction::calculate_size_in_bytes(bytecode_function.bytecode.len())
@@ -533,6 +581,7 @@ impl HeapItem for BytecodeFunction {
 
         visitor.visit_pointer_opt(&mut bytecode_function.constant_table);
         visitor.visit_pointer_opt(&mut bytecode_function.exception_handlers);
+        visitor.visit_pointer_opt(&mut bytecode_function.caches);
         visitor.visit_pointer(&mut bytecode_function.realm);
         visitor.visit_pointer_opt(&mut bytecode_function.name);
         visitor.visit_pointer_opt(&mut bytecode_function.source_file);

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -35,13 +35,15 @@ use crate::{
         bytecode::{
             constant_table_builder::{ConstantTableBuilder, ConstantTableIndex},
             exception_handlers::{ExceptionHandlerBuilder, ExceptionHandlersBuilder},
-            function::{BytecodeFunction, ClosureObject, dump_bytecode_function},
+            function::{BytecodeFunction, CacheArray, ClosureObject, dump_bytecode_function},
             graphviz::save_bytecode_dotfile_if_needed,
             instruction::{
                 DecodeInfo, DefinePrivatePropertyFlags, DefinePropertyFlags, EvalFlags, OpCode,
                 ThrowNewErrorKind,
             },
-            operand::{ConstantIndex, Operand, Register, SInt, UInt, min_width_for_signed},
+            operand::{
+                CacheIndex, ConstantIndex, Operand, Register, SInt, UInt, min_width_for_signed,
+            },
             register_allocator::TemporaryRegisterAllocator,
             source_map::BytecodeSourceMap,
             width::{ExtraWide, Narrow, UnsignedWidthRepr, Wide, Width, WidthEnum},
@@ -1099,6 +1101,9 @@ pub struct BytecodeFunctionGenerator<'a> {
     register_allocator: TemporaryRegisterAllocator,
     exception_handler_builder: ExceptionHandlersBuilder,
 
+    /// Number of caches allocated for this function so far.
+    num_caches: u32,
+
     /// Queue of functions that still need to be generated.
     pending_functions_queue: PendingFunctionNodes<'a>,
 }
@@ -1158,6 +1163,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             constant_table_builder: ConstantTableBuilder::new(),
             register_allocator: TemporaryRegisterAllocator::new(num_local_registers),
             exception_handler_builder: ExceptionHandlersBuilder::new(),
+            num_caches: 0,
             pending_functions_queue: vec![],
         }
     }
@@ -1386,6 +1392,12 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
     fn is_generator(&self) -> bool {
         self.generator_index.is_some()
+    }
+
+    fn new_cache_index(&mut self) -> GenCacheIndex {
+        let index = self.num_caches;
+        self.num_caches += 1;
+        CacheIndex::new(index)
     }
 
     fn new_block(&mut self) -> BlockId {
@@ -1975,6 +1987,23 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         Ok(self.finish()?)
     }
 
+    fn gen_get_named_property_instruction(
+        &mut self,
+        dest: GenRegister,
+        object: GenRegister,
+        name_constant_index: GenConstantIndex,
+        pos: usize,
+    ) {
+        let cache_index = self.new_cache_index();
+        self.writer.get_named_property_instruction(
+            dest,
+            object,
+            name_constant_index,
+            cache_index,
+            pos,
+        );
+    }
+
     /// Finish generating the bytecode for a function. Returns the bytecode function and the
     /// queue of AST node functions from the body that need to be generated.
     fn finish(self) -> AllocResult<EmitFunctionResult<'a>> {
@@ -1984,6 +2013,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         let constant_table = self.constant_table_builder.finish(self.cx)?;
         let exception_handlers = self.exception_handler_builder.finish(self.cx)?;
+        let caches = CacheArray::new(self.cx, self.num_caches)?;
 
         let is_async = self.is_async();
 
@@ -2002,6 +2032,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             bytecode,
             constant_table,
             exception_handlers,
+            caches,
             self.realm,
             num_registers,
             self.num_parameters,
@@ -4374,7 +4405,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             }
 
             let dest = self.allocate_destination(dest)?;
-            self.writer.get_named_property_instruction(
+            self.gen_get_named_property_instruction(
                 dest,
                 object,
                 name_constant_index,
@@ -4659,14 +4690,13 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                             key,
                             member_operator_pos,
                         ),
-                        Property::Named(name_constant_index) => {
-                            self.writer.get_named_property_instruction(
+                        Property::Named(name_constant_index) => self
+                            .gen_get_named_property_instruction(
                                 temp,
                                 object,
                                 name_constant_index,
                                 member_operator_pos,
-                            )
-                        }
+                            ),
                         Property::Private(key) => self.writer.get_private_property_instruction(
                             temp,
                             object,
@@ -4940,7 +4970,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     // Must be a named access
                     let name = member.property.to_id();
                     let name_constant_index = self.add_wtf8_string_constant(name.name)?;
-                    self.writer.get_named_property_instruction(
+                    self.gen_get_named_property_instruction(
                         temp,
                         object,
                         name_constant_index,
@@ -5461,12 +5491,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         // Check if the iterator result is valid then check if iterator is done
         self.writer
             .check_iterator_result_object_instruction(iterator_result, pos);
-        self.writer.get_named_property_instruction(
-            is_done,
-            iterator_result,
-            done_constant_index,
-            pos,
-        );
+        self.gen_get_named_property_instruction(is_done, iterator_result, done_constant_index, pos);
 
         // If iterator is not done then continue to yield
         let done_block = self.new_block();
@@ -5475,12 +5500,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         // If iterator is done then yield* evaluates to the result object's current value
         self.start_block(done_block);
-        self.writer.get_named_property_instruction(
-            dest,
-            iterator_result,
-            value_constant_index,
-            pos,
-        );
+        self.gen_get_named_property_instruction(dest, iterator_result, value_constant_index, pos);
         self.write_jump_instruction(join_block)?;
 
         // Yield had an abnormal completion - check if this is a return or throw
@@ -5522,12 +5542,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         // Check if the iterator result is valid then check if iterator is done
         self.writer
             .check_iterator_result_object_instruction(iterator_result, pos);
-        self.writer.get_named_property_instruction(
-            is_done,
-            iterator_result,
-            done_constant_index,
-            pos,
-        );
+        self.gen_get_named_property_instruction(is_done, iterator_result, done_constant_index, pos);
 
         // If iterator is not done then continue to yield
         let done_block = self.new_block();
@@ -5537,7 +5552,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         // If iterator is done then return the result object's current value
         self.start_block(done_block);
         let return_value = self.register_allocator.allocate()?;
-        self.writer.get_named_property_instruction(
+        self.gen_get_named_property_instruction(
             return_value,
             iterator_result,
             value_constant_index,
@@ -5589,12 +5604,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         // Check if the iterator result is valid then check if iterator is done
         self.writer
             .check_iterator_result_object_instruction(iterator_result, pos);
-        self.writer.get_named_property_instruction(
-            is_done,
-            iterator_result,
-            done_constant_index,
-            pos,
-        );
+        self.gen_get_named_property_instruction(is_done, iterator_result, done_constant_index, pos);
 
         // If iterator is not done then continue to yield
         let done_block = self.new_block();
@@ -5603,12 +5613,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         // If iterator is done then yield* evaluates to the result object's current value
         self.start_block(done_block);
-        self.writer.get_named_property_instruction(
-            dest,
-            iterator_result,
-            value_constant_index,
-            pos,
-        );
+        self.gen_get_named_property_instruction(dest, iterator_result, value_constant_index, pos);
         self.write_jump_instruction(join_block)?;
 
         // If the iterator is not done we end here, performing a yield then starting another
@@ -5629,7 +5634,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         } else {
             // Async generators must extract the value from the iter result object and yield it
             let value = self.register_allocator.allocate()?;
-            self.writer.get_named_property_instruction(
+            self.gen_get_named_property_instruction(
                 value,
                 iterator_result,
                 value_constant_index,
@@ -6405,7 +6410,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     }
 
                     // Read named property from object
-                    self.writer.get_named_property_instruction(
+                    self.gen_get_named_property_instruction(
                         property_value,
                         object_value,
                         name_constant_index,
@@ -9499,6 +9504,7 @@ pub type GenRegister = Register<ExtraWide>;
 type GenUInt = UInt<ExtraWide>;
 type GenSInt = SInt<ExtraWide>;
 type GenConstantIndex = ConstantIndex<ExtraWide>;
+type GenCacheIndex = CacheIndex<ExtraWide>;
 
 enum PendingFunctionNode<'a> {
     Declaration(AstPtr<ast::Function<'a>>),

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -11,7 +11,7 @@ use crate::{
         HeapPtr,
         bytecode::{
             function::BytecodeFunction,
-            operand::{ConstantIndex, Operand, OperandType, Register, SInt, UInt},
+            operand::{CacheIndex, ConstantIndex, Operand, OperandType, Register, SInt, UInt},
             width::{
                 ExtraWide, Narrow, SignedWidthRepr, UnsignedWidthRepr, Wide, Width, WidthEnum,
             },
@@ -1319,6 +1319,7 @@ define_instructions!(
             [0] dest: Register,
             [1] object: Register,
             [2] name_constant_index: ConstantIndex,
+            [3] cache_index: CacheIndex,
         }
     }
 

--- a/src/js/runtime/bytecode/mod.rs
+++ b/src/js/runtime/bytecode/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod constant_table;
 mod constant_table_builder;
 pub mod exception_handlers;

--- a/src/js/runtime/bytecode/operand.rs
+++ b/src/js/runtime/bytecode/operand.rs
@@ -123,12 +123,16 @@ operand_type!(SInt, SIGNED);
 // An index into the constant table
 operand_type!(ConstantIndex, UNSIGNED);
 
+// An index into the cache array
+operand_type!(CacheIndex, UNSIGNED);
+
 #[derive(PartialEq)]
 pub enum OperandType {
     Register,
     UInt,
     SInt,
     ConstantIndex,
+    CacheIndex,
 }
 
 /// Registers may be either registers local to a function or arguments to that function. Registers
@@ -322,6 +326,24 @@ impl<W: Width> ConstantIndex<W> {
 impl<W: Width> fmt::Display for ConstantIndex<W> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "c{}", self.value())
+    }
+}
+
+impl<W: Width> CacheIndex<W> {
+    #[inline]
+    pub fn new(value: W::UInt) -> Self {
+        Self::from_unsigned(value)
+    }
+
+    #[inline]
+    pub fn value(&self) -> W::UInt {
+        self.unsigned()
+    }
+}
+
+impl<W: Width> fmt::Display for CacheIndex<W> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "k{}", self.value())
     }
 }
 

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -4,7 +4,6 @@ use std::{
     ops::Deref,
 };
 
-use crate::runtime::intrinsics::error_object::ErrorObject;
 use crate::{
     common::numeric::Numeric,
     eval_err, handle_scope, handle_scope_guard, must,
@@ -23,6 +22,7 @@ use crate::{
         async_generator_object::{AsyncGeneratorObject, async_generator_complete_step},
         boxed_value::BoxedValue,
         bytecode::{
+            cache::{Cache, GetNamedPropertyCache, GetNamedPropertyCacheResult},
             constant_table::ConstantTable,
             function::{BytecodeFunction, ClosureObject},
             generator::BytecodeScript,
@@ -86,7 +86,7 @@ use crate::{
                 GenericJumpToBooleanConstantInstruction, GenericJumpToBooleanInstruction,
                 GenericJumpUndefinedConstantInstruction, GenericJumpUndefinedInstruction,
             },
-            operand::{ConstantIndex, Register, SInt, UInt},
+            operand::{CacheIndex, ConstantIndex, Register, SInt, UInt},
             stack_frame::{FIRST_ARGUMENT_SLOT_INDEX, NUM_STACK_SLOTS, StackFrame, StackSlotValue},
             width::{ExtraWide, Narrow, SignedWidthRepr, UnsignedWidthRepr, Wide, Width},
         },
@@ -114,6 +114,7 @@ use crate::{
         get,
         intrinsics::{
             async_generator_prototype::AsyncGeneratorPrototype,
+            error_object::ErrorObject,
             generator_prototype::GeneratorPrototype,
             intrinsics::Intrinsic,
             native_error::{ReferenceError, TypeError},
@@ -1469,6 +1470,24 @@ impl VM {
     fn get_constant_offset<W: Width>(&self, constant_index: ConstantIndex<W>) -> isize {
         self.constant_table()
             .get_constant_offset(constant_index.value().to_usize())
+    }
+
+    #[inline]
+    fn get_cache<W: Width>(&self, cache_index: CacheIndex<W>) -> Cache {
+        self.closure()
+            .function_ptr()
+            .caches_ptr()
+            .unwrap()
+            .get(cache_index.value().to_usize())
+    }
+
+    #[inline]
+    fn set_cache<W: Width>(&mut self, cache_index: CacheIndex<W>, cache: Cache) {
+        self.closure()
+            .function_ptr()
+            .caches_ptr()
+            .unwrap()
+            .set(cache_index.value().to_usize(), cache);
     }
 
     /// Set the PC to the jump target, specified as a relative offset immediate.
@@ -3717,13 +3736,53 @@ impl VM {
         &mut self,
         instr: &GetNamedPropertyInstruction<W>,
     ) -> EvalResult<()> {
+        let object_value = self.read_register(instr.object());
+        let dest = instr.dest();
+        let cache_index = instr.cache_index();
+
+        // Check if the cache still matches the object and its prototype chain
+        let mut fill_cache = false;
+        if object_value.is_object() {
+            let object = object_value.as_object();
+            let cache = self.get_cache(cache_index);
+
+            match cache {
+                Cache::Uninitialized => fill_cache = true,
+                Cache::Failed => {}
+                Cache::GetNamedProperty(cache) => match cache.try_match(object) {
+                    // Cache hit for data property, simply return cached value
+                    GetNamedPropertyCacheResult::Data(value) => {
+                        self.write_register(dest, value);
+                        return Ok(());
+                    }
+                    // Cache hit for accessor property, call the cached getter
+                    GetNamedPropertyCacheResult::Accessor(getter) => {
+                        return handle_scope!(self.cx(), {
+                            let getter = getter.to_handle();
+                            let receiver = object.to_handle().as_value();
+                            let result = call_object(self.cx(), getter, receiver, &[])?;
+                            self.write_register(dest, *result);
+
+                            Ok(())
+                        });
+                    }
+                    // The prototype chain changed, refill the cache below
+                    GetNamedPropertyCacheResult::InvalidGuard => fill_cache = true,
+                    // Polymorphic access not yet supported, stop caching
+                    GetNamedPropertyCacheResult::DifferentShape => {
+                        self.set_cache(cache_index, Cache::Failed);
+                    }
+                },
+            }
+        }
+
+        // Perform the full property access, filling the cache if necessary
         handle_scope!(self.cx(), {
             let object = self.read_register_to_handle(instr.object());
 
             let key = self.get_constant(instr.name_constant_index());
             let key = key.as_string().to_handle();
 
-            let dest = instr.dest();
             let is_strict = self.closure().function_ptr().is_strict();
 
             // May allocate, replace handle
@@ -3742,6 +3801,12 @@ impl VM {
             let result = coerced_object.get(self.cx(), property_key, receiver)?;
 
             self.write_register(dest, *result);
+
+            if fill_cache {
+                let cache = GetNamedPropertyCache::fill(self.cx(), coerced_object, property_key)?;
+                let cache = Cache::get_named_property(cache);
+                self.set_cache(cache_index, cache);
+            }
 
             Ok(())
         })
@@ -4000,7 +4065,7 @@ impl VM {
                 Property::private_method(value.as_object())
             } else if flags.contains(DefinePrivatePropertyFlags::GETTER) {
                 if flags.contains(DefinePrivatePropertyFlags::SETTER) {
-                    Property::private_accessor(Accessor::from_value(value))
+                    Property::private_accessor(Accessor::from_value_handle(value))
                 } else {
                     Property::private_getter(self.cx(), value.as_object())?
                 }

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -13,7 +13,7 @@ use crate::{
         bytecode::{
             constant_table::ConstantTable,
             exception_handlers::ExceptionHandlers,
-            function::{BytecodeFunction, ClosureObject},
+            function::{BytecodeFunction, CacheArray, ClosureObject},
             generator::FunctionVec,
             stack_frame::StackFrameArray,
         },
@@ -284,6 +284,7 @@ register_heap_items!(
     (U32Array),
     (ModuleRequestArray),
     (ModuleOptionArray),
+    (CacheArray),
     (StackFrameInfoArray),
     (StackFrameArray),
     (FinalizationRegistryCells),

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -19,7 +19,7 @@ use crate::{
         property_descriptor::PropertyDescriptor,
         property_key::PropertyKey,
         proxy_object::ProxyObject,
-        shape::{DefinePropertyLocation, TransitionResult},
+        shape::{DefinePropertyLocation, TransitionResult, ValidityGuard},
         transitions::PropertyLocation,
         type_utilities::is_callable_object,
         value::Value,
@@ -166,7 +166,7 @@ impl ObjectValue {
     /// Fetch a named property value from the object given its property location.
     ///
     /// Assumes the object is in array mode and the property location is valid.
-    fn lookup_location_unchecked(&self, location: PropertyLocation) -> Value {
+    pub fn lookup_location_unchecked(&self, location: PropertyLocation) -> Value {
         match location {
             PropertyLocation::PropertyArray { index } => *self
                 .named_properties
@@ -266,6 +266,15 @@ impl ObjectValue {
             NamedProperties::Array
         } else {
             NamedProperties::Map(self.named_properties.cast::<NamedPropertiesMap>())
+        }
+    }
+
+    #[inline]
+    pub fn named_properties_map_opt(&self) -> Option<HeapPtr<NamedPropertiesMap>> {
+        if self.named_properties.is::<NamedPropertiesMap>() {
+            Some(self.named_properties.cast::<NamedPropertiesMap>())
+        } else {
+            None
         }
     }
 
@@ -672,6 +681,27 @@ impl Handle<ObjectValue> {
     #[inline]
     pub fn as_typed_array(&self) -> DynTypedArray {
         self.virtual_object().as_typed_array()
+    }
+
+    /// Request a validity guard for this object's entire prototype chain.
+    ///
+    /// Returns None only when this object has no prototype.
+    pub fn request_validity_guard(&mut self, cx: Context) -> AllocResult<Option<ValidityGuard>> {
+        let Some(prototype) = self.prototype() else {
+            return Ok(None);
+        };
+
+        let mut shape = prototype.shape();
+
+        // Shapes are lazily converted into prototype shapes
+        if !shape.is_prototype_object() {
+            let mut prototype = prototype.to_handle();
+            let prototype_shape = shape.clone_as_prototype_object_shape(cx)?;
+            prototype.set_shape(*prototype_shape);
+            shape = prototype_shape;
+        }
+
+        Ok(Some(shape.request_validity_guard(cx)?))
     }
 }
 

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -155,7 +155,7 @@ pub fn ordinary_get_own_property(
         Some(property) => {
             let value = property.value();
             if property.is_accessor() {
-                let accessor_value = Accessor::from_value(value);
+                let accessor_value = Accessor::from_value_handle(value);
                 Some(PropertyDescriptor::accessor(
                     accessor_value.get.map(|f| f.to_handle()),
                     accessor_value.set.map(|f| f.to_handle()),
@@ -366,12 +366,12 @@ pub fn validate_and_apply_property_descriptor(
             }
         } else {
             if desc.has_get {
-                let mut accessor_value = Accessor::from_value(property.value());
+                let mut accessor_value = Accessor::from_value_handle(property.value());
                 accessor_value.get = desc.get.map(|x| *x);
             }
 
             if desc.has_set {
-                let mut accessor_value = Accessor::from_value(property.value());
+                let mut accessor_value = Accessor::from_value_handle(property.value());
                 accessor_value.set = desc.set.map(|x| *x);
             }
         }

--- a/src/js/runtime/property.rs
+++ b/src/js/runtime/property.rs
@@ -43,6 +43,10 @@ bitflags! {
 }
 
 impl PropertyFlags {
+    pub fn is_accessor(&self) -> bool {
+        self.contains(PropertyFlags::IS_ACCESSOR)
+    }
+
     pub fn is_private(&self) -> bool {
         self.intersects(
             PropertyFlags::IS_PRIVATE_FIELD

--- a/src/js/runtime/shape.rs
+++ b/src/js/runtime/shape.rs
@@ -69,7 +69,7 @@ pub struct Shape {
     /// into the `property_definitions` array.
     ///
     /// Not used in map mode.
-    array_mode_property_count: u32,
+    array_mode_property_count: u16,
 
     /// The parent shape which links to this shape via a transition, if in the transition tree.
     parent_shape: Option<HeapPtr<Shape>>,
@@ -94,7 +94,7 @@ pub struct Shape {
     /// Guards are lazily created when requested.
     ///
     /// Invariant: If the guard field is set then the guard's value is true.
-    validity_guard: Option<HeapPtr<BoxedValue>>,
+    validity_guard: Option<ValidityGuard>,
 
     /// A collection of prototype object shapes for prototype objects whose prototype is this
     /// object. Elements in this collection may be cleared to None.
@@ -272,6 +272,11 @@ impl Shape {
     }
 
     #[inline]
+    pub fn is_prototype_object(&self) -> bool {
+        self.is_prototype_object
+    }
+
+    #[inline]
     pub fn prototype_ptr(&self) -> Option<HeapPtr<ObjectValue>> {
         self.prototype
     }
@@ -286,7 +291,7 @@ impl Shape {
         self.shape = shape;
     }
 
-    pub fn num_properties(&self) -> u32 {
+    pub fn num_properties(&self) -> u16 {
         self.array_mode_property_count
     }
 
@@ -377,7 +382,7 @@ impl Shape {
     /// guard since guards are lazily created when requested.
     fn invalidate_own_guard(&mut self) {
         if let Some(mut guard) = self.validity_guard {
-            guard.set(Value::bool(false));
+            guard.invalidate();
             self.validity_guard = None;
         }
     }
@@ -481,7 +486,7 @@ impl Handle<Shape> {
     }
 
     /// Create a shallow clone of this shape except converted to a prototype object shape.
-    fn clone_as_prototype_object_shape(&self, cx: Context) -> AllocResult<Handle<Shape>> {
+    pub fn clone_as_prototype_object_shape(&self, cx: Context) -> AllocResult<Handle<Shape>> {
         let mut cloned = self.shallow_clone(cx)?;
 
         // Convert to a prototype object shape
@@ -904,7 +909,7 @@ impl Handle<Shape> {
 
     /// Request a validity guard for the entire prototype chain starting at this prototype object
     /// shape.
-    pub fn request_validity_guard(&mut self, cx: Context) -> AllocResult<HeapPtr<BoxedValue>> {
+    pub fn request_validity_guard(&mut self, cx: Context) -> AllocResult<ValidityGuard> {
         debug_assert!(self.is_prototype_object);
 
         let mut shape = *self;
@@ -939,7 +944,7 @@ impl Handle<Shape> {
         if let Some(guard) = self.validity_guard {
             Ok(guard)
         } else {
-            let guard = BoxedValue::new(cx, cx.bool(true))?;
+            let guard = ValidityGuard::new(cx)?;
             self.validity_guard = Some(guard);
             Ok(guard)
         }
@@ -974,6 +979,31 @@ pub enum DefinePropertyLocation {
 pub enum TransitionResult {
     Transitioned(HeapPtr<Shape>),
     EnterMapMode,
+}
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct ValidityGuard {
+    inner: HeapPtr<BoxedValue>,
+}
+
+impl ValidityGuard {
+    pub fn new(cx: Context) -> AllocResult<Self> {
+        let inner = BoxedValue::new(cx, cx.bool(true))?;
+        Ok(Self { inner })
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.inner.get().is_true()
+    }
+
+    fn invalidate(&mut self) {
+        self.inner.set(Value::bool(false));
+    }
+
+    pub fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+        visitor.visit_pointer(&mut self.inner);
+    }
 }
 
 impl_vec_instance!(TransitionVec, Transition);
@@ -1153,6 +1183,9 @@ impl HeapItem for Shape {
         }
 
         visitor.visit_pointer_opt(&mut shape.prototype_object_children_shapes);
-        visitor.visit_pointer_opt(&mut shape.validity_guard);
+
+        if let Some(validity_guard) = &mut shape.validity_guard {
+            validity_guard.visit_pointers(visitor);
+        }
     }
 }

--- a/src/js/runtime/shape_registry.rs
+++ b/src/js/runtime/shape_registry.rs
@@ -227,6 +227,7 @@ impl ShapeRegistry {
         non_object_heap_item_shape!(HeapItemKind::U32Array);
         non_object_heap_item_shape!(HeapItemKind::ModuleRequestArray);
         non_object_heap_item_shape!(HeapItemKind::ModuleOptionArray);
+        non_object_heap_item_shape!(HeapItemKind::CacheArray);
         non_object_heap_item_shape!(HeapItemKind::StackFrameInfoArray);
         non_object_heap_item_shape!(HeapItemKind::StackFrameArray);
         non_object_heap_item_shape!(HeapItemKind::FinalizationRegistryCells);

--- a/src/js/runtime/transitions.rs
+++ b/src/js/runtime/transitions.rs
@@ -21,7 +21,7 @@ impl PropertyDefinition {
 /// Where a property is stored on an object.
 pub enum PropertyLocation {
     /// Property is stored in the named properties array at this index.
-    PropertyArray { index: u32 },
+    PropertyArray { index: u16 },
 }
 
 #[derive(Clone, Copy)]

--- a/tests/integration/language/expression/member/cache/absent_property.js
+++ b/tests/integration/language/expression/member/cache/absent_property.js
@@ -1,0 +1,66 @@
+/*---
+description: GetNamedProperty cache handles absent properties.
+---*/
+
+// Missing property, then added to the receiver: the shape transition forces a miss.
+(function () {
+  function get(o) { return o.x; }
+  var o = { y: 1 };
+  assert.sameValue(get(o), undefined);
+  assert.sameValue(get(o), undefined);
+  o.x = 3;
+  assert.sameValue(get(o), 3);
+})();
+
+// Missing property, then added to the prototype: the guard must invalidate so the new value is seen.
+(function () {
+  function get(o) { return o.x; }
+  var proto = {};
+  var o = Object.create(proto);
+  get(o); get(o);
+  proto.x = 8;
+  assert.sameValue(get(o), 8);
+})();
+
+// Not found across a deep chain, then added at the top: the guard spans the whole chain.
+(function () {
+  function get(o) { return o.x; }
+  var top = {};
+  var mid = Object.create(top);
+  var o = Object.create(mid);
+  get(o); get(o);
+  top.x = 1;
+  assert.sameValue(get(o), 1);
+})();
+
+// Null-prototype receiver: an absent property is undefined with no guard needed.
+(function () {
+  function get(o) { return o.x; }
+  var o = Object.create(null);
+  o.y = 1;
+  assert.sameValue(get(o), undefined);
+  assert.sameValue(get(o), undefined);
+})();
+
+// An unrelated property added to the prototype invalidates the not-found guard, but the property stays absent.
+(function () {
+  function get(o) { return o.x; }
+  var proto = {};
+  var o = Object.create(proto);
+  assert.sameValue(get(o), undefined);
+  assert.sameValue(get(o), undefined);
+  proto.y = 1;
+  assert.sameValue(get(o), undefined);
+  proto.x = 9;
+  assert.sameValue(get(o), 9);
+})();
+
+// A not-found lookup stays undefined across a garbage collection.
+(function () {
+  function get(o) { return o.x; }
+  var proto = { y: 1 };
+  var o = Object.create(proto);
+  assert.sameValue(get(o), undefined);
+  $262.gc();
+  assert.sameValue(get(o), undefined);
+})();

--- a/tests/integration/language/expression/member/cache/exotic_objects.js
+++ b/tests/integration/language/expression/member/cache/exotic_objects.js
@@ -1,0 +1,61 @@
+/*---
+description: GetNamedProperty cache on exotic objects.
+---*/
+
+// Array length - a warm callsite must see live updates, never a stale cached length.
+(function () {
+  function len(a) { return a.length; }
+  var a = [1, 2];
+  assert.sameValue(len(a), 2);
+  assert.sameValue(len(a), 2);
+  a.push(3);
+  assert.sameValue(len(a), 3);
+  a.length = 1;
+  assert.sameValue(len(a), 1);
+})();
+
+// A non-length property on an array is ordinary and may be cached.
+(function () {
+  function get(a) { return a.foo; }
+  var a = [];
+  a.foo = 7;
+  assert.sameValue(get(a), 7);
+  assert.sameValue(get(a), 7);
+})();
+
+// A proxy in the chain must run its trap on every access, so it is never cached.
+(function () {
+  var count = 0;
+  function get(o) { return o.x; }
+  var proto = new Proxy({}, { get: function () { return ++count; } });
+  var o = Object.create(proto);
+  assert.sameValue(get(o), 1);
+  assert.sameValue(get(o), 2);
+  assert.sameValue(get(o), 3);
+})();
+
+// String object indexing - named access stays correct across different instances at one callsite.
+(function () {
+  function len(s) { return s.length; }
+  assert.sameValue(len(new String("ab")), 2);
+  assert.sameValue(len(new String("cdef")), 4);
+})();
+
+// Typed arrays intercept canonical numeric keys, so named access is never cached but stays correct.
+(function () {
+  function len(a) { return a.length; }
+  function byteLen(a) { return a.byteLength; }
+  var ta = new Uint8Array(4);
+  assert.sameValue(len(ta), 4);
+  assert.sameValue(len(ta), 4);
+  assert.sameValue(byteLen(ta), 4);
+})();
+
+// An ordinary named property on a typed array reads correctly across a warm callsite.
+(function () {
+  function get(a) { return a.foo; }
+  var ta = new Uint8Array(2);
+  ta.foo = 7;
+  assert.sameValue(get(ta), 7);
+  assert.sameValue(get(ta), 7);
+})();

--- a/tests/integration/language/expression/member/cache/invalidation.js
+++ b/tests/integration/language/expression/member/cache/invalidation.js
@@ -1,0 +1,86 @@
+/*---
+description: GetNamedProperty cache misses and refills on shape transitions, prototype mutations, and polymorphism.
+---*/
+
+// Data property redefined as an accessor changes the shape, the cache must switch to the getter.
+(function () {
+  function get(o) { return o.x; }
+  var o = { x: 1 };
+  get(o); get(o);
+  Object.defineProperty(o, "x", { get: function () { return 99; } });
+  assert.sameValue(get(o), 99);
+})();
+
+// Accessor redefined as a data property changes the shape, the cache must switch to the new value.
+(function () {
+  function get(o) { return o.x; }
+  var o = { get x() { return 1; } };
+  get(o); get(o);
+  Object.defineProperty(o, "x", { value: 5, configurable: true });
+  assert.sameValue(get(o), 5);
+})();
+
+// Replacing the prototype invalidates a not-found lookup.
+(function () {
+  function get(o) { return o.x; }
+  var o = {};
+  get(o); get(o);
+  Object.setPrototypeOf(o, { x: 11 });
+  assert.sameValue(get(o), 11);
+})();
+
+// A shadowing property added to an intermediate prototype overrides a deeper holder.
+(function () {
+  function get(o) { return o.x; }
+  var top = { x: 1 };
+  var mid = Object.create(top);
+  var o = Object.create(mid);
+  assert.sameValue(get(o), 1);
+  assert.sameValue(get(o), 1);
+  mid.x = 2;
+  assert.sameValue(get(o), 2);
+})();
+
+// Removing the prototype's property falls through to the next prototype.
+(function () {
+  function get(o) { return o.x; }
+  var top = { x: 1 };
+  var mid = Object.create(top);
+  mid.x = 2;
+  var o = Object.create(mid);
+  assert.sameValue(get(o), 2);
+  assert.sameValue(get(o), 2);
+  delete mid.x;
+  assert.sameValue(get(o), 1);
+})();
+
+// One callsite, many shapes: the cache fails and uses the slow path.
+(function () {
+  function get(o) { return o.x; }
+  assert.sameValue(get({ x: 1 }), 1);
+  assert.sameValue(get({ x: 2, y: 0 }), 2);
+  assert.sameValue(get({ x: 3 }), 3);
+  assert.sameValue(get(Object.create({ x: 4 })), 4);
+  assert.sameValue(get({ x: 5 }), 5);
+})();
+
+// Changing an intermediate prototype's own prototype is reflected at a warm callsite.
+(function () {
+  function get(o) { return o.x; }
+  var top = { x: 1 };
+  var mid = Object.create(top);
+  var o = Object.create(mid);
+  assert.sameValue(get(o), 1);
+  assert.sameValue(get(o), 1);
+  Object.setPrototypeOf(mid, { x: 2 });
+  assert.sameValue(get(o), 2);
+})();
+
+// Freezing the receiver transitions its shape, so the cached entry must miss.
+(function () {
+  function get(o) { return o.x; }
+  var o = { x: 1 };
+  get(o); get(o);
+  Object.freeze(o);
+  assert.sameValue(get(o), 1);
+})();

--- a/tests/integration/language/expression/member/cache/module_namespace.js
+++ b/tests/integration/language/expression/member/cache/module_namespace.js
@@ -1,0 +1,23 @@
+/*---
+description: GetNamedProperty cache does not cache module namespace objects.
+flags: [module]
+---*/
+
+import * as ns from "./module_namespace_FIXTURE.js";
+import { setValue } from "./module_namespace_FIXTURE.js";
+
+// Module binding updates live, not affected by cache.
+(function () {
+  function get(o) { return o.value; }
+  assert.sameValue(get(ns), 1);
+  assert.sameValue(get(ns), 1);
+  setValue(2);
+  assert.sameValue(get(ns), 2);
+})();
+
+// A missing export reads as undefined.
+(function () {
+  function get(o) { return o.missing; }
+  assert.sameValue(get(ns), undefined);
+  assert.sameValue(get(ns), undefined);
+})();

--- a/tests/integration/language/expression/member/cache/module_namespace_FIXTURE.js
+++ b/tests/integration/language/expression/member/cache/module_namespace_FIXTURE.js
@@ -1,0 +1,2 @@
+export let value = 1;
+export function setValue(v) { value = v; }

--- a/tests/integration/language/expression/member/cache/own_property.js
+++ b/tests/integration/language/expression/member/cache/own_property.js
@@ -1,0 +1,91 @@
+/*---
+description: GetNamedProperty cache handles own data and accessor properties.
+---*/
+
+// Own data property.
+(function () {
+  function get(o) { return o.x; }
+  var o = { x: 1 };
+  assert.sameValue(get(o), 1);
+  assert.sameValue(get(o), 1);
+  o.x = 2;
+  assert.sameValue(get(o), 2);
+})();
+
+// Deleting the property transitions the shape, so the cached entry must miss.
+(function () {
+  function get(o) { return o.x; }
+  var o = { x: 1 };
+  get(o); get(o);
+  delete o.x;
+  assert.sameValue(get(o), undefined);
+})();
+
+// Adding a second property after warming grows the shape but keeps x reachable.
+(function () {
+  function get(o) { return o.x; }
+  var o = { x: 1 };
+  get(o); get(o);
+  o.y = 2;
+  assert.sameValue(get(o), 1);
+})();
+
+// Own getters.
+(function () {
+  var seenThis;
+  function get(o) { return o.x; }
+  var o = {
+    n: 10,
+    get x() { seenThis = this; return this.n; },
+  };
+  assert.sameValue(get(o), 10);
+  o.n = 20;
+  assert.sameValue(get(o), 20);
+  assert.sameValue(seenThis, o);
+})();
+
+// Getter replaced in place keeps the same shape.
+(function () {
+  function get(o) { return o.x; }
+  var o = { get x() { return 1; } };
+  get(o); get(o);
+  Object.defineProperty(o, "x", { get: function () { return 2; } });
+  assert.sameValue(get(o), 2);
+})();
+
+// Getter removed in place leaves a setter-only accessor, returns undefined.
+(function () {
+  function get(o) { return o.x; }
+  var o = { get x() { return 1; } };
+  get(o); get(o);
+  Object.defineProperty(o, "x", { get: undefined });
+  assert.sameValue(get(o), undefined);
+})();
+
+// Setter-only accessor reads as undefined through the cache.
+(function () {
+  function get(o) { return o.x; }
+  var o = { set x(v) {} };
+  assert.sameValue(get(o), undefined);
+  assert.sameValue(get(o), undefined);
+})();
+
+// A cached getter that throws propagates the exception on a warm cache hit.
+(function () {
+  var shouldThrow = false;
+  function get(o) { return o.x; }
+  var o = { get x() { if (shouldThrow) { throw new TypeError("boom"); } return 1; } };
+  assert.sameValue(get(o), 1);
+  assert.sameValue(get(o), 1);
+  shouldThrow = true;
+  assert.throws(TypeError, function () { get(o); });
+})();
+
+// An own data property read stays correct across a garbage collection.
+(function () {
+  function get(o) { return o.x; }
+  var o = { x: 1 };
+  assert.sameValue(get(o), 1);
+  $262.gc();
+  assert.sameValue(get(o), 1);
+})();

--- a/tests/integration/language/expression/member/cache/prototype_property.js
+++ b/tests/integration/language/expression/member/cache/prototype_property.js
@@ -1,0 +1,85 @@
+/*---
+description: GetNamedProperty cache handles data and accessor properties from the prototype chain.
+---*/
+
+// Prototype data property.
+(function () {
+  function get(o) { return o.x; }
+  var proto = { x: 1 };
+  var o = Object.create(proto);
+  assert.sameValue(get(o), 1);
+  assert.sameValue(get(o), 1);
+  proto.x = 2;
+  assert.sameValue(get(o), 2);
+})();
+
+// An own property shadows the prototype.
+(function () {
+  function get(o) { return o.x; }
+  var proto = { x: 1 };
+  var o = Object.create(proto);
+  get(o); get(o);
+  o.x = 5;
+  assert.sameValue(get(o), 5);
+})();
+
+// Two receivers sharing a prototype have the same shape.
+(function () {
+  function get(o) { return o.x; }
+  var proto = { x: 7 };
+  var a = Object.create(proto);
+  var b = Object.create(proto);
+  assert.sameValue(get(a), 7);
+  assert.sameValue(get(b), 7);
+})();
+
+// Prototype getter.
+(function () {
+  var seenThis;
+  function get(o) { return o.x; }
+  var proto = { get x() { seenThis = this; return 42; } };
+  var o = Object.create(proto);
+  assert.sameValue(get(o), 42);
+  assert.sameValue(get(o), 42);
+  assert.sameValue(seenThis, o);
+})();
+
+// Setter-only accessor on the prototype reads as undefined.
+(function () {
+  function get(o) { return o.x; }
+  var proto = { set x(v) {} };
+  var o = Object.create(proto);
+  assert.sameValue(get(o), undefined);
+  assert.sameValue(get(o), undefined);
+})();
+
+// A cached prototype getter binds `this` to the actual receiver, not the one that filled the cache.
+(function () {
+  function get(o) { return o.x; }
+  var proto = { get x() { return this.tag; } };
+  var a = Object.create(proto); a.tag = "a";
+  var b = Object.create(proto); b.tag = "b";
+  assert.sameValue(get(a), "a");
+  assert.sameValue(get(a), "a");
+  assert.sameValue(get(b), "b");
+})();
+
+// Replacing the getter in place on the prototype is seen at a warm callsite.
+(function () {
+  function get(o) { return o.x; }
+  var proto = { get x() { return 1; } };
+  var o = Object.create(proto);
+  get(o); get(o);
+  Object.defineProperty(proto, "x", { get: function () { return 2; }, configurable: true });
+  assert.sameValue(get(o), 2);
+})();
+
+// A prototype data property read stays correct across a garbage collection.
+(function () {
+  function get(o) { return o.x; }
+  var proto = { x: 42 };
+  var o = Object.create(proto);
+  assert.sameValue(get(o), 42);
+  $262.gc();
+  assert.sameValue(get(o), 42);
+})();

--- a/tests/snapshot/bytecode/arguments_object/unmapped_arguments.exp
+++ b/tests/snapshot/bytecode/arguments_object/unmapped_arguments.exp
@@ -45,9 +45,9 @@
 [BytecodeFunction: destructuringForcesUnmapped] {
   Parameters: 1, Registers: 3
     0: NewUnmappedArguments r1
-    2: GetNamedProperty r0, a0, c0
-    6: LoadUndefined r2
-    8: Ret r2
+    2: GetNamedProperty r0, a0, c0, k0
+    7: LoadUndefined r2
+    9: Ret r2
   Constant Table:
     0: [String: x]
 }

--- a/tests/snapshot/bytecode/bytecode/assign_hazard.exp
+++ b/tests/snapshot/bytecode/bytecode/assign_hazard.exp
@@ -105,15 +105,15 @@
 [BytecodeFunction: inVarDeclarator] {
   Parameters: 1, Registers: 4
      0: NewObject r1
-     2: GetNamedProperty r2, r1, c0
-     6: JumpNotUndefined r2, 13 (.L0)
-     9: Mov r3, a0
-    12: LoadImmediate a0, 2
-    15: Add r2, r3, a0
+     2: GetNamedProperty r2, r1, c0, k0
+     7: JumpNotUndefined r2, 13 (.L0)
+    10: Mov r3, a0
+    13: LoadImmediate a0, 2
+    16: Add r2, r3, a0
   .L0:
-    19: Mov r0, r2
-    22: LoadUndefined r1
-    24: Ret r1
+    20: Mov r0, r2
+    23: LoadUndefined r1
+    25: Ret r1
   Constant Table:
     0: [String: x]
 }

--- a/tests/snapshot/bytecode/class/constructor.exp
+++ b/tests/snapshot/bytecode/class/constructor.exp
@@ -74,11 +74,11 @@
 
 [BytecodeFunction: ThisInBaseConstructor] {
   Parameters: 0, Registers: 1
-     0: GetNamedProperty r0, <this>, c0
-     4: LoadImmediate r0, 1
-     7: SetNamedProperty <this>, c0, r0
-    11: LoadUndefined r0
-    13: Ret r0
+     0: GetNamedProperty r0, <this>, c0, k0
+     5: LoadImmediate r0, 1
+     8: SetNamedProperty <this>, c0, r0
+    12: LoadUndefined r0
+    14: Ret r0
   Constant Table:
     0: [String: x]
 }
@@ -92,12 +92,12 @@
     14: CheckSuperAlreadyCalled <this>
     16: Mov <this>, r2
     19: CheckThisInitialized <this>
-    21: GetNamedProperty r2, <this>, c0
-    25: CheckThisInitialized <this>
-    27: LoadImmediate r2, 1
-    30: SetNamedProperty <this>, c0, r2
-    34: CheckThisInitialized <this>
-    36: Ret <this>
+    21: GetNamedProperty r2, <this>, c0, k0
+    26: CheckThisInitialized <this>
+    28: LoadImmediate r2, 1
+    31: SetNamedProperty <this>, c0, r2
+    35: CheckThisInitialized <this>
+    37: Ret <this>
   Constant Table:
     0: [String: x]
 }
@@ -145,14 +145,14 @@
     30: NewClosure r2, c1
     33: LoadFromScope r2, 0, 0
     37: CheckThisInitialized r2
-    39: GetNamedProperty r2, r2, c2
-    43: LoadFromScope r3, 0, 0
-    47: CheckThisInitialized r3
-    49: LoadImmediate r2, 1
-    52: SetNamedProperty r3, c2, r2
-    56: LoadFromScope r2, 0, 0
-    60: CheckThisInitialized r2
-    62: Ret r2
+    39: GetNamedProperty r2, r2, c2, k0
+    44: LoadFromScope r3, 0, 0
+    48: CheckThisInitialized r3
+    50: LoadImmediate r2, 1
+    53: SetNamedProperty r3, c2, r2
+    57: LoadFromScope r2, 0, 0
+    61: CheckThisInitialized r2
+    63: Ret r2
   Constant Table:
     0: [ScopeNames]
     1: [BytecodeFunction: <anonymous>]

--- a/tests/snapshot/bytecode/class/private_member.exp
+++ b/tests/snapshot/bytecode/class/private_member.exp
@@ -135,10 +135,10 @@
 [BytecodeFunction: privateDestructure] {
   Parameters: 1, Registers: 2
      0: LoadFromScope r1, 1, 0
-     4: GetNamedProperty r0, a0, c0
-     8: SetPrivateProperty <this>, r1, r0
-    12: LoadUndefined r0
-    14: Ret r0
+     4: GetNamedProperty r0, a0, c0, k0
+     9: SetPrivateProperty <this>, r1, r0
+    13: LoadUndefined r0
+    15: Ret r0
   Constant Table:
     0: [String: x]
 }

--- a/tests/snapshot/bytecode/class/super_call.exp
+++ b/tests/snapshot/bytecode/class/super_call.exp
@@ -99,10 +99,10 @@
     16: NewClosure r0, c1
     19: LoadFromScope r0, 0, 0
     23: CheckThisInitialized r0
-    25: GetNamedProperty r0, r0, c2
-    29: LoadFromScope r0, 0, 0
-    33: CheckThisInitialized r0
-    35: Ret r0
+    25: GetNamedProperty r0, r0, c2, k0
+    30: LoadFromScope r0, 0, 0
+    34: CheckThisInitialized r0
+    36: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [BytecodeFunction: <anonymous>]

--- a/tests/snapshot/bytecode/eval/derived_constructor_this.exp
+++ b/tests/snapshot/bytecode/eval/derived_constructor_this.exp
@@ -201,10 +201,10 @@
      3: CheckThisInitialized r1
      5: LoadDynamic r2, c0
      8: CheckThisInitialized r2
-    10: GetNamedProperty r3, r2, c2
-    14: CallWithReceiver r0, r3, r2, r3, 0
-    20: SetNamedProperty r1, c1, r0
-    24: Ret r0
+    10: GetNamedProperty r3, r2, c2, k0
+    15: CallWithReceiver r0, r3, r2, r3, 0
+    21: SetNamedProperty r1, c1, r0
+    25: Ret r0
   Constant Table:
     0: [String: this]
     1: [String: fromEval]

--- a/tests/snapshot/bytecode/eval/nested_eval.exp
+++ b/tests/snapshot/bytecode/eval/nested_eval.exp
@@ -15,13 +15,13 @@
     38: Construct r0, r0, r0, r0, 0
     44: StoreGlobal r0, c6
     47: LoadGlobal r0, c6
-    50: GetNamedProperty r1, r0, c7
-    54: CallWithReceiver r0, r1, r0, r1, 0
-    60: LoadGlobal r0, c6
-    63: GetNamedProperty r1, r0, c8
-    67: CallWithReceiver r0, r1, r0, r1, 0
-    73: LoadUndefined r0
-    75: Ret r0
+    50: GetNamedProperty r1, r0, c7, k0
+    55: CallWithReceiver r0, r1, r0, r1, 0
+    61: LoadGlobal r0, c6
+    64: GetNamedProperty r1, r0, c8, k1
+    69: CallWithReceiver r0, r1, r0, r1, 0
+    75: LoadUndefined r0
+    77: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [BytecodeFunction: method1]

--- a/tests/snapshot/bytecode/eval/private_names.exp
+++ b/tests/snapshot/bytecode/eval/private_names.exp
@@ -13,10 +13,10 @@
     31: StoreToScope r0, 1, 0
     35: LoadFromScope r0, 1, 0
     39: CheckTdz r0, c5
-    42: GetNamedProperty r1, r0, c6
-    46: CallWithReceiver r0, r1, r0, r1, 0
-    52: LoadUndefined r0
-    54: Ret r0
+    42: GetNamedProperty r1, r0, c6, k0
+    47: CallWithReceiver r0, r1, r0, r1, 0
+    53: LoadUndefined r0
+    55: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: field]

--- a/tests/snapshot/bytecode/eval/super_members.exp
+++ b/tests/snapshot/bytecode/eval/super_members.exp
@@ -17,14 +17,14 @@
     48: Construct r0, r0, r0, r0, 0
     54: StoreGlobal r0, c8
     57: LoadGlobal r0, c8
-    60: GetNamedProperty r1, r0, c9
-    64: CallWithReceiver r0, r1, r0, r1, 0
-    70: LoadFromScope r0, 1, 0
-    74: CheckTdz r0, c7
-    77: GetNamedProperty r1, r0, c10
-    81: CallWithReceiver r0, r1, r0, r1, 0
-    87: LoadUndefined r0
-    89: Ret r0
+    60: GetNamedProperty r1, r0, c9, k0
+    65: CallWithReceiver r0, r1, r0, r1, 0
+    71: LoadFromScope r0, 1, 0
+    75: CheckTdz r0, c7
+    78: GetNamedProperty r1, r0, c10, k1
+    83: CallWithReceiver r0, r1, r0, r1, 0
+    89: LoadUndefined r0
+    91: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: String]

--- a/tests/snapshot/bytecode/expression/assign.exp
+++ b/tests/snapshot/bytecode/expression/assign.exp
@@ -361,18 +361,18 @@
 [BytecodeFunction: objectDestructuringAssign] {
   Parameters: 1, Registers: 3
      0: LoadImmediate r2, 1
-     3: GetNamedProperty r1, r2, c0
-     7: LoadImmediate r2, 2
-    10: GetNamedProperty r1, r2, c0
-    14: Mov a0, r2
-    17: LoadImmediate r2, 3
-    20: GetNamedProperty r1, r2, c0
-    24: Mov r0, r2
-    27: LoadImmediate r2, 4
-    30: GetNamedProperty r1, r2, c0
-    34: StoreGlobal r2, c1
-    37: LoadUndefined r2
-    39: Ret r2
+     3: GetNamedProperty r1, r2, c0, k0
+     8: LoadImmediate r2, 2
+    11: GetNamedProperty r1, r2, c0, k1
+    16: Mov a0, r2
+    19: LoadImmediate r2, 3
+    22: GetNamedProperty r1, r2, c0, k2
+    27: Mov r0, r2
+    30: LoadImmediate r2, 4
+    33: GetNamedProperty r1, r2, c0, k3
+    38: StoreGlobal r2, c1
+    41: LoadUndefined r2
+    43: Ret r2
   Constant Table:
     0: [String: a]
     1: [String: global]
@@ -410,41 +410,41 @@
 
 [BytecodeFunction: operatorMemberAssign] {
   Parameters: 2, Registers: 5
-      0: GetNamedProperty r0, a0, c0
-      4: LoadImmediate r1, 1
-      7: Add r0, r0, r1
-     11: SetNamedProperty a0, c0, r0
-     15: LoadGlobal r0, c1
-     18: Mov r2, a0
-     21: GetNamedProperty r1, r2, c0
-     25: LoadImmediate r3, 2
-     28: Add r1, r1, r3
-     32: SetNamedProperty r2, c0, r1
-     36: Call r0, r0, r1, 1
-     41: Mov r1, a0
-     44: GetNamedProperty r0, r1, c0
-     48: Mov r3, a0
-     51: GetNamedProperty r2, r3, c2
-     55: LoadImmediate r4, 3
-     58: Add r2, r2, r4
-     62: SetNamedProperty r3, c2, r2
-     66: Add r0, r0, r2
-     70: SetNamedProperty r1, c0, r0
-     74: LoadGlobal r0, c1
-     77: Mov r2, a0
-     80: GetNamedProperty r1, r2, c0
-     84: Mov r3, a0
-     87: Add r1, r1, r3
-     91: SetNamedProperty r2, c0, r1
-     95: Call r0, r0, r1, 1
-    100: Mov r1, a0
-    103: GetNamedProperty r0, r1, c0
-    107: LoadImmediate r2, 4
-    110: Add r0, r0, r2
-    114: SetNamedProperty r1, c0, r0
-    118: Mov a1, r0
-    121: LoadUndefined r0
-    123: Ret r0
+      0: GetNamedProperty r0, a0, c0, k0
+      5: LoadImmediate r1, 1
+      8: Add r0, r0, r1
+     12: SetNamedProperty a0, c0, r0
+     16: LoadGlobal r0, c1
+     19: Mov r2, a0
+     22: GetNamedProperty r1, r2, c0, k1
+     27: LoadImmediate r3, 2
+     30: Add r1, r1, r3
+     34: SetNamedProperty r2, c0, r1
+     38: Call r0, r0, r1, 1
+     43: Mov r1, a0
+     46: GetNamedProperty r0, r1, c0, k2
+     51: Mov r3, a0
+     54: GetNamedProperty r2, r3, c2, k3
+     59: LoadImmediate r4, 3
+     62: Add r2, r2, r4
+     66: SetNamedProperty r3, c2, r2
+     70: Add r0, r0, r2
+     74: SetNamedProperty r1, c0, r0
+     78: LoadGlobal r0, c1
+     81: Mov r2, a0
+     84: GetNamedProperty r1, r2, c0, k4
+     89: Mov r3, a0
+     92: Add r1, r1, r3
+     96: SetNamedProperty r2, c0, r1
+    100: Call r0, r0, r1, 1
+    105: Mov r1, a0
+    108: GetNamedProperty r0, r1, c0, k5
+    113: LoadImmediate r2, 4
+    116: Add r0, r0, r2
+    120: SetNamedProperty r1, c0, r0
+    124: Mov a1, r0
+    127: LoadUndefined r0
+    129: Ret r0
   Constant Table:
     0: [String: foo]
     1: [String: use]
@@ -453,56 +453,56 @@
 
 [BytecodeFunction: operatorMemberAllOperators] {
   Parameters: 1, Registers: 2
-      0: GetNamedProperty r0, a0, c0
-      4: LoadImmediate r1, 1
-      7: Add r0, r0, r1
-     11: SetNamedProperty a0, c0, r0
-     15: GetNamedProperty r0, a0, c0
-     19: LoadImmediate r1, 2
-     22: Sub r0, r0, r1
-     26: SetNamedProperty a0, c0, r0
-     30: GetNamedProperty r0, a0, c0
-     34: LoadImmediate r1, 3
-     37: Mul r0, r0, r1
-     41: SetNamedProperty a0, c0, r0
-     45: GetNamedProperty r0, a0, c0
-     49: LoadImmediate r1, 4
-     52: Div r0, r0, r1
-     56: SetNamedProperty a0, c0, r0
-     60: GetNamedProperty r0, a0, c0
-     64: LoadImmediate r1, 5
-     67: Rem r0, r0, r1
-     71: SetNamedProperty a0, c0, r0
-     75: GetNamedProperty r0, a0, c0
-     79: LoadImmediate r1, 6
-     82: Exp r0, r0, r1
-     86: SetNamedProperty a0, c0, r0
-     90: GetNamedProperty r0, a0, c0
-     94: LoadImmediate r1, 7
-     97: BitAnd r0, r0, r1
-    101: SetNamedProperty a0, c0, r0
-    105: GetNamedProperty r0, a0, c0
-    109: LoadImmediate r1, 8
-    112: BitOr r0, r0, r1
-    116: SetNamedProperty a0, c0, r0
-    120: GetNamedProperty r0, a0, c0
-    124: LoadImmediate r1, 9
-    127: BitXor r0, r0, r1
-    131: SetNamedProperty a0, c0, r0
-    135: GetNamedProperty r0, a0, c0
-    139: LoadImmediate r1, 10
-    142: ShiftLeft r0, r0, r1
-    146: SetNamedProperty a0, c0, r0
-    150: GetNamedProperty r0, a0, c0
-    154: LoadImmediate r1, 11
-    157: ShiftRightArithmetic r0, r0, r1
-    161: SetNamedProperty a0, c0, r0
-    165: GetNamedProperty r0, a0, c0
-    169: LoadImmediate r1, 12
-    172: ShiftRightLogical r0, r0, r1
-    176: SetNamedProperty a0, c0, r0
-    180: LoadUndefined r0
-    182: Ret r0
+      0: GetNamedProperty r0, a0, c0, k0
+      5: LoadImmediate r1, 1
+      8: Add r0, r0, r1
+     12: SetNamedProperty a0, c0, r0
+     16: GetNamedProperty r0, a0, c0, k1
+     21: LoadImmediate r1, 2
+     24: Sub r0, r0, r1
+     28: SetNamedProperty a0, c0, r0
+     32: GetNamedProperty r0, a0, c0, k2
+     37: LoadImmediate r1, 3
+     40: Mul r0, r0, r1
+     44: SetNamedProperty a0, c0, r0
+     48: GetNamedProperty r0, a0, c0, k3
+     53: LoadImmediate r1, 4
+     56: Div r0, r0, r1
+     60: SetNamedProperty a0, c0, r0
+     64: GetNamedProperty r0, a0, c0, k4
+     69: LoadImmediate r1, 5
+     72: Rem r0, r0, r1
+     76: SetNamedProperty a0, c0, r0
+     80: GetNamedProperty r0, a0, c0, k5
+     85: LoadImmediate r1, 6
+     88: Exp r0, r0, r1
+     92: SetNamedProperty a0, c0, r0
+     96: GetNamedProperty r0, a0, c0, k6
+    101: LoadImmediate r1, 7
+    104: BitAnd r0, r0, r1
+    108: SetNamedProperty a0, c0, r0
+    112: GetNamedProperty r0, a0, c0, k7
+    117: LoadImmediate r1, 8
+    120: BitOr r0, r0, r1
+    124: SetNamedProperty a0, c0, r0
+    128: GetNamedProperty r0, a0, c0, k8
+    133: LoadImmediate r1, 9
+    136: BitXor r0, r0, r1
+    140: SetNamedProperty a0, c0, r0
+    144: GetNamedProperty r0, a0, c0, k9
+    149: LoadImmediate r1, 10
+    152: ShiftLeft r0, r0, r1
+    156: SetNamedProperty a0, c0, r0
+    160: GetNamedProperty r0, a0, c0, k10
+    165: LoadImmediate r1, 11
+    168: ShiftRightArithmetic r0, r0, r1
+    172: SetNamedProperty a0, c0, r0
+    176: GetNamedProperty r0, a0, c0, k11
+    181: LoadImmediate r1, 12
+    184: ShiftRightLogical r0, r0, r1
+    188: SetNamedProperty a0, c0, r0
+    192: LoadUndefined r0
+    194: Ret r0
   Constant Table:
     0: [String: foo]
 }
@@ -520,12 +520,12 @@
     25: CheckTdz r2, c2
     28: StoreToScope r1, 0, 0
     32: LoadImmediate r1, 2
-    35: GetNamedProperty r2, r1, c2
-    39: LoadFromScope r3, 0, 0
-    43: CheckTdz r3, c2
-    46: StoreToScope r2, 0, 0
-    50: LoadUndefined r1
-    52: Ret r1
+    35: GetNamedProperty r2, r1, c2, k0
+    40: LoadFromScope r3, 0, 0
+    44: CheckTdz r3, c2
+    47: StoreToScope r2, 0, 0
+    51: LoadUndefined r1
+    53: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [BytecodeFunction: inner]

--- a/tests/snapshot/bytecode/expression/calls/member.exp
+++ b/tests/snapshot/bytecode/expression/calls/member.exp
@@ -23,21 +23,21 @@
 
 [BytecodeFunction: testNamedMemberCall] {
   Parameters: 1, Registers: 5
-     0: GetNamedProperty r1, a0, c0
-     4: CallWithReceiver r1, r1, a0, r1, 0
-    10: GetNamedProperty r1, a0, c0
-    14: LoadImmediate r2, 1
-    17: LoadImmediate r3, 2
-    20: LoadImmediate r4, 3
-    23: CallWithReceiver r1, r1, a0, r2, 3
-    29: LoadImmediate r1, 1
-    32: LoadImmediate r2, 2
-    35: Add r0, r1, r2
-    39: GetNamedProperty r1, r0, c0
-    43: LoadImmediate r2, 4
-    46: CallWithReceiver r1, r1, r0, r2, 1
-    52: LoadUndefined r1
-    54: Ret r1
+     0: GetNamedProperty r1, a0, c0, k0
+     5: CallWithReceiver r1, r1, a0, r1, 0
+    11: GetNamedProperty r1, a0, c0, k1
+    16: LoadImmediate r2, 1
+    19: LoadImmediate r3, 2
+    22: LoadImmediate r4, 3
+    25: CallWithReceiver r1, r1, a0, r2, 3
+    31: LoadImmediate r1, 1
+    34: LoadImmediate r2, 2
+    37: Add r0, r1, r2
+    41: GetNamedProperty r1, r0, c0, k2
+    46: LoadImmediate r2, 4
+    49: CallWithReceiver r1, r1, r0, r2, 1
+    55: LoadUndefined r1
+    57: Ret r1
   Constant Table:
     0: [String: foo]
 }
@@ -72,25 +72,25 @@
 [BytecodeFunction: testOptionalNamedMemberCall] {
   Parameters: 1, Registers: 2
      0: Mov r0, a0
-     3: JumpNullish r0, 9 (.L0)
-     6: GetNamedProperty r1, r0, c0
-    10: Jump 6 (.L1)
+     3: JumpNullish r0, 10 (.L0)
+     6: GetNamedProperty r1, r0, c0, k0
+    11: Jump 6 (.L1)
   .L0:
-    12: LoadUndefined r1
-    14: LoadUndefined r0
+    13: LoadUndefined r1
+    15: LoadUndefined r0
   .L1:
-    16: CallWithReceiver r0, r1, r0, r1, 0
-    22: JumpNullish a0, 13 (.L2)
-    25: GetNamedProperty r0, a0, c1
-    29: GetNamedProperty r1, r0, c2
-    33: Jump 6 (.L3)
+    17: CallWithReceiver r0, r1, r0, r1, 0
+    23: JumpNullish a0, 15 (.L2)
+    26: GetNamedProperty r0, a0, c1, k1
+    31: GetNamedProperty r1, r0, c2, k2
+    36: Jump 6 (.L3)
   .L2:
-    35: LoadUndefined r1
-    37: LoadUndefined r0
+    38: LoadUndefined r1
+    40: LoadUndefined r0
   .L3:
-    39: CallWithReceiver r0, r1, r0, r1, 0
-    45: LoadUndefined r0
-    47: Ret r0
+    42: CallWithReceiver r0, r1, r0, r1, 0
+    48: LoadUndefined r0
+    50: Ret r0
   Constant Table:
     0: [String: foo]
     1: [String: a]

--- a/tests/snapshot/bytecode/expression/calls/spread.exp
+++ b/tests/snapshot/bytecode/expression/calls/spread.exp
@@ -106,19 +106,19 @@
 
 [BytecodeFunction: spreadWithReceiver] {
   Parameters: 2, Registers: 7
-     0: GetNamedProperty r0, a0, c0
-     4: NewArray r1
-     6: LoadImmediate r2, 0
-     9: GetIterator r3, r4, a1
+     0: GetNamedProperty r0, a0, c0, k0
+     5: NewArray r1
+     7: LoadImmediate r2, 0
+    10: GetIterator r3, r4, a1
   .L0:
-    13: IteratorNext r5, r6, r3, r4
-    18: JumpTrue r6, 11 (.L1)
-    21: SetArrayProperty r1, r2, r5
-    25: Inc r2
-    27: Jump -14 (.L0)
+    14: IteratorNext r5, r6, r3, r4
+    19: JumpTrue r6, 11 (.L1)
+    22: SetArrayProperty r1, r2, r5
+    26: Inc r2
+    28: Jump -14 (.L0)
   .L1:
-    29: CallVarargs r0, r0, a0, r1
-    34: Ret r0
+    30: CallVarargs r0, r0, a0, r1
+    35: Ret r0
   Constant Table:
     0: [String: f]
 }

--- a/tests/snapshot/bytecode/expression/chain.exp
+++ b/tests/snapshot/bytecode/expression/chain.exp
@@ -32,40 +32,40 @@
 
 [BytecodeFunction: namedMember] {
   Parameters: 1, Registers: 1
-     0: JumpNullish a0, 9 (.L0)
-     3: GetNamedProperty r0, a0, c0
-     7: Jump 4 (.L1)
+     0: JumpNullish a0, 10 (.L0)
+     3: GetNamedProperty r0, a0, c0, k0
+     8: Jump 4 (.L1)
   .L0:
-     9: LoadUndefined r0
+    10: LoadUndefined r0
   .L1:
-    11: Neg r0, r0
-    14: JumpNullish a0, 16 (.L2)
-    17: GetNamedProperty r0, a0, c0
-    21: JumpNullish r0, 9 (.L2)
-    24: GetNamedProperty r0, r0, c1
-    28: Jump 4 (.L3)
+    12: Neg r0, r0
+    15: JumpNullish a0, 18 (.L2)
+    18: GetNamedProperty r0, a0, c0, k1
+    23: JumpNullish r0, 10 (.L2)
+    26: GetNamedProperty r0, r0, c1, k2
+    31: Jump 4 (.L3)
   .L2:
-    30: LoadUndefined r0
+    33: LoadUndefined r0
   .L3:
-    32: Neg r0, r0
-    35: JumpNullish a0, 13 (.L4)
-    38: GetNamedProperty r0, a0, c0
-    42: GetNamedProperty r0, r0, c1
-    46: Jump 4 (.L5)
+    35: Neg r0, r0
+    38: JumpNullish a0, 15 (.L4)
+    41: GetNamedProperty r0, a0, c0, k3
+    46: GetNamedProperty r0, r0, c1, k4
+    51: Jump 4 (.L5)
   .L4:
-    48: LoadUndefined r0
+    53: LoadUndefined r0
   .L5:
-    50: Neg r0, r0
-    53: GetNamedProperty r0, a0, c0
-    57: JumpNullish r0, 9 (.L6)
-    60: GetNamedProperty r0, r0, c1
-    64: Jump 4 (.L7)
+    55: Neg r0, r0
+    58: GetNamedProperty r0, a0, c0, k5
+    63: JumpNullish r0, 10 (.L6)
+    66: GetNamedProperty r0, r0, c1, k6
+    71: Jump 4 (.L7)
   .L6:
-    66: LoadUndefined r0
+    73: LoadUndefined r0
   .L7:
-    68: Neg r0, r0
-    71: LoadUndefined r0
-    73: Ret r0
+    75: Neg r0, r0
+    78: LoadUndefined r0
+    80: Ret r0
   Constant Table:
     0: [String: b]
     1: [String: c]
@@ -125,95 +125,95 @@
     10: LoadUndefined r0
   .L1:
     12: Neg r0, r0
-    15: JumpNullish a0, 18 (.L2)
-    18: GetNamedProperty r0, a0, c0
-    22: JumpNullish r0, 11 (.L2)
-    25: CallWithReceiver r0, r0, a0, r0, 0
-    31: Jump 4 (.L3)
+    15: JumpNullish a0, 19 (.L2)
+    18: GetNamedProperty r0, a0, c0, k0
+    23: JumpNullish r0, 11 (.L2)
+    26: CallWithReceiver r0, r0, a0, r0, 0
+    32: Jump 4 (.L3)
   .L2:
-    33: LoadUndefined r0
+    34: LoadUndefined r0
   .L3:
-    35: Neg r0, r0
-    38: JumpNullish a0, 15 (.L4)
-    41: GetNamedProperty r0, a0, c0
-    45: CallWithReceiver r0, r0, a0, r0, 0
-    51: Jump 4 (.L5)
+    36: Neg r0, r0
+    39: JumpNullish a0, 16 (.L4)
+    42: GetNamedProperty r0, a0, c0, k1
+    47: CallWithReceiver r0, r0, a0, r0, 0
+    53: Jump 4 (.L5)
   .L4:
-    53: LoadUndefined r0
+    55: LoadUndefined r0
   .L5:
-    55: Neg r0, r0
-    58: GetNamedProperty r0, a0, c0
-    62: JumpNullish r0, 11 (.L6)
-    65: CallWithReceiver r0, r0, a0, r0, 0
-    71: Jump 4 (.L7)
+    57: Neg r0, r0
+    60: GetNamedProperty r0, a0, c0, k2
+    65: JumpNullish r0, 11 (.L6)
+    68: CallWithReceiver r0, r0, a0, r0, 0
+    74: Jump 4 (.L7)
   .L6:
-    73: LoadUndefined r0
+    76: LoadUndefined r0
   .L7:
-    75: Neg r0, r0
-    78: LoadUndefined r0
-    80: Ret r0
+    78: Neg r0, r0
+    81: LoadUndefined r0
+    83: Ret r0
   Constant Table:
     0: [String: b]
 }
 
 [BytecodeFunction: nested] {
   Parameters: 1, Registers: 2
-      0: JumpNullish a0, 30 (.L0)
-      3: GetNamedProperty r0, a0, c0
-      7: JumpNullish r0, 23 (.L0)
-     10: GetNamedProperty r0, r0, c1
-     14: JumpNullish r0, 16 (.L0)
-     17: GetNamedProperty r0, r0, c2
-     21: JumpNullish r0, 9 (.L0)
-     24: GetNamedProperty r0, r0, c3
-     28: Jump 4 (.L1)
+      0: JumpNullish a0, 34 (.L0)
+      3: GetNamedProperty r0, a0, c0, k0
+      8: JumpNullish r0, 26 (.L0)
+     11: GetNamedProperty r0, r0, c1, k1
+     16: JumpNullish r0, 18 (.L0)
+     19: GetNamedProperty r0, r0, c2, k2
+     24: JumpNullish r0, 10 (.L0)
+     27: GetNamedProperty r0, r0, c3, k3
+     32: Jump 4 (.L1)
   .L0:
-     30: LoadUndefined r0
+     34: LoadUndefined r0
   .L1:
-     32: Neg r0, r0
-     35: GetNamedProperty r0, a0, c0
-     39: JumpNullish r0, 20 (.L2)
-     42: GetNamedProperty r0, r0, c1
-     46: GetNamedProperty r0, r0, c2
-     50: JumpNullish r0, 9 (.L2)
-     53: GetNamedProperty r0, r0, c3
-     57: Jump 4 (.L3)
+     36: Neg r0, r0
+     39: GetNamedProperty r0, a0, c0, k4
+     44: JumpNullish r0, 23 (.L2)
+     47: GetNamedProperty r0, r0, c1, k5
+     52: GetNamedProperty r0, r0, c2, k6
+     57: JumpNullish r0, 10 (.L2)
+     60: GetNamedProperty r0, r0, c3, k7
+     65: Jump 4 (.L3)
   .L2:
-     59: LoadUndefined r0
+     67: LoadUndefined r0
   .L3:
-     61: Neg r0, r0
-     64: GetNamedProperty r0, a0, c0
-     68: JumpNullish r0, 32 (.L4)
-     71: GetNamedProperty r1, r0, c1
-     75: CallWithReceiver r0, r1, r0, r1, 0
-     81: GetNamedProperty r0, r0, c2
-     85: JumpNullish r0, 15 (.L4)
-     88: GetNamedProperty r1, r0, c3
-     92: CallWithReceiver r0, r1, r0, r1, 0
-     98: Jump 4 (.L5)
+     69: Neg r0, r0
+     72: GetNamedProperty r0, a0, c0, k8
+     77: JumpNullish r0, 35 (.L4)
+     80: GetNamedProperty r1, r0, c1, k9
+     85: CallWithReceiver r0, r1, r0, r1, 0
+     91: GetNamedProperty r0, r0, c2, k10
+     96: JumpNullish r0, 16 (.L4)
+     99: GetNamedProperty r1, r0, c3, k11
+    104: CallWithReceiver r0, r1, r0, r1, 0
+    110: Jump 4 (.L5)
   .L4:
-    100: LoadUndefined r0
+    112: LoadUndefined r0
   .L5:
-    102: Neg r0, r0
-    105: JumpNullish a0, 48 (.L6)
-    108: GetNamedProperty r0, a0, c0
-    112: JumpNullish r0, 41 (.L6)
-    115: GetNamedProperty r1, r0, c1
-    119: JumpNullish r1, 34 (.L6)
-    122: CallWithReceiver r0, r1, r0, r1, 0
-    128: JumpNullish r0, 25 (.L6)
-    131: GetNamedProperty r0, r0, c2
-    135: JumpNullish r0, 18 (.L6)
-    138: GetNamedProperty r1, r0, c3
-    142: JumpNullish r1, 11 (.L6)
-    145: CallWithReceiver r0, r1, r0, r1, 0
-    151: Jump 4 (.L7)
+    114: Neg r0, r0
+    117: JumpNullish a0, 52 (.L6)
+    120: GetNamedProperty r0, a0, c0, k12
+    125: JumpNullish r0, 44 (.L6)
+    128: GetNamedProperty r1, r0, c1, k13
+    133: JumpNullish r1, 36 (.L6)
+    136: CallWithReceiver r0, r1, r0, r1, 0
+    142: JumpNullish r0, 27 (.L6)
+    145: GetNamedProperty r0, r0, c2, k14
+    150: JumpNullish r0, 19 (.L6)
+    153: GetNamedProperty r1, r0, c3, k15
+    158: JumpNullish r1, 11 (.L6)
+    161: CallWithReceiver r0, r1, r0, r1, 0
+    167: Jump 4 (.L7)
   .L6:
-    153: LoadUndefined r0
+    169: LoadUndefined r0
   .L7:
-    155: Neg r0, r0
-    158: LoadUndefined r0
-    160: Ret r0
+    171: Neg r0, r0
+    174: LoadUndefined r0
+    176: Ret r0
   Constant Table:
     0: [String: b]
     1: [String: c]
@@ -225,24 +225,24 @@
   Parameters: 0, Registers: 1
      0: LoadFromScope r0, 0, 0
      4: GetNamedSuperProperty r0, r0, <this>, c0
-     9: JumpNullish r0, 9 (.L0)
-    12: GetNamedProperty r0, r0, c1
-    16: Jump 4 (.L1)
+     9: JumpNullish r0, 10 (.L0)
+    12: GetNamedProperty r0, r0, c1, k0
+    17: Jump 4 (.L1)
   .L0:
-    18: LoadUndefined r0
+    19: LoadUndefined r0
   .L1:
-    20: Neg r0, r0
-    23: LoadFromScope r0, 0, 0
-    27: GetNamedSuperProperty r0, r0, <this>, c0
-    32: JumpNullish r0, 11 (.L2)
-    35: CallWithReceiver r0, r0, <this>, r0, 0
-    41: Jump 4 (.L3)
+    21: Neg r0, r0
+    24: LoadFromScope r0, 0, 0
+    28: GetNamedSuperProperty r0, r0, <this>, c0
+    33: JumpNullish r0, 11 (.L2)
+    36: CallWithReceiver r0, r0, <this>, r0, 0
+    42: Jump 4 (.L3)
   .L2:
-    43: LoadUndefined r0
+    44: LoadUndefined r0
   .L3:
-    45: Neg r0, r0
-    48: LoadUndefined r0
-    50: Ret r0
+    46: Neg r0, r0
+    49: LoadUndefined r0
+    51: Ret r0
   Constant Table:
     0: [String: a]
     1: [String: b]

--- a/tests/snapshot/bytecode/expression/delete.exp
+++ b/tests/snapshot/bytecode/expression/delete.exp
@@ -69,13 +69,13 @@
   Parameters: 1, Registers: 2
      0: LoadConstant r0, c0
      3: DeleteProperty r0, a0, r0
-     7: GetNamedProperty r0, a0, c1
-    11: LoadConstant r1, c0
-    14: DeleteProperty r0, r0, r1
-    18: LoadImmediate r0, 1
-    21: DeleteProperty r0, a0, r0
-    25: LoadUndefined r0
-    27: Ret r0
+     7: GetNamedProperty r0, a0, c1, k0
+    12: LoadConstant r1, c0
+    15: DeleteProperty r0, r0, r1
+    19: LoadImmediate r0, 1
+    22: DeleteProperty r0, a0, r0
+    26: LoadUndefined r0
+    28: Ret r0
   Constant Table:
     0: [String: foo]
     1: [String: inner]
@@ -97,18 +97,18 @@
   .L2:
     26: LoadTrue r0
   .L3:
-    28: JumpNullish a0, 23 (.L4)
-    31: GetNamedProperty r0, a0, c0
-    35: GetNamedProperty r0, r0, c1
-    39: JumpNullish r0, 12 (.L4)
-    42: LoadConstant r1, c2
-    45: DeleteProperty r0, r0, r1
-    49: Jump 4 (.L5)
+    28: JumpNullish a0, 25 (.L4)
+    31: GetNamedProperty r0, a0, c0, k0
+    36: GetNamedProperty r0, r0, c1, k1
+    41: JumpNullish r0, 12 (.L4)
+    44: LoadConstant r1, c2
+    47: DeleteProperty r0, r0, r1
+    51: Jump 4 (.L5)
   .L4:
-    51: LoadTrue r0
+    53: LoadTrue r0
   .L5:
-    53: LoadUndefined r0
-    55: Ret r0
+    55: LoadUndefined r0
+    57: Ret r0
   Constant Table:
     0: [String: foo]
     1: [String: bar]

--- a/tests/snapshot/bytecode/expression/logical_assign.exp
+++ b/tests/snapshot/bytecode/expression/logical_assign.exp
@@ -42,20 +42,20 @@
     21: LoadImmediate r1, 3
     24: StoreGlobal r1, c0
   .L2:
-    27: GetNamedProperty r1, a0, c1
-    31: JumpToBooleanFalse r1, 10 (.L3)
-    34: LoadImmediate r1, 4
-    37: SetNamedProperty a0, c1, r1
+    27: GetNamedProperty r1, a0, c1, k0
+    32: JumpToBooleanFalse r1, 10 (.L3)
+    35: LoadImmediate r1, 4
+    38: SetNamedProperty a0, c1, r1
   .L3:
-    41: LoadGlobal r1, c2
-    44: Mov r2, a0
-    47: JumpToBooleanFalse r2, 6 (.L4)
-    50: LoadImmediate a0, 5
+    42: LoadGlobal r1, c2
+    45: Mov r2, a0
+    48: JumpToBooleanFalse r2, 6 (.L4)
+    51: LoadImmediate a0, 5
   .L4:
-    53: Mov r2, a0
-    56: Call r1, r1, r2, 1
-    61: LoadUndefined r1
-    63: Ret r1
+    54: Mov r2, a0
+    57: Call r1, r1, r2, 1
+    62: LoadUndefined r1
+    64: Ret r1
   Constant Table:
     0: [String: global]
     1: [String: foo]
@@ -76,20 +76,20 @@
     21: LoadImmediate r1, 3
     24: StoreGlobal r1, c0
   .L2:
-    27: GetNamedProperty r1, a0, c1
-    31: JumpToBooleanTrue r1, 10 (.L3)
-    34: LoadImmediate r1, 4
-    37: SetNamedProperty a0, c1, r1
+    27: GetNamedProperty r1, a0, c1, k0
+    32: JumpToBooleanTrue r1, 10 (.L3)
+    35: LoadImmediate r1, 4
+    38: SetNamedProperty a0, c1, r1
   .L3:
-    41: LoadGlobal r1, c2
-    44: Mov r2, a0
-    47: JumpToBooleanTrue r2, 6 (.L4)
-    50: LoadImmediate a0, 5
+    42: LoadGlobal r1, c2
+    45: Mov r2, a0
+    48: JumpToBooleanTrue r2, 6 (.L4)
+    51: LoadImmediate a0, 5
   .L4:
-    53: Mov r2, a0
-    56: Call r1, r1, r2, 1
-    61: LoadUndefined r1
-    63: Ret r1
+    54: Mov r2, a0
+    57: Call r1, r1, r2, 1
+    62: LoadUndefined r1
+    64: Ret r1
   Constant Table:
     0: [String: global]
     1: [String: foo]
@@ -110,20 +110,20 @@
     21: LoadImmediate r1, 3
     24: StoreGlobal r1, c0
   .L2:
-    27: GetNamedProperty r1, a0, c1
-    31: JumpNotNullish r1, 10 (.L3)
-    34: LoadImmediate r1, 4
-    37: SetNamedProperty a0, c1, r1
+    27: GetNamedProperty r1, a0, c1, k0
+    32: JumpNotNullish r1, 10 (.L3)
+    35: LoadImmediate r1, 4
+    38: SetNamedProperty a0, c1, r1
   .L3:
-    41: LoadGlobal r1, c2
-    44: Mov r2, a0
-    47: JumpNotNullish r2, 6 (.L4)
-    50: LoadImmediate a0, 5
+    42: LoadGlobal r1, c2
+    45: Mov r2, a0
+    48: JumpNotNullish r2, 6 (.L4)
+    51: LoadImmediate a0, 5
   .L4:
-    53: Mov r2, a0
-    56: Call r1, r1, r2, 1
-    61: LoadUndefined r1
-    63: Ret r1
+    54: Mov r2, a0
+    57: Call r1, r1, r2, 1
+    62: LoadUndefined r1
+    64: Ret r1
   Constant Table:
     0: [String: global]
     1: [String: foo]

--- a/tests/snapshot/bytecode/expression/member.exp
+++ b/tests/snapshot/bytecode/expression/member.exp
@@ -19,10 +19,10 @@
 
 [BytecodeFunction: testNamedMember] {
   Parameters: 1, Registers: 1
-     0: GetNamedProperty r0, a0, c0
-     4: GetNamedProperty r0, a0, c1
-     8: LoadUndefined r0
-    10: Ret r0
+     0: GetNamedProperty r0, a0, c0, k0
+     5: GetNamedProperty r0, a0, c1, k1
+    10: LoadUndefined r0
+    12: Ret r0
   Constant Table:
     0: [String: foo]
     1: [String: x]
@@ -47,9 +47,9 @@
 
 [BytecodeFunction: propertyNamesNotResolved] {
   Parameters: 1, Registers: 2
-    0: GetNamedProperty r0, a0, c0
-    4: LoadUndefined r1
-    6: Ret r1
+    0: GetNamedProperty r0, a0, c0, k0
+    5: LoadUndefined r1
+    7: Ret r1
   Constant Table:
     0: [String: a]
 }

--- a/tests/snapshot/bytecode/expression/object/basic.exp
+++ b/tests/snapshot/bytecode/expression/object/basic.exp
@@ -146,16 +146,16 @@
      4: NewObject r3
      6: LoadImmediate r4, 1
      9: DefineNamedProperty r3, c0, r4
-    13: GetNamedProperty r0, r3, c0
-    17: NewObject r3
-    19: CheckTdz r1, c1
-    22: DefineNamedProperty r3, c1, r1
-    26: CheckTdz r2, c3
-    29: DefineNamedProperty r3, c2, r2
-    33: GetNamedProperty r1, r3, c1
-    37: GetNamedProperty r2, r3, c3
-    41: LoadUndefined r3
-    43: Ret r3
+    13: GetNamedProperty r0, r3, c0, k0
+    18: NewObject r3
+    20: CheckTdz r1, c1
+    23: DefineNamedProperty r3, c1, r1
+    27: CheckTdz r2, c3
+    30: DefineNamedProperty r3, c2, r2
+    34: GetNamedProperty r1, r3, c1, k1
+    39: GetNamedProperty r2, r3, c3, k2
+    44: LoadUndefined r3
+    46: Ret r3
   Constant Table:
     0: [String: a]
     1: [String: b]

--- a/tests/snapshot/bytecode/expression/tagged_template.exp
+++ b/tests/snapshot/bytecode/expression/tagged_template.exp
@@ -91,20 +91,20 @@
 
 [BytecodeFunction: namedMemberTag] {
   Parameters: 1, Registers: 5
-     0: GetNamedProperty r1, a0, c0
-     4: LoadConstant r2, c1
-     7: LoadImmediate r3, 1
-    10: LoadImmediate r4, 2
-    13: CallWithReceiver r1, r1, a0, r2, 3
-    19: LoadImmediate r1, 1
-    22: LoadImmediate r2, 2
-    25: Add r0, r1, r2
-    29: GetNamedProperty r1, r0, c0
-    33: LoadConstant r2, c2
-    36: LoadImmediate r3, 3
-    39: CallWithReceiver r1, r1, r0, r2, 2
-    45: LoadUndefined r1
-    47: Ret r1
+     0: GetNamedProperty r1, a0, c0, k0
+     5: LoadConstant r2, c1
+     8: LoadImmediate r3, 1
+    11: LoadImmediate r4, 2
+    14: CallWithReceiver r1, r1, a0, r2, 3
+    20: LoadImmediate r1, 1
+    23: LoadImmediate r2, 2
+    26: Add r0, r1, r2
+    30: GetNamedProperty r1, r0, c0, k1
+    35: LoadConstant r2, c2
+    38: LoadImmediate r3, 3
+    41: CallWithReceiver r1, r1, r0, r2, 2
+    47: LoadUndefined r1
+    49: Ret r1
   Constant Table:
     0: [String: foo]
     1: [ArrayObject]
@@ -138,29 +138,29 @@
 [BytecodeFunction: optionalNamedMemberTag] {
   Parameters: 1, Registers: 4
      0: Mov r0, a0
-     3: JumpNullish r0, 9 (.L0)
-     6: GetNamedProperty r1, r0, c0
-    10: Jump 6 (.L1)
+     3: JumpNullish r0, 10 (.L0)
+     6: GetNamedProperty r1, r0, c0, k0
+    11: Jump 6 (.L1)
   .L0:
-    12: LoadUndefined r1
-    14: LoadUndefined r0
+    13: LoadUndefined r1
+    15: LoadUndefined r0
   .L1:
-    16: LoadConstant r2, c1
-    19: LoadImmediate r3, 1
-    22: CallWithReceiver r0, r1, r0, r2, 2
-    28: JumpNullish a0, 13 (.L2)
-    31: GetNamedProperty r0, a0, c2
-    35: GetNamedProperty r1, r0, c3
-    39: Jump 6 (.L3)
+    17: LoadConstant r2, c1
+    20: LoadImmediate r3, 1
+    23: CallWithReceiver r0, r1, r0, r2, 2
+    29: JumpNullish a0, 15 (.L2)
+    32: GetNamedProperty r0, a0, c2, k1
+    37: GetNamedProperty r1, r0, c3, k2
+    42: Jump 6 (.L3)
   .L2:
-    41: LoadUndefined r1
-    43: LoadUndefined r0
+    44: LoadUndefined r1
+    46: LoadUndefined r0
   .L3:
-    45: LoadConstant r2, c4
-    48: LoadImmediate r3, 1
-    51: CallWithReceiver r0, r1, r0, r2, 2
-    57: LoadUndefined r0
-    59: Ret r0
+    48: LoadConstant r2, c4
+    51: LoadImmediate r3, 1
+    54: CallWithReceiver r0, r1, r0, r2, 2
+    60: LoadUndefined r0
+    62: Ret r0
   Constant Table:
     0: [String: foo]
     1: [ArrayObject]

--- a/tests/snapshot/bytecode/expression/update.exp
+++ b/tests/snapshot/bytecode/expression/update.exp
@@ -220,26 +220,26 @@
 [BytecodeFunction: prefixMember] {
   Parameters: 2, Registers: 3
      0: Mov r1, a0
-     3: GetNamedProperty r0, r1, c0
-     7: ToNumeric r0, r0
-    10: Inc r0
-    12: SetNamedProperty r1, c0, r0
-    16: Neg r0, r0
-    19: Mov r1, a0
-    22: LoadImmediate r2, 0
-    25: GetProperty r0, r1, r2
-    29: ToNumeric r0, r0
-    32: Inc r0
-    34: SetProperty r1, r2, r0
-    38: Neg r0, r0
-    41: Mov r1, a0
-    44: GetNamedProperty r0, r1, c0
-    48: ToNumeric r0, r0
-    51: Inc r0
-    53: SetNamedProperty r1, c0, r0
-    57: Mov a1, r0
-    60: LoadUndefined r0
-    62: Ret r0
+     3: GetNamedProperty r0, r1, c0, k0
+     8: ToNumeric r0, r0
+    11: Inc r0
+    13: SetNamedProperty r1, c0, r0
+    17: Neg r0, r0
+    20: Mov r1, a0
+    23: LoadImmediate r2, 0
+    26: GetProperty r0, r1, r2
+    30: ToNumeric r0, r0
+    33: Inc r0
+    35: SetProperty r1, r2, r0
+    39: Neg r0, r0
+    42: Mov r1, a0
+    45: GetNamedProperty r0, r1, c0, k1
+    50: ToNumeric r0, r0
+    53: Inc r0
+    55: SetNamedProperty r1, c0, r0
+    59: Mov a1, r0
+    62: LoadUndefined r0
+    64: Ret r0
   Constant Table:
     0: [String: prop]
 }
@@ -247,29 +247,29 @@
 [BytecodeFunction: postfixMember] {
   Parameters: 2, Registers: 4
      0: Mov r1, a0
-     3: GetNamedProperty r0, r1, c0
-     7: ToNumeric r0, r0
-    10: Mov r2, r0
-    13: Inc r2
-    15: SetNamedProperty r1, c0, r2
-    19: Neg r0, r0
-    22: Mov r1, a0
-    25: LoadImmediate r2, 0
-    28: GetProperty r0, r1, r2
-    32: ToNumeric r0, r0
-    35: Mov r3, r0
-    38: Inc r3
-    40: SetProperty r1, r2, r3
-    44: Neg r0, r0
-    47: Mov r1, a0
-    50: GetNamedProperty r0, r1, c0
-    54: ToNumeric r0, r0
-    57: Mov r2, r0
-    60: Inc r2
-    62: SetNamedProperty r1, c0, r2
-    66: Mov a1, r0
-    69: LoadUndefined r0
-    71: Ret r0
+     3: GetNamedProperty r0, r1, c0, k0
+     8: ToNumeric r0, r0
+    11: Mov r2, r0
+    14: Inc r2
+    16: SetNamedProperty r1, c0, r2
+    20: Neg r0, r0
+    23: Mov r1, a0
+    26: LoadImmediate r2, 0
+    29: GetProperty r0, r1, r2
+    33: ToNumeric r0, r0
+    36: Mov r3, r0
+    39: Inc r3
+    41: SetProperty r1, r2, r3
+    45: Neg r0, r0
+    48: Mov r1, a0
+    51: GetNamedProperty r0, r1, c0, k1
+    56: ToNumeric r0, r0
+    59: Mov r2, r0
+    62: Inc r2
+    64: SetNamedProperty r1, c0, r2
+    68: Mov a1, r0
+    71: LoadUndefined r0
+    73: Ret r0
   Constant Table:
     0: [String: prop]
 }
@@ -336,17 +336,17 @@
      5: ToNumeric a0, a0
      8: Mov r0, a0
     11: Dec a0
-    13: GetNamedProperty r0, a0, c0
-    17: ToNumeric r0, r0
-    20: Dec r0
-    22: SetNamedProperty a0, c0, r0
-    26: GetNamedProperty r0, a0, c0
-    30: ToNumeric r0, r0
-    33: Mov r1, r0
-    36: Dec r1
-    38: SetNamedProperty a0, c0, r1
-    42: LoadUndefined r0
-    44: Ret r0
+    13: GetNamedProperty r0, a0, c0, k0
+    18: ToNumeric r0, r0
+    21: Dec r0
+    23: SetNamedProperty a0, c0, r0
+    27: GetNamedProperty r0, a0, c0, k1
+    32: ToNumeric r0, r0
+    35: Mov r1, r0
+    38: Dec r1
+    40: SetNamedProperty a0, c0, r1
+    44: LoadUndefined r0
+    46: Ret r0
   Constant Table:
     0: [String: prop]
 }

--- a/tests/snapshot/bytecode/expression/yield_star.exp
+++ b/tests/snapshot/bytecode/expression/yield_star.exp
@@ -20,48 +20,48 @@
       6: LoadUndefined r4
       8: LoadTrue r5
   .L0:
-     10: JumpNullish r5, 26 (.L2)
+     10: JumpNullish r5, 28 (.L2)
      13: CallWithReceiver r6, r3, r2, r4, 1
      19: CheckIteratorResultObject r6
-     21: GetNamedProperty r7, r6, c0
-     25: JumpTrue r7, 5 (.L1)
-     28: Jump 78 (.L8)
+     21: GetNamedProperty r7, r6, c0, k0
+     26: JumpTrue r7, 5 (.L1)
+     29: Jump 83 (.L8)
   .L1:
-     30: GetNamedProperty r1, r6, c1
-     34: Jump 79 (.L9)
+     31: GetNamedProperty r1, r6, c1, k1
+     36: Jump 83 (.L9)
   .L2:
-     36: JumpNotUndefined r5, 35 (.L5)
-     39: GetMethod r8, r2, c3
-     43: JumpNotUndefined r8, 5 (.L3)
-     46: Ret r4
+     38: JumpNotUndefined r5, 37 (.L5)
+     41: GetMethod r8, r2, c3
+     45: JumpNotUndefined r8, 5 (.L3)
+     48: Ret r4
   .L3:
-     48: CallWithReceiver r6, r8, r2, r4, 1
-     54: CheckIteratorResultObject r6
-     56: GetNamedProperty r7, r6, c0
-     60: JumpTrue r7, 5 (.L4)
-     63: Jump 43 (.L8)
+     50: CallWithReceiver r6, r8, r2, r4, 1
+     56: CheckIteratorResultObject r6
+     58: GetNamedProperty r7, r6, c0, k2
+     63: JumpTrue r7, 5 (.L4)
+     66: Jump 46 (.L8)
   .L4:
-     65: GetNamedProperty r8, r6, c1
-     69: Ret r8
+     68: GetNamedProperty r8, r6, c1, k3
+     73: Ret r8
   .L5:
-     71: GetMethod r8, r2, c2
-     75: JumpNotUndefined r8, 8 (.L6)
-     78: IteratorClose r2
-     80: ThrowNewError 1, c4
+     75: GetMethod r8, r2, c2
+     79: JumpNotUndefined r8, 8 (.L6)
+     82: IteratorClose r2
+     84: ThrowNewError 1, c4
   .L6:
-     83: CallWithReceiver r6, r8, r2, r4, 1
-     89: CheckIteratorResultObject r6
-     91: GetNamedProperty r7, r6, c0
-     95: JumpTrue r7, 5 (.L7)
-     98: Jump 8 (.L8)
+     87: CallWithReceiver r6, r8, r2, r4, 1
+     93: CheckIteratorResultObject r6
+     95: GetNamedProperty r7, r6, c0, k4
+    100: JumpTrue r7, 5 (.L7)
+    103: Jump 9 (.L8)
   .L7:
-    100: GetNamedProperty r1, r6, c1
-    104: Jump 9 (.L9)
+    105: GetNamedProperty r1, r6, c1, k5
+    110: Jump 9 (.L9)
   .L8:
-    106: Yield r4, r5, r0, r6
-    111: Jump -101 (.L0)
+    112: Yield r4, r5, r0, r6
+    117: Jump -107 (.L0)
   .L9:
-    113: Ret r1
+    119: Ret r1
   Constant Table:
     0: [String: done]
     1: [String: value]
@@ -77,85 +77,86 @@
       6: LoadUndefined r4
       8: LoadTrue r5
   .L0:
-     10: JumpNullish r5, 36 (.L3)
+     10: JumpNullish r5, 38 (.L3)
      13: CallWithReceiver r6, r3, r2, r4, 1
      19: Await r6, r8, r0, r6
      24: JumpTrue r8, 5 (.L1)
      27: Throw r6
   .L1:
      29: CheckIteratorResultObject r6
-     31: GetNamedProperty r7, r6, c0
-     35: JumpTrue r7, 5 (.L2)
-     38: Jump 125 (.L14)
+     31: GetNamedProperty r7, r6, c0, k0
+     36: JumpTrue r7, 5 (.L2)
+     39: JumpConstant c5 (.L14)
   .L2:
-     40: GetNamedProperty r1, r6, c1
-     44: JumpConstant c5 (.L15)
+     41: GetNamedProperty r1, r6, c1, k1
+     46: JumpConstant c6 (.L15)
   .L3:
-     46: JumpNotUndefined r5, 55 (.L8)
-     49: GetMethod r8, r2, c3
-     53: JumpNotUndefined r8, 15 (.L5)
-     56: Await r4, r9, r0, r4
-     61: JumpTrue r9, 5 (.L4)
-     64: Throw r4
+     48: JumpNotUndefined r5, 57 (.L8)
+     51: GetMethod r8, r2, c3
+     55: JumpNotUndefined r8, 15 (.L5)
+     58: Await r4, r9, r0, r4
+     63: JumpTrue r9, 5 (.L4)
+     66: Throw r4
   .L4:
-     66: Ret r4
+     68: Ret r4
   .L5:
-     68: CallWithReceiver r6, r8, r2, r4, 1
-     74: Await r6, r8, r0, r6
-     79: JumpTrue r8, 5 (.L6)
-     82: Throw r6
+     70: CallWithReceiver r6, r8, r2, r4, 1
+     76: Await r6, r8, r0, r6
+     81: JumpTrue r8, 5 (.L6)
+     84: Throw r6
   .L6:
-     84: CheckIteratorResultObject r6
-     86: GetNamedProperty r7, r6, c0
-     90: JumpTrue r7, 5 (.L7)
-     93: Jump 70 (.L14)
+     86: CheckIteratorResultObject r6
+     88: GetNamedProperty r7, r6, c0, k2
+     93: JumpTrue r7, 5 (.L7)
+     96: Jump 73 (.L14)
   .L7:
-     95: GetNamedProperty r8, r6, c1
-     99: Ret r8
+     98: GetNamedProperty r8, r6, c1, k3
+    103: Ret r8
   .L8:
-    101: GetMethod r8, r2, c2
-    105: JumpNotUndefined r8, 25 (.L11)
-    108: AsyncIteratorCloseStart r10, r9, r2
-    112: JumpFalse r9, 15 (.L10)
-    115: Await r10, r11, r0, r10
-    120: JumpTrue r11, 5 (.L9)
-    123: Throw r10
+    105: GetMethod r8, r2, c2
+    109: JumpNotUndefined r8, 25 (.L11)
+    112: AsyncIteratorCloseStart r10, r9, r2
+    116: JumpFalse r9, 15 (.L10)
+    119: Await r10, r11, r0, r10
+    124: JumpTrue r11, 5 (.L9)
+    127: Throw r10
   .L9:
-    125: AsyncIteratorCloseFinish r10
+    129: AsyncIteratorCloseFinish r10
   .L10:
-    127: ThrowNewError 1, c4
+    131: ThrowNewError 1, c4
   .L11:
-    130: CallWithReceiver r6, r8, r2, r4, 1
-    136: Await r6, r8, r0, r6
-    141: JumpTrue r8, 5 (.L12)
-    144: Throw r6
+    134: CallWithReceiver r6, r8, r2, r4, 1
+    140: Await r6, r8, r0, r6
+    145: JumpTrue r8, 5 (.L12)
+    148: Throw r6
   .L12:
-    146: CheckIteratorResultObject r6
-    148: GetNamedProperty r7, r6, c0
-    152: JumpTrue r7, 5 (.L13)
-    155: Jump 8 (.L14)
+    150: CheckIteratorResultObject r6
+    152: GetNamedProperty r7, r6, c0, k4
+    157: JumpTrue r7, 5 (.L13)
+    160: Jump 9 (.L14)
   .L13:
-    157: GetNamedProperty r1, r6, c1
-    161: Jump 35 (.L15)
+    162: GetNamedProperty r1, r6, c1, k5
+    167: Jump 37 (.L15)
   .L14:
-    163: GetNamedProperty r8, r6, c1
-    167: Yield r4, r5, r0, r8
-    172: JumpNotUndefined (Wide) r5, -162 (.L0)
-    178: Await r4, r5, r0, r4
-    183: JumpNullish (Wide) r5, -173 (.L0)
-    190: LoadUndefined r5
-    192: Jump (Wide) -182 (.L0)
+    169: GetNamedProperty r8, r6, c1, k6
+    174: Yield r4, r5, r0, r8
+    179: JumpNotUndefined (Wide) r5, -169 (.L0)
+    186: Await r4, r5, r0, r4
+    191: JumpNullish (Wide) r5, -181 (.L0)
+    198: LoadUndefined r5
+    200: Jump (Wide) -190 (.L0)
   .L15:
-    196: Await r1, r2, r0, r1
-    201: JumpTrue r2, 5 (.L16)
-    204: Throw r1
+    204: Await r1, r2, r0, r1
+    209: JumpTrue r2, 5 (.L16)
+    212: Throw r1
   .L16:
-    206: Ret r1
+    214: Ret r1
   Constant Table:
     0: [String: done]
     1: [String: value]
     2: [String: throw]
     3: [String: return]
     4: [String: iterator does not have a throw method]
-    5: 152
+    5: 130
+    6: 158
 }

--- a/tests/snapshot/bytecode/function/parameters.exp
+++ b/tests/snapshot/bytecode/function/parameters.exp
@@ -39,16 +39,16 @@
 
 [BytecodeFunction: destructuring] {
   Parameters: 2, Registers: 5
-     0: GetNamedProperty r0, a0, c0
-     4: GetNamedProperty r1, a0, c1
-     8: GetNamedProperty r2, a1, c2
-    12: GetNamedProperty r4, a1, c3
-    16: JumpNotUndefined r4, 6 (.L0)
-    19: LoadImmediate r4, 1
+     0: GetNamedProperty r0, a0, c0, k0
+     5: GetNamedProperty r1, a0, c1, k1
+    10: GetNamedProperty r2, a1, c2, k2
+    15: GetNamedProperty r4, a1, c3, k3
+    20: JumpNotUndefined r4, 6 (.L0)
+    23: LoadImmediate r4, 1
   .L0:
-    22: Mov r3, r4
-    25: LoadUndefined r4
-    27: Ret r4
+    26: Mov r3, r4
+    29: LoadUndefined r4
+    31: Ret r4
   Constant Table:
     0: [String: a]
     1: [String: b]
@@ -84,9 +84,9 @@
 [BytecodeFunction: restDestructuring] {
   Parameters: 2, Registers: 2
     0: RestParameter r1
-    2: GetNamedProperty r0, r1, c0
-    6: LoadUndefined r1
-    8: Ret r1
+    2: GetNamedProperty r0, r1, c0, k0
+    7: LoadUndefined r1
+    9: Ret r1
   Constant Table:
     0: [String: c]
 }
@@ -94,17 +94,17 @@
 [BytecodeFunction: captured] {
   Parameters: 2, Registers: 2
      0: PushFunctionScope c0
-     2: GetNamedProperty r1, a0, c1
-     6: StoreToScope r1, 0, 0
-    10: JumpNotUndefined a1, 6 (.L0)
-    13: LoadImmediate a1, 1
+     2: GetNamedProperty r1, a0, c1, k0
+     7: StoreToScope r1, 0, 0
+    11: JumpNotUndefined a1, 6 (.L0)
+    14: LoadImmediate a1, 1
   .L0:
-    16: StoreToScope a1, 1, 0
-    20: RestParameter r1
-    22: StoreToScope r1, 2, 0
-    26: NewClosure r0, c2
-    29: LoadUndefined r1
-    31: Ret r1
+    17: StoreToScope a1, 1, 0
+    21: RestParameter r1
+    23: StoreToScope r1, 2, 0
+    27: NewClosure r0, c2
+    30: LoadUndefined r1
+    32: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: a]

--- a/tests/snapshot/bytecode/pattern/basic.exp
+++ b/tests/snapshot/bytecode/pattern/basic.exp
@@ -6,27 +6,27 @@
      9: StoreGlobal r0, c3
     12: LoadImmediate r0, 1
     15: LoadConstant r1, c4
-    18: GetNamedProperty r4, r0, c4
-    22: StoreGlobal r4, c4
-    25: LoadConstant r2, c5
-    28: GetNamedProperty r4, r0, c5
-    32: StoreGlobal r4, c6
-    35: LoadImmediate r5, 2
-    38: ToPropertyKey r3, r5
-    41: GetProperty r4, r0, r3
-    45: StoreGlobal r4, c7
-    48: ToObject r5, r0
-    51: NewObject r4
-    53: CopyDataProperties r4, r0, r1, 3
-    58: StoreGlobal r4, c8
-    61: PushLexicalScope c9
-    63: NewObject r0
-    65: StoreToScope r0, 0, 0
-    69: NewClosure r1, c11
-    72: DefineNamedProperty r0, c10, r1
-    76: PopScope 
-    77: LoadUndefined r0
-    79: Ret r0
+    18: GetNamedProperty r4, r0, c4, k0
+    23: StoreGlobal r4, c4
+    26: LoadConstant r2, c5
+    29: GetNamedProperty r4, r0, c5, k1
+    34: StoreGlobal r4, c6
+    37: LoadImmediate r5, 2
+    40: ToPropertyKey r3, r5
+    43: GetProperty r4, r0, r3
+    47: StoreGlobal r4, c7
+    50: ToObject r5, r0
+    53: NewObject r4
+    55: CopyDataProperties r4, r0, r1, 3
+    60: StoreGlobal r4, c8
+    63: PushLexicalScope c9
+    65: NewObject r0
+    67: StoreToScope r0, 0, 0
+    71: NewClosure r1, c11
+    74: DefineNamedProperty r0, c10, r1
+    78: PopScope 
+    79: LoadUndefined r0
+    81: Ret r0
   Constant Table:
     0: [BytecodeFunction: constants]
     1: [String: constants]
@@ -46,17 +46,17 @@
   Parameters: 0, Registers: 9
      0: LoadImmediate r4, 1
      3: LoadConstant r5, c0
-     6: GetNamedProperty r0, r4, c0
-    10: LoadConstant r6, c1
-    13: GetNamedProperty r1, r4, c1
-    17: LoadImmediate r8, 2
-    20: ToPropertyKey r7, r8
-    23: GetProperty r2, r4, r7
-    27: ToObject r8, r4
-    30: NewObject r3
-    32: CopyDataProperties r3, r4, r5, 3
-    37: LoadUndefined r4
-    39: Ret r4
+     6: GetNamedProperty r0, r4, c0, k0
+    11: LoadConstant r6, c1
+    14: GetNamedProperty r1, r4, c1, k1
+    19: LoadImmediate r8, 2
+    22: ToPropertyKey r7, r8
+    25: GetProperty r2, r4, r7
+    29: ToObject r8, r4
+    32: NewObject r3
+    34: CopyDataProperties r3, r4, r5, 3
+    39: LoadUndefined r4
+    41: Ret r4
   Constant Table:
     0: [String: a]
     1: [String: z]
@@ -65,10 +65,10 @@
 [BytecodeFunction: nestedMember] {
   Parameters: 1, Registers: 2
      0: LoadImmediate r0, 1
-     3: GetNamedProperty r1, r0, c1
-     7: SetNamedProperty a0, c0, r1
-    11: LoadUndefined r0
-    13: Ret r0
+     3: GetNamedProperty r1, r0, c1, k0
+     8: SetNamedProperty a0, c0, r1
+    12: LoadUndefined r0
+    14: Ret r0
   Constant Table:
     0: [String: b]
     1: [String: a]
@@ -79,10 +79,10 @@
      0: LoadImmediate r0, 1
      3: LoadFromScope r2, 0, 0
      7: LoadConstant r3, c0
-    10: GetNamedProperty r1, r0, c1
-    14: SetSuperProperty r2, <this>, r3, r1
-    19: LoadUndefined r0
-    21: Ret r0
+    10: GetNamedProperty r1, r0, c1, k0
+    15: SetSuperProperty r2, <this>, r3, r1
+    20: LoadUndefined r0
+    22: Ret r0
   Constant Table:
     0: [String: x]
     1: [String: a]

--- a/tests/snapshot/bytecode/pattern/iterator_destructuring.exp
+++ b/tests/snapshot/bytecode/pattern/iterator_destructuring.exp
@@ -307,38 +307,38 @@
   .L2:
     37: LoadUndefined r8
   .L3:
-    39: GetNamedProperty r1, r8, c0
-    43: JumpTrue r3, 50 (.L8)
-    46: LoadImmediate r4, 1
-    49: Jump 5 (.L4)
-    51: LoadImmediate r4, 0
+    39: GetNamedProperty r1, r8, c0, k0
+    44: JumpTrue r3, 50 (.L8)
+    47: LoadImmediate r4, 1
+    50: Jump 5 (.L4)
+    52: LoadImmediate r4, 0
   .L4:
-    54: Mov <scope>, r6
-    57: JumpTrue r3, 22 (.L6)
-    60: IteratorClose r2
-    62: Jump 17 (.L6)
-    64: LoadImmediate r7, 0
-    67: StrictNotEqual r7, r7, r4
-    71: JumpTrue r7, 6 (.L5)
-    74: Mov r6, r5
+    55: Mov <scope>, r6
+    58: JumpTrue r3, 22 (.L6)
+    61: IteratorClose r2
+    63: Jump 17 (.L6)
+    65: LoadImmediate r7, 0
+    68: StrictNotEqual r7, r7, r4
+    72: JumpTrue r7, 6 (.L5)
+    75: Mov r6, r5
   .L5:
-    77: Rethrow r6
+    78: Rethrow r6
   .L6:
-    79: LoadImmediate r6, 0
-    82: StrictEqual r6, r4, r6
-    86: JumpFalse r6, 5 (.L7)
-    89: Rethrow r5
+    80: LoadImmediate r6, 0
+    83: StrictEqual r6, r4, r6
+    87: JumpFalse r6, 5 (.L7)
+    90: Rethrow r5
   .L7:
-    91: Jump 2 (.L8)
+    92: Jump 2 (.L8)
   .L8:
-    93: LoadUndefined r2
-    95: Ret r2
+    94: LoadUndefined r2
+    96: Ret r2
   Constant Table:
     0: [String: b]
   Exception Handlers:
-    17-26 -> 51 (r5)
-    39-43 -> 51 (r5)
-    60-62 -> 64 (r6)
+    17-26 -> 52 (r5)
+    39-44 -> 52 (r5)
+    61-63 -> 65 (r6)
 }
 
 [BytecodeFunction: onlyRest] {
@@ -457,37 +457,37 @@
     24: Inc r9
     26: Jump -14 (.L0)
   .L1:
-    28: GetNamedProperty r0, r8, c0
-    32: JumpTrue r2, 50 (.L6)
-    35: LoadImmediate r3, 1
-    38: Jump 5 (.L2)
-    40: LoadImmediate r3, 0
+    28: GetNamedProperty r0, r8, c0, k0
+    33: JumpTrue r2, 50 (.L6)
+    36: LoadImmediate r3, 1
+    39: Jump 5 (.L2)
+    41: LoadImmediate r3, 0
   .L2:
-    43: Mov <scope>, r5
-    46: JumpTrue r2, 22 (.L4)
-    49: IteratorClose r1
-    51: Jump 17 (.L4)
-    53: LoadImmediate r6, 0
-    56: StrictNotEqual r6, r6, r3
-    60: JumpTrue r6, 6 (.L3)
-    63: Mov r5, r4
+    44: Mov <scope>, r5
+    47: JumpTrue r2, 22 (.L4)
+    50: IteratorClose r1
+    52: Jump 17 (.L4)
+    54: LoadImmediate r6, 0
+    57: StrictNotEqual r6, r6, r3
+    61: JumpTrue r6, 6 (.L3)
+    64: Mov r5, r4
   .L3:
-    66: Rethrow r5
+    67: Rethrow r5
   .L4:
-    68: LoadImmediate r5, 0
-    71: StrictEqual r5, r3, r5
-    75: JumpFalse r5, 5 (.L5)
-    78: Rethrow r4
+    69: LoadImmediate r5, 0
+    72: StrictEqual r5, r3, r5
+    76: JumpFalse r5, 5 (.L5)
+    79: Rethrow r4
   .L5:
-    80: Jump 2 (.L6)
+    81: Jump 2 (.L6)
   .L6:
-    82: LoadUndefined r1
-    84: Ret r1
+    83: LoadUndefined r1
+    85: Ret r1
   Constant Table:
     0: [String: b]
   Exception Handlers:
-    28-32 -> 40 (r4)
-    49-51 -> 53 (r5)
+    28-33 -> 41 (r4)
+    50-52 -> 54 (r5)
 }
 
 [BytecodeFunction: elementEvaluationOrder] {

--- a/tests/snapshot/bytecode/pattern/object_destructuring.exp
+++ b/tests/snapshot/bytecode/pattern/object_destructuring.exp
@@ -56,12 +56,12 @@
 [BytecodeFunction: shorthand] {
   Parameters: 1, Registers: 5
      0: LoadImmediate r4, 1
-     3: GetNamedProperty r0, r4, c0
-     7: GetNamedProperty r1, a0, c1
-    11: GetNamedProperty r2, a0, c2
-    15: GetNamedProperty r3, a0, c3
-    19: LoadUndefined r4
-    21: Ret r4
+     3: GetNamedProperty r0, r4, c0, k0
+     8: GetNamedProperty r1, a0, c1, k1
+    13: GetNamedProperty r2, a0, c2, k2
+    18: GetNamedProperty r3, a0, c3, k3
+    23: LoadUndefined r4
+    25: Ret r4
   Constant Table:
     0: [String: a]
     1: [String: b]
@@ -78,12 +78,12 @@
 
 [BytecodeFunction: propertyAliases] {
   Parameters: 1, Registers: 5
-     0: GetNamedProperty r0, a0, c0
-     4: GetNamedProperty r1, a0, c1
-     8: GetNamedProperty r2, a0, c2
-    12: GetNamedProperty r3, a0, c3
-    16: LoadUndefined r4
-    18: Ret r4
+     0: GetNamedProperty r0, a0, c0, k0
+     5: GetNamedProperty r1, a0, c1, k1
+    10: GetNamedProperty r2, a0, c2, k2
+    15: GetNamedProperty r3, a0, c3, k3
+    20: LoadUndefined r4
+    22: Ret r4
   Constant Table:
     0: [String: a]
     1: [String: b]
@@ -93,14 +93,14 @@
 
 [BytecodeFunction: nested] {
   Parameters: 1, Registers: 5
-     0: GetNamedProperty r3, a0, c0
-     4: GetNamedProperty r0, r3, c1
-     8: GetNamedProperty r3, a0, c2
-    12: GetNamedProperty r1, r3, c3
-    16: GetNamedProperty r4, r3, c4
-    20: GetNamedProperty r2, r4, c5
-    24: LoadUndefined r3
-    26: Ret r3
+     0: GetNamedProperty r3, a0, c0, k0
+     5: GetNamedProperty r0, r3, c1, k1
+    10: GetNamedProperty r3, a0, c2, k2
+    15: GetNamedProperty r1, r3, c3, k3
+    20: GetNamedProperty r4, r3, c4, k4
+    25: GetNamedProperty r2, r4, c5, k5
+    30: LoadUndefined r3
+    32: Ret r3
   Constant Table:
     0: [String: a]
     1: [String: b]
@@ -124,34 +124,34 @@
 
 [BytecodeFunction: defaultValue] {
   Parameters: 2, Registers: 6
-     0: GetNamedProperty r4, a0, c0
-     4: JumpNotUndefined r4, 6 (.L0)
-     7: LoadImmediate r4, 1
+     0: GetNamedProperty r4, a0, c0, k0
+     5: JumpNotUndefined r4, 6 (.L0)
+     8: LoadImmediate r4, 1
   .L0:
-    10: Mov r0, r4
-    13: GetNamedProperty r4, a0, c0
-    17: JumpNotUndefined r4, 6 (.L1)
-    20: LoadImmediate r4, 1
+    11: Mov r0, r4
+    14: GetNamedProperty r4, a0, c0, k1
+    19: JumpNotUndefined r4, 6 (.L1)
+    22: LoadImmediate r4, 1
   .L1:
-    23: Mov r1, r4
-    26: GetNamedProperty r4, a0, c1
-    30: JumpNotUndefined r4, 6 (.L2)
-    33: Mov r4, a1
+    25: Mov r1, r4
+    28: GetNamedProperty r4, a0, c1, k2
+    33: JumpNotUndefined r4, 6 (.L2)
+    36: Mov r4, a1
   .L2:
-    36: Mov r2, r4
-    39: GetNamedProperty r4, a0, c0
-    43: JumpNotUndefined r4, 6 (.L3)
-    46: Mov r4, a1
+    39: Mov r2, r4
+    42: GetNamedProperty r4, a0, c0, k3
+    47: JumpNotUndefined r4, 6 (.L3)
+    50: Mov r4, a1
   .L3:
-    49: Mov r3, r4
-    52: LoadImmediate r5, 1
-    55: GetProperty r4, a0, r5
-    59: JumpNotUndefined r4, 6 (.L4)
-    62: LoadImmediate r4, 2
+    53: Mov r3, r4
+    56: LoadImmediate r5, 1
+    59: GetProperty r4, a0, r5
+    63: JumpNotUndefined r4, 6 (.L4)
+    66: LoadImmediate r4, 2
   .L4:
-    65: Mov r0, r4
-    68: LoadUndefined r4
-    70: Ret r4
+    69: Mov r0, r4
+    72: LoadUndefined r4
+    74: Ret r4
   Constant Table:
     0: [String: a]
     1: [String: c]
@@ -160,21 +160,21 @@
 [BytecodeFunction: namedExpression] {
   Parameters: 0, Registers: 4
      0: NewClosure r2, c0
-     3: GetNamedProperty r0, r2, c1
-     7: LoadImmediate r2, 1
-    10: GetNamedProperty r3, r2, c1
-    14: JumpNotUndefined r3, 6 (.L0)
-    17: NewClosure r3, c2
+     3: GetNamedProperty r0, r2, c1, k0
+     8: LoadImmediate r2, 1
+    11: GetNamedProperty r3, r2, c1, k1
+    16: JumpNotUndefined r3, 6 (.L0)
+    19: NewClosure r3, c2
   .L0:
-    20: Mov r0, r3
-    23: LoadImmediate r2, 1
-    26: GetNamedProperty r3, r2, c1
-    30: JumpNotUndefined r3, 6 (.L1)
-    33: NewClosure r3, c3
+    22: Mov r0, r3
+    25: LoadImmediate r2, 1
+    28: GetNamedProperty r3, r2, c1, k2
+    33: JumpNotUndefined r3, 6 (.L1)
+    36: NewClosure r3, c3
   .L1:
-    36: Mov r1, r3
-    39: LoadUndefined r2
-    41: Ret r2
+    39: Mov r1, r3
+    42: LoadUndefined r2
+    44: Ret r2
   Constant Table:
     0: [BytecodeFunction: <anonymous>]
     1: [String: a]
@@ -206,25 +206,25 @@
      3: NewObject r0
      5: CopyDataProperties r0, a0, a0, 0
     10: LoadConstant r5, c0
-    13: GetNamedProperty r0, a0, c0
-    17: LoadConstant r6, c1
-    20: GetNamedProperty r1, a0, c1
-    24: ToObject r7, a0
-    27: NewObject r2
-    29: CopyDataProperties r2, a0, r5, 2
-    34: LoadConstant r5, c0
-    37: GetNamedProperty r0, a0, c0
-    41: LoadImmediate r8, 1
-    44: ToPropertyKey r6, r8
-    47: GetProperty r1, a0, r6
-    51: LoadImmediate r8, 2
-    54: ToPropertyKey r7, r8
-    57: GetProperty r3, a0, r7
-    61: ToObject r8, a0
-    64: NewObject r4
-    66: CopyDataProperties r4, a0, r5, 3
-    71: LoadUndefined r5
-    73: Ret r5
+    13: GetNamedProperty r0, a0, c0, k0
+    18: LoadConstant r6, c1
+    21: GetNamedProperty r1, a0, c1, k1
+    26: ToObject r7, a0
+    29: NewObject r2
+    31: CopyDataProperties r2, a0, r5, 2
+    36: LoadConstant r5, c0
+    39: GetNamedProperty r0, a0, c0, k2
+    44: LoadImmediate r8, 1
+    47: ToPropertyKey r6, r8
+    50: GetProperty r1, a0, r6
+    54: LoadImmediate r8, 2
+    57: ToPropertyKey r7, r8
+    60: GetProperty r3, a0, r7
+    64: ToObject r8, a0
+    67: NewObject r4
+    69: CopyDataProperties r4, a0, r5, 3
+    74: LoadUndefined r5
+    76: Ret r5
   Constant Table:
     0: [String: a]
     1: [String: b]
@@ -233,11 +233,11 @@
 [BytecodeFunction: propertyNamesNotResolved] {
   Parameters: 0, Registers: 4
      0: LoadImmediate r2, 1
-     3: GetNamedProperty r0, r2, c0
-     7: GetNamedProperty r3, r2, c1
-    11: GetNamedProperty r1, r3, c0
-    15: LoadUndefined r2
-    17: Ret r2
+     3: GetNamedProperty r0, r2, c0, k0
+     8: GetNamedProperty r3, r2, c1, k1
+    13: GetNamedProperty r1, r3, c0, k2
+    18: LoadUndefined r2
+    20: Ret r2
   Constant Table:
     0: [String: a]
     1: [String: b]
@@ -247,11 +247,11 @@
   Parameters: 0, Registers: 3
      0: LoadEmpty r0
      2: LoadImmediate r2, 1
-     5: GetNamedProperty r0, r2, c0
-     9: CheckTdz r0, c0
-    12: GetProperty r1, r2, r0
-    16: LoadUndefined r2
-    18: Ret r2
+     5: GetNamedProperty r0, r2, c0, k0
+    10: CheckTdz r0, c0
+    13: GetProperty r1, r2, r0
+    17: LoadUndefined r2
+    19: Ret r2
   Constant Table:
     0: [String: a]
 }
@@ -282,18 +282,18 @@
      0: LoadGlobal r0, c0
      3: Call r0, r0, r0, 0
      8: LoadConstant r1, c1
-    11: GetNamedProperty r2, r0, c1
-    15: StoreGlobal r2, c1
-    18: LoadGlobal r3, c2
-    21: Call r3, r3, r3, 0
-    26: LoadGlobal r4, c3
-    29: Call r4, r4, r4, 0
-    34: ToObject r5, r0
-    37: NewObject r2
-    39: CopyDataProperties r2, r0, r1, 1
-    44: SetProperty r3, r4, r2
-    48: LoadUndefined r0
-    50: Ret r0
+    11: GetNamedProperty r2, r0, c1, k0
+    16: StoreGlobal r2, c1
+    19: LoadGlobal r3, c2
+    22: Call r3, r3, r3, 0
+    27: LoadGlobal r4, c3
+    30: Call r4, r4, r4, 0
+    35: ToObject r5, r0
+    38: NewObject r2
+    40: CopyDataProperties r2, r0, r1, 1
+    45: SetProperty r3, r4, r2
+    49: LoadUndefined r0
+    51: Ret r0
   Constant Table:
     0: [String: d]
     1: [String: a]

--- a/tests/snapshot/bytecode/scope/catch.exp
+++ b/tests/snapshot/bytecode/scope/catch.exp
@@ -25,23 +25,23 @@
   Parameters: 0, Registers: 6
      0: Mov r3, <scope>
      3: LoadImmediate r4, 1
-     6: Jump 38 (.L1)
+     6: Jump 40 (.L1)
      8: Mov <scope>, r3
     11: LoadEmpty r1
-    13: GetNamedProperty r5, r4, c0
-    17: JumpNotUndefined r5, 9 (.L0)
-    20: CheckTdz r1, c1
-    23: Mov r5, r1
+    13: GetNamedProperty r5, r4, c0, k0
+    18: JumpNotUndefined r5, 9 (.L0)
+    21: CheckTdz r1, c1
+    24: Mov r5, r1
   .L0:
-    26: Mov r0, r5
-    29: GetNamedProperty r1, r4, c1
-    33: LoadEmpty r2
-    35: LoadImmediate r4, 2
-    38: CheckTdz r2, c2
-    41: LoadImmediate r2, 1
+    27: Mov r0, r5
+    30: GetNamedProperty r1, r4, c1, k1
+    35: LoadEmpty r2
+    37: LoadImmediate r4, 2
+    40: CheckTdz r2, c2
+    43: LoadImmediate r2, 1
   .L1:
-    44: LoadUndefined r3
-    46: Ret r3
+    46: LoadUndefined r3
+    48: Ret r3
   Constant Table:
     0: [String: a]
     1: [String: b]

--- a/tests/snapshot/bytecode/scope/function.exp
+++ b/tests/snapshot/bytecode/scope/function.exp
@@ -61,25 +61,25 @@
   Parameters: 3, Registers: 2
      0: PushFunctionScope c0
      2: StoreToScope a0, 0, 0
-     6: GetNamedProperty r1, a1, c1
-    10: StoreToScope r1, 1, 0
-    14: JumpNotUndefined a2, 6 (.L0)
-    17: LoadImmediate a2, 2
+     6: GetNamedProperty r1, a1, c1, k0
+    11: StoreToScope r1, 1, 0
+    15: JumpNotUndefined a2, 6 (.L0)
+    18: LoadImmediate a2, 2
   .L0:
-    20: StoreToScope a2, 2, 0
-    24: RestParameter r1
-    26: StoreToScope r1, 3, 0
-    30: NewClosure r0, c2
-    33: LoadImmediate r1, 1
-    36: StoreToScope r1, 0, 0
-    40: LoadImmediate r1, 2
-    43: StoreToScope r1, 1, 0
-    47: LoadImmediate r1, 3
-    50: StoreToScope r1, 2, 0
-    54: LoadImmediate r1, 4
-    57: StoreToScope r1, 3, 0
-    61: LoadUndefined r1
-    63: Ret r1
+    21: StoreToScope a2, 2, 0
+    25: RestParameter r1
+    27: StoreToScope r1, 3, 0
+    31: NewClosure r0, c2
+    34: LoadImmediate r1, 1
+    37: StoreToScope r1, 0, 0
+    41: LoadImmediate r1, 2
+    44: StoreToScope r1, 1, 0
+    48: LoadImmediate r1, 3
+    51: StoreToScope r1, 2, 0
+    55: LoadImmediate r1, 4
+    58: StoreToScope r1, 3, 0
+    62: LoadUndefined r1
+    64: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: y]

--- a/tests/snapshot/bytecode/statement/for_in.exp
+++ b/tests/snapshot/bytecode/statement/for_in.exp
@@ -158,41 +158,41 @@
   Parameters: 1, Registers: 6
      0: LoadImmediate r3, 1
      3: NewObject r3
-     5: JumpNullish r3, 38 (.L2)
+     5: JumpNullish r3, 41 (.L2)
      8: NewForInIterator r3, r3
   .L0:
     11: ForInNext r4, r3
-    14: JumpNullish r4, 29 (.L2)
-    17: GetNamedProperty r0, r4, c0
-    21: GetNamedProperty r1, r4, c1
-    25: GetNamedProperty r5, r4, c2
-    29: JumpNotUndefined r5, 6 (.L1)
-    32: LoadImmediate r5, 1
+    14: JumpNullish r4, 32 (.L2)
+    17: GetNamedProperty r0, r4, c0, k0
+    22: GetNamedProperty r1, r4, c1, k1
+    27: GetNamedProperty r5, r4, c2, k2
+    32: JumpNotUndefined r5, 6 (.L1)
+    35: LoadImmediate r5, 1
   .L1:
-    35: Mov r2, r5
-    38: LoadImmediate r4, 2
-    41: Jump -30 (.L0)
+    38: Mov r2, r5
+    41: LoadImmediate r4, 2
+    44: Jump -33 (.L0)
   .L2:
-    43: LoadImmediate r3, 3
-    46: NewObject r3
-    48: JumpNullish r3, 38 (.L5)
-    51: NewForInIterator r3, r3
+    46: LoadImmediate r3, 3
+    49: NewObject r3
+    51: JumpNullish r3, 41 (.L5)
+    54: NewForInIterator r3, r3
   .L3:
-    54: ForInNext r4, r3
-    57: JumpNullish r4, 29 (.L5)
-    60: GetNamedProperty r0, r4, c0
-    64: GetNamedProperty r1, r4, c1
-    68: GetNamedProperty r5, r4, c2
-    72: JumpNotUndefined r5, 6 (.L4)
-    75: LoadImmediate r5, 1
+    57: ForInNext r4, r3
+    60: JumpNullish r4, 32 (.L5)
+    63: GetNamedProperty r0, r4, c0, k3
+    68: GetNamedProperty r1, r4, c1, k4
+    73: GetNamedProperty r5, r4, c2, k5
+    78: JumpNotUndefined r5, 6 (.L4)
+    81: LoadImmediate r5, 1
   .L4:
-    78: Mov r2, r5
-    81: LoadImmediate r4, 4
-    84: Jump -30 (.L3)
+    84: Mov r2, r5
+    87: LoadImmediate r4, 4
+    90: Jump -33 (.L3)
   .L5:
-    86: LoadImmediate r3, 5
-    89: LoadUndefined r3
-    91: Ret r3
+    92: LoadImmediate r3, 5
+    95: LoadUndefined r3
+    97: Ret r3
   Constant Table:
     0: [String: a]
     1: [String: b]

--- a/tests/snapshot/bytecode/statement/for_of.exp
+++ b/tests/snapshot/bytecode/statement/for_of.exp
@@ -252,59 +252,59 @@
       5: GetIterator r3, r4, r5
   .L0:
       9: IteratorNext r5, r6, r3, r4
-     14: JumpTrue r6, 44 (.L3)
-     17: GetNamedProperty r0, r5, c0
-     21: GetNamedProperty r1, r5, c1
-     25: GetNamedProperty r6, r5, c2
-     29: JumpNotUndefined r6, 6 (.L1)
-     32: LoadImmediate r6, 1
+     14: JumpTrue r6, 47 (.L3)
+     17: GetNamedProperty r0, r5, c0, k0
+     22: GetNamedProperty r1, r5, c1, k1
+     27: GetNamedProperty r6, r5, c2, k2
+     32: JumpNotUndefined r6, 6 (.L1)
+     35: LoadImmediate r6, 1
   .L1:
-     35: Mov r2, r6
-     38: Mov r7, <scope>
-     41: LoadImmediate r8, 2
-     44: Jump 12 (.L2)
-     46: LoadImmediate r5, 0
-     49: Mov <scope>, r7
-     52: IteratorClose r3
-     54: Rethrow r6
+     38: Mov r2, r6
+     41: Mov r7, <scope>
+     44: LoadImmediate r8, 2
+     47: Jump 12 (.L2)
+     49: LoadImmediate r5, 0
+     52: Mov <scope>, r7
+     55: IteratorClose r3
+     57: Rethrow r6
   .L2:
-     56: Jump -47 (.L0)
+     59: Jump -50 (.L0)
   .L3:
-     58: LoadImmediate r3, 3
-     61: NewArray r5
-     63: GetIterator r3, r4, r5
+     61: LoadImmediate r3, 3
+     64: NewArray r5
+     66: GetIterator r3, r4, r5
   .L4:
-     67: IteratorNext r5, r6, r3, r4
-     72: JumpTrue r6, 44 (.L7)
-     75: GetNamedProperty r0, r5, c0
-     79: GetNamedProperty r1, r5, c1
-     83: GetNamedProperty r6, r5, c2
-     87: JumpNotUndefined r6, 6 (.L5)
-     90: LoadImmediate r6, 1
+     70: IteratorNext r5, r6, r3, r4
+     75: JumpTrue r6, 47 (.L7)
+     78: GetNamedProperty r0, r5, c0, k3
+     83: GetNamedProperty r1, r5, c1, k4
+     88: GetNamedProperty r6, r5, c2, k5
+     93: JumpNotUndefined r6, 6 (.L5)
+     96: LoadImmediate r6, 1
   .L5:
-     93: Mov r2, r6
-     96: Mov r7, <scope>
-     99: LoadImmediate r8, 4
-    102: Jump 12 (.L6)
-    104: LoadImmediate r5, 0
-    107: Mov <scope>, r7
-    110: IteratorClose r3
-    112: Rethrow r6
+     99: Mov r2, r6
+    102: Mov r7, <scope>
+    105: LoadImmediate r8, 4
+    108: Jump 12 (.L6)
+    110: LoadImmediate r5, 0
+    113: Mov <scope>, r7
+    116: IteratorClose r3
+    118: Rethrow r6
   .L6:
-    114: Jump -47 (.L4)
+    120: Jump -50 (.L4)
   .L7:
-    116: LoadImmediate r3, 5
-    119: LoadUndefined r3
-    121: Ret r3
+    122: LoadImmediate r3, 5
+    125: LoadUndefined r3
+    127: Ret r3
   Constant Table:
     0: [String: a]
     1: [String: b]
     2: [String: d]
   Exception Handlers:
-    17-44 -> 46 (r6)
-    52-54 -> 54
-    75-102 -> 104 (r6)
-    110-112 -> 112
+    17-47 -> 49 (r6)
+    55-57 -> 57
+    78-108 -> 110 (r6)
+    116-118 -> 118
 }
 
 [BytecodeFunction: lhsTdz] {

--- a/tests/snapshot/bytecode/statement/try/catch.exp
+++ b/tests/snapshot/bytecode/statement/try/catch.exp
@@ -55,19 +55,19 @@
      0: LoadImmediate r2, 1
      3: Mov r2, <scope>
      6: LoadImmediate r3, 2
-     9: Jump 25 (.L1)
+     9: Jump 27 (.L1)
     11: Mov <scope>, r2
-    14: GetNamedProperty r0, r3, c0
-    18: GetNamedProperty r4, r3, c1
-    22: JumpNotUndefined r4, 6 (.L0)
-    25: LoadImmediate r4, 3
+    14: GetNamedProperty r0, r3, c0, k0
+    19: GetNamedProperty r4, r3, c1, k1
+    24: JumpNotUndefined r4, 6 (.L0)
+    27: LoadImmediate r4, 3
   .L0:
-    28: Mov r1, r4
-    31: LoadImmediate r3, 4
+    30: Mov r1, r4
+    33: LoadImmediate r3, 4
   .L1:
-    34: LoadImmediate r2, 5
-    37: LoadUndefined r2
-    39: Ret r2
+    36: LoadImmediate r2, 5
+    39: LoadUndefined r2
+    41: Ret r2
   Constant Table:
     0: [String: a]
     1: [String: b]

--- a/tests/snapshot/bytecode/statement/try/finally.exp
+++ b/tests/snapshot/bytecode/statement/try/finally.exp
@@ -120,31 +120,31 @@
      3: Mov r3, <scope>
      6: LoadImmediate r4, 2
      9: LoadImmediate r1, 1
-    12: Jump 20 (.L0)
+    12: Jump 21 (.L0)
     14: Mov <scope>, r3
-    17: GetNamedProperty r0, r4, c0
-    21: LoadImmediate r4, 3
-    24: LoadImmediate r1, 1
-    27: Jump 5 (.L0)
-    29: LoadImmediate r1, 0
+    17: GetNamedProperty r0, r4, c0, k0
+    22: LoadImmediate r4, 3
+    25: LoadImmediate r1, 1
+    28: Jump 5 (.L0)
+    30: LoadImmediate r1, 0
   .L0:
-    32: Mov <scope>, r3
-    35: LoadImmediate r3, 4
-    38: LoadImmediate r3, 0
-    41: StrictEqual r3, r1, r3
-    45: JumpFalse r3, 5 (.L1)
-    48: Rethrow r2
+    33: Mov <scope>, r3
+    36: LoadImmediate r3, 4
+    39: LoadImmediate r3, 0
+    42: StrictEqual r3, r1, r3
+    46: JumpFalse r3, 5 (.L1)
+    49: Rethrow r2
   .L1:
-    50: Jump 2 (.L2)
+    51: Jump 2 (.L2)
   .L2:
-    52: LoadImmediate r1, 5
-    55: LoadUndefined r1
-    57: Ret r1
+    53: LoadImmediate r1, 5
+    56: LoadUndefined r1
+    58: Ret r1
   Constant Table:
     0: [String: e]
   Exception Handlers:
     6-9 -> 14 (r4)
-    14-24 -> 29 (r2)
+    14-25 -> 30 (r2)
 }
 
 [BytecodeFunction: nested] {


### PR DESCRIPTION
## Summary

Implement the first property cache, for the `GetNamedProperty` instruction. This uses the recently implemented shapes and prototype chain validity guards to cache the location of property lookups. Own properties only need to cache the shape while prototype properties need to cache the prototype object, shape, and validity guard.

We have a fast path now to check the `GetNamedPropertyCache` for the instruction (lazily initialized). On a cache miss we perform the existing full property lookup, then write the cached location if desired.

Set up general infra for adding more caches:
- Cache indices and a cache array generated for bytecode function
- Wrote simple `ValidityGuard` wrapper
- `Cache` set up to be extended with new variants as caches are added

Polymorphic caches are currently not supported (nor are megamorphic caches of any form). The first time we see multiple shapes we stop caching entirely.

Significant performance impact. This instruction cache alone is +11% on octane.

| Benchmark | Before | After | Change |
|:---|---:|---:|---:|
| Richards | 399 | 557 | +39.6% |
| DeltaBlue | 572 | 804 | +40.6% |
| Crypto | 490 | 531 | +8.4% |
| RayTrace | 1,106 | 1,371 | +24.0% |
| EarleyBoyer | 1,707 | 1,888 | +10.6% |
| RegExp | 356 | 367 | +3.1% |
| Splay | 2,369 | 2,318 | -2.2% |
| SplayLatency | 5,952 | 6,132 | +3.0% |
| NavierStokes | 608 | 627 | +3.1% |
| PdfJS | 2,489 | 2,674 | +7.4% |
| Mandreel | 257 | 264 | +2.7% |
| MandreelLatency | 1,623 | 1,678 | +3.4% |
| Gameboy | 2,337 | 2,384 | +2.0% |
| CodeLoad | 38,355 | 38,155 | -0.5% |
| Box2D | 1,757 | 2,588 | +47.3% |
| zlib | 843 | 842 | -0.1% |
| Typescript | 7,923 | 9,369 | +18.3% |
| **Total (octane)** | **1,470** | **1,638** | **+11.4%** |

## Tests

- CI
- Assorted integration tests that hit various `GetNamedProperty` cache paths
- Updated all bytecode snapshot instructions that used `GetNamedProperty` to include the cache index