### PR TITLE
[runtime] Store caches array directly in the stack frame

### DIFF
--- a/src/js/runtime/bytecode/stack_frame.rs
+++ b/src/js/runtime/bytecode/stack_frame.rs
@@ -3,7 +3,10 @@ use crate::{
     impl_array_instance,
     runtime::{
         HeapPtr, Value,
-        bytecode::{constant_table::ConstantTable, function::ClosureObject},
+        bytecode::{
+            constant_table::ConstantTable,
+            function::{CacheArray, ClosureObject},
+        },
         collections::ArrayInstance,
         gc::{HeapItem, HeapVisitor},
         scope::Scope,
@@ -20,12 +23,14 @@ use crate::{
 ///     |       ...        |
 ///     +------------------+
 ///     |       arg0       |  (first arg)
-/// +64 +------------------+                     ^                ^
+/// +72 +------------------+                     ^                ^
 ///     |     receiver     |  (receiver)         | caller's frame |
-/// +56 +------------------+                     +----------------+
+/// +64 +------------------+                     +----------------+
 ///     |       argc       |                     | callee's frame |
-/// +48 +------------------+                     v                v
+/// +56 +------------------+                     v                v
 ///     |      closure     |  (closure of the caller)
+/// +48 +------------------+
+///     |      caches      |  (caches of the called closure)
 /// +40 +------------------+
 ///     |  constant_table  |  (constant table of the called closure)
 /// +32 +------------------+
@@ -195,6 +200,19 @@ impl StackFrame {
         unsafe { &mut *(self.fp.add(CONSTANT_TABLE_SLOT_INDEX) as *mut HeapPtr<ConstantTable>) }
     }
 
+    /// The caches of the callee function in this stack frame.
+    #[inline]
+    pub fn caches(&self) -> HeapPtr<CacheArray> {
+        let ptr = unsafe { *self.fp.add(CACHES_SLOT_INDEX) };
+        HeapPtr::from_ptr(ptr as *mut CacheArray)
+    }
+
+    /// A mutable reference to the caches of the callee function in this stack frame.
+    #[inline]
+    pub fn caches_mut(&mut self) -> &mut HeapPtr<CacheArray> {
+        unsafe { &mut *(self.fp.add(CACHES_SLOT_INDEX) as *mut HeapPtr<CacheArray>) }
+    }
+
     /// The callee function in this stack frame.
     #[inline]
     pub fn closure(&self) -> HeapPtr<ClosureObject> {
@@ -281,6 +299,7 @@ impl StackFrame {
 
         visitor.visit_pointer(self.closure_mut());
         visitor.visit_pointer(self.constant_table_mut());
+        visitor.visit_pointer(self.caches_mut());
         visitor.visit_pointer(self.scope_mut());
     }
 }
@@ -321,13 +340,15 @@ pub const SCOPE_SLOT_INDEX: usize = 3;
 
 const CONSTANT_TABLE_SLOT_INDEX: usize = 4;
 
-pub const CLOSURE_SLOT_INDEX: usize = 5;
+const CACHES_SLOT_INDEX: usize = 5;
 
-const ARGC_SLOT_INDEX: usize = 6;
+pub const CLOSURE_SLOT_INDEX: usize = 6;
 
-pub const RECEIVER_SLOT_INDEX: usize = 7;
+const ARGC_SLOT_INDEX: usize = 7;
 
-pub const FIRST_ARGUMENT_SLOT_INDEX: usize = 8;
+pub const RECEIVER_SLOT_INDEX: usize = 8;
+
+pub const FIRST_ARGUMENT_SLOT_INDEX: usize = 9;
 
 // An array of opaque stack slot values. Can not be interpreted on its own, we need to know the FP
 // in order to know the layout of the stack frame.

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -27,7 +27,7 @@ use crate::{
                 SetNamedPropertyCacheResult,
             },
             constant_table::ConstantTable,
-            function::{BytecodeFunction, ClosureObject},
+            function::{BytecodeFunction, CacheArray, ClosureObject},
             generator::BytecodeScript,
             instruction::{
                 AddInstruction, AsyncIteratorCloseFinishInstruction,
@@ -1413,6 +1413,11 @@ impl VM {
     }
 
     #[inline]
+    fn caches(&self) -> HeapPtr<CacheArray> {
+        self.stack_frame().caches()
+    }
+
+    #[inline]
     fn argc(&self) -> usize {
         self.stack_frame().argc()
     }
@@ -1477,20 +1482,12 @@ impl VM {
 
     #[inline]
     fn get_cache<W: Width>(&self, cache_index: CacheIndex<W>) -> Cache {
-        self.closure()
-            .function_ptr()
-            .caches_ptr()
-            .unwrap()
-            .get(cache_index.value().to_usize())
+        self.caches().get(cache_index.value().to_usize())
     }
 
     #[inline]
     fn set_cache<W: Width>(&mut self, cache_index: CacheIndex<W>, cache: Cache) {
-        self.closure()
-            .function_ptr()
-            .caches_ptr()
-            .unwrap()
-            .set(cache_index.value().to_usize(), cache);
+        self.caches().set(cache_index.value().to_usize(), cache);
     }
 
     /// Set the PC to the jump target, specified as a relative offset immediate.
@@ -2097,6 +2094,14 @@ impl VM {
 
         // Push the function
         self.push(closure.as_ptr() as StackSlotValue);
+
+        // Push the caches
+        let caches = unsafe {
+            std::mem::transmute::<Option<HeapPtr<CacheArray>>, usize>(
+                bytecode_function.caches_ptr(),
+            )
+        };
+        self.push(caches);
 
         // Push the constant table
         let constant_table = unsafe {


### PR DESCRIPTION
## Summary

Accessing a cache for a function currently requires a sequence of dependent loads starting from the closure -> function -> caches -> unwrap -> get. This will become an increasingly common operation so let's reduce it as much as possible by storing the caches array directly in the stack frame (and eliding the unwrap).

Seeing roughly ~0.5% increase on octane score.

## Tests

- CI