### PR TITLE
[bytecode] Store PropertyKeys directly into constant table

### DIFF
--- a/src/js/runtime/bytecode/constant_table_builder.rs
+++ b/src/js/runtime/bytecode/constant_table_builder.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, hash};
 
 use crate::runtime::{
-    Context, Handle, Value,
+    Context, Handle, PropertyKey, Value,
     alloc_error::AllocResult,
     bytecode::{
         constant_table::ConstantTable,
@@ -19,6 +19,8 @@ enum ConstantTableEntry {
     String(Handle<FlatString>),
     /// Generic heap items - not deduplicated, so keep a unique incremented index as a unique id.
     HeapItem { item: Handle<AnyHeapItem>, key: ConstantTableIndex },
+    /// A property key that is a valid array index, stored as a smi. Cannot contain u32::MAX.
+    ArrayIndex(u32),
     /// Double encoded as a value.
     Double(Value),
     /// Jump offset in bytes, not encoded as a value.
@@ -32,6 +34,11 @@ impl ConstantTableEntry {
         match self {
             ConstantTableEntry::String(string) => ToValueResult::Value(string.cast()),
             ConstantTableEntry::HeapItem { item, .. } => ToValueResult::Value(item.cast()),
+            // Intentionally store the u32 array index in the i32 smi payload, matching PropertyKey
+            ConstantTableEntry::ArrayIndex(index) => {
+                let raw_value = PropertyKey::array_index_unchecked(index).to_raw_value();
+                ToValueResult::Value(raw_value.to_handle(cx))
+            }
             ConstantTableEntry::Double(double) => ToValueResult::Value(double.to_handle(cx)),
             // Bytecode offsets are stored directly, not encoded as a value
             ConstantTableEntry::BytecodeOffset(offset) => {
@@ -64,6 +71,9 @@ impl PartialEq for ConstantTableEntry {
                 ConstantTableEntry::HeapItem { key: lhs, .. },
                 ConstantTableEntry::HeapItem { key: rhs, .. },
             ) => lhs == rhs,
+            (ConstantTableEntry::ArrayIndex(lhs), ConstantTableEntry::ArrayIndex(rhs)) => {
+                lhs == rhs
+            }
             (ConstantTableEntry::Double(lhs), ConstantTableEntry::Double(rhs)) => {
                 lhs.as_raw_bits() == rhs.as_raw_bits()
             }
@@ -83,6 +93,7 @@ impl hash::Hash for ConstantTableEntry {
             ConstantTableEntry::String(string) => string.hash(state),
             // Heap items are not deduplicated, so use the unique key
             ConstantTableEntry::HeapItem { key, .. } => key.hash(state),
+            ConstantTableEntry::ArrayIndex(index) => index.hash(state),
             // Use raw bits as hash for doubles. Note that this differentiates between +0 and -0,
             // unlike values used as ValueCollectionKeys.
             ConstantTableEntry::Double(double) => double.as_raw_bits().hash(state),
@@ -303,6 +314,12 @@ impl ConstantTableBuilder {
     pub fn add_string(&mut self, string: Handle<FlatString>) -> EmitResult<ConstantTableIndex> {
         debug_assert!(string.is_interned());
         self.insert_if_missing(ConstantTableEntry::String(string))
+    }
+
+    /// Add an array index property key to the constant table.
+    pub fn add_array_index(&mut self, index: u32) -> EmitResult<ConstantTableIndex> {
+        debug_assert!(index != u32::MAX);
+        self.insert_if_missing(ConstantTableEntry::ArrayIndex(index))
     }
 
     pub fn add_heap_item(&mut self, item: Handle<AnyHeapItem>) -> EmitResult<ConstantTableIndex> {

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -62,6 +62,7 @@ use crate::{
                 NamedReExportEntry, SourceTextModule,
             },
         },
+        property_key::PropertyKey,
         regexp::compiler::compile_regexp,
         scope::Scope,
         scope_names::{ScopeFlags, ScopeNameFlags, ScopeNames},
@@ -1743,6 +1744,38 @@ impl<'a> BytecodeFunctionGenerator<'a> {
     fn add_wtf8_string_constant(&mut self, str: &Wtf8Str) -> EmitResult<GenConstantIndex> {
         let string = self.get_cached_wtf8_str(str)?.as_flat();
         let constant_index = self.constant_table_builder.add_string(string)?;
+        Ok(ConstantIndex::new(constant_index))
+    }
+
+    fn add_string_property_key_constant(
+        &mut self,
+        str: &'static str,
+    ) -> EmitResult<GenConstantIndex> {
+        let string = self.get_cached_static_str(str)?.as_flat();
+        self.add_property_key_constant(string)
+    }
+
+    fn add_wtf8_string_property_key_constant(
+        &mut self,
+        str: &Wtf8Str,
+    ) -> EmitResult<GenConstantIndex> {
+        let string = self.get_cached_wtf8_str(str)?.as_flat();
+        self.add_property_key_constant(string)
+    }
+
+    fn add_property_key_constant(
+        &mut self,
+        string: Handle<FlatString>,
+    ) -> EmitResult<GenConstantIndex> {
+        // Property keys are stored as either valid array indices or strings
+        let key = PropertyKey::from_interned_string(self.cx, string)?;
+        let constant_index = if key.is_array_index() {
+            self.constant_table_builder
+                .add_array_index(key.as_array_index())?
+        } else {
+            self.constant_table_builder.add_string(string)?
+        };
+
         Ok(ConstantIndex::new(constant_index))
     }
 
@@ -4149,14 +4182,15 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             } else {
                 match &property.key {
                     ast::Expression::Id(id) => {
-                        let constant_index = self.add_wtf8_string_constant(id.name)?;
+                        let constant_index = self.add_wtf8_string_property_key_constant(id.name)?;
                         let name = id.name;
                         let is_proto = id.name == "__proto__";
 
                         Property::Named { constant_index, name, is_proto }
                     }
                     ast::Expression::String(string) => {
-                        let constant_index = self.add_wtf8_string_constant(string.value)?;
+                        let constant_index =
+                            self.add_wtf8_string_property_key_constant(string.value)?;
                         let name = string.value;
                         let is_proto = string.value == "__proto__";
 
@@ -4415,7 +4449,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         } else {
             // Must be a named access
             let name = expr.property.to_id();
-            let name_constant_index = self.add_wtf8_string_constant(name.name)?;
+            let name_constant_index = self.add_wtf8_string_property_key_constant(name.name)?;
 
             if release_object {
                 self.register_allocator.release(object);
@@ -4664,7 +4698,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                         // Must be a super named access, but we do not have a SetNamedSuperProperty
                         // instruction so load to a register.
                         let name = member.property.to_id();
-                        let name_constant_index = self.add_wtf8_string_constant(name.name)?;
+                        let name_constant_index =
+                            self.add_wtf8_string_property_key_constant(name.name)?;
 
                         let key = self.register_allocator.allocate()?;
                         self.writer
@@ -4686,7 +4721,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     } else {
                         // Must be a named access
                         let name = member.property.to_id();
-                        let name_constant_index = self.add_wtf8_string_constant(name.name)?;
+                        let name_constant_index =
+                            self.add_wtf8_string_property_key_constant(name.name)?;
                         Property::Named(name_constant_index)
                     }
                 };
@@ -4951,7 +4987,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     // Must be a super named access, but we do not have a SetNamedSuperProperty
                     // instruction so load to a register.
                     let name = member.property.to_id();
-                    let name_constant_index = self.add_wtf8_string_constant(name.name)?;
+                    let name_constant_index =
+                        self.add_wtf8_string_property_key_constant(name.name)?;
 
                     let key = self.register_allocator.allocate()?;
                     self.writer
@@ -4986,7 +5023,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 } else {
                     // Must be a named access
                     let name = member.property.to_id();
-                    let name_constant_index = self.add_wtf8_string_constant(name.name)?;
+                    let name_constant_index =
+                        self.add_wtf8_string_property_key_constant(name.name)?;
                     self.write_get_named_property_instruction(
                         temp,
                         object,
@@ -5347,7 +5385,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         self.writer.new_object_instruction(iter_result);
 
         // Iterator result object holds the yielded value
-        let value_constant_index = self.add_string_constant("value")?;
+        let value_constant_index = self.add_string_property_key_constant("value")?;
         // No source position needed since instruction cannot throw - it is a set on a fresh object
         self.write_set_named_property_instruction(
             iter_result,
@@ -5357,7 +5395,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         );
 
         // Iterator result object is marked as not done
-        let done_constant_index = self.add_string_constant("done")?;
+        let done_constant_index = self.add_string_property_key_constant("done")?;
         self.writer.load_false_instruction(temp_value);
         // No source position needed since instruction cannot throw - it is a set on a fresh object
         self.write_set_named_property_instruction(
@@ -5465,10 +5503,10 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 .get_iterator_instruction(iterator, next_method, argument, pos);
         }
 
-        let done_constant_index = self.add_string_constant("done")?;
-        let value_constant_index = self.add_string_constant("value")?;
-        let throw_constant_index = self.add_string_constant("throw")?;
-        let return_constant_index = self.add_string_constant("return")?;
+        let done_constant_index = self.add_string_property_key_constant("done")?;
+        let value_constant_index = self.add_string_property_key_constant("value")?;
+        let throw_constant_index = self.add_string_property_key_constant("throw")?;
+        let return_constant_index = self.add_string_property_key_constant("return")?;
 
         let completion_value = self.register_allocator.allocate()?;
         let completion_type = self.register_allocator.allocate()?;
@@ -5781,7 +5819,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         } else {
             // Must be a named access
             let name = expr.property.to_id();
-            let name_constant_index = self.add_wtf8_string_constant(name.name)?;
+            let name_constant_index = self.add_wtf8_string_property_key_constant(name.name)?;
 
             self.register_allocator.release(home_object);
             if release_receiver {
@@ -6253,7 +6291,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         } else {
             // Must be a named access
             let name = member.property.to_id();
-            let property = self.add_wtf8_string_constant(name.name)?;
+            let property = self.add_wtf8_string_property_key_constant(name.name)?;
             Ok(Reference::new(ReferenceKind::NamedProperty { object, property, operator_pos }))
         }
     }
@@ -6427,7 +6465,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
             match &key {
                 Property::Named(id) => {
-                    let name_constant_index = self.add_wtf8_string_constant(id.name)?;
+                    let name_constant_index =
+                        self.add_wtf8_string_property_key_constant(id.name)?;
 
                     // If there is a rest element name must be saved in the reserved registers. Can
                     // load directly to the temporary register since name is already a property key.
@@ -7391,7 +7430,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         match field {
             ClassField::Named { name, .. } => {
-                let name_constant_index = self.add_wtf8_string_constant(name)?;
+                let name_constant_index = self.add_wtf8_string_property_key_constant(name)?;
                 self.writer.define_named_property_instruction(
                     target,
                     name_constant_index,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1309,8 +1309,8 @@ define_instructions!(
         }
     }
 
-    /// Get a named property from an object, storing the result in dest. The name must be a string
-    /// literal in the constant table.
+    /// Get a named property from an object, storing the result in dest. The name must be a property
+    /// key in the constant table.
     GetNamedProperty {
         camel_case: GetNamedPropertyInstruction,
         snake_case: get_named_property_instruction,
@@ -1323,8 +1323,8 @@ define_instructions!(
         }
     }
 
-    /// Set a named property on an object to the given value. The name must be a string literal in
-    /// the constant table.
+    /// Set a named property on an object to the given value. The name must be a property key in the
+    /// constant table.
     SetNamedProperty {
         camel_case: SetNamedPropertyInstruction,
         snake_case: set_named_property_instruction,
@@ -1337,7 +1337,7 @@ define_instructions!(
         }
     }
 
-    /// Define a named property on an object with the given value. The name must be a string literal
+    /// Define a named property on an object with the given value. The name must be a property key
     /// in the constant table.
     DefineNamedProperty {
         camel_case: DefineNamedPropertyInstruction,
@@ -1364,7 +1364,7 @@ define_instructions!(
         }
     }
 
-    /// Get a named super property, storing the result in dest. The name must be a string literal
+    /// Get a named super property, storing the result in dest. The name must be a property key
     /// in the constant table. Takes both the home object and receiver of the enclosing method.
     GetNamedSuperProperty {
         camel_case: GetNamedSuperPropertyInstruction,
@@ -1495,9 +1495,9 @@ define_instructions!(
         }
     }
 
-    /// Lookup a method with the given name on a value, storing the result in dest. If there is no
-    /// property with the given name the result is undefined. If there is a property but it is not
-    /// nullish and not callable then error.
+    /// Lookup a method with the given name on a value, storing the result in dest. The name must be
+    /// a property key in the constant table. If there is no property with the given name the result
+    /// is undefined. If there is a property but it is not nullish and not callable then error.
     GetMethod {
         camel_case: GetMethodInstruction,
         snake_case: get_method_instruction,

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -2133,6 +2133,11 @@ impl VM {
     }
 
     #[inline]
+    fn get_property_key_constant<W: Width>(&self, constant_index: ConstantIndex<W>) -> PropertyKey {
+        PropertyKey::from_raw_value(self.get_constant(constant_index))
+    }
+
+    #[inline]
     fn get_constant_offset<W: Width>(&self, constant_index: ConstantIndex<W>) -> isize {
         self.constant_table()
             .get_constant_offset(constant_index.value().to_usize())
@@ -4308,15 +4313,13 @@ impl VM {
         handle_scope!(self.cx(), {
             let object = self.read_register_to_handle(instr.object());
 
-            let key = self.get_string_constant(instr.name_constant_index());
-            let key = key.to_handle();
+            let property_key = self
+                .get_property_key_constant(instr.name_constant_index())
+                .to_handle(self.cx());
 
             let is_strict = self.closure().function_ptr().is_strict();
 
-            // May allocate, replace handle
-            let property_key = PropertyKey::from_interned_string(self.cx(), key)?;
-            let property_key = key.replace_into(property_key);
-
+            // May allocate
             let coerced_object = to_object(self.cx(), object)?;
 
             // Result of ToObject is used as receiver in sloppy mode
@@ -4427,15 +4430,14 @@ impl VM {
         // Perform the full property store, filling the cache if necessary
         handle_scope!(self.cx(), {
             let object = object_value.to_handle(self.cx());
-            let key = self.get_string_constant(name_index).to_handle();
+            let property_key = self
+                .get_property_key_constant(name_index)
+                .to_handle(self.cx());
             let value = self.read_register_to_handle(value_register);
             let is_strict = self.closure().function_ptr().is_strict();
 
             // May allocate
             let mut coerced_object = to_object(self.cx(), object)?;
-
-            let property_key = PropertyKey::from_interned_string(self.cx(), key)?;
-            let property_key = key.replace_into(property_key);
 
             // The shape before the store is needed for the cache
             let old_shape = if fill_cache {
@@ -4476,16 +4478,14 @@ impl VM {
         handle_scope!(self.cx(), {
             let object = self.read_register_to_handle(instr.object());
 
-            let key = self.get_string_constant(instr.name_constant_index());
-            let key = key.to_handle();
+            let property_key = self
+                .get_property_key_constant(instr.name_constant_index())
+                .to_handle(self.cx());
 
             let value = self.read_register_to_handle(instr.value());
 
             // May allocate
             let object = to_object(self.cx(), object)?;
-
-            let property_key = PropertyKey::from_interned_string(self.cx(), key)?;
-            let property_key = key.replace_into(property_key);
 
             create_data_property_or_throw(self.cx(), object, property_key, value)
         })
@@ -4530,15 +4530,13 @@ impl VM {
                 .as_object();
             let receiver = self.read_register_to_handle(instr.receiver());
 
-            let key = self.get_string_constant(instr.name_constant_index());
-            let key = key.to_handle();
+            let property_key = self
+                .get_property_key_constant(instr.name_constant_index())
+                .to_handle(self.cx());
 
             let dest = instr.dest();
 
-            // May allocate, replace handle
-            let property_key = PropertyKey::from_interned_string(self.cx(), key)?;
-            let property_key = key.replace_into(property_key);
-
+            // May allocate
             let home_prototype = match home_object.get_prototype_of(self.cx())? {
                 None => return type_error(self.cx(), "prototype is null"),
                 Some(prototype) => prototype,
@@ -4766,9 +4764,9 @@ impl VM {
         handle_scope!(self.cx(), {
             let dest = instr.dest();
             let object = self.read_register_to_handle(instr.object());
-            let key = self.get_string_constant(instr.name()).to_handle();
-
-            let key = PropertyKey::from_interned_string(self.cx(), key)?.to_handle(self.cx());
+            let key = self
+                .get_property_key_constant(instr.name())
+                .to_handle(self.cx());
 
             let function = get_v(self.cx(), object, key)?;
 

--- a/src/js/runtime/property_key.rs
+++ b/src/js/runtime/property_key.rs
@@ -87,8 +87,17 @@ impl PropertyKey {
             return PropertyKey::string_not_array_index(cx, string_value);
         }
 
+        Ok(Self::array_index_unchecked(value))
+    }
+
+    /// Create a property key that is known to be an array index. Be sure to not u32::MAX which is
+    /// not a valid array index.
+    #[inline]
+    pub fn array_index_unchecked(value: u32) -> PropertyKey {
+        debug_assert!(value != u32::MAX);
+
         // Intentionally store u32 value in i32 smi payload
-        Ok(PropertyKey { value: Value::smi(value as i32) })
+        PropertyKey { value: Value::smi(value as i32) }
     }
 
     #[inline]
@@ -152,6 +161,23 @@ impl PropertyKey {
         } else {
             Ok(PropertyKey { value: *string.as_value() })
         }
+    }
+
+    /// Create a property key from a raw value that is known to already be a valid property key,
+    /// (e.g. property keys loaded from a constant table). Value must be an interned string, symbol,
+    /// or array index encoded as a smi.
+    #[inline]
+    pub fn from_raw_value(value: Value) -> PropertyKey {
+        debug_assert!(value.is_smi() || value.is_string() || value.is_symbol());
+
+        PropertyKey { value }
+    }
+
+    /// The underlying raw value of this property key, which may be an interned string, symbol, or
+    /// array index encoded as a smi.
+    #[inline]
+    pub fn to_raw_value(self) -> Value {
+        self.value
     }
 
     #[inline]


### PR DESCRIPTION
## Summary

Improvement on top of https://github.com/Hans-Halverson/brimstone/pull/430. We actually should just be storing the property keys directly into the constant table. This allows the VM to directly cast the value in the constant table to a property key instead of performing (minimal) conversion checks.

## Tests

- CI