### PR TITLE
[runtime] Global and dynamic load/store instructions must TDZ check lexical bindings

### DIFF
--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -878,6 +878,7 @@ impl<'a> Parser<'a> {
         // Function scope node must contain the params and body, but not function name.
         let scope = self.enter_function_scope(
             start_pos, /* is_arrow */ false, /* is_expression */ !is_decl,
+            /* is_derived_constructor */ false,
         )?;
 
         // Named function expressions bind name within function scope
@@ -933,6 +934,7 @@ impl<'a> Parser<'a> {
         start_pos: Pos,
         is_arrow: bool,
         is_expression: bool,
+        is_derived_constructor: bool,
     ) -> ParseResult<AstPtr<AstScopeNode<'a>>> {
         let scope = self.scope_builder.enter_scope(ScopeNodeKind::Function {
             id: start_pos,
@@ -944,6 +946,12 @@ impl<'a> Parser<'a> {
         // when determining if it is captured by an arrow function.
         if !is_arrow {
             let kind = BindingKind::new_implicit_this();
+
+            // Mark `this` bindings in derived constructors
+            kind.as_implicit_this()
+                .unwrap()
+                .set_in_derived_constructor(is_derived_constructor);
+
             self.scope_builder.add_binding(&THIS_NAME, kind).unwrap();
         }
 
@@ -1757,6 +1765,7 @@ impl<'a> Parser<'a> {
         // Function scope node must contain params and body
         let scope = self.enter_function_scope(
             start_pos, /* is_arrow */ true, /* is_expression */ false,
+            /* is_derived_constructor */ false,
         )?;
 
         let is_async = self.token == Token::Async;
@@ -3714,7 +3723,10 @@ impl<'a> Parser<'a> {
 
         // Function scope node must contain params and body
         let scope = self.enter_function_scope(
-            start_pos, /* is_arrow */ false, /* is_expression */ false,
+            start_pos,
+            /* is_arrow */ false,
+            /* is_expression */ false,
+            is_derived_constructor,
         )?;
 
         // Derived constructors add self as a fake binding, since they will need to be looked up
@@ -4055,6 +4067,7 @@ impl<'a> Parser<'a> {
 
         let init_scope = self.enter_function_scope(
             start_pos, /* is_arrow */ false, /* is_expression */ false,
+            /* is_derived_constructor */ false,
         )?;
         *scope = Some(init_scope);
 

--- a/src/js/parser/scope_tree.rs
+++ b/src/js/parser/scope_tree.rs
@@ -1125,6 +1125,10 @@ impl<'a> BindingKind<'a> {
         matches!(self, BindingKind::PrivateName)
     }
 
+    pub fn is_import(&self) -> bool {
+        matches!(self, BindingKind::Import { .. })
+    }
+
     pub fn is_namespace_import(&self) -> bool {
         matches!(self, BindingKind::Import { is_namespace: true })
     }

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -7797,6 +7797,16 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 flags |= ScopeNameFlags::IS_MODULE_BINDING;
             }
 
+            if binding.kind().is_import() {
+                flags |= ScopeNameFlags::IS_IMPORT_BINDING;
+            }
+
+            if let Some(implicit_this) = binding.kind().as_implicit_this()
+                && implicit_this.in_derived_constructor()
+            {
+                flags |= ScopeNameFlags::IS_DERIVED_CONSTRUCTOR_THIS;
+            }
+
             all_flags.push(flags);
         }
 

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -95,8 +95,8 @@ use crate::{
         },
         class_names::{ClassNames, new_class},
         error::{
-            err_assign_constant, err_cannot_set_property, err_not_defined, reference_error,
-            stack_overflow_error, type_error, type_error_value,
+            err_access_before_initialization, err_assign_constant, err_cannot_set_property,
+            err_not_defined, reference_error, stack_overflow_error, type_error, type_error_value,
         },
         eval::{
             eval::perform_eval,
@@ -3285,19 +3285,20 @@ impl VM {
             let global_object = self.closure().global_object();
 
             // Must first check if it is a lexical name in one of the realm's global scopes
-            let value = if let Some(value) = self.closure().realm().get_lexical_name(*name) {
-                value
-            } else if has_property(cx, global_object, name_key)? {
-                // Otherwise might be a property in the global object
-                *get(cx, global_object, name_key)?
-            } else if error_on_unresolved {
-                // Error if property is not found
-                return err_not_defined(cx, name.as_string());
-            } else {
-                // If not erroring, return undefined for unresolved names
-                self.write_register(dest, Value::undefined());
-                return Ok(());
-            };
+            let value =
+                if let Some(value) = self.closure().realm().get_lexical_name(self.cx(), *name)? {
+                    value
+                } else if has_property(cx, global_object, name_key)? {
+                    // Otherwise might be a property in the global object
+                    *get(cx, global_object, name_key)?
+                } else if error_on_unresolved {
+                    // Error if property is not found
+                    return err_not_defined(cx, name.as_string());
+                } else {
+                    // If not erroring, return undefined for unresolved names
+                    self.write_register(dest, Value::undefined());
+                    return Ok(());
+                };
 
             self.write_register(dest, value);
 
@@ -5058,9 +5059,8 @@ impl VM {
         }
 
         let name = self.get_constant(instr.name_constant_index()).as_string();
-        let name_str = name.to_handle().format()?;
 
-        reference_error(self.cx(), &format!("cannot access `{name_str}` before initialization"))
+        err_access_before_initialization(self.cx(), name.to_handle())
     }
 
     #[inline]

--- a/src/js/runtime/error.rs
+++ b/src/js/runtime/error.rs
@@ -206,6 +206,13 @@ pub fn err_not_defined<T>(cx: Context, name: Handle<StringValue>) -> EvalResult<
     reference_error(cx, &format!("`{}` is not defined", name.format()?))
 }
 
+pub fn err_access_before_initialization<T>(
+    cx: Context,
+    name: Handle<StringValue>,
+) -> EvalResult<T> {
+    reference_error(cx, &format!("cannot access `{}` before initialization", name.format()?))
+}
+
 pub fn err_assign_constant<T>(cx: Context, name: HeapPtr<FlatString>) -> EvalResult<T> {
     type_error(cx, &format!("cannot assign constant `{name}`"))
 }

--- a/src/js/runtime/eval/eval.rs
+++ b/src/js/runtime/eval/eval.rs
@@ -188,7 +188,7 @@ fn check_eval_var_name_conflicts(
         if scope.kind() == ScopeKind::Global {
             let realm = scope.global_scope_realm();
             for name in eval_var_names.iter().chain(eval_func_names.iter()) {
-                if realm.get_lexical_name(**name).is_some() {
+                if realm.has_lexical_name(**name) {
                     return error_name_already_declared(cx, *name);
                 }
             }

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -9,7 +9,7 @@ use crate::{
         builtin_function::BuiltinFunction,
         bytecode::function::ClosureObject,
         collections::{HashMapInstance, InlineArray, hash_map::BsHashMapField},
-        error::{err_assign_constant, syntax_error},
+        error::{err_access_before_initialization, err_assign_constant, syntax_error},
         gc::{Handle, HeapItem, HeapPtr, HeapVisitor},
         gc_object::GcObject,
         global_names::has_restricted_global_property,
@@ -129,19 +129,38 @@ impl Realm {
         self.intrinsics.get(intrinsic)
     }
 
+    /// Whether the name exists in the realm's lexical names map, in any global scope.
+    ///
+    /// Does not perform any validation checks like TDZ.
+    pub fn has_lexical_name(&self, name: HeapPtr<FlatString>) -> bool {
+        self.lexical_names.get(&name).is_some()
+    }
+
     /// Get the value associated with a lexical name in the realm's lexical names map, if one
     /// exists. The lexical name could be in any global scope.
-    pub fn get_lexical_name(&self, name: HeapPtr<FlatString>) -> Option<Value> {
-        let location = self.lexical_names.get(&name)?;
+    pub fn get_lexical_name(
+        &self,
+        cx: Context,
+        name: HeapPtr<FlatString>,
+    ) -> EvalResult<Option<Value>> {
+        let Some(location) = self.lexical_names.get(&name) else {
+            return Ok(None);
+        };
 
         let global_scope = self.global_scopes.get(location.global_scope_index);
         let value = global_scope.get_slot(location.slot_index as usize);
 
-        Some(value)
+        // Perform TDZ check since binding may not yet be initialized
+        if value.is_empty() {
+            return err_access_before_initialization(cx, name.as_string().to_handle());
+        }
+
+        Ok(Some(value))
     }
 
     /// Try to set the value associated with a lexical name in the realms lexical names map.
-    /// Return whether the lexical name was found and set.
+    /// Performs validation checks like TDZ and immutability. Return whether the lexical name was
+    /// found and successfully set.
     pub fn set_lexical_name(
         &mut self,
         cx: Context,
@@ -149,12 +168,20 @@ impl Realm {
         value: Value,
     ) -> EvalResult<bool> {
         if let Some(location) = self.lexical_names.get(&name) {
+            let mut global_scope = self.global_scopes.get(location.global_scope_index);
+
+            // Must perform TDZ check since binding may not be initialized
+            let slot_value = global_scope.get_slot_mut(location.slot_index as usize);
+            if slot_value.is_empty() {
+                return err_access_before_initialization(cx, name.as_string().to_handle());
+            }
+
+            // Cannot reassign an immutable binding. This error has lower precedence than the TDZ.
             if location.is_immutable() {
                 return err_assign_constant(cx, name);
             }
 
-            let mut global_scope = self.global_scopes.get(location.global_scope_index);
-            global_scope.set_slot(location.slot_index as usize, value);
+            *slot_value = value;
 
             Ok(true)
         } else {
@@ -203,7 +230,7 @@ impl Handle<Realm> {
             key.replace(PropertyKey::string(cx, name.as_string())?);
 
             let is_global_var_name = has_restricted_global_property(cx, global_object, key)?;
-            let is_global_lex_name = self.get_lexical_name(*name).is_some();
+            let is_global_lex_name = self.has_lexical_name(*name);
 
             if is_global_var_name || is_global_lex_name {
                 return syntax_error(cx, &format!("redeclaration of `{}`", *name));
@@ -221,7 +248,7 @@ impl Handle<Realm> {
         names: &[HeapPtr<FlatString>],
     ) -> EvalResult<()> {
         for name in names {
-            if self.get_lexical_name(*name).is_some() {
+            if self.has_lexical_name(*name) {
                 return syntax_error(cx, &format!("redeclaration of `{name}`"));
             }
         }

--- a/src/js/runtime/scope.rs
+++ b/src/js/runtime/scope.rs
@@ -6,7 +6,10 @@ use crate::{
         alloc_error::AllocResult,
         boxed_value::BoxedValue,
         collections::InlineArray,
-        error::{err_assign_constant, err_cannot_set_property, err_not_defined},
+        error::{
+            err_access_before_initialization, err_assign_constant, err_cannot_set_property,
+            err_not_defined,
+        },
         gc::{AnyHeapItem, HeapItem, HeapVisitor},
         get,
         module::source_text_module::SourceTextModule,
@@ -141,6 +144,11 @@ impl Scope {
         self.slots.as_slice()[index]
     }
 
+    #[inline]
+    pub fn get_slot_mut(&mut self, index: usize) -> &mut Value {
+        &mut self.slots.as_mut_slice()[index]
+    }
+
     /// Dynamically look up the `this` binding in this scope, walking the scope chain until found.
     pub fn lookup_this_for_eval(cx: Context, mut scope: HeapPtr<Self>) -> Value {
         loop {
@@ -217,6 +225,8 @@ impl Handle<Scope> {
 
     /// Dynamically look up a name in this scope, walking the scope chain until found. The name must
     /// be an interned string.
+    ///
+    /// Perform validation such as TDZ checks.
     #[inline]
     pub fn lookup(
         &self,
@@ -237,12 +247,21 @@ impl Handle<Scope> {
 
                 // If found in a module scope then must check if loading a module binding, meaning
                 // we need to load the value from the BoxedValue.
-                if scope.kind == ScopeKind::Module && scope_names.is_module_binding(index) {
-                    let boxed_value = slot_value.as_pointer().cast::<BoxedValue>();
-                    return Ok(Some(boxed_value.get().to_handle(cx)));
-                } else {
-                    return Ok(Some(slot_value.to_handle(cx)));
+                let value =
+                    if scope.kind == ScopeKind::Module && scope_names.is_module_binding(index) {
+                        let boxed_value = slot_value.as_pointer().cast::<BoxedValue>();
+                        boxed_value.get()
+                    } else {
+                        slot_value
+                    };
+
+                // Perform TDZ check since binding may not yet be initialized. The only exception is
+                // for `this` in a derived constructor which performs a separate init check.
+                if value.is_empty() && !scope_names.is_derived_constructor_this(index) {
+                    return err_access_before_initialization(cx, name);
                 }
+
+                return Ok(Some(value.to_handle(cx)));
             }
 
             // Then check scope object if one exists
@@ -274,7 +293,7 @@ impl Handle<Scope> {
             } else {
                 // Finally check for global lexical names
                 let realm = scope.global_scope_realm();
-                let value = realm.get_lexical_name(*name.as_flat());
+                let value = realm.get_lexical_name(cx, *name.as_flat())?;
 
                 return Ok(value.map(|v| v.to_handle(cx)));
             }
@@ -283,6 +302,8 @@ impl Handle<Scope> {
 
     /// Dynamically store a name in this scope, walking the scope chain until found. Return whether
     /// the name was found. The name must be an interned string.
+    ///
+    /// Perform validation such as TDZ and immutability checks.
     #[inline]
     pub fn lookup_store(
         &mut self,
@@ -300,6 +321,35 @@ impl Handle<Scope> {
             // First check inline slots using scope names table
             let scope_names = scope.scope_names_ptr();
             if let Some(index) = scope_names.lookup_name(*name.as_flat()) {
+                // Perform TDZ check since binding may not yet be initialized. The only exception is
+                // for `this` in a derived constructor which performs a separate init check.
+                if scope.get_slot(index).is_empty()
+                    && !scope_names.is_derived_constructor_this(index)
+                {
+                    return err_access_before_initialization(cx, name);
+                }
+
+                // If found in a module scope then must check if storing to a module binding,
+                // meaning we need to store the value in the BoxedValue.
+                if scope.kind == ScopeKind::Module && scope_names.is_module_binding(index) {
+                    let mut boxed_value = scope.get_module_slot(index);
+
+                    // Perform TDZ check since binding may not yet be initialized. Note that import
+                    // bindings are created as initialized local bindings - the value here actually
+                    // tracks whether the binding within the source module has been initialized.
+                    if boxed_value.get().is_empty() && !scope_names.is_import_binding(index) {
+                        return err_access_before_initialization(cx, name);
+                    }
+
+                    // Check if storing to a constant
+                    if scope_names.is_immutable(index) {
+                        return err_assign_constant(cx, *name.as_flat());
+                    }
+
+                    boxed_value.set(*value);
+                    return Ok(true);
+                }
+
                 // Check if storing to a constant
                 if scope_names.is_immutable(index) {
                     return err_assign_constant(cx, *name.as_flat());
@@ -313,14 +363,6 @@ impl Handle<Scope> {
                     } else {
                         return Ok(true);
                     }
-                }
-
-                // If found in a module scope then must check if storing to a module binding,
-                // meaning we need to store the value in the BoxedValue.
-                if scope.kind == ScopeKind::Module && scope_names.is_module_binding(index) {
-                    let mut boxed_value = scope.get_module_slot(index);
-                    boxed_value.set(*value);
-                    return Ok(true);
                 }
 
                 scope.set_slot(index, *value);

--- a/src/js/runtime/scope_names.rs
+++ b/src/js/runtime/scope_names.rs
@@ -52,6 +52,10 @@ bitflags! {
         const IS_PRIVATE_NAME = 1 << 4;
         /// Whether this is a module binding.
         const IS_MODULE_BINDING = 1 << 5;
+        /// Whether this is an import binding.
+        const IS_IMPORT_BINDING = 1 << 6;
+        /// Whether this is a `this` binding in a derived constructor.
+        const IS_DERIVED_CONSTRUCTOR_THIS = 1 << 7;
     }
 }
 
@@ -181,6 +185,18 @@ impl ScopeNames {
     pub fn is_module_binding(&self, index: usize) -> bool {
         self.get_name_flags(index)
             .contains(ScopeNameFlags::IS_MODULE_BINDING)
+    }
+
+    /// Return whether the binding at index is an import binding.
+    pub fn is_import_binding(&self, index: usize) -> bool {
+        self.get_name_flags(index)
+            .contains(ScopeNameFlags::IS_IMPORT_BINDING)
+    }
+
+    /// Return whether the binding at index is a `this` binding in a derived constructor.
+    pub fn is_derived_constructor_this(&self, index: usize) -> bool {
+        self.get_name_flags(index)
+            .contains(ScopeNameFlags::IS_DERIVED_CONSTRUCTOR_THIS)
     }
 }
 

--- a/tests/integration/language/class/derived_constructor_this_in_eval.js
+++ b/tests/integration/language/class/derived_constructor_this_in_eval.js
@@ -20,7 +20,7 @@ class C1 extends Base {
     }
 }
 
-assert.throws(ReferenceError, () => new C());
+assert.throws(ReferenceError, () => new C1());
 
 // Successful access to `this` from direct eval after initialization
 class C2 extends Base {

--- a/tests/integration/language/scope/load_store_dynamic_module_binding_tdz.js
+++ b/tests/integration/language/scope/load_store_dynamic_module_binding_tdz.js
@@ -1,0 +1,52 @@
+/*---
+description: Dynamically loading and storing uninitialized lexical module bindings.
+flags: [module]
+---*/
+
+// The fixture module is evaluated first, dynamically accessing this module's exported bindings
+// while they are still uninitialized.
+import { checkAfterInitialization } from "./load_store_dynamic_module_binding_tdz_FIXTURE.js";
+
+const readL1 = () => eval("l1");
+const typeofL2 = () => eval("typeof l2");
+const writeL3 = () => eval("l3 = 1");
+const readC1 = () => eval("c1");
+const typeofC2 = () => eval("typeof c2");
+const writeC3 = () => eval("c3 = 2");
+const readK1 = () => eval("K1");
+const typeofK2 = () => eval("typeof K2");
+const writeK3 = () => eval("K3 = 3");
+
+assert.throws(ReferenceError, () => readL1());
+assert.throws(ReferenceError, () => typeofL2());
+assert.throws(ReferenceError, () => writeL3());
+assert.throws(ReferenceError, () => readC1());
+assert.throws(ReferenceError, () => typeofC2());
+assert.throws(ReferenceError, () => writeC3());
+assert.throws(ReferenceError, () => readK1());
+assert.throws(ReferenceError, () => typeofK2());
+assert.throws(ReferenceError, () => writeK3());
+
+export let l1 = "l1";
+export let l2 = "l2";
+export let l3 = "l3";
+
+export const c1 = "c1";
+export const c2 = "c2";
+export const c3 = "c3";
+
+export class K1 {}
+export class K2 {}
+export class K3 {}
+
+assert.sameValue(readL1(), "l1");
+assert.sameValue(typeofL2(), "string");
+assert.sameValue(writeL3(), 1);
+assert.sameValue(readC1(), "c1");
+assert.sameValue(typeofC2(), "string");
+assert.throws(TypeError, () => writeC3());
+assert.sameValue(readK1(), K1);
+assert.sameValue(typeofK2(), "function");
+assert.sameValue(writeK3(), 3);
+
+checkAfterInitialization();

--- a/tests/integration/language/scope/load_store_dynamic_module_binding_tdz_FIXTURE.js
+++ b/tests/integration/language/scope/load_store_dynamic_module_binding_tdz_FIXTURE.js
@@ -1,0 +1,29 @@
+// This module is evaluated before the module that imports it, so all of the imported bindings are
+// still uninitialized while the top level of this module is evaluated.
+import { l1, l2, l3, c1, c2, K1, K2 } from "./load_store_dynamic_module_binding_tdz.js";
+
+const readL1 = () => eval("l1");
+const typeofL2 = () => eval("typeof l2");
+const writeL3 = () => eval("l3 = 1");
+const readC1 = () => eval("c1");
+const typeofC2 = () => eval("typeof c2");
+const readK1 = () => eval("K1");
+const typeofK2 = () => eval("typeof K2");
+
+assert.throws(ReferenceError, () => readL1());
+assert.throws(ReferenceError, () => typeofL2());
+assert.throws(TypeError, () => writeL3());
+assert.throws(ReferenceError, () => readC1());
+assert.throws(ReferenceError, () => typeofC2());
+assert.throws(ReferenceError, () => readK1());
+assert.throws(ReferenceError, () => typeofK2());
+
+export function checkAfterInitialization() {
+  assert.sameValue(readL1(), "l1");
+  assert.sameValue(typeofL2(), "string");
+  assert.throws(TypeError, () => writeL3());
+  assert.sameValue(readC1(), "c1");
+  assert.sameValue(typeofC2(), "string");
+  assert.sameValue(readK1(), K1);
+  assert.sameValue(typeofK2(), "function");
+}

--- a/tests/integration/language/scope/load_store_dynamic_tdz.js
+++ b/tests/integration/language/scope/load_store_dynamic_tdz.js
@@ -1,0 +1,127 @@
+/*---
+description: Dynamically loading and storing uninitialized lexical bindings.
+---*/
+
+// Dynamic load/store from own global scope
+const readL1 = () => eval("l1");
+const typeofL2 = () => eval("typeof l2");
+const writeL3 = () => eval("l3 = 1");
+const readC1 = () => eval("c1");
+const typeofC2 = () => eval("typeof c2");
+const writeC3 = () => eval("c3 = 2");
+const readK1 = () => eval("K1");
+const typeofK2 = () => eval("typeof K2");
+const writeK3 = () => eval("K3 = 3");
+
+// Dynamic load/store from a different script's global scope
+const readL4 = Function('return eval("l4");');
+const typeofL5 = Function('return eval("typeof l5");');
+const writeL6 = Function('return eval("l6 = 4");');
+const readC4 = Function('return eval("c4");');
+const typeofC5 = Function('return eval("typeof c5");');
+const writeC6 = Function('return eval("c6 = 5");');
+const readK4 = Function('return eval("K4");');
+const typeofK5 = Function('return eval("typeof K5");');
+const writeK6 = Function('return eval("K6 = 6");');
+
+assert.throws(ReferenceError, () => readL1());
+assert.throws(ReferenceError, () => typeofL2());
+assert.throws(ReferenceError, () => writeL3());
+assert.throws(ReferenceError, () => readC1());
+assert.throws(ReferenceError, () => typeofC2());
+assert.throws(ReferenceError, () => writeC3());
+assert.throws(ReferenceError, () => readK1());
+assert.throws(ReferenceError, () => typeofK2());
+assert.throws(ReferenceError, () => writeK3());
+assert.throws(ReferenceError, () => readL4());
+assert.throws(ReferenceError, () => typeofL5());
+assert.throws(ReferenceError, () => writeL6());
+assert.throws(ReferenceError, () => readC4());
+assert.throws(ReferenceError, () => typeofC5());
+assert.throws(ReferenceError, () => writeC6());
+assert.throws(ReferenceError, () => readK4());
+assert.throws(ReferenceError, () => typeofK5());
+assert.throws(ReferenceError, () => writeK6());
+
+let l1 = "l1";
+let l2 = "l2";
+let l3 = "l3";
+let l4 = "l4";
+let l5 = "l5";
+let l6 = "l6";
+
+const c1 = "c1";
+const c2 = "c2";
+const c3 = "c3";
+const c4 = "c4";
+const c5 = "c5";
+const c6 = "c6";
+
+class K1 {}
+class K2 {}
+class K3 {}
+class K4 {}
+class K5 {}
+class K6 {}
+
+assert.sameValue(readL1(), "l1");
+assert.sameValue(typeofL2(), "string");
+assert.sameValue(writeL3(), 1);
+assert.sameValue(readC1(), "c1");
+assert.sameValue(typeofC2(), "string");
+assert.throws(TypeError, () => writeC3());
+assert.sameValue(readK1(), K1);
+assert.sameValue(typeofK2(), "function");
+assert.sameValue(writeK3(), 3);
+assert.sameValue(readL4(), "l4");
+assert.sameValue(typeofL5(), "string");
+assert.sameValue(writeL6(), 4);
+assert.sameValue(readC4(), "c4");
+assert.sameValue(typeofC5(), "string");
+assert.throws(TypeError, () => writeC6());
+assert.sameValue(readK4(), K4);
+assert.sameValue(typeofK5(), "function");
+assert.sameValue(writeK6(), 6);
+
+// Dynamic load/store from function scope
+(function test() {
+  const readL1 = () => eval("l1");
+  const typeofL2 = () => eval("typeof l2");
+  const writeL3 = () => eval("l3 = 1");
+  const readC1 = () => eval("c1");
+  const typeofC2 = () => eval("typeof c2");
+  const writeC3 = () => eval("c3 = 2");
+  const readK1 = () => eval("K1");
+  const typeofK2 = () => eval("typeof K2");
+  const writeK3 = () => eval("K3 = 3");
+
+  assert.throws(ReferenceError, () => readL1());
+  assert.throws(ReferenceError, () => typeofL2());
+  assert.throws(ReferenceError, () => writeL3());
+  assert.throws(ReferenceError, () => readC1());
+  assert.throws(ReferenceError, () => typeofC2());
+  assert.throws(ReferenceError, () => writeC3());
+  assert.throws(ReferenceError, () => readK1());
+  assert.throws(ReferenceError, () => typeofK2());
+  assert.throws(ReferenceError, () => writeK3());
+
+  let l1 = "l1";
+  let l2 = "l2";
+  let l3 = "l3";
+  const c1 = "c1";
+  const c2 = "c2";
+  const c3 = "c3";
+  class K1 {}
+  class K2 {}
+  class K3 {}
+
+  assert.sameValue(readL1(), "l1");
+  assert.sameValue(typeofL2(), "string");
+  assert.sameValue(writeL3(), 1);
+  assert.sameValue(readC1(), "c1");
+  assert.sameValue(typeofC2(), "string");
+  assert.throws(TypeError, () => writeC3());
+  assert.sameValue(readK1(), K1);
+  assert.sameValue(typeofK2(), "function");
+  assert.sameValue(writeK3(), 3);
+})();

--- a/tests/integration/language/scope/load_store_global_tdz.js
+++ b/tests/integration/language/scope/load_store_global_tdz.js
@@ -1,0 +1,45 @@
+/*---
+description: Loading and storing uninitialized global lexical bindings.
+---*/
+
+const readL1 = Function("return l1;");
+const typeofL2 = Function("return typeof l2;");
+const writeL3 = Function("return l3 = 1;");
+const readC1 = Function("return c1;");
+const typeofC2 = Function("return typeof c2;");
+const writeC3 = Function("return c3 = 2;");
+const readK1 = Function("return K1;");
+const typeofK2 = Function("return typeof K2;");
+const writeK3 = Function("return K3 = 3;");
+
+assert.throws(ReferenceError, () => readL1());
+assert.throws(ReferenceError, () => typeofL2());
+assert.throws(ReferenceError, () => writeL3());
+assert.throws(ReferenceError, () => readC1());
+assert.throws(ReferenceError, () => typeofC2());
+assert.throws(ReferenceError, () => writeC3());
+assert.throws(ReferenceError, () => readK1());
+assert.throws(ReferenceError, () => typeofK2());
+assert.throws(ReferenceError, () => writeK3());
+
+let l1 = "l1";
+let l2 = "l2";
+let l3 = "l3";
+
+const c1 = "c1";
+const c2 = "c2";
+const c3 = "c3";
+
+class K1 {}
+class K2 {}
+class K3 {}
+
+assert.sameValue(readL1(), "l1");
+assert.sameValue(typeofL2(), "string");
+assert.sameValue(writeL3(), 1);
+assert.sameValue(readC1(), "c1");
+assert.sameValue(typeofC2(), "string");
+assert.throws(TypeError, () => writeC3());
+assert.sameValue(readK1(), K1);
+assert.sameValue(typeofK2(), "function");
+assert.sameValue(writeK3(), 3);


### PR DESCRIPTION
## Summary

The global and dynamic load/store instructions were failing to properly TDZ check lexical bindings. For global bindings this only applies to lexical bindings defined in another script/global scope.

- For global load/stores we add TDZ checks to `Realm::{get_lexical_name, set_lexical_name}` but not `has_lexical_name`
- For dynamic loads/stores we add TDZ checks to `Scope::{lookup, lookup_store}`
- Care must be taken to distinguish uninitialized derived constructors which do not need the TDZ check
- Care must be taken to distinguish import bindings since they are always initialized even though the target value may be uninitialized (in the source module).

## Tests

- Added pretty thorough integration tests for global and dynamic TDZ checks, both before and after initialization
- Fix an existing bug caught in `integration/language/class/derived_constructor_this_in_eval.js`