### PR TITLE
[runtime] [[GetOwnProperty]] returns property directly, only convert to full property descriptor when necessary

### DIFF
--- a/src/brimstone_macros/src/wrap_ordinary_object.rs
+++ b/src/brimstone_macros/src/wrap_ordinary_object.rs
@@ -31,7 +31,7 @@ pub fn wrap_ordinary_object(_attr: TokenStream, item: TokenStream) -> TokenStrea
             &self,
             cx: Context,
             key: Handle<PropertyKey>,
-        ) -> EvalResult<Option<PropertyDescriptor>> {
+        ) -> EvalResult<Option<Property>> {
             self.ordinary_object().get_own_property(cx, key)
         }
     );

--- a/src/js/runtime/abstract_operations.rs
+++ b/src/js/runtime/abstract_operations.rs
@@ -169,8 +169,8 @@ pub fn has_own_property(
     object: Handle<ObjectValue>,
     key: Handle<PropertyKey>,
 ) -> EvalResult<bool> {
-    let desc = object.get_own_property(cx, key)?;
-    Ok(desc.is_some())
+    let property = object.get_own_property(cx, key)?;
+    Ok(property.is_some())
 }
 
 /// Call (https://tc39.es/ecma262/#sec-call)
@@ -239,9 +239,9 @@ pub fn set_integrity_level(
 
             for key_value in keys {
                 key.replace(must!(PropertyKey::from_value(cx, key_value)));
-                let current_desc = object.get_own_property(cx, key)?;
-                if let Some(current_desc) = current_desc {
-                    let desc = if current_desc.is_accessor_descriptor() {
+                let current_prop = object.get_own_property(cx, key)?;
+                if let Some(current_prop) = current_prop {
+                    let desc = if current_prop.is_accessor() {
                         PropertyDescriptor::attributes(None, None, Some(false))
                     } else {
                         PropertyDescriptor::attributes(Some(false), None, Some(false))
@@ -273,14 +273,14 @@ pub fn test_integrity_level(
 
     for key_value in keys {
         key.replace(must!(PropertyKey::from_value(cx, key_value)));
-        let current_desc = object.get_own_property(cx, key)?;
-        if let Some(current_desc) = current_desc {
-            if let Some(true) = current_desc.is_configurable {
+        let current_prop = object.get_own_property(cx, key)?;
+        if let Some(current_prop) = current_prop {
+            if current_prop.is_configurable() {
                 return Ok(false);
             }
 
-            if level == IntegrityLevel::Frozen && current_desc.is_data_descriptor() {
-                if let Some(true) = current_desc.is_writable {
+            if level == IntegrityLevel::Frozen && !current_prop.is_accessor() {
+                if current_prop.is_writable() {
                     return Ok(false);
                 }
             }
@@ -439,10 +439,10 @@ pub fn enumerable_own_property_names(
         }
 
         key.replace(must!(PropertyKey::from_value(cx, key_value)));
-        let desc = object.get_own_property(cx, key)?;
+        let property = object.get_own_property(cx, key)?;
 
-        if let Some(desc) = desc {
-            if let Some(true) = desc.is_enumerable {
+        if let Some(property) = property {
+            if property.is_enumerable() {
                 match kind {
                     KeyOrValue::Key => properties.push(key_value),
                     KeyOrValue::Value => {
@@ -517,9 +517,9 @@ pub fn copy_data_properties(
         next_key.replace(must!(PropertyKey::from_value(cx, next_key_value)));
 
         if !excluded_items.contains(&next_key) {
-            let desc = from.get_own_property(cx, next_key)?;
-            match desc {
-                Some(desc) if desc.is_enumerable() => {
+            let property = from.get_own_property(cx, next_key)?;
+            match property {
+                Some(property) if property.is_enumerable() => {
                     let prop_value = get(cx, from, next_key)?;
                     must!(create_data_property_or_throw(cx, target, next_key, prop_value));
                 }
@@ -705,9 +705,9 @@ pub fn setter_that_ignores_prototype_properties(
         return type_error(cx, "cannot set property");
     }
 
-    let descriptor = this_object.get_own_property(cx, key)?;
+    let property = this_object.get_own_property(cx, key)?;
 
-    if descriptor.is_none() {
+    if property.is_none() {
         create_data_property_or_throw(cx, this_object, key, value)
     } else {
         set(cx, this_object, key, value, true)

--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -19,6 +19,7 @@ use crate::{
             object_create, ordinary_define_own_property, ordinary_delete, ordinary_get,
             ordinary_get_own_property, ordinary_set,
         },
+        property::Property,
         property_descriptor::PropertyDescriptor,
         property_key::PropertyKey,
         rust_vtables::extract_virtual_object_vtable,
@@ -167,17 +168,17 @@ impl VirtualObject for Handle<MappedArgumentsObject> {
         &self,
         cx: Context,
         key: Handle<PropertyKey>,
-    ) -> EvalResult<Option<PropertyDescriptor>> {
-        let mut desc = ordinary_get_own_property(cx, self.as_object(), key);
-        if let Some(desc) = &mut desc {
-            if let Some(scope_index) = self.get_mapped_scope_index_for_key(key) {
-                desc.value = Some(self.get_mapped_argument(cx, scope_index));
-            }
-        } else {
-            return Ok(None);
+    ) -> EvalResult<Option<Property>> {
+        let mut property = match ordinary_get_own_property(cx, self.as_object(), key) {
+            Some(property) => property,
+            None => return Ok(None),
+        };
+
+        if let Some(scope_index) = self.get_mapped_scope_index_for_key(key) {
+            property.set_value(self.get_mapped_argument(cx, scope_index));
         }
 
-        Ok(desc)
+        Ok(Some(property))
     }
 
     /// [[DefineOwnProperty]] (https://tc39.es/ecma262/#sec-arguments-exotic-objects-defineownproperty-p-desc)

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -18,6 +18,7 @@ use crate::{
             ordinary_filtered_own_indexed_property_keys, ordinary_get_own_property,
             ordinary_own_string_symbol_property_keys,
         },
+        property::Property,
         property_descriptor::PropertyDescriptor,
         property_key::PropertyKey,
         rust_vtables::extract_virtual_object_vtable,
@@ -81,15 +82,10 @@ impl VirtualObject for Handle<ArrayObject> {
         &self,
         cx: Context,
         key: Handle<PropertyKey>,
-    ) -> EvalResult<Option<PropertyDescriptor>> {
+    ) -> EvalResult<Option<Property>> {
         if key.is_string() && key.as_string().equals(&cx.names.length().as_string())? {
             let length_value = cx.number(self.as_object().array_properties_length());
-            return Ok(Some(PropertyDescriptor::data(
-                length_value,
-                self.is_length_writable,
-                false,
-                false,
-            )));
+            return Ok(Some(Property::data(length_value, self.is_length_writable, false, false)));
         }
 
         Ok(ordinary_get_own_property(cx, self.as_object(), key))

--- a/src/js/runtime/for_in_iterator.rs
+++ b/src/js/runtime/for_in_iterator.rs
@@ -84,8 +84,8 @@ impl ForInIterator {
                 }
 
                 // Only collect enumerable keys
-                if let Some(desc) = current_object.get_own_property(cx, property_key)? {
-                    if desc.is_enumerable() {
+                if let Some(property) = current_object.get_own_property(cx, property_key)? {
+                    if property.is_enumerable() {
                         keys.push(key);
                     }
                 }

--- a/src/js/runtime/global_names.rs
+++ b/src/js/runtime/global_names.rs
@@ -222,7 +222,7 @@ pub fn can_declare_global_function(
                 return Ok(true);
             }
 
-            let result = existing_prop.is_data_descriptor()
+            let result = !existing_prop.is_accessor()
                 && existing_prop.is_writable()
                 && existing_prop.is_enumerable();
 

--- a/src/js/runtime/global_object.rs
+++ b/src/js/runtime/global_object.rs
@@ -13,8 +13,7 @@ use crate::{
         ordinary_object::{
             PropertyStorage, object_create_with_proto, ordinary_define_own_property,
             ordinary_delete, ordinary_filtered_own_indexed_property_keys,
-            ordinary_get_own_property, to_property_descriptor,
-            validate_and_apply_property_descriptor,
+            ordinary_get_own_property, validate_and_apply_property_descriptor,
         },
         property::{DEFAULT_DATA_PROPERTY_FLAGS, HeapProperty, Property, PropertyFlags},
         property_descriptor::PropertyDescriptor,
@@ -70,17 +69,15 @@ impl VirtualObject for Handle<GlobalObject> {
         &self,
         cx: Context,
         key: Handle<PropertyKey>,
-    ) -> EvalResult<Option<PropertyDescriptor>> {
+    ) -> EvalResult<Option<Property>> {
         if key.is_array_index() {
             return Ok(ordinary_get_own_property(cx, self.as_object(), key));
         }
 
         // All named properties are intercepted by the global object
-        if let Some(property) = self.lookup_named_property(*key) {
-            Ok(Some(to_property_descriptor(&property.to_property(cx))))
-        } else {
-            Ok(None)
-        }
+        Ok(self
+            .lookup_named_property(*key)
+            .map(|property| property.to_property(cx)))
     }
 
     fn define_own_property(
@@ -94,7 +91,9 @@ impl VirtualObject for Handle<GlobalObject> {
         }
 
         // All named properties are intercepted by the global object
-        let current_desc = self.get_own_property(cx, key)?;
+        let current_desc = self
+            .get_own_property(cx, key)?
+            .map(|property| PropertyDescriptor::from_property(&property));
         let is_extensible = self.as_object().is_extensible(cx)?;
 
         Ok(validate_and_apply_property_descriptor(

--- a/src/js/runtime/intrinsics/object_constructor.rs
+++ b/src/js/runtime/intrinsics/object_constructor.rs
@@ -118,9 +118,9 @@ impl ObjectConstructor {
 
                 for next_key in keys {
                     property_key.replace(must!(PropertyKey::from_value(cx, next_key)));
-                    let desc = from.get_own_property(cx, property_key)?;
-                    if let Some(desc) = desc {
-                        if let Some(true) = desc.is_enumerable {
+                    let property = from.get_own_property(cx, property_key)?;
+                    if let Some(property) = property {
+                        if property.is_enumerable() {
                             let value = get(cx, from, property_key)?;
                             set(cx, to, property_key, value, true)?;
                         }
@@ -185,9 +185,9 @@ impl ObjectConstructor {
 
         for key_value in keys {
             let key = must!(PropertyKey::from_value(cx, key_value)).to_handle(cx);
-            let prop_desc = properties.get_own_property(cx, key)?;
-            if let Some(prop_desc) = prop_desc {
-                if let Some(true) = prop_desc.is_enumerable {
+            let prop = properties.get_own_property(cx, key)?;
+            if let Some(prop) = prop {
+                if prop.is_enumerable() {
                     let desc_object = get(cx, properties, key)?;
                     let desc = to_property_descriptor(cx, desc_object)?;
 
@@ -270,7 +270,7 @@ impl ObjectConstructor {
         let property_arg = arguments.get(cx, 1);
         let property_key = to_property_key(cx, property_arg)?;
 
-        match object.get_own_property(cx, property_key)? {
+        match object.get_own_property_descriptor(cx, property_key)? {
             None => Ok(cx.undefined()),
             Some(desc) => Ok(from_property_descriptor(cx, desc)?.as_value()),
         }
@@ -291,7 +291,7 @@ impl ObjectConstructor {
 
         for key_value in keys {
             key.replace(must!(PropertyKey::from_value(cx, key_value)));
-            let desc = object.get_own_property(cx, key)?;
+            let desc = object.get_own_property_descriptor(cx, key)?;
             if let Some(desc) = desc {
                 let desc_object = from_property_descriptor(cx, desc)?;
                 must!(create_data_property_or_throw(cx, descriptors, key, desc_object.into()));

--- a/src/js/runtime/intrinsics/object_prototype_object.rs
+++ b/src/js/runtime/intrinsics/object_prototype_object.rs
@@ -5,6 +5,7 @@ use crate::{
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr,
         abstract_operations::{define_property_or_throw, get, has_own_property, invoke},
+        accessor::Accessor,
         alloc_error::AllocResult,
         error::type_error,
         gc::{HeapItem, HeapVisitor},
@@ -126,7 +127,7 @@ impl ObjectPrototypeObject {
 
         match this_object.get_own_property(cx, property_key)? {
             None => Ok(cx.bool(false)),
-            Some(desc) => Ok(cx.bool(desc.is_enumerable())),
+            Some(property) => Ok(cx.bool(property.is_enumerable())),
         }
     }}
 
@@ -275,12 +276,13 @@ impl ObjectPrototypeObject {
 
         let mut current_object = object;
         loop {
-            let desc = current_object.get_own_property(cx, key)?;
-            match desc {
-                Some(desc) => {
-                    return if desc.is_accessor_descriptor() {
-                        match desc.get {
-                            Some(get) => Ok(get.as_value()),
+            let property = current_object.get_own_property(cx, key)?;
+            match property {
+                Some(property) => {
+                    return if property.is_accessor() {
+                        let accessor = Accessor::from_value_handle(property.value());
+                        match accessor.get {
+                            Some(get) => Ok(get.to_handle().as_value()),
                             None => Ok(cx.undefined()),
                         }
                     } else {
@@ -304,12 +306,13 @@ impl ObjectPrototypeObject {
 
         let mut current_object = object;
         loop {
-            let desc = current_object.get_own_property(cx, key)?;
-            match desc {
-                Some(desc) => {
-                    return if desc.is_accessor_descriptor() {
-                        match desc.set {
-                            Some(set) => Ok(set.as_value()),
+            let property = current_object.get_own_property(cx, key)?;
+            match property {
+                Some(property) => {
+                    return if property.is_accessor() {
+                        let accessor = Accessor::from_value_handle(property.value());
+                        match accessor.set {
+                            Some(set) => Ok(set.to_handle().as_value()),
                             None => Ok(cx.undefined()),
                         }
                     } else {

--- a/src/js/runtime/intrinsics/reflect_object.rs
+++ b/src/js/runtime/intrinsics/reflect_object.rs
@@ -157,7 +157,7 @@ impl ReflectObject {
         let key_arg = arguments.get(cx, 1);
         let key = to_property_key(cx, key_arg)?;
 
-        let desc = target.get_own_property(cx, key)?;
+        let desc = target.get_own_property_descriptor(cx, key)?;
 
         Ok(desc
             .map(|desc| from_property_descriptor(cx, desc))

--- a/src/js/runtime/intrinsics/typed_array.rs
+++ b/src/js/runtime/intrinsics/typed_array.rs
@@ -34,6 +34,7 @@ use crate::{
             ordinary_delete, ordinary_get, ordinary_get_own_property, ordinary_has_property,
             ordinary_own_string_symbol_property_keys, ordinary_set,
         },
+        property::Property,
         property_descriptor::PropertyDescriptor,
         property_key::PropertyKey,
         realm::Realm,

--- a/src/js/runtime/intrinsics/typed_array_object.rs
+++ b/src/js/runtime/intrinsics/typed_array_object.rs
@@ -81,7 +81,7 @@ macro_rules! create_typed_array_object {
                 &self,
                 cx: Context,
                 key: Handle<PropertyKey>,
-            ) -> EvalResult<Option<PropertyDescriptor>> {
+            ) -> EvalResult<Option<Property>> {
                 match canonical_numeric_index_string(cx, key, self.as_typed_array())? {
                     CanonicalIndexType::NotAnIndex => {
                         Ok(ordinary_get_own_property(cx, self.as_object(), key))
@@ -93,9 +93,7 @@ macro_rules! create_typed_array_object {
 
                         let value = self.read_element_value(cx, array_buffer_ptr, byte_index)?;
 
-                        let desc = PropertyDescriptor::data(value, true, true, true);
-
-                        Ok(Some(desc))
+                        Ok(Some(Property::data(value, true, true, true)))
                     }
                 }
             }

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -164,7 +164,7 @@ impl VirtualObject for Handle<ModuleNamespaceObject> {
         &self,
         cx: Context,
         key: Handle<PropertyKey>,
-    ) -> EvalResult<Option<PropertyDescriptor>> {
+    ) -> EvalResult<Option<Property>> {
         if key.is_symbol() {
             return Ok(ordinary_get_own_property(cx, (*self).into(), key));
         }
@@ -173,8 +173,7 @@ impl VirtualObject for Handle<ModuleNamespaceObject> {
             None => Ok(None),
             Some(value) => {
                 let value = value.to_handle(cx);
-                let desc = PropertyDescriptor::data(value, true, true, false);
-                Ok(Some(desc))
+                Ok(Some(Property::data(value, true, true, false)))
             }
         }
     }
@@ -190,9 +189,9 @@ impl VirtualObject for Handle<ModuleNamespaceObject> {
             return ordinary_define_own_property(cx, (*self).into(), key, desc);
         }
 
-        let current_desc = match self.get_own_property(cx, key)? {
+        let current_prop = match self.get_own_property(cx, key)? {
             None => return Ok(false),
-            Some(desc) => desc,
+            Some(property) => property,
         };
 
         // Property descriptor attributes must match (writable, enumerable, non-configurable)
@@ -206,7 +205,7 @@ impl VirtualObject for Handle<ModuleNamespaceObject> {
 
         // If a value was provided it must match the current value
         if let Some(desc_value) = desc.value {
-            return Ok(same_value(desc_value, current_desc.value.unwrap())?);
+            return Ok(same_value(desc_value, current_prop.value())?);
         }
 
         Ok(true)

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -636,8 +636,20 @@ impl Handle<ObjectValue> {
         &self,
         cx: Context,
         key: Handle<PropertyKey>,
-    ) -> EvalResult<Option<PropertyDescriptor>> {
+    ) -> EvalResult<Option<Property>> {
         self.virtual_object().get_own_property(cx, key)
+    }
+
+    /// [[GetOwnProperty]] which returns a full property descriptor matching the spec.
+    #[inline]
+    pub fn get_own_property_descriptor(
+        &self,
+        cx: Context,
+        key: Handle<PropertyKey>,
+    ) -> EvalResult<Option<PropertyDescriptor>> {
+        Ok(self
+            .get_own_property(cx, key)?
+            .map(|property| PropertyDescriptor::from_property(&property)))
     }
 
     #[inline]
@@ -759,7 +771,7 @@ pub trait VirtualObject {
         &self,
         cx: Context,
         key: Handle<PropertyKey>,
-    ) -> EvalResult<Option<PropertyDescriptor>>;
+    ) -> EvalResult<Option<Property>>;
 
     fn define_own_property(
         &mut self,

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -93,7 +93,7 @@ impl VirtualObject for Handle<OrdinaryObject> {
         &self,
         cx: Context,
         key: Handle<PropertyKey>,
-    ) -> EvalResult<Option<PropertyDescriptor>> {
+    ) -> EvalResult<Option<Property>> {
         Ok(ordinary_get_own_property(cx, self.as_object(), key))
     }
 
@@ -149,31 +149,8 @@ pub fn ordinary_get_own_property(
     cx: Context,
     object: Handle<ObjectValue>,
     key: Handle<PropertyKey>,
-) -> Option<PropertyDescriptor> {
-    object
-        .get_property(cx, key)
-        .map(|property| to_property_descriptor(&property))
-}
-
-/// Convert a stored property to a full property descriptor.
-pub fn to_property_descriptor(property: &Property) -> PropertyDescriptor {
-    let value = property.value();
-    if property.is_accessor() {
-        let accessor_value = Accessor::from_value_handle(value);
-        PropertyDescriptor::accessor(
-            accessor_value.get.map(|f| f.to_handle()),
-            accessor_value.set.map(|f| f.to_handle()),
-            property.is_enumerable(),
-            property.is_configurable(),
-        )
-    } else {
-        PropertyDescriptor::data(
-            value,
-            property.is_writable(),
-            property.is_enumerable(),
-            property.is_configurable(),
-        )
-    }
+) -> Option<Property> {
+    object.get_property(cx, key)
 }
 
 /// Trait for generic property storage on an object, either ordinary or exotic. Used to generalize
@@ -211,7 +188,7 @@ pub fn ordinary_define_own_property(
     key: Handle<PropertyKey>,
     desc: PropertyDescriptor,
 ) -> EvalResult<bool> {
-    let current_desc = object.get_own_property(cx, key)?;
+    let current_desc = object.get_own_property_descriptor(cx, key)?;
     let is_extensible = object.is_extensible(cx)?;
 
     Ok(validate_and_apply_property_descriptor(
@@ -438,8 +415,8 @@ pub fn ordinary_get(
     key: Handle<PropertyKey>,
     receiver: Handle<Value>,
 ) -> EvalResult<Handle<Value>> {
-    let desc = object.get_own_property(cx, key)?;
-    match desc {
+    let property = object.get_own_property(cx, key)?;
+    match property {
         None => {
             let parent = object.get_prototype_of(cx)?;
             match parent {
@@ -447,11 +424,11 @@ pub fn ordinary_get(
                 Some(parent) => parent.get(cx, key, receiver),
             }
         }
-        Some(desc) if desc.is_data_descriptor() => Ok(desc.value.unwrap()),
-        Some(PropertyDescriptor { get: None, .. }) => Ok(cx.undefined()),
-        Some(PropertyDescriptor { get: Some(getter), .. }) => {
-            call_object(cx, getter, receiver, &[])
-        }
+        Some(property) if !property.is_accessor() => Ok(property.value()),
+        Some(property) => match Accessor::from_value_handle(property.value()).get {
+            None => Ok(cx.undefined()),
+            Some(getter) => call_object(cx, getter.to_handle(), receiver, &[]),
+        },
     }
 }
 
@@ -464,20 +441,20 @@ pub fn ordinary_set(
     value: Handle<Value>,
     receiver: Handle<Value>,
 ) -> EvalResult<bool> {
-    let own_desc = object.get_own_property(cx, key)?;
-    let own_desc = match own_desc {
+    let own_prop = object.get_own_property(cx, key)?;
+    let own_prop = match own_prop {
         None => {
             let parent = object.get_prototype_of(cx)?;
             match parent {
-                None => PropertyDescriptor::data(cx.undefined(), true, true, true),
+                None => Property::data(cx.undefined(), true, true, true),
                 Some(mut parent) => return parent.set(cx, key, value, receiver),
             }
         }
-        Some(own_desc) => own_desc,
+        Some(own_prop) => own_prop,
     };
 
-    if own_desc.is_data_descriptor() {
-        if let Some(false) = own_desc.is_writable {
+    if !own_prop.is_accessor() {
+        if !own_prop.is_writable() {
             return Ok(false);
         }
 
@@ -486,21 +463,21 @@ pub fn ordinary_set(
         }
 
         let mut receiver = receiver.as_object();
-        let existing_descriptor = receiver.get_own_property(cx, key)?;
-        match existing_descriptor {
+        let existing = receiver.get_own_property(cx, key)?;
+        match existing {
             None => create_data_property(cx, receiver, key, value),
-            Some(existing_descriptor) if existing_descriptor.is_accessor_descriptor() => Ok(false),
-            Some(PropertyDescriptor { is_writable: Some(false), .. }) => Ok(false),
+            Some(existing) if existing.is_accessor() => Ok(false),
+            Some(existing) if !existing.is_writable() => Ok(false),
             Some(_) => {
                 let value_desc = PropertyDescriptor::data_value_only(value);
                 receiver.define_own_property(cx, key, value_desc)
             }
         }
     } else {
-        match own_desc.set {
+        match Accessor::from_value_handle(own_prop.value()).set {
             None => Ok(false),
             Some(setter) => {
-                call_object(cx, setter, receiver, &[value])?;
+                call_object(cx, setter.to_handle(), receiver, &[value])?;
                 Ok(true)
             }
         }
@@ -513,11 +490,11 @@ pub fn ordinary_delete(
     mut object: Handle<ObjectValue>,
     key: Handle<PropertyKey>,
 ) -> EvalResult<bool> {
-    let desc = object.get_own_property(cx, key)?;
-    match desc {
+    let property = object.get_own_property(cx, key)?;
+    match property {
         None => Ok(true),
-        Some(desc) => {
-            if desc.is_configurable() {
+        Some(property) => {
+            if property.is_configurable() {
                 object.remove_property(cx, key)?;
                 Ok(true)
             } else {

--- a/src/js/runtime/property_descriptor.rs
+++ b/src/js/runtime/property_descriptor.rs
@@ -3,12 +3,14 @@ use crate::{
     runtime::{
         Context, Value,
         abstract_operations::{create_data_property_or_throw, get, has_property},
+        accessor::Accessor,
         alloc_error::AllocResult,
         error::type_error,
         eval_result::EvalResult,
         gc::Handle,
         object_value::ObjectValue,
         ordinary_object::ordinary_object_create,
+        property::Property,
         type_utilities::{is_callable, to_boolean},
     },
 };
@@ -132,6 +134,43 @@ impl PropertyDescriptor {
             has_set: false,
             get: None,
             set: None,
+        }
+    }
+
+    pub fn from_property(property: &Property) -> PropertyDescriptor {
+        if property.is_accessor() {
+            let accessor = Accessor::from_value_handle(property.value());
+            PropertyDescriptor::accessor(
+                accessor.get.map(|f| f.to_handle()),
+                accessor.set.map(|f| f.to_handle()),
+                property.is_enumerable(),
+                property.is_configurable(),
+            )
+        } else {
+            PropertyDescriptor::data(
+                property.value(),
+                property.is_writable(),
+                property.is_enumerable(),
+                property.is_configurable(),
+            )
+        }
+    }
+
+    pub fn to_property(&self, cx: Context) -> AllocResult<Property> {
+        if self.is_accessor_descriptor() {
+            let accessor = Accessor::new(cx, self.get, self.set)?;
+            Ok(Property::accessor(
+                accessor.into(),
+                self.is_enumerable(),
+                self.is_configurable(),
+            ))
+        } else {
+            Ok(Property::data(
+                self.value.unwrap(),
+                self.is_writable(),
+                self.is_enumerable(),
+                self.is_configurable(),
+            ))
         }
     }
 

--- a/src/js/runtime/proxy_object.rs
+++ b/src/js/runtime/proxy_object.rs
@@ -16,6 +16,7 @@ use crate::{
         intrinsics::intrinsics::Intrinsic,
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{is_compatible_property_descriptor, object_create},
+        property::Property,
         property_descriptor::{
             PropertyDescriptor, from_property_descriptor, to_property_descriptor,
         },
@@ -99,7 +100,7 @@ impl VirtualObject for Handle<ProxyObject> {
         &self,
         cx: Context,
         key: Handle<PropertyKey>,
-    ) -> EvalResult<Option<PropertyDescriptor>> {
+    ) -> EvalResult<Option<Property>> {
         if self.is_revoked() {
             return type_error(cx, "operation attempted on revoked proxy");
         }
@@ -117,7 +118,7 @@ impl VirtualObject for Handle<ProxyObject> {
         let trap_result = call_object(cx, trap.unwrap(), handler, &trap_arguments)?;
 
         if trap_result.is_undefined() {
-            let target_desc = target.get_own_property(cx, key)?;
+            let target_desc = target.get_own_property_descriptor(cx, key)?;
             if target_desc.is_none() {
                 return Ok(None);
             }
@@ -150,7 +151,7 @@ impl VirtualObject for Handle<ProxyObject> {
             );
         }
 
-        let target_desc = target.get_own_property(cx, key)?;
+        let target_desc = target.get_own_property_descriptor(cx, key)?;
         let is_target_extensible = is_extensible_(cx, target)?;
 
         let mut result_desc = to_property_descriptor(cx, trap_result)?;
@@ -189,7 +190,7 @@ impl VirtualObject for Handle<ProxyObject> {
             }
         }
 
-        Ok(Some(result_desc))
+        Ok(Some(result_desc.to_property(cx)?))
     }
 
     /// [[DefineOwnProperty]] (https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc)
@@ -220,7 +221,7 @@ impl VirtualObject for Handle<ProxyObject> {
             return Ok(false);
         }
 
-        let target_desc = target.get_own_property(cx, key)?;
+        let target_desc = target.get_own_property_descriptor(cx, key)?;
         let is_target_extensible = is_extensible_(cx, target)?;
 
         let mut is_setting_non_configurable = false;
@@ -314,7 +315,7 @@ impl VirtualObject for Handle<ProxyObject> {
         let trap_result = to_boolean(*trap_result);
 
         if !trap_result {
-            let target_desc = target.get_own_property(cx, key)?;
+            let target_desc = target.get_own_property_descriptor(cx, key)?;
             if let Some(desc) = target_desc {
                 if let Some(false) = desc.is_configurable {
                     return type_error(
@@ -364,7 +365,7 @@ impl VirtualObject for Handle<ProxyObject> {
         let trap_arguments = [target.into(), key.to_value(cx)?, receiver];
         let trap_result = call_object(cx, trap.unwrap(), handler, &trap_arguments)?;
 
-        let target_desc = target.get_own_property(cx, key)?;
+        let target_desc = target.get_own_property_descriptor(cx, key)?;
         if let Some(target_desc) = target_desc {
             if let Some(false) = target_desc.is_configurable {
                 if target_desc.is_data_descriptor() {
@@ -425,7 +426,7 @@ impl VirtualObject for Handle<ProxyObject> {
             return Ok(false);
         }
 
-        let target_desc = target.get_own_property(cx, key)?;
+        let target_desc = target.get_own_property_descriptor(cx, key)?;
         if let Some(target_desc) = target_desc {
             if let Some(false) = target_desc.is_configurable {
                 if target_desc.is_data_descriptor() {
@@ -477,7 +478,7 @@ impl VirtualObject for Handle<ProxyObject> {
             return Ok(false);
         }
 
-        let target_desc = target.get_own_property(cx, key)?;
+        let target_desc = target.get_own_property_descriptor(cx, key)?;
         if let Some(target_desc) = target_desc {
             if let Some(false) = target_desc.is_configurable {
                 return type_error(
@@ -572,7 +573,7 @@ impl VirtualObject for Handle<ProxyObject> {
 
         for key in target_keys {
             let property_key = must!(PropertyKey::from_value(cx, key)).to_handle(cx);
-            let desc = target.get_own_property(cx, property_key)?;
+            let desc = target.get_own_property_descriptor(cx, property_key)?;
 
             if let Some(PropertyDescriptor { is_configurable: Some(false), .. }) = desc {
                 target_non_configurable_keys.push(property_key);

--- a/src/js/runtime/string_object.rs
+++ b/src/js/runtime/string_object.rs
@@ -153,12 +153,14 @@ impl VirtualObject for Handle<StringObject> {
         &self,
         cx: Context,
         key: Handle<PropertyKey>,
-    ) -> EvalResult<Option<PropertyDescriptor>> {
-        let desc = ordinary_get_own_property(cx, self.as_object(), key);
-        if desc.is_none() {
-            Ok(self.string_get_own_property(cx, key)?)
-        } else {
-            Ok(desc)
+    ) -> EvalResult<Option<Property>> {
+        if let Some(property) = ordinary_get_own_property(cx, self.as_object(), key) {
+            return Ok(Some(property));
+        }
+
+        match self.string_get_own_property(cx, key)? {
+            Some(desc) => Ok(Some(desc.to_property(cx)?)),
+            None => Ok(None),
         }
     }
 


### PR DESCRIPTION
## Summary

The virtual `[[GetOwnProperty]]` method currently returns a full `PropertyDescriptor`. This does more work than necessary - let's return the `Property` directly and only convert to a full spec `PropertyDescriptor` when explicitly needed.

Noise, but consistently getting a nice ~+2% increase to octane score.

| Benchmark | 1ba00cd83 (base) | 4006692ac | Change |
|-----------|------------------|-----------|--------|
| Richards | 1,524 med 1,518 ±10.9 n=4 | 1,518 med 1,505 ±9.0 n=4 | -0.4% |
| DeltaBlue | 1,292 med 1,284 ±5.8 n=4 | 1,305 med 1,304 ±8.0 n=4 | +1.0% |
| Crypto | 1,207 med 1,163 ±44.6 n=4 | 1,299 med 1,298 ±2.4 n=4 | +7.6% |
| RayTrace | 2,094 med 2,080 ±10.0 n=4 | 2,103 med 2,100 ±5.3 n=4 | +0.4% |
| EarleyBoyer | 3,808 med 3,776 ±27.0 n=4 | 3,810 med 3,806 ±4.0 n=4 | +0.1% |
| RegExp | 387 med 386 ±2.7 n=4 | 395 med 395 ±1.0 n=4 | +2.1% |
| Splay | 2,971 med 2,946 ±33.7 n=4 | 3,056 med 3,011 ±34.0 n=4 | +2.9% |
| SplayLatency | 5,639 med 5,543 ±84.6 n=4 | 5,851 med 5,789 ±93.4 n=4 | +3.8% |
| NavierStokes | 934 med 931 ±6.2 n=4 | 970 med 965 ±3.7 n=4 | +3.9% |
| PdfJS | 3,479 med 3,475 ±6.5 n=4 | 3,603 med 3,602 ±9.1 n=4 | +3.6% |
| Mandreel | 1,002 med 998 ±17.3 n=4 | 1,028 med 1,024 ±22.7 n=4 | +2.6% |
| MandreelLatency | 6,391 med 6,267 ±122 n=4 | 6,466 med 6,392 ±93.8 n=4 | +1.2% |
| Gameboy | 3,258 med 3,231 ±14.2 n=4 | 3,358 med 3,353 ±5.9 n=4 | +3.1% |
| CodeLoad | 38,081 med 38,044 ±141 n=4 | 38,096 med 38,039 ±60.1 n=4 | +0.0% |
| Box2D | 6,156 med 6,128 ±21.2 n=4 | 6,398 med 6,379 ±87.0 n=4 | +3.9% |
| zlib | 2,144 med 2,029 ±104 n=4 | 2,083 med 2,075 ±11.4 n=4 | -2.8% |
| Typescript | 13,728 med 13,699 ±25.1 n=4 | 14,139 med 14,112 ±36.2 n=4 | +3.0% |
| Total (octane) | 2,857 med 2,818 ±21.8 n=4 | 2,911 med 2,905 ±9.9 n=4 | +1.9% |

## Tests

- CI