### PR TITLE
[runtime] Create global var/function bindings in declaration order

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashMap, VecDeque},
     error::Error,
     fmt,
     ops::Range,
@@ -9443,17 +9443,17 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         &mut self,
         global_scope: &AstScopeNode,
     ) -> AllocResult<Handle<GlobalNames>> {
-        // Collect all global variables and functions in scope
-        let mut global_vars = HashSet::new();
-        let mut global_funcs = HashSet::new();
+        // Collect all global variables and functions in scope, in declaration order. Enumeration
+        // order of the created global bindings must match creation order, which is declaration
+        // order, so names are kept in order rather than grouped by kind. `iter_var_decls` yields
+        // each name once in declaration order.
+        let mut global_names = vec![];
+        let mut is_function = vec![];
 
         for (name, binding) in global_scope.iter_var_decls() {
             let name = self.get_cached_wtf8_str(name)?.as_flat();
-            if let BindingKind::Function { .. } = binding.kind() {
-                global_funcs.insert(name);
-            } else {
-                global_vars.insert(name);
-            }
+            global_names.push(name);
+            is_function.push(matches!(binding.kind(), BindingKind::Function { .. }));
         }
 
         // VM scope node is guaranteed to exist, since at minimum the realm is always stored.
@@ -9469,7 +9469,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         // Add all var and lex names to the GlobalNames object, which will be used later when
         // instantiating the global scope.
-        GlobalNames::new(self.cx, global_vars, global_funcs, scope_names)
+        GlobalNames::new(self.cx, &global_names, &is_function, scope_names)
     }
 
     /// Generate the name of a declaration that is part of a default export declaration, defaulting

--- a/src/js/runtime/global_names.rs
+++ b/src/js/runtime/global_names.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use crate::{
     field_offset,
     runtime::{
@@ -23,44 +21,67 @@ use crate::{
 #[repr(C)]
 pub struct GlobalNames {
     shape: HeapPtr<Shape>,
-    /// Number of functions
-    num_functions: usize,
-    /// Scopes names for this global scope, containing all lexical names.
+    /// Scope names for this global scope, containing all lexical names.
     scope_names: HeapPtr<ScopeNames>,
-    /// Array of global names. The first `num_functions` are global var scoped functions, the rest
-    /// are global vars. All names are interned strings.
+    /// Array of global var-scoped names in declaration (creation) order. All names are interned
+    /// strings.
     names: InlineArray<HeapPtr<FlatString>>,
+    /// Trailing region with one byte per name, nonzero if the corresponding name is a var-scoped
+    /// function declaration (as opposed to a plain var). Enumeration order of the created bindings
+    /// must follow declaration order, so functions and vars are interleaved in `names` rather than
+    /// being separated by kind.
+    _is_function: [u8; 1],
 }
 
 impl GlobalNames {
     pub fn new(
         cx: Context,
-        vars: HashSet<Handle<FlatString>>,
-        funcs: HashSet<Handle<FlatString>>,
+        names: &[Handle<FlatString>],
+        is_function: &[bool],
         scope_names: Handle<ScopeNames>,
     ) -> AllocResult<Handle<GlobalNames>> {
-        let num_funcs = funcs.len();
-        let num_names = vars.len() + num_funcs;
+        debug_assert_eq!(names.len(), is_function.len());
+        let num_names = names.len();
 
         let size = Self::calculate_size_in_bytes(num_names);
         let mut global_names = cx.alloc_uninit_with_size::<GlobalNames>(size)?;
 
         set_uninit!(global_names.shape, cx.shapes.get(HeapItemKind::GlobalNames));
         set_uninit!(global_names.scope_names, *scope_names);
-        global_names.num_functions = funcs.len();
 
-        // Place function names first in the names array
+        // Names are stored in declaration order, with a parallel is-function flag per name
         global_names.names.init_with_uninit(num_names);
-        for (i, name) in funcs.iter().chain(vars.iter()).enumerate() {
+        for (i, name) in names.iter().enumerate() {
             global_names.names.set_unchecked(i, **name);
+        }
+
+        let is_function_ptr = global_names.get_is_function_ptr() as *mut u8;
+        for (i, &is_func) in is_function.iter().enumerate() {
+            unsafe { is_function_ptr.add(i).write(is_func as u8) };
         }
 
         Ok(global_names.to_handle())
     }
 
+    const NAMES_OFFSET: usize = field_offset!(GlobalNames, names);
+
     fn calculate_size_in_bytes(num_names: usize) -> usize {
-        let names_offset = field_offset!(GlobalNames, names);
-        names_offset + InlineArray::<HeapPtr<FlatString>>::calculate_size_in_bytes(num_names)
+        Self::is_function_offset(num_names) + num_names
+    }
+
+    fn is_function_offset(num_names: usize) -> usize {
+        Self::NAMES_OFFSET
+            + InlineArray::<HeapPtr<FlatString>>::calculate_size_in_bytes(num_names)
+    }
+
+    fn get_is_function_ptr(&self) -> *const u8 {
+        let ptr = self as *const GlobalNames as *const u8;
+        unsafe { ptr.add(Self::is_function_offset(self.names.len())) }
+    }
+
+    /// Whether the name at the given index is a var-scoped function declaration.
+    fn is_function(&self, index: usize) -> bool {
+        unsafe { *self.get_is_function_ptr().add(index) != 0 }
     }
 
     pub fn scope_names(&self) -> Handle<ScopeNames> {
@@ -141,7 +162,7 @@ fn global_declaration_instantiation(
         // Safe since already an interned string
         let name_key = name_handle.cast::<PropertyKey>();
 
-        if i < global_names.num_functions {
+        if global_names.is_function(i) {
             if !can_declare_global_function(cx, global_object, name_key)? {
                 return type_error(
                     cx,
@@ -165,7 +186,7 @@ fn global_declaration_instantiation(
 
         let name_key = name_handle.cast::<PropertyKey>();
 
-        if i < global_names.num_functions {
+        if global_names.is_function(i) {
             create_global_function_binding(
                 cx,
                 global_object,

--- a/tests/integration/regression/000031.js
+++ b/tests/integration/regression/000031.js
@@ -1,0 +1,27 @@
+/*---
+description: ^
+  Global var and function declarations must be created (and therefore enumerated) in declaration
+  order. Previously the names were collected into a HashSet before being installed on the global
+  object, producing a nondeterministic order that varied between runs and separated functions from
+  vars instead of interleaving them in declaration order.
+includes: [compareArray.js]
+---*/
+
+var g_zebra = 1;
+function g_apple() {}
+var g_mango = 2;
+function g_delta() {}
+// Redeclaring g_apple as a var must not move it from its first-declaration position.
+var g_apple = 3;
+var g_yak = 4;
+
+assert.compareArray(
+  Object.keys(globalThis).filter((k) => k.startsWith("g_")),
+  ["g_zebra", "g_apple", "g_mango", "g_delta", "g_yak"]
+);
+
+// The bindings are enumerable own data properties regardless of kind.
+assert.compareArray(
+  Object.getOwnPropertyNames(globalThis).filter((k) => k.startsWith("g_")),
+  ["g_zebra", "g_apple", "g_mango", "g_delta", "g_yak"]
+);


### PR DESCRIPTION
## Problem

`Object.keys(globalThis)` returned global var/function names in a **nondeterministic order that varied run-to-run** within the same binary. `GlobalNames::new` collected the names into `HashSet<Handle<FlatString>>`, and iterating a `HashSet` yields an arbitrary order.

The spec requires bindings to be created (and thus enumerated) in **creation order = declaration order**, with functions and vars interleaved. The old code both randomized the order *and* grouped all functions ahead of all vars.

This predates the current branch — it reproduces on `master` (and `HEAD~1`) — but it's a genuine spec bug, and it makes any test asserting on `globalThis` enumeration order flaky.

## Fix

`GlobalNames` now stores names in declaration order with a parallel per-name byte flag marking which names are var-scoped functions (mirroring the trailing flags region already used by `ScopeNames`). `iter_var_decls()` already yields each name once in declaration order (the scope's `bindings` is an insertion-ordered `AstIndexMap`), so the correct order falls out directly — no more `HashSet`.

`global_declaration_instantiation` now consults the per-name flag to pick `can_declare_global_function`/`create_global_function_binding` vs the var variants, instead of relying on a `num_functions` "functions first" split.

Verified against V8: for interleaved declarations the enumeration order now matches Node/V8 exactly and is stable across runs.

## Test

Adds `tests/integration/regression/000031.js`, asserting `Object.keys(globalThis)` (and `getOwnPropertyNames`) enumerate global declarations in declaration order — including that redeclaring a function name as a var keeps its original position.

## Testing

- `cargo btest --release -- --ignore-unimplemented` → integration 145/0, test262 44867/0, zero regressions.