### PR TITLE
[runtime] Global var and function declarations added to global object in declaration order

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashMap, VecDeque},
     error::Error,
     fmt,
     ops::Range,
@@ -9443,17 +9443,13 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         &mut self,
         global_scope: &AstScopeNode,
     ) -> AllocResult<Handle<GlobalNames>> {
-        // Collect all global variables and functions in scope
-        let mut global_vars = HashSet::new();
-        let mut global_funcs = HashSet::new();
+        // Collect all global vars and var scoped functions in declaration order
+        let mut global_names = vec![];
 
         for (name, binding) in global_scope.iter_var_decls() {
             let name = self.get_cached_wtf8_str(name)?.as_flat();
-            if let BindingKind::Function { .. } = binding.kind() {
-                global_funcs.insert(name);
-            } else {
-                global_vars.insert(name);
-            }
+            let is_function = matches!(binding.kind(), BindingKind::Function { .. });
+            global_names.push((name, is_function));
         }
 
         // VM scope node is guaranteed to exist, since at minimum the realm is always stored.
@@ -9469,7 +9465,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         // Add all var and lex names to the GlobalNames object, which will be used later when
         // instantiating the global scope.
-        GlobalNames::new(self.cx, global_vars, global_funcs, scope_names)
+        GlobalNames::new(self.cx, &global_names, scope_names)
     }
 
     /// Generate the name of a declaration that is part of a default export declaration, defaulting

--- a/src/js/runtime/global_names.rs
+++ b/src/js/runtime/global_names.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use crate::{
     field_offset,
     runtime::{
@@ -23,36 +21,36 @@ use crate::{
 #[repr(C)]
 pub struct GlobalNames {
     shape: HeapPtr<Shape>,
-    /// Number of functions
-    num_functions: usize,
-    /// Scopes names for this global scope, containing all lexical names.
+    /// Scope names for this global scope, containing all lexical names.
     scope_names: HeapPtr<ScopeNames>,
-    /// Array of global names. The first `num_functions` are global var scoped functions, the rest
-    /// are global vars. All names are interned strings.
-    names: InlineArray<HeapPtr<FlatString>>,
+    /// Array of global var and var scoped function declarations in declaration order.
+    names: InlineArray<GlobalDeclaration>,
+}
+
+pub struct GlobalDeclaration {
+    pub name: HeapPtr<FlatString>,
+    pub is_function: bool,
 }
 
 impl GlobalNames {
     pub fn new(
         cx: Context,
-        vars: HashSet<Handle<FlatString>>,
-        funcs: HashSet<Handle<FlatString>>,
+        names: &[(Handle<FlatString>, bool)],
         scope_names: Handle<ScopeNames>,
     ) -> AllocResult<Handle<GlobalNames>> {
-        let num_funcs = funcs.len();
-        let num_names = vars.len() + num_funcs;
+        let num_names = names.len();
 
         let size = Self::calculate_size_in_bytes(num_names);
         let mut global_names = cx.alloc_uninit_with_size::<GlobalNames>(size)?;
 
         set_uninit!(global_names.shape, cx.shapes.get(HeapItemKind::GlobalNames));
         set_uninit!(global_names.scope_names, *scope_names);
-        global_names.num_functions = funcs.len();
 
-        // Place function names first in the names array
         global_names.names.init_with_uninit(num_names);
-        for (i, name) in funcs.iter().chain(vars.iter()).enumerate() {
-            global_names.names.set_unchecked(i, **name);
+        for (i, (name, is_function)) in names.iter().enumerate() {
+            global_names
+                .names
+                .set_unchecked(i, GlobalDeclaration { name: **name, is_function: *is_function });
         }
 
         Ok(global_names.to_handle())
@@ -60,7 +58,7 @@ impl GlobalNames {
 
     fn calculate_size_in_bytes(num_names: usize) -> usize {
         let names_offset = field_offset!(GlobalNames, names);
-        names_offset + InlineArray::<HeapPtr<FlatString>>::calculate_size_in_bytes(num_names)
+        names_offset + InlineArray::<GlobalDeclaration>::calculate_size_in_bytes(num_names)
     }
 
     pub fn scope_names(&self) -> Handle<ScopeNames> {
@@ -77,8 +75,8 @@ impl HeapItem for GlobalNames {
         visitor.visit_pointer(&mut global_names.shape);
         visitor.visit_pointer(&mut global_names.scope_names);
 
-        for name in global_names.names.as_mut_slice() {
-            visitor.visit_pointer(name);
+        for decl in global_names.names.as_mut_slice() {
+            visitor.visit_pointer(&mut decl.name);
         }
     }
 }
@@ -135,13 +133,13 @@ fn global_declaration_instantiation(
 
     // First check if functions and then variables can be declared in the global object
     for i in 0..global_names.names.len() {
-        let name = global_names.names.get_unchecked(i);
-        name_handle.replace(*name);
+        let decl = global_names.names.get_unchecked(i);
+        name_handle.replace(decl.name);
 
         // Safe since already an interned string
         let name_key = name_handle.cast::<PropertyKey>();
 
-        if i < global_names.num_functions {
+        if decl.is_function {
             if !can_declare_global_function(cx, global_object, name_key)? {
                 return type_error(
                     cx,
@@ -160,12 +158,12 @@ fn global_declaration_instantiation(
 
     // Then declare the functions and variables in the global object
     for i in 0..global_names.names.len() {
-        let name = global_names.names.get_unchecked(i);
-        name_handle.replace(*name);
+        let decl = global_names.names.get_unchecked(i);
+        name_handle.replace(decl.name);
 
         let name_key = name_handle.cast::<PropertyKey>();
 
-        if i < global_names.num_functions {
+        if decl.is_function {
             create_global_function_binding(
                 cx,
                 global_object,

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -12,7 +12,7 @@ use crate::{
         error::{err_access_before_initialization, err_assign_constant, syntax_error},
         gc::{Handle, HeapItem, HeapPtr, HeapVisitor},
         gc_object::GcObject,
-        global_names::has_restricted_global_property,
+        global_names::{GlobalDeclaration, has_restricted_global_property},
         global_object::GlobalObject,
         interned_strings::InternedStrings,
         intrinsics::{
@@ -257,11 +257,11 @@ impl Handle<Realm> {
     pub fn can_declare_var_names(
         &self,
         cx: Context,
-        names: &[HeapPtr<FlatString>],
+        decls: &[GlobalDeclaration],
     ) -> EvalResult<()> {
-        for name in names {
-            if self.has_lexical_name(*name) {
-                return syntax_error(cx, &format!("redeclaration of `{name}`"));
+        for decl in decls {
+            if self.has_lexical_name(decl.name) {
+                return syntax_error(cx, &format!("redeclaration of `{}`", decl.name));
             }
         }
 

--- a/tests/integration/built-ins/RegExp/duplicate_named_capture_groups.js
+++ b/tests/integration/built-ins/RegExp/duplicate_named_capture_groups.js
@@ -1,5 +1,5 @@
 /*---
-description: ^
+description: >
   Duplicate named capture group may be used in separate alternatives. Detect cases where the named
   capture groups appear in nested structures and make sure they are properly detected.
 ---*/

--- a/tests/integration/built-ins/RegExp/unicodeSets/case_insensitive_strings_set_operations.js
+++ b/tests/integration/built-ins/RegExp/unicodeSets/case_insensitive_strings_set_operations.js
@@ -1,5 +1,5 @@
 /*---
-description: ^
+description: >
   Set operations in case insensitive mode treat case equivalent strings as the same string.
 ---*/
 

--- a/tests/integration/built-ins/RegExp/unicode_lastindex_surrogate_boundary.js
+++ b/tests/integration/built-ins/RegExp/unicode_lastindex_surrogate_boundary.js
@@ -1,5 +1,5 @@
 /*---
-description: ^
+description: >
   In unicode mode if `lastIndex` points to the middle of a valid surrogate pair then snap it to the
   beginning of the encoded code point.
 ---*/

--- a/tests/integration/language/function/mapped_arguments_bounds_check.js
+++ b/tests/integration/language/function/mapped_arguments_bounds_check.js
@@ -1,5 +1,5 @@
 /*---
-description: ^
+description: >
   Reading and writing beyond the bounds of a mapped arguments object should not read or write mapped
   parameters.
 ---*/

--- a/tests/integration/language/global/declaration_order_interleaved.js
+++ b/tests/integration/language/global/declaration_order_interleaved.js
@@ -1,0 +1,27 @@
+/*---
+description: >
+  Interleaved global var and function declarations preserve declaration order, and redeclarations
+  do not change the order of the original declaration.
+includes: [compareArray.js]
+---*/
+
+var g_one = 1;
+function g_two() {}
+var g_three = 2;
+function g_four() {}
+
+// Redeclaring g_two as a var must not move it from its original order in the global object.
+var g_two = 3;
+
+var g_five = 4;
+
+assert.compareArray(
+  Object.keys(globalThis).filter((k) => k.startsWith("g_")),
+  ["g_one", "g_two", "g_three", "g_four", "g_five"]
+);
+
+// The bindings are enumerable own data properties regardless of kind.
+assert.compareArray(
+  Object.getOwnPropertyNames(globalThis).filter((k) => k.startsWith("g_")),
+  ["g_one", "g_two", "g_three", "g_four", "g_five"]
+);

--- a/tests/integration/language/syntax/long_unicode_escape_sequences.js
+++ b/tests/integration/language/syntax/long_unicode_escape_sequences.js
@@ -1,5 +1,5 @@
 /*---
-description: ^
+description: >
   Unicode code point escape sequences `\u{...}` of any length are parsed correctly, including with
   any number of leading zeros.
 ---*/

--- a/tests/integration/regression/000027.js
+++ b/tests/integration/regression/000027.js
@@ -1,5 +1,5 @@
 /*---
-description: ^
+description: >
   Ensure the RegExp comparison register is cleared after a failed lookaround so it does not leak to
   affect another match.
 ---*/

--- a/tests/integration/regression/000028.js
+++ b/tests/integration/regression/000028.js
@@ -1,5 +1,5 @@
 /*---
-description: ^
+description: >
   A repetition within a lookbehind was failing to clear captures correctly, causing a backreference
   to incorrectly match a capture which is not complete.
 ---*/

--- a/tests/integration/regression/000029.js
+++ b/tests/integration/regression/000029.js
@@ -1,5 +1,5 @@
 /*---
-description: ^
+description: >
   A lazy quantifier inside a greedy quantifier could trigger a progress check bug that resulted in
   incorrect matches.
 ---*/

--- a/tests/integration/regression/000030.js
+++ b/tests/integration/regression/000030.js
@@ -1,5 +1,5 @@
 /*---
-description: ^
+description: >
   Bug in BsHashMap insertion where value was inserted at first deleted entry even if a matching
   occupied entry for that key existed later in the probing sequence.
 ---*/


### PR DESCRIPTION
## Summary

Global var and function declarations should be created and added to the global object in declaration order (ignoring redeclarations). This is observable in `[[OwnPropertyKeys]]` order.

We were failing to respect this because we dropped order and split the names into separate lists of vars and functions. Instead let's preserve order and keep an `is_function` flag to distinguish the names in `GlobalNames`.

## Tests

- Added new integration tests verifying declaration order (including in the presence of redeclaration) - previously failed
- Fixed YAML syntax in other tests files