### PR TITLE
[runtime] Parameterize hash maps by hasher

### DIFF
--- a/src/js/runtime/array_properties.rs
+++ b/src/js/runtime/array_properties.rs
@@ -3,7 +3,7 @@ use crate::{
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
-        collections::{BsHashMapField, HashMapInstance, InlineArray},
+        collections::{BsDefaultHasher, BsHashMapField, HashMapInstance, InlineArray},
         gc::{HeapItem, HeapVisitor, IsHeapItem},
         object_value::ObjectValue,
         property::{HeapProperty, Property},
@@ -475,6 +475,7 @@ impl_hash_map_instance!(
     SparseArrayPropertiesMap,
     u32,
     HeapProperty,
+    BsDefaultHasher,
     SparseArrayPropertiesExtraStorage
 );
 

--- a/src/js/runtime/collections/hash_map.rs
+++ b/src/js/runtime/collections/hash_map.rs
@@ -1,8 +1,8 @@
 use std::{
     borrow::Borrow,
     cell::Cell,
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
+    hash::{DefaultHasher, Hash, Hasher},
+    marker::PhantomData,
     slice,
 };
 
@@ -17,18 +17,38 @@ use crate::{
     set_uninit,
 };
 
+/// A hasher that can be built from a shape pointer. This allows the hasher to be specialized for a
+/// particular type of map, with the hasher itself having access to the shared Context where a seed
+/// can be retrieved.
+pub trait BsBuildHasher {
+    fn build_hasher(shape_ptr: HeapPtr<Shape>) -> impl Hasher;
+}
+
+/// Default hasher for collections, defers to unseeded DefaultHasher.
+pub struct BsDefaultHasher;
+
+impl BsBuildHasher for BsDefaultHasher {
+    fn build_hasher(_: HeapPtr<Shape>) -> impl Hasher {
+        DefaultHasher::default()
+    }
+}
+
 /// Generic flat HashMap implementation using quadratic probing.
 ///
-/// May store extra data of type `H` in the header. Caller is responsible for initializing.
+/// May store extra data of type `E` in the header. Caller is responsible for initializing.
+///
+/// Keys are hashed with the hasher `H`.
 #[repr(C)]
-pub struct BsHashMap<K, V, H = ()> {
+pub struct BsHashMap<K, V, H = BsDefaultHasher, E = ()> {
     shape: HeapPtr<Shape>,
-    // Extra data stored in the header, if any
-    extra_data: H,
-    // Number of kv pairs inserted in the map
+    /// Extra data stored in the header, if any
+    extra_data: E,
+    /// Marker for the hasher type this map is specialized for
+    _hasher: PhantomData<H>,
+    /// Number of kv pairs inserted in the map
     len: usize,
-    // Inline array of entries which may be empty, occupied, or deleted. Total capacity must be
-    // a power of 2.
+    /// Inline array of entries which may be empty, occupied, or deleted. Total capacity must be
+    /// a power of 2.
     entries: InlineArray<Entry<K, V>>,
 }
 
@@ -47,13 +67,13 @@ struct KVPair<K, V> {
     value: V,
 }
 
-impl<K: Eq + Hash + Clone, V: Clone, H> BsHashMap<K, V, H> {
+impl<K: Eq + Hash + Clone, V: Clone, H: BsBuildHasher, E> BsHashMap<K, V, H, E> {
     pub const MIN_CAPACITY: usize = 4;
 
     pub fn new(cx: Context, kind: HeapItemKind, capacity: usize) -> AllocResult<HeapPtr<Self>> {
         // Size of a dense array with the given capacity, in bytes
         let size = Self::calculate_size_in_bytes(capacity);
-        let mut hash_map = cx.alloc_uninit_with_size::<BsHashMap<K, V, H>>(size)?;
+        let mut hash_map = cx.alloc_uninit_with_size::<Self>(size)?;
 
         hash_map.init(cx, kind, capacity);
 
@@ -88,13 +108,13 @@ impl<K: Eq + Hash + Clone, V: Clone, H> BsHashMap<K, V, H> {
 
     /// The extra data stored in the header, if any.
     #[inline]
-    pub fn extra_data(&self) -> &H {
+    pub fn extra_data(&self) -> &E {
         &self.extra_data
     }
 
     /// The extra data stored in the header, if any.
     #[inline]
-    pub fn extra_data_mut(&mut self) -> &mut H {
+    pub fn extra_data_mut(&mut self) -> &mut E {
         &mut self.extra_data
     }
 
@@ -205,12 +225,12 @@ impl<K: Eq + Hash + Clone, V: Clone, H> BsHashMap<K, V, H> {
     }
 
     #[inline]
-    fn key_hash_code<Q>(key: &Q) -> usize
+    fn key_hash_code<Q>(&self, key: &Q) -> usize
     where
         K: Borrow<Q>,
         Q: Eq + Hash + ?Sized,
     {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = H::build_hasher(self.shape);
         key.borrow().hash(&mut hasher);
         hasher.finish() as usize
     }
@@ -223,7 +243,7 @@ impl<K: Eq + Hash + Clone, V: Clone, H> BsHashMap<K, V, H> {
         K: Borrow<Q>,
         Q: Eq + Hash + ?Sized,
     {
-        let hash_code = Self::key_hash_code(key);
+        let hash_code = self.key_hash_code(key);
         let mut probe_index = self.initial_probe_index(hash_code);
 
         // Quadratic probing - probe stride increases by 1 each iteration
@@ -254,7 +274,7 @@ impl<K: Eq + Hash + Clone, V: Clone, H> BsHashMap<K, V, H> {
     /// Assumes there is room to insert a key value pair, silently fails to insert if map is full.
     #[inline]
     pub fn insert_without_growing(&mut self, key: K, value: V) -> bool {
-        let hash_code = Self::key_hash_code(&key);
+        let hash_code = self.key_hash_code(&key);
         let mut probe_index = self.initial_probe_index(hash_code);
 
         let mut first_deleted_index = None;
@@ -309,50 +329,70 @@ impl<K: Eq + Hash + Clone, V: Clone, H> BsHashMap<K, V, H> {
 pub trait HashMapInstance:
     IsHeapItem
     + WithHeapItemKind
-    + std::ops::Deref<Target = BsHashMap<Self::K, Self::V, Self::H>>
-    + std::ops::DerefMut<Target = BsHashMap<Self::K, Self::V, Self::H>>
+    + std::ops::Deref<Target = BsHashMap<Self::K, Self::V, Self::H, Self::E>>
+    + std::ops::DerefMut<Target = BsHashMap<Self::K, Self::V, Self::H, Self::E>>
 {
     type K: Eq + std::hash::Hash + Clone;
     type V: Clone;
-    type H;
+    type H: BsBuildHasher;
+    type E;
 
     fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsHashMap::<Self::K, Self::V, Self::H>::new(cx, Self::KIND, capacity)?.cast())
+        Ok(BsHashMap::<Self::K, Self::V, Self::H, Self::E>::new(cx, Self::KIND, capacity)?.cast())
     }
 
     fn new_initial(cx: Context) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsHashMap::<Self::K, Self::V, Self::H>::new_initial(cx, Self::KIND)?.cast())
+        Ok(BsHashMap::<Self::K, Self::V, Self::H, Self::E>::new_initial(cx, Self::KIND)?.cast())
     }
 
     fn calculate_size_in_bytes(capacity: usize) -> usize {
-        BsHashMap::<Self::K, Self::V, Self::H>::calculate_size_in_bytes(capacity)
+        BsHashMap::<Self::K, Self::V, Self::H, Self::E>::calculate_size_in_bytes(capacity)
     }
 
     fn min_capacity_needed(num_elements: usize) -> usize {
-        BsHashMap::<Self::K, Self::V, Self::H>::min_capacity_needed(num_elements)
+        BsHashMap::<Self::K, Self::V, Self::H, Self::E>::min_capacity_needed(num_elements)
     }
 }
 
 #[macro_export]
 macro_rules! impl_hash_map_instance {
     ($map_type:ident, $key_type:ty, $value_type:ty) => {
-        $crate::impl_hash_map_instance!($map_type, $key_type, $value_type, ());
+        $crate::impl_hash_map_instance!(
+            $map_type,
+            $key_type,
+            $value_type,
+            $crate::runtime::collections::BsDefaultHasher,
+            ()
+        );
     };
-    ($map_type:ident, $key_type:ty, $value_type:ty, $extra_data_type:ty) => {
+    ($map_type:ident, $key_type:ty, $value_type:ty, $hasher_type:ty) => {
+        $crate::impl_hash_map_instance!($map_type, $key_type, $value_type, $hasher_type, ());
+    };
+    ($map_type:ident, $key_type:ty, $value_type:ty, $hasher_type:ty, $extra_data_type:ty) => {
         #[repr(transparent)]
         pub struct $map_type(
-            $crate::runtime::collections::BsHashMap<$key_type, $value_type, $extra_data_type>,
+            $crate::runtime::collections::BsHashMap<
+                $key_type,
+                $value_type,
+                $hasher_type,
+                $extra_data_type,
+            >,
         );
 
         impl $crate::runtime::collections::HashMapInstance for $map_type {
             type K = $key_type;
             type V = $value_type;
-            type H = $extra_data_type;
+            type H = $hasher_type;
+            type E = $extra_data_type;
         }
 
         impl std::ops::Deref for $map_type {
-            type Target =
-                $crate::runtime::collections::BsHashMap<$key_type, $value_type, $extra_data_type>;
+            type Target = $crate::runtime::collections::BsHashMap<
+                $key_type,
+                $value_type,
+                $hasher_type,
+                $extra_data_type,
+            >;
 
             fn deref(&self) -> &Self::Target {
                 &self.0
@@ -372,14 +412,15 @@ macro_rules! impl_hash_map_instance {
 ///
 /// `set_new` callback creates a new map with the given capacity and uses it from then on.
 #[inline]
-pub fn maybe_grow_for_insertion<K, V, H>(
+pub fn maybe_grow_for_insertion<K, V, H, E>(
     cx: Context,
-    map: HeapPtr<BsHashMap<K, V, H>>,
-    mut set_new: impl FnMut(Context, usize) -> AllocResult<HeapPtr<BsHashMap<K, V, H>>>,
-) -> AllocResult<HeapPtr<BsHashMap<K, V, H>>>
+    map: HeapPtr<BsHashMap<K, V, H, E>>,
+    mut set_new: impl FnMut(Context, usize) -> AllocResult<HeapPtr<BsHashMap<K, V, H, E>>>,
+) -> AllocResult<HeapPtr<BsHashMap<K, V, H, E>>>
 where
     K: Eq + Hash + Clone,
     V: Clone,
+    H: BsBuildHasher,
 {
     // Keep at least half of the entries empty, otherwise grow
     let new_length = map.len() + 1;
@@ -418,7 +459,7 @@ pub trait BsHashMapField<I: HashMapInstance> {
     fn maybe_grow_for_insertion(&mut self, cx: Context) -> AllocResult<HeapPtr<I>> {
         Ok(maybe_grow_for_insertion(
             cx,
-            self.get(cx).cast::<BsHashMap<I::K, I::V, I::H>>(),
+            self.get(cx).cast::<BsHashMap<I::K, I::V, I::H, I::E>>(),
             |cx, capacity| Ok(self.set_new(cx, capacity)?.cast()),
         )?
         .cast())
@@ -577,4 +618,4 @@ impl<'a, K: Clone, V: Clone> Iterator for GcUnsafeKeysIterMut<'a, K, V> {
 }
 
 // Only necessary so we get deref for HeapPtrs.
-impl<K, V, H> IsHeapItem for BsHashMap<K, V, H> {}
+impl<K, V, H, E> IsHeapItem for BsHashMap<K, V, H, E> {}

--- a/src/js/runtime/collections/hash_set.rs
+++ b/src/js/runtime/collections/hash_set.rs
@@ -4,29 +4,31 @@ use crate::runtime::{
     Context, HeapItemKind, HeapPtr,
     alloc_error::AllocResult,
     collections::{
-        BsHashMap,
-        hash_map::{GcUnsafeEntryMutIter, GcUnsafeKeysIterMut, maybe_grow_for_insertion},
+        BsDefaultHasher, BsHashMap,
+        hash_map::{
+            BsBuildHasher, GcUnsafeEntryMutIter, GcUnsafeKeysIterMut, maybe_grow_for_insertion,
+        },
     },
     gc::{HeapVisitor, IsHeapItem, WithHeapItemKind},
 };
 
 /// Generic flat HashSet implementation which is a simple wrapper over a HashMap with unit values.
 #[repr(transparent)]
-pub struct BsHashSet<T>(InnerMap<T>);
+pub struct BsHashSet<T, H = BsDefaultHasher>(InnerMap<T, H>);
 
-type InnerMap<T> = BsHashMap<T, ()>;
+type InnerMap<T, H> = BsHashMap<T, (), H, ()>;
 
-impl<T: Eq + Hash + Clone> BsHashSet<T> {
+impl<T: Eq + Hash + Clone, H: BsBuildHasher> BsHashSet<T, H> {
     pub fn new(cx: Context, kind: HeapItemKind, capacity: usize) -> AllocResult<HeapPtr<Self>> {
-        Ok(InnerMap::<T>::new(cx, kind, capacity)?.cast())
+        Ok(InnerMap::<T, H>::new(cx, kind, capacity)?.cast())
     }
 
     pub fn new_initial(cx: Context, kind: HeapItemKind) -> AllocResult<HeapPtr<Self>> {
-        Ok(InnerMap::<T>::new_initial(cx, kind)?.cast())
+        Ok(InnerMap::<T, H>::new_initial(cx, kind)?.cast())
     }
 
     pub fn calculate_size_in_bytes(capacity: usize) -> usize {
-        InnerMap::<T>::calculate_size_in_bytes(capacity)
+        InnerMap::<T, H>::calculate_size_in_bytes(capacity)
     }
 
     /// Total number of elements in the backing array.
@@ -80,36 +82,45 @@ impl<T: Eq + Hash + Clone> BsHashSet<T> {
 pub trait HashSetInstance:
     IsHeapItem
     + WithHeapItemKind
-    + std::ops::Deref<Target = BsHashSet<Self::T>>
-    + std::ops::DerefMut<Target = BsHashSet<Self::T>>
+    + std::ops::Deref<Target = BsHashSet<Self::T, Self::H>>
+    + std::ops::DerefMut<Target = BsHashSet<Self::T, Self::H>>
 {
     type T: Eq + std::hash::Hash + Clone;
+    type H: BsBuildHasher;
 
     fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsHashSet::<Self::T>::new(cx, Self::KIND, capacity)?.cast())
+        Ok(BsHashSet::<Self::T, Self::H>::new(cx, Self::KIND, capacity)?.cast())
     }
 
     fn new_initial(cx: Context) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsHashSet::<Self::T>::new_initial(cx, Self::KIND)?.cast())
+        Ok(BsHashSet::<Self::T, Self::H>::new_initial(cx, Self::KIND)?.cast())
     }
 
     fn calculate_size_in_bytes(capacity: usize) -> usize {
-        BsHashSet::<Self::T>::calculate_size_in_bytes(capacity)
+        BsHashSet::<Self::T, Self::H>::calculate_size_in_bytes(capacity)
     }
 }
 
 #[macro_export]
 macro_rules! impl_hash_set_instance {
     ($set_type:ident, $element_type:ty) => {
+        $crate::impl_hash_set_instance!(
+            $set_type,
+            $element_type,
+            $crate::runtime::collections::BsDefaultHasher
+        );
+    };
+    ($set_type:ident, $element_type:ty, $hasher_type:ty) => {
         #[repr(transparent)]
-        pub struct $set_type($crate::runtime::collections::BsHashSet<$element_type>);
+        pub struct $set_type($crate::runtime::collections::BsHashSet<$element_type, $hasher_type>);
 
         impl $crate::runtime::collections::HashSetInstance for $set_type {
             type T = $element_type;
+            type H = $hasher_type;
         }
 
         impl std::ops::Deref for $set_type {
-            type Target = $crate::runtime::collections::BsHashSet<$element_type>;
+            type Target = $crate::runtime::collections::BsHashSet<$element_type, $hasher_type>;
 
             fn deref(&self) -> &Self::Target {
                 &self.0
@@ -137,14 +148,14 @@ pub trait BsHashSetField<I: HashSetInstance>: Clone {
     /// to point to new set if there is no room to insert another entry in the set.
     #[inline]
     fn maybe_grow_for_insertion(&mut self, cx: Context) -> AllocResult<HeapPtr<I>> {
-        Ok(
-            maybe_grow_for_insertion(cx, self.get(cx).cast::<InnerMap<I::T>>(), |cx, capacity| {
-                Ok(self.set_new(cx, capacity)?.cast())
-            })?
-            .cast(),
-        )
+        Ok(maybe_grow_for_insertion(
+            cx,
+            self.get(cx).cast::<InnerMap<I::T, I::H>>(),
+            |cx, capacity| Ok(self.set_new(cx, capacity)?.cast()),
+        )?
+        .cast())
     }
 }
 
 // Only necessary so we get deref for HeapPtrs.
-impl<T> IsHeapItem for BsHashSet<T> {}
+impl<T, H> IsHeapItem for BsHashSet<T, H> {}

--- a/src/js/runtime/collections/index_map.rs
+++ b/src/js/runtime/collections/index_map.rs
@@ -1,6 +1,6 @@
 use std::{
-    collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
+    marker::PhantomData,
     mem::size_of,
     slice,
 };
@@ -10,7 +10,7 @@ use crate::{
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
-        collections::InlineArray,
+        collections::{BsDefaultHasher, InlineArray, hash_map::BsBuildHasher},
         gc::{HeapVisitor, IsHeapItem, WithHeapItemKind},
         shape::Shape,
     },
@@ -22,25 +22,27 @@ use crate::{
 /// Based on the hash table described by Jason Orendorff at
 /// https://wiki.mozilla.org/User:Jorend/Deterministic_hash_tables
 #[repr(C)]
-pub struct BsIndexMap<K, V> {
+pub struct BsIndexMap<K, V, H = BsDefaultHasher> {
     shape: HeapPtr<Shape>,
-    // Whether this is a tombstone object. Tombstone objects point to the new map that this map was
-    // moved to during a resize. Tombstone objects are used to update iterators that point to the
-    // tombstone.
+    /// Marker for the hasher type this map is specialized for
+    _hasher: PhantomData<H>,
+    /// Whether this is a tombstone object. Tombstone objects point to the new map that this map was
+    /// moved to during a resize. Tombstone objects are used to update iterators that point to the
+    /// tombstone.
     is_tombstone: bool,
-    // Number of entries currently inserted, excluding deleted entries
+    /// Number of entries currently inserted, excluding deleted entries
     num_occupied: usize,
-    // Number of deleted entries
+    /// Number of deleted entries
     num_deleted: usize,
-    // Inline array of indices into the entries array. The special index value EMPTY_INDEX signals
-    // an empty index slot.
-    //
-    // Total capacity must be a power of 2.
-    //
-    // If this is a tombstone object then a pointer to the new map is stored at the first index.
-    // This requires that the map is non-empty, so we must not create any empty maps.
+    /// Inline array of indices into the entries array. The special index value EMPTY_INDEX signals
+    /// an empty index slot.
+    ///
+    /// Total capacity must be a power of 2.
+    ///
+    /// If this is a tombstone object then a pointer to the new map is stored at the first index.
+    /// This requires that the map is non-empty, so we must not create any empty maps.
     indices: InlineArray<usize>,
-    // Array of entries in insertion order. Must have the same capacity as the indices array.
+    /// Array of entries in insertion order. Must have the same capacity as the indices array.
     _entries: [Entry<K, V>; 1],
 }
 
@@ -61,7 +63,7 @@ struct OccupiedEntry<K, V> {
 
 const INDICES_BYTE_OFFSET: usize = field_offset!(BsIndexMap<String, String>, indices);
 
-impl<K: Eq + Hash + Clone, V: Clone> BsIndexMap<K, V> {
+impl<K: Eq + Hash + Clone, V: Clone, H: BsBuildHasher> BsIndexMap<K, V, H> {
     pub const MIN_CAPACITY: usize = 4;
 
     // Public interface
@@ -69,7 +71,7 @@ impl<K: Eq + Hash + Clone, V: Clone> BsIndexMap<K, V> {
     pub fn new(cx: Context, kind: HeapItemKind, capacity: usize) -> AllocResult<HeapPtr<Self>> {
         // Size of a dense array with the given capacity, in bytes
         let size = Self::calculate_size_in_bytes(capacity);
-        let mut hash_map = cx.alloc_uninit_with_size::<BsIndexMap<K, V>>(size)?;
+        let mut hash_map = cx.alloc_uninit_with_size::<Self>(size)?;
 
         set_uninit!(hash_map.shape, cx.shapes.get(kind));
         set_uninit!(hash_map.is_tombstone, false);
@@ -306,8 +308,8 @@ impl<K: Eq + Hash + Clone, V: Clone> BsIndexMap<K, V> {
     }
 
     #[inline]
-    fn key_hash_code(key: &K) -> usize {
-        let mut hasher = DefaultHasher::new();
+    fn key_hash_code(&self, key: &K) -> usize {
+        let mut hasher = H::build_hasher(self.shape);
         key.hash(&mut hasher);
         hasher.finish() as usize
     }
@@ -321,7 +323,7 @@ impl<K: Eq + Hash + Clone, V: Clone> BsIndexMap<K, V> {
             return None;
         }
 
-        let hash_code = Self::key_hash_code(key);
+        let hash_code = self.key_hash_code(key);
         let hash_index = self.hash_index(hash_code);
         let mut current_entry_index = self.get_index_unchecked(hash_index);
 
@@ -352,7 +354,7 @@ impl<K: Eq + Hash + Clone, V: Clone> BsIndexMap<K, V> {
     /// Assumes there is room to insert a key value pair, silently fails to insert if map is full.
     #[inline]
     pub fn insert_without_growing(&mut self, key: K, value: V) -> bool {
-        let hash_code = Self::key_hash_code(&key);
+        let hash_code = self.key_hash_code(&key);
         let hash_index = self.hash_index(hash_code);
         let mut current_entry_index = self.get_index_unchecked(hash_index);
         let next_empty_entry_index = self.num_entries_used();
@@ -426,10 +428,10 @@ impl<K: Eq + Hash + Clone, V: Clone> BsIndexMap<K, V> {
     }
 }
 
-impl<K: Eq + Hash + Clone, V: Clone> Handle<BsIndexMap<K, V>> {
+impl<K: Eq + Hash + Clone, V: Clone, H: BsBuildHasher> Handle<BsIndexMap<K, V, H>> {
     /// Return an iterator over the entries of the map. Iterator is GC-safe so it is safe to live
     /// across allocations.
-    pub fn iter_gc_safe(&self) -> GcSafeEntriesIter<K, V> {
+    pub fn iter_gc_safe(&self) -> GcSafeEntriesIter<K, V, H> {
         GcSafeEntriesIter::new(*self)
     }
 }
@@ -439,59 +441,76 @@ impl<K: Eq + Hash + Clone, V: Clone> Handle<BsIndexMap<K, V>> {
 pub trait IndexMapInstance:
     IsHeapItem
     + WithHeapItemKind
-    + std::ops::Deref<Target = BsIndexMap<Self::K, Self::V>>
-    + std::ops::DerefMut<Target = BsIndexMap<Self::K, Self::V>>
+    + std::ops::Deref<Target = BsIndexMap<Self::K, Self::V, Self::H>>
+    + std::ops::DerefMut<Target = BsIndexMap<Self::K, Self::V, Self::H>>
 {
     type K: Eq + std::hash::Hash + Clone;
     type V: Clone;
+    type H: BsBuildHasher;
 
-    const MIN_CAPACITY: usize = BsIndexMap::<Self::K, Self::V>::MIN_CAPACITY;
+    const MIN_CAPACITY: usize = BsIndexMap::<Self::K, Self::V, Self::H>::MIN_CAPACITY;
 
     fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsIndexMap::<Self::K, Self::V>::new(cx, Self::KIND, capacity)?.cast())
+        Ok(BsIndexMap::<Self::K, Self::V, Self::H>::new(cx, Self::KIND, capacity)?.cast())
     }
 
     fn calculate_size_in_bytes(capacity: usize) -> usize {
-        BsIndexMap::<Self::K, Self::V>::calculate_size_in_bytes(capacity)
+        BsIndexMap::<Self::K, Self::V, Self::H>::calculate_size_in_bytes(capacity)
     }
 
     fn min_capacity_needed(num_elements: usize) -> usize {
-        BsIndexMap::<Self::K, Self::V>::min_capacity_needed(num_elements)
+        BsIndexMap::<Self::K, Self::V, Self::H>::min_capacity_needed(num_elements)
     }
 
     fn fix_iterator_for_resized_map(
         tombstone_map: HeapPtr<Self>,
         next_entry_index: &mut usize,
     ) -> HeapPtr<Self> {
-        BsIndexMap::<Self::K, Self::V>::fix_iterator_for_resized_map(
+        BsIndexMap::<Self::K, Self::V, Self::H>::fix_iterator_for_resized_map(
             tombstone_map.cast(),
             next_entry_index,
         )
         .cast()
     }
 
-    fn visit_pointers_impl<H: HeapVisitor>(
+    fn visit_pointers_impl<Visitor: HeapVisitor>(
         map: HeapPtr<Self>,
-        visitor: &mut H,
-        entries_visitor: impl FnMut(HeapPtr<BsIndexMap<Self::K, Self::V>>, &mut H),
+        visitor: &mut Visitor,
+        entries_visitor: impl FnMut(HeapPtr<BsIndexMap<Self::K, Self::V, Self::H>>, &mut Visitor),
     ) {
-        BsIndexMap::<Self::K, Self::V>::visit_pointers_impl(map.cast(), visitor, entries_visitor);
+        BsIndexMap::<Self::K, Self::V, Self::H>::visit_pointers_impl(
+            map.cast(),
+            visitor,
+            entries_visitor,
+        );
     }
 }
 
 #[macro_export]
 macro_rules! impl_index_map_instance {
     ($map_type:ident, $key_type:ty, $value_type:ty) => {
+        $crate::impl_index_map_instance!(
+            $map_type,
+            $key_type,
+            $value_type,
+            $crate::runtime::collections::BsDefaultHasher
+        );
+    };
+    ($map_type:ident, $key_type:ty, $value_type:ty, $hasher_type:ty) => {
         #[repr(transparent)]
-        pub struct $map_type($crate::runtime::collections::BsIndexMap<$key_type, $value_type>);
+        pub struct $map_type(
+            $crate::runtime::collections::BsIndexMap<$key_type, $value_type, $hasher_type>,
+        );
 
         impl $crate::runtime::collections::IndexMapInstance for $map_type {
             type K = $key_type;
             type V = $value_type;
+            type H = $hasher_type;
         }
 
         impl std::ops::Deref for $map_type {
-            type Target = $crate::runtime::collections::BsIndexMap<$key_type, $value_type>;
+            type Target =
+                $crate::runtime::collections::BsIndexMap<$key_type, $value_type, $hasher_type>;
 
             fn deref(&self) -> &Self::Target {
                 &self.0
@@ -511,14 +530,15 @@ macro_rules! impl_index_map_instance {
 ///
 /// `set_new` callback creates a new map with the given capacity and uses it from then on.
 #[inline]
-pub fn maybe_grow_for_insertion<K, V>(
+pub fn maybe_grow_for_insertion<K, V, H>(
     cx: Context,
-    map: HeapPtr<BsIndexMap<K, V>>,
-    mut set_new: impl FnMut(Context, usize) -> AllocResult<HeapPtr<BsIndexMap<K, V>>>,
-) -> AllocResult<HeapPtr<BsIndexMap<K, V>>>
+    map: HeapPtr<BsIndexMap<K, V, H>>,
+    mut set_new: impl FnMut(Context, usize) -> AllocResult<HeapPtr<BsIndexMap<K, V, H>>>,
+) -> AllocResult<HeapPtr<BsIndexMap<K, V, H>>>
 where
     K: Eq + Hash + Clone,
     V: Clone,
+    H: BsBuildHasher,
 {
     let num_entries_used = map.num_entries_used();
     let capacity = map.capacity();
@@ -533,7 +553,7 @@ where
     // Capacity jumps from 0 to min capacity
     let new_capacity;
     if capacity == 0 {
-        new_capacity = BsIndexMap::<K, V>::MIN_CAPACITY;
+        new_capacity = BsIndexMap::<K, V, H>::MIN_CAPACITY;
     } else if old_map.num_deleted > (capacity / 2) {
         // New capacity stays the same if most elements are deleted
         new_capacity = capacity;
@@ -577,7 +597,7 @@ pub trait BsIndexMapField<I: IndexMapInstance> {
     fn maybe_grow_for_insertion(&mut self, cx: Context) -> AllocResult<HeapPtr<I>> {
         Ok(maybe_grow_for_insertion(
             cx,
-            self.get().cast::<BsIndexMap<I::K, I::V>>(),
+            self.get().cast::<BsIndexMap<I::K, I::V, I::H>>(),
             |cx, capacity| Ok(self.set_new(cx, capacity)?.cast()),
         )?
         .cast())
@@ -687,30 +707,30 @@ impl<'a, K: Clone, V: Clone> Iterator for GcUnsafeKeysIterMut<'a, K, V> {
 }
 
 #[repr(C)]
-pub struct GcSafeEntriesIter<K, V> {
-    map: Handle<BsIndexMap<K, V>>,
+pub struct GcSafeEntriesIter<K, V, H> {
+    map: Handle<BsIndexMap<K, V, H>>,
     // Index of the next entry to check
     next_entry_index: usize,
 }
 
-impl<K, V> GcSafeEntriesIter<K, V> {
+impl<K, V, H> GcSafeEntriesIter<K, V, H> {
     #[inline]
-    pub fn new(map: Handle<BsIndexMap<K, V>>) -> Self {
+    pub fn new(map: Handle<BsIndexMap<K, V, H>>) -> Self {
         GcSafeEntriesIter { map, next_entry_index: 0 }
     }
 
     #[inline]
-    pub fn from_parts(map: Handle<BsIndexMap<K, V>>, next_entry_index: usize) -> Self {
+    pub fn from_parts(map: Handle<BsIndexMap<K, V, H>>, next_entry_index: usize) -> Self {
         GcSafeEntriesIter { map, next_entry_index }
     }
 
     #[inline]
-    pub fn to_parts(&self) -> (Handle<BsIndexMap<K, V>>, usize) {
+    pub fn to_parts(&self) -> (Handle<BsIndexMap<K, V, H>>, usize) {
         (self.map, self.next_entry_index)
     }
 }
 
-impl<K: Eq + Hash + Clone, V: Clone> Iterator for GcSafeEntriesIter<K, V> {
+impl<K: Eq + Hash + Clone, V: Clone, H: BsBuildHasher> Iterator for GcSafeEntriesIter<K, V, H> {
     type Item = (K, V);
 
     #[inline]
@@ -736,12 +756,12 @@ impl<K: Eq + Hash + Clone, V: Clone> Iterator for GcSafeEntriesIter<K, V> {
     }
 }
 
-impl<K: Eq + Hash + Clone, V: Clone> BsIndexMap<K, V> {
+impl<K: Eq + Hash + Clone, V: Clone, H: BsBuildHasher> BsIndexMap<K, V, H> {
     #[inline]
-    pub fn visit_pointers_impl<H: HeapVisitor>(
+    pub fn visit_pointers_impl<Visitor: HeapVisitor>(
         mut map: HeapPtr<Self>,
-        visitor: &mut H,
-        mut entries_visitor: impl FnMut(HeapPtr<Self>, &mut H),
+        visitor: &mut Visitor,
+        mut entries_visitor: impl FnMut(HeapPtr<Self>, &mut Visitor),
     ) {
         visitor.visit_pointer(&mut map.shape);
 
@@ -757,4 +777,4 @@ impl<K: Eq + Hash + Clone, V: Clone> BsIndexMap<K, V> {
 }
 
 // Only necessary so we get deref for HeapPtrs.
-impl<K, V> IsHeapItem for BsIndexMap<K, V> {}
+impl<K, V, H> IsHeapItem for BsIndexMap<K, V, H> {}

--- a/src/js/runtime/collections/index_set.rs
+++ b/src/js/runtime/collections/index_set.rs
@@ -4,7 +4,8 @@ use crate::runtime::{
     Context, Handle, HeapItemKind, HeapPtr,
     alloc_error::AllocResult,
     collections::{
-        BsIndexMap,
+        BsDefaultHasher, BsIndexMap,
+        hash_map::BsBuildHasher,
         index_map::{GcSafeEntriesIter, GcUnsafeKeysIterMut, maybe_grow_for_insertion},
     },
     gc::{HeapVisitor, IsHeapItem, WithHeapItemKind},
@@ -12,24 +13,24 @@ use crate::runtime::{
 
 /// Generic flat IndexSet implementation which is a simple wrapper over an IndexMap with unit values.
 #[repr(transparent)]
-pub struct BsIndexSet<T>(InnerMap<T>);
+pub struct BsIndexSet<T, H = BsDefaultHasher>(InnerMap<T, H>);
 
-type InnerMap<T> = BsIndexMap<T, ()>;
+type InnerMap<T, H> = BsIndexMap<T, (), H>;
 
-impl<T: Eq + Hash + Clone> BsIndexSet<T> {
-    pub const MIN_CAPACITY: usize = BsIndexMap::<T, ()>::MIN_CAPACITY;
+impl<T: Eq + Hash + Clone, H: BsBuildHasher> BsIndexSet<T, H> {
+    pub const MIN_CAPACITY: usize = InnerMap::<T, H>::MIN_CAPACITY;
 
     pub fn new(cx: Context, kind: HeapItemKind, capacity: usize) -> AllocResult<HeapPtr<Self>> {
-        Ok(InnerMap::<T>::new(cx, kind, capacity)?.cast())
+        Ok(InnerMap::<T, H>::new(cx, kind, capacity)?.cast())
     }
 
     pub fn calculate_size_in_bytes(capacity: usize) -> usize {
-        InnerMap::<T>::calculate_size_in_bytes(capacity)
+        InnerMap::<T, H>::calculate_size_in_bytes(capacity)
     }
 
     /// Create a new set whose entries are copied from the provided set.
     pub fn new_from_set(cx: Context, set: Handle<Self>) -> AllocResult<HeapPtr<Self>> {
-        Ok(InnerMap::<T>::new_from_map(cx, set.cast())?.cast())
+        Ok(InnerMap::<T, H>::new_from_map(cx, set.cast())?.cast())
     }
 
     /// Number of elements inserted in the set.
@@ -71,10 +72,10 @@ impl<T: Eq + Hash + Clone> BsIndexSet<T> {
     }
 }
 
-impl<T: Eq + Hash + Clone> Handle<BsIndexSet<T>> {
+impl<T: Eq + Hash + Clone, H: BsBuildHasher> Handle<BsIndexSet<T, H>> {
     /// Return an iterator over the entries of the set. Iterator is GC-safe so it is safe to live
     /// across allocations.
-    pub fn iter_gc_safe(&self) -> GcSafeEntriesIter<T, ()> {
+    pub fn iter_gc_safe(&self) -> GcSafeEntriesIter<T, (), H> {
         GcSafeEntriesIter::new(self.cast())
     }
 }
@@ -84,54 +85,66 @@ impl<T: Eq + Hash + Clone> Handle<BsIndexSet<T>> {
 pub trait IndexSetInstance:
     IsHeapItem
     + WithHeapItemKind
-    + std::ops::Deref<Target = BsIndexSet<Self::T>>
-    + std::ops::DerefMut<Target = BsIndexSet<Self::T>>
+    + std::ops::Deref<Target = BsIndexSet<Self::T, Self::H>>
+    + std::ops::DerefMut<Target = BsIndexSet<Self::T, Self::H>>
 {
     type T: Eq + std::hash::Hash + Clone;
+    type H: BsBuildHasher;
 
-    const MIN_CAPACITY: usize = BsIndexSet::<Self::T>::MIN_CAPACITY;
+    const MIN_CAPACITY: usize = BsIndexSet::<Self::T, Self::H>::MIN_CAPACITY;
 
     fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsIndexSet::<Self::T>::new(cx, Self::KIND, capacity)?.cast())
+        Ok(BsIndexSet::<Self::T, Self::H>::new(cx, Self::KIND, capacity)?.cast())
     }
 
     fn new_from_set(cx: Context, set: Handle<Self>) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsIndexSet::<Self::T>::new_from_set(cx, set.cast())?.cast())
+        Ok(BsIndexSet::<Self::T, Self::H>::new_from_set(cx, set.cast())?.cast())
     }
 
     fn calculate_size_in_bytes(capacity: usize) -> usize {
-        BsIndexSet::<Self::T>::calculate_size_in_bytes(capacity)
+        BsIndexSet::<Self::T, Self::H>::calculate_size_in_bytes(capacity)
     }
 
     fn fix_iterator_for_resized_map(
         tombstone_map: HeapPtr<Self>,
         next_entry_index: &mut usize,
     ) -> HeapPtr<Self> {
-        InnerMap::<Self::T>::fix_iterator_for_resized_map(tombstone_map.cast(), next_entry_index)
-            .cast()
+        InnerMap::<Self::T, Self::H>::fix_iterator_for_resized_map(
+            tombstone_map.cast(),
+            next_entry_index,
+        )
+        .cast()
     }
 
-    fn visit_pointers_impl<H: HeapVisitor>(
+    fn visit_pointers_impl<Visitor: HeapVisitor>(
         map: HeapPtr<Self>,
-        visitor: &mut H,
-        entries_visitor: impl FnMut(HeapPtr<BsIndexSet<Self::T>>, &mut H),
+        visitor: &mut Visitor,
+        entries_visitor: impl FnMut(HeapPtr<BsIndexSet<Self::T, Self::H>>, &mut Visitor),
     ) {
-        BsIndexSet::<Self::T>::visit_pointers_impl(map.cast(), visitor, entries_visitor);
+        BsIndexSet::<Self::T, Self::H>::visit_pointers_impl(map.cast(), visitor, entries_visitor);
     }
 }
 
 #[macro_export]
 macro_rules! impl_index_set_instance {
     ($set_type:ident, $element_type:ty) => {
+        $crate::impl_index_set_instance!(
+            $set_type,
+            $element_type,
+            $crate::runtime::collections::BsDefaultHasher
+        );
+    };
+    ($set_type:ident, $element_type:ty, $hasher_type:ty) => {
         #[repr(transparent)]
-        pub struct $set_type($crate::runtime::collections::BsIndexSet<$element_type>);
+        pub struct $set_type($crate::runtime::collections::BsIndexSet<$element_type, $hasher_type>);
 
         impl $crate::runtime::collections::IndexSetInstance for $set_type {
             type T = $element_type;
+            type H = $hasher_type;
         }
 
         impl std::ops::Deref for $set_type {
-            type Target = $crate::runtime::collections::BsIndexSet<$element_type>;
+            type Target = $crate::runtime::collections::BsIndexSet<$element_type, $hasher_type>;
 
             fn deref(&self) -> &Self::Target {
                 &self.0
@@ -159,27 +172,27 @@ pub trait BsIndexSetField<I: IndexSetInstance>: Clone {
     /// to point to new set if there is no room to insert another entry in the set.
     #[inline]
     fn maybe_grow_for_insertion(&mut self, cx: Context) -> AllocResult<HeapPtr<I>> {
-        Ok(
-            maybe_grow_for_insertion(cx, self.get().cast::<InnerMap<I::T>>(), |cx, capacity| {
-                Ok(self.set_new(cx, capacity)?.cast())
-            })?
-            .cast(),
-        )
+        Ok(maybe_grow_for_insertion(
+            cx,
+            self.get().cast::<InnerMap<I::T, I::H>>(),
+            |cx, capacity| Ok(self.set_new(cx, capacity)?.cast()),
+        )?
+        .cast())
     }
 }
 
-impl<T: Eq + Hash + Clone> BsIndexSet<T> {
+impl<T: Eq + Hash + Clone, H: BsBuildHasher> BsIndexSet<T, H> {
     #[inline]
-    pub fn visit_pointers_impl<H: HeapVisitor>(
+    pub fn visit_pointers_impl<Visitor: HeapVisitor>(
         set: HeapPtr<Self>,
-        visitor: &mut H,
-        mut entries_visitor: impl FnMut(HeapPtr<Self>, &mut H),
+        visitor: &mut Visitor,
+        mut entries_visitor: impl FnMut(HeapPtr<Self>, &mut Visitor),
     ) {
-        BsIndexMap::<T, ()>::visit_pointers_impl(set.cast(), visitor, |set, visitor| {
+        InnerMap::<T, H>::visit_pointers_impl(set.cast(), visitor, |set, visitor| {
             entries_visitor(set.cast(), visitor)
         })
     }
 }
 
 // Only necessary so we get deref for HeapPtrs.
-impl<T> IsHeapItem for BsIndexSet<T> {}
+impl<T, H> IsHeapItem for BsIndexSet<T, H> {}

--- a/src/js/runtime/collections/mod.rs
+++ b/src/js/runtime/collections/mod.rs
@@ -7,7 +7,7 @@ mod inline_array;
 pub mod vec;
 
 pub use array::{ArrayInstance, BsArray};
-pub use hash_map::{BsHashMap, BsHashMapField, HashMapInstance};
+pub use hash_map::{BsDefaultHasher, BsHashMap, BsHashMapField, HashMapInstance};
 pub use hash_set::{BsHashSet, BsHashSetField, HashSetInstance};
 pub use index_map::{BsIndexMap, BsIndexMapField, IndexMapInstance};
 pub use index_set::{BsIndexSet, BsIndexSetField, IndexSetInstance};

--- a/src/js/runtime/collections/vec.rs
+++ b/src/js/runtime/collections/vec.rs
@@ -11,23 +11,23 @@ use crate::{
 
 /// A growable array of values.
 ///
-/// May store extra data of type `H` in the header. Caller is responsible for initializing.
+/// May store extra data of type `E` in the header. Caller is responsible for initializing.
 #[repr(C)]
-pub struct BsVec<T, H = ()> {
+pub struct BsVec<T, E = ()> {
     shape: HeapPtr<Shape>,
     /// Extra data stored in the header, if any.
-    extra_data: H,
+    extra_data: E,
     /// The number of elements stored in the array.
     length: usize,
     /// The array along with its capacity, which is always a power of 2.
     array: InlineArray<T>,
 }
 
-impl<T, H> BsVec<T, H> {
+impl<T, E> BsVec<T, E> {
     /// Create a new BsVec with the given capacity.
     pub fn new(cx: Context, kind: HeapItemKind, capacity: usize) -> AllocResult<HeapPtr<Self>> {
         let size = Self::calculate_size_in_bytes(capacity);
-        let mut vec = cx.alloc_uninit_with_size::<BsVec<T, H>>(size)?;
+        let mut vec = cx.alloc_uninit_with_size::<Self>(size)?;
 
         vec.init(cx, kind, capacity);
 
@@ -71,13 +71,13 @@ impl<T, H> BsVec<T, H> {
 
     /// The extra data stored in the header, if any.
     #[inline]
-    pub fn extra_data(&self) -> &H {
+    pub fn extra_data(&self) -> &E {
         &self.extra_data
     }
 
     /// The extra data stored in the header, if any.
     #[inline]
-    pub fn extra_data_mut(&mut self) -> &mut H {
+    pub fn extra_data_mut(&mut self) -> &mut E {
         &mut self.extra_data
     }
 
@@ -120,24 +120,24 @@ impl<T, H> BsVec<T, H> {
 pub trait VecInstance:
     IsHeapItem
     + WithHeapItemKind
-    + std::ops::Deref<Target = BsVec<Self::T, Self::H>>
-    + std::ops::DerefMut<Target = BsVec<Self::T, Self::H>>
+    + std::ops::Deref<Target = BsVec<Self::T, Self::E>>
+    + std::ops::DerefMut<Target = BsVec<Self::T, Self::E>>
 {
     type T: Clone + Copy;
-    type H;
+    type E;
 
-    const MIN_CAPACITY: usize = BsVec::<Self::T, Self::H>::MIN_CAPACITY;
+    const MIN_CAPACITY: usize = BsVec::<Self::T, Self::E>::MIN_CAPACITY;
 
     fn new(cx: Context, capacity: usize) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsVec::<Self::T, Self::H>::new(cx, Self::KIND, capacity)?.cast())
+        Ok(BsVec::<Self::T, Self::E>::new(cx, Self::KIND, capacity)?.cast())
     }
 
     fn new_initial(cx: Context) -> AllocResult<HeapPtr<Self>> {
-        Ok(BsVec::<Self::T, Self::H>::new(cx, Self::KIND, Self::MIN_CAPACITY)?.cast())
+        Ok(BsVec::<Self::T, Self::E>::new(cx, Self::KIND, Self::MIN_CAPACITY)?.cast())
     }
 
     fn calculate_size_in_bytes(capacity: usize) -> usize {
-        BsVec::<Self::T, Self::H>::calculate_size_in_bytes(capacity)
+        BsVec::<Self::T, Self::E>::calculate_size_in_bytes(capacity)
     }
 }
 
@@ -152,7 +152,7 @@ macro_rules! impl_vec_instance {
 
         impl $crate::runtime::collections::VecInstance for $vec_type {
             type T = $element_type;
-            type H = $extra_data_type;
+            type E = $extra_data_type;
         }
 
         impl std::ops::Deref for $vec_type {
@@ -207,7 +207,7 @@ pub trait BsVecField<I: VecInstance> {
 }
 
 // Only necessary so we get deref for HeapPtrs.
-impl<T, H> IsHeapItem for BsVec<T, H> {}
+impl<T, E> IsHeapItem for BsVec<T, E> {}
 
 impl_vec_instance!(ValueVec, Value);
 

--- a/src/js/runtime/intrinsics/map_iterator_object.rs
+++ b/src/js/runtime/intrinsics/map_iterator_object.rs
@@ -6,7 +6,10 @@ use crate::{
         Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
-        collections::index_map::{GcSafeEntriesIter, IndexMapInstance},
+        collections::{
+            BsDefaultHasher,
+            index_map::{GcSafeEntriesIter, IndexMapInstance},
+        },
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
@@ -42,6 +45,8 @@ pub enum MapIteratorKind {
     KeyAndValue,
 }
 
+type GcSafeMapEntriesIter = GcSafeEntriesIter<ValueCollectionKey, Value, BsDefaultHasher>;
+
 impl MapIteratorObject {
     pub fn new(
         cx: Context,
@@ -64,14 +69,11 @@ impl MapIteratorObject {
 
     cast_from_value_fn!(MapIteratorObject, "Map Iterator");
 
-    fn get_iter(&self) -> GcSafeEntriesIter<ValueCollectionKey, Value> {
-        GcSafeEntriesIter::<ValueCollectionKey, Value>::from_parts(
-            self.map.to_handle().cast(),
-            self.next_entry_index,
-        )
+    fn get_iter(&self) -> GcSafeMapEntriesIter {
+        GcSafeMapEntriesIter::from_parts(self.map.to_handle().cast(), self.next_entry_index)
     }
 
-    fn store_iter(&mut self, iter: GcSafeEntriesIter<ValueCollectionKey, Value>) {
+    fn store_iter(&mut self, iter: GcSafeMapEntriesIter) {
         let (map, next_entry_index) = iter.to_parts();
         self.map = (*map).cast();
         self.next_entry_index = next_entry_index;

--- a/src/js/runtime/intrinsics/set_iterator_object.rs
+++ b/src/js/runtime/intrinsics/set_iterator_object.rs
@@ -6,7 +6,9 @@ use crate::{
         Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
-        collections::{BsIndexMap, IndexSetInstance, index_map::GcSafeEntriesIter},
+        collections::{
+            BsDefaultHasher, BsIndexMap, IndexSetInstance, index_map::GcSafeEntriesIter,
+        },
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
@@ -41,6 +43,8 @@ pub enum SetIteratorKind {
     KeyAndValue,
 }
 
+type GcSafeSetEntriesIter = GcSafeEntriesIter<ValueCollectionKey, (), BsDefaultHasher>;
+
 impl SetIteratorObject {
     pub fn new(
         cx: Context,
@@ -63,20 +67,17 @@ impl SetIteratorObject {
 
     cast_from_value_fn!(SetIteratorObject, "Set Iterator");
 
-    fn get_iter(&self) -> GcSafeEntriesIter<ValueCollectionKey, ()> {
-        GcSafeEntriesIter::<ValueCollectionKey, ()>::from_parts(
-            self.set.to_handle().cast(),
-            self.next_entry_index,
-        )
+    fn get_iter(&self) -> GcSafeSetEntriesIter {
+        GcSafeSetEntriesIter::from_parts(self.set.to_handle().cast(), self.next_entry_index)
     }
 
-    fn store_iter(&mut self, iter: GcSafeEntriesIter<ValueCollectionKey, ()>) {
+    fn store_iter(&mut self, iter: GcSafeSetEntriesIter) {
         let (set, next_entry_index) = iter.to_parts();
         self.set = (*set).cast();
         self.next_entry_index = next_entry_index;
     }
 
-    fn set_inner_map(&self) -> HeapPtr<BsIndexMap<ValueCollectionKey, ()>> {
+    fn set_inner_map(&self) -> HeapPtr<BsIndexMap<ValueCollectionKey, (), BsDefaultHasher>> {
         self.set.cast()
     }
 }


### PR DESCRIPTION
## Summary

We want flexibility in choice of hash algorithm. Add as hasher type parameter to all the heap collections so that we can specialize each instantiation for a specific hasher if desired. Currently `DefaultHasher` is used by default.

Note that we represent the hasher with a custom `BsBuildHasher` trait that builds the hasher from a reference to a shape. This lets us get access to the `Context` and builder a hasher from it (e.g. from a seed stored in the `Context`).

The hasher parameter takes the name `H`, and. the old extra data header parameter now uses the name `E` (also changed to `E` in `BsVec` for consistency).

No hasher specialization added yet.

## Tests

- CI