### PR TITLE
[tests] Fix misc jetstream benchmarks

### DIFF
--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -26,7 +26,6 @@ use crate::{
     runtime::{
         EvalResult, Handle, HeapPtr, SymbolValue, Value,
         alloc_error::AllocResult,
-        annex_b::init_annex_b_methods,
         array_properties::{ArrayProperties, DenseArrayProperties},
         builtin_names::{BuiltinNames, BuiltinSymbols},
         bytecode::{
@@ -191,12 +190,6 @@ impl Context {
 
         // Stop using deterministic PRNG
         cx.rand = StdRng::from_entropy();
-
-        // Annex B methods may not be included in the serialized heap so they must be initialized
-        // separately.
-        if options.annex_b {
-            init_annex_b_methods(cx, cx.initial_realm())?;
-        }
 
         Ok(cx)
     }

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -6,6 +6,7 @@ use crate::{
     runtime::{
         Context, EvalResult, HeapItemKind, PropertyKey, Value,
         alloc_error::AllocResult,
+        annex_b::init_annex_b_methods,
         builtin_function::BuiltinFunction,
         bytecode::function::ClosureObject,
         collections::{FastHasher, HashMapInstance, InlineArray, hash_map::BsHashMapField},
@@ -346,6 +347,10 @@ impl Handle<Realm> {
     /// included in the Context's options.
     pub fn install_optional_globals(&mut self, cx: Context) -> AllocResult<()> {
         handle_scope!(cx, {
+            if cx.options.annex_b {
+                init_annex_b_methods(cx, *self)?;
+            }
+
             if cx.options.expose_gc {
                 GcObject::install(cx, *self)?;
             }

--- a/tests/perf/install.sh
+++ b/tests/perf/install.sh
@@ -34,9 +34,17 @@ else
   echo "==> Octane already installed"
 fi
 
-if [ ! -d "$JETSTREAM_DIR/.git" ]; then
+if [ ! -f "$JETSTREAM_DIR/RexBench/FlightPlanner/waypoints.js" ]; then
   echo "==> Installing JetStream"
-  clone_pinned "$JETSTREAM_DIR" https://github.com/WebKit/JetStream "$JETSTREAM_COMMIT"
+  if [ ! -d "$JETSTREAM_DIR/.git" ]; then
+    clone_pinned "$JETSTREAM_DIR" https://github.com/WebKit/JetStream "$JETSTREAM_COMMIT"
+  fi
+  (
+    # Decompress included data files
+    cd "$JETSTREAM_DIR"
+    [ -d node_modules ] || npm ci
+    npm run decompress
+  )
 else
   echo "==> JetStream already installed"
 fi


### PR DESCRIPTION
## Summary

Fix a number of failing jetstream benchmarks.

- We were failing to install Annex B builtins to new realms, they were only being added to the initial realm. Move setup to `Realm::install_optional_globals`.
- We need to decompress some data files when installing the suite, updated the install script

## Tests

- Both classes of failing test now run successfully with `cargo run -p brimstone_perf -- --suite jetstream`