### PR TITLE
[ci] Run integration tests on MacOS and prepare Windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,36 @@ jobs:
 
       - name: Run integration tests on nightly without alloc_error feature enabled
         run: cargo brimstone-test --release --no-default-features --features nightly -- --reindex --ignore-unimplemented
-    
+
+  integration-tests-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      
+      - name: Checkout test262 repo
+        run: ./tests/test262/install_test262.sh
+
+      - name: Run integration tests
+        run: cargo brimstone-test -- --reindex --ignore-unimplemented
+
+  integration-tests-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Checkout test262 repo
+        shell: bash
+        run: ./tests/test262/install_test262.sh
+
+      - name: Run integration tests
+        run: cargo build
+
   build-perf:
     runs-on: ubuntu-latest
     steps:

--- a/src/brimstone_serialized_heap/build.rs
+++ b/src/brimstone_serialized_heap/build.rs
@@ -60,8 +60,8 @@ struct AlignedBytes<Align, Bytes: ?Sized = [u8]> {{
     bytes: Bytes, 
 }}
 
-const SERIALIZED_PERMANENT_SPACE: &[u8] = include_bytes!("{}");
-const SERIALIZED_CURRENT_SPACE: &[u8] = include_bytes!("{}");
+const SERIALIZED_PERMANENT_SPACE: &[u8] = include_bytes!({:?});
+const SERIALIZED_CURRENT_SPACE: &[u8] = include_bytes!({:?});
 const SERIALIZED_ROOT_OFFSETS: &[usize] = u8_slice_to_usize_slice(&ALIGNED_SERIALIZED_ROOT_OFFSETS.bytes);
 
 const fn u8_slice_to_usize_slice(slice: &[u8]) -> &[usize] {{
@@ -72,7 +72,7 @@ const fn u8_slice_to_usize_slice(slice: &[u8]) -> &[usize] {{
 /// Must make sure that byte sequence has the right alignment so that it can be read as a &[usize].
 static ALIGNED_SERIALIZED_ROOT_OFFSETS: &AlignedBytes<usize> = &AlignedBytes {{
     _align: [],
-    bytes: *include_bytes!("{}"),
+    bytes: *include_bytes!({:?}),
 }};
 
 /// The default serialized heap embedded in the binary.

--- a/src/js/Cargo.toml
+++ b/src/js/Cargo.toml
@@ -27,9 +27,6 @@ temporal_rs = { workspace = true, features = ["float64_representable_durations",
 timezone_provider = { workspace = true, features = ["tzif"] }
 xsum.workspace = true
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.6"
-
 # Internal crates
 brimstone_icu_collections.workspace = true
 brimstone_macros.workspace = true
@@ -46,6 +43,9 @@ icu_provider_baked.workspace = true
 icu_provider_adapters.workspace = true
 zerotrie.workspace = true
 zerovec.workspace = true
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.6"
 
 [features]
 default = ["jemalloc"]


### PR DESCRIPTION
## Summary

We should be testing on all major platforms. Run integration tests on MacOS and Windows in CI as well. Note that the Windows build does not run correctly yet so we only build it in CI for now.

Fix all compile-time Windows issues:
- Rearrange non-MSVC dependency section in `Cargo.toml` so that only `tikv-jemallocator` is non-MSVC
- Fix escaping of paths in `build.rs` for the serialized heap on Windows

## Tests

- CI