### PR TITLE
[common] Support 32-bit builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,26 @@ jobs:
       - name: Run integration tests
         run: cargo build
 
+  integration-tests-linux-32-bit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install 32-bit toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib g++-multilib
+          rustup target add i686-unknown-linux-gnu
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Checkout test262 repo
+        run: ./tests/test262/install_test262.sh
+
+      - name: Run integration tests
+        run: RUST_BACKTRACE=1 cargo brimstone-test --target i686-unknown-linux-gnu -- --reindex --ignore-unimplemented
+
   build-perf:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         run: ./tests/test262/install_test262.sh
 
       - name: Run integration tests
-        run: RUST_BACKTRACE=1 cargo brimstone-test --target i686-unknown-linux-gnu -- --reindex --ignore-unimplemented
+        run: RUST_BACKTRACE=1 cargo brimstone-test --target i686-unknown-linux-gnu -- --reindex --ignore-unimplemented -t 1 -v
 
   build-perf:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"

--- a/src/brimstone_serialized_heap/build.rs
+++ b/src/brimstone_serialized_heap/build.rs
@@ -15,7 +15,14 @@ fn main() {
     let out_path = Path::new(&out_dir);
     let dest_path = out_path.join("generated_serialized_heap.rs");
 
-    let serialized_heap_file = gen_serialized_heap_file(out_path);
+    // Heap snapshot is generated on the host and cross compilation is not yet supported. Restrict
+    // heap snapshots to 64-bit targets for now.
+    let is_64_bit = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").as_deref() == Ok("64");
+    let serialized_heap_file = if is_64_bit {
+        gen_serialized_heap_file(out_path)
+    } else {
+        placeholder_serialized_heap_file()
+    };
 
     fs::write(&dest_path, &serialized_heap_file).unwrap();
 }
@@ -101,4 +108,19 @@ fn write_bytes_to_file(bytes: &[u8], out_path: &Path, file_name: &str) -> PathBu
 const fn usize_slice_to_u8_slice(slice: &[usize]) -> &[u8] {
     let num_bytes = std::mem::size_of_val(slice);
     unsafe { std::slice::from_raw_parts(slice.as_ptr().cast(), num_bytes) }
+}
+
+fn placeholder_serialized_heap_file() -> String {
+    r#"
+use brimstone_core::common::serialized_heap::{SerializedHeap, SerializedSemispace};
+
+/// Placeholder snapshot, never installed (32-bit targets do not support heap snapshots).
+pub const SERIALIZED_HEAP: SerializedHeap<'static> = SerializedHeap {
+    permanent_space: SerializedSemispace { bytes: &[], start_offset: 0 },
+    current_space: SerializedSemispace { bytes: &[], start_offset: 0 },
+    root_offsets: &[],
+    heap_info_size: 0,
+};
+"#
+    .to_string()
 }

--- a/src/brimstone_serialized_heap/src/lib.rs
+++ b/src/brimstone_serialized_heap/src/lib.rs
@@ -1,12 +1,16 @@
+// Heap snapshots are enabled for 64-bit targets only.
+#![cfg_attr(target_pointer_width = "32", allow(dead_code))]
 mod generated_serialized_heap {
     include!(concat!(env!("OUT_DIR"), "/generated_serialized_heap.rs"));
 }
 
+#[cfg(target_pointer_width = "64")]
 use brimstone_core::common::serialized_heap::set_default_serialized_heap;
 
 /// Initialize the default serialized heap. Must be called before a Context is created.
 ///
 /// Can be safely called any number of times.
 pub fn init() {
+    #[cfg(target_pointer_width = "64")]
     set_default_serialized_heap(generated_serialized_heap::SERIALIZED_HEAP);
 }

--- a/src/js/common/constants.rs
+++ b/src/js/common/constants.rs
@@ -5,24 +5,36 @@ pub const MEGABYTE_BYTES: usize = 1024 * 1024;
 pub const GIGABYTE_BYTES: usize = 1024 * 1024 * 1024;
 
 /// Default minimum size of the heap in bytes.
+#[cfg(target_pointer_width = "64")]
 pub const DEFAULT_MIN_HEAP_SIZE: usize = 64 * MEGABYTE_BYTES;
+#[cfg(target_pointer_width = "32")]
+pub const DEFAULT_MIN_HEAP_SIZE: usize = 16 * MEGABYTE_BYTES;
 
 /// Default maximum size of the heap in bytes.
+#[cfg(target_pointer_width = "64")]
 pub const DEFAULT_MAX_HEAP_SIZE: usize = GIGABYTE_BYTES;
+#[cfg(target_pointer_width = "32")]
+pub const DEFAULT_MAX_HEAP_SIZE: usize = 128 * MEGABYTE_BYTES;
 
 /// The minimum size the heap can ever be in bytes.
 pub const MIN_HEAP_SIZE: usize = MEGABYTE_BYTES;
 
 /// The maximum size the heap can ever be in bytes.
+#[cfg(target_pointer_width = "64")]
 pub const MAX_HEAP_SIZE: usize = 4 * GIGABYTE_BYTES;
+#[cfg(target_pointer_width = "32")]
+pub const MAX_HEAP_SIZE: usize = 256 * MEGABYTE_BYTES;
 
 /// Maximum allowed string length in number of code units for strings in the JS runtime.
 ///
 /// Also used as max allowed UTF-8 source size. This guarantees:
 /// - Source positions can be represented with a u32.
 /// - Every string from the source is within the runtime string length limit.
-///
+/// - On 32-bit platforms a string's widest (two-byte) byte size must fit in a usize.
+#[cfg(target_pointer_width = "64")]
 pub const MAX_STRING_LENGTH: u32 = u32::MAX - 2;
+#[cfg(target_pointer_width = "32")]
+pub const MAX_STRING_LENGTH: u32 = 1 << 28;
 
 /// Total number of nanoseconds in a millisecond.
 pub const NANOSECONDS_IN_ONE_MILLISECOND: u32 = 1_000_000;

--- a/src/js/common/constants.rs
+++ b/src/js/common/constants.rs
@@ -14,7 +14,7 @@ pub const DEFAULT_MIN_HEAP_SIZE: usize = 16 * MEGABYTE_BYTES;
 #[cfg(target_pointer_width = "64")]
 pub const DEFAULT_MAX_HEAP_SIZE: usize = GIGABYTE_BYTES;
 #[cfg(target_pointer_width = "32")]
-pub const DEFAULT_MAX_HEAP_SIZE: usize = 128 * MEGABYTE_BYTES;
+pub const DEFAULT_MAX_HEAP_SIZE: usize = 64 * MEGABYTE_BYTES;
 
 /// The minimum size the heap can ever be in bytes.
 pub const MIN_HEAP_SIZE: usize = MEGABYTE_BYTES;
@@ -23,7 +23,7 @@ pub const MIN_HEAP_SIZE: usize = MEGABYTE_BYTES;
 #[cfg(target_pointer_width = "64")]
 pub const MAX_HEAP_SIZE: usize = 4 * GIGABYTE_BYTES;
 #[cfg(target_pointer_width = "32")]
-pub const MAX_HEAP_SIZE: usize = 256 * MEGABYTE_BYTES;
+pub const MAX_HEAP_SIZE: usize = 64 * MEGABYTE_BYTES;
 
 /// Maximum allowed string length in number of code units for strings in the JS runtime.
 ///

--- a/src/js/runtime/bytecode/stack_frame.rs
+++ b/src/js/runtime/bytecode/stack_frame.rs
@@ -10,6 +10,7 @@ use crate::{
         collections::ArrayInstance,
         gc::{HeapItem, HeapVisitor},
         scope::Scope,
+        value::ValueRepr,
     },
 };
 
@@ -109,28 +110,31 @@ impl StackFrame {
     }
 
     /// Highest bit of the return address slot indicates whether the caller is the Rust runtime.
-    const IS_RUST_CALLER_TAG: usize = 1 << (usize::BITS - 1);
+    const IS_RUST_CALLER_TAG: StackSlotValue = 1 << (StackSlotValue::BITS - 1);
 
     /// The return address slot holds both the return address and a flag (in the topmost bit)
     /// indicating whether the caller is the Rust runtime.
     #[inline]
-    fn encode_return_address_slot(return_address: *const u8, is_rust_caller: bool) -> usize {
+    fn encode_return_address_slot(
+        return_address: *const u8,
+        is_rust_caller: bool,
+    ) -> StackSlotValue {
         if is_rust_caller {
-            (return_address as usize) | Self::IS_RUST_CALLER_TAG
+            (return_address as StackSlotValue) | Self::IS_RUST_CALLER_TAG
         } else {
-            return_address as usize
+            return_address as StackSlotValue
         }
     }
 
     /// Encode the return address slot for a call from Rust.
     #[inline]
-    pub fn return_address_from_rust(return_address: *const u8) -> usize {
+    pub fn return_address_from_rust(return_address: *const u8) -> StackSlotValue {
         Self::encode_return_address_slot(return_address, true)
     }
 
     /// Encode the return address slot for a call from the JS VM.
     #[inline]
-    pub fn return_address_from_vm(return_address: *const u8) -> usize {
+    pub fn return_address_from_vm(return_address: *const u8) -> StackSlotValue {
         Self::encode_return_address_slot(return_address, false)
     }
 
@@ -159,7 +163,7 @@ impl StackFrame {
 
     /// Set the encoded return address, containing both the return address and the Rust caller flag.
     #[inline]
-    pub fn set_encoded_return_address(&mut self, encoded_address: usize) {
+    pub fn set_encoded_return_address(&mut self, encoded_address: StackSlotValue) {
         unsafe { *(self.fp.add(RETURN_ADDRESS_SLOT_INDEX).cast_mut()) = encoded_address }
     }
 
@@ -230,7 +234,7 @@ impl StackFrame {
     /// added due to underapplication.
     #[inline]
     pub fn argc(&self) -> usize {
-        unsafe { *self.fp.add(ARGC_SLOT_INDEX) }
+        unsafe { *self.fp.add(ARGC_SLOT_INDEX) as usize }
     }
 
     /// The receiver for the function call in this stack frame.
@@ -323,8 +327,8 @@ impl Iterator for StackFrameIter {
     }
 }
 
-/// Generic value stored in a stack slot.
-pub type StackSlotValue = usize;
+/// Generic value stored in a stack slot. Must be value-sized.
+pub type StackSlotValue = ValueRepr;
 
 /// Total size of the stack.
 const STACK_SIZE: usize = 4 * MEGABYTE_BYTES;

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -2424,8 +2424,7 @@ impl VM {
         // Find address of the return value register
         let return_value_address = self.register_address(instr.dest());
 
-        // TODO: Check if this cast is safe
-        let new_target = self.read_register(instr.new_target()).as_object();
+        let new_target = self.read_register(instr.new_target());
 
         // Check whether the value is a constructor, potentially deferring to proxy.
         let closure_ptr = match self.check_value_is_constructor(function_value)? {
@@ -2434,7 +2433,7 @@ impl VM {
             CallableObject::Proxy(proxy) => {
                 return handle_scope!(self.cx(), {
                     let proxy = proxy.to_handle();
-                    let new_target = new_target.to_handle();
+                    let new_target = new_target.as_object().to_handle();
                     let arguments = self.prepare_rust_runtime_args(args);
                     let return_value = proxy.construct(self.cx(), &arguments, new_target)?;
 
@@ -2447,6 +2446,7 @@ impl VM {
             CallableObject::Error(error) => return eval_err!(error),
         };
 
+        let new_target = new_target.as_object();
         let function_ptr = closure_ptr.function_ptr();
 
         // Check if this is a call to a function in the Rust runtime

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -2658,7 +2658,7 @@ impl VM {
         self.push(receiver.as_raw_bits() as StackSlotValue);
 
         // Push argc
-        self.push(argc);
+        self.push(argc as StackSlotValue);
 
         // Push the function
         self.push(closure.as_ptr() as StackSlotValue);
@@ -2669,7 +2669,7 @@ impl VM {
                 bytecode_function.caches_ptr(),
             )
         };
-        self.push(caches);
+        self.push(caches as StackSlotValue);
 
         // Push the constant table
         let constant_table = unsafe {
@@ -2677,7 +2677,7 @@ impl VM {
                 bytecode_function.constant_table_ptr(),
             )
         };
-        self.push(constant_table);
+        self.push(constant_table as StackSlotValue);
 
         // Push the current scope
         self.push(scope.as_ptr() as StackSlotValue);

--- a/src/js/runtime/collections/inline_array.rs
+++ b/src/js/runtime/collections/inline_array.rs
@@ -50,7 +50,7 @@ impl<T> InlineArray<T> {
 
     #[inline]
     pub fn calculate_size_in_bytes(len: usize) -> usize {
-        size_of::<usize>() + len * size_of::<T>()
+        std::mem::offset_of!(Self, data) + len * size_of::<T>()
     }
 
     #[inline]

--- a/src/js/runtime/gc/handle.rs
+++ b/src/js/runtime/gc/handle.rs
@@ -10,10 +10,11 @@ use crate::runtime::{
     gc::{Heap, HeapInfo, HeapPtr, HeapVisitor, IsHeapItem},
     object_value::ObjectValue,
     string_value::StringValue,
+    value::ValueRepr,
 };
 
-/// Handles store a pointer-sized unit of data. This may be either a value or a heap pointer.
-pub type HandleContents = usize;
+/// Handles store a value-sized unit of data. This may be either a value or a heap pointer.
+pub type HandleContents = ValueRepr;
 
 pub trait ToHandleContents {
     type Impl;

--- a/src/js/runtime/gc/heap.rs
+++ b/src/js/runtime/gc/heap.rs
@@ -67,6 +67,11 @@ impl Heap {
         unsafe {
             let layout = Layout::from_size_align(initial_size, HEAP_ALIGNMENT).unwrap();
             let heap_start = std::alloc::alloc(layout);
+            if heap_start.is_null() {
+                println!("FOUND AN ALLOC ERROR");
+                std::alloc::handle_alloc_error(layout);
+            }
+
             let heap_end = heap_start.add(initial_size);
 
             let semispace_size = (initial_size - size_of::<HeapInfo>()) / 2;

--- a/src/js/runtime/gc/heap_visitor.rs
+++ b/src/js/runtime/gc/heap_visitor.rs
@@ -59,16 +59,24 @@ pub trait HeapVisitor {
     /// Visit a strongly held value.
     #[inline]
     fn visit_value(&mut self, value: &mut Value) {
+        // Note that we must convert and write back instead of transumuting, since pointers and
+        // values have different size on 32-bit systems.
         if value.is_pointer() {
-            unsafe { self.visit(transmute::<&mut Value, &mut HeapPtr<AnyHeapItem>>(value)) };
+            let mut ptr = value.as_pointer();
+            self.visit(&mut ptr);
+            *value = Value::heap_item(ptr);
         }
     }
 
     /// Visit a weakly held value.
     #[inline]
     fn visit_weak_value(&mut self, value: &mut Value) {
+        // Note that we must convert and write back instead of transumuting, since pointers and
+        // values have different size on 32-bit systems.
         if value.is_pointer() {
-            unsafe { self.visit_weak(transmute::<&mut Value, &mut HeapPtr<AnyHeapItem>>(value)) };
+            let mut ptr = value.as_pointer();
+            self.visit_weak(&mut ptr);
+            *value = Value::heap_item(ptr);
         }
     }
 

--- a/src/js/runtime/gc/pointer.rs
+++ b/src/js/runtime/gc/pointer.rs
@@ -49,7 +49,7 @@ impl<T: IsHeapItem> ToHandleContents for T {
 
     #[inline]
     fn to_handle_contents(heap_ptr: HeapPtr<T>) -> HandleContents {
-        heap_ptr.ptr.as_ptr() as usize
+        heap_ptr.ptr.as_ptr() as HandleContents
     }
 }
 

--- a/src/js/runtime/intrinsics/array_buffer_object.rs
+++ b/src/js/runtime/intrinsics/array_buffer_object.rs
@@ -15,8 +15,10 @@ use crate::{
     set_uninit,
 };
 
-// 4GB max array buffer size
+#[cfg(target_pointer_width = "64")]
 const MAX_ARRAY_BUFFER_SIZE: usize = 1 << 32;
+#[cfg(target_pointer_width = "32")]
+const MAX_ARRAY_BUFFER_SIZE: usize = 1 << 31;
 
 extend_object! {
     /// ArrayBuffer Objects (https://tc39.es/ecma262/#sec-arraybuffer-objects)

--- a/src/js/runtime/intrinsics/typed_array_constructor.rs
+++ b/src/js/runtime/intrinsics/typed_array_constructor.rs
@@ -375,7 +375,7 @@ macro_rules! create_typed_array_constructor {
                 proto: Handle<ObjectValue>,
                 length: usize,
             ) -> EvalResult<Handle<ObjectValue>> {
-                let byte_length = element_size!() * length;
+                let byte_length = Self::typed_array_byte_length(cx, length, element_size!())?;
 
                 let array_buffer_constructor = cx.get_intrinsic(Intrinsic::ArrayBufferConstructor);
                 let array_buffer = ArrayBufferObject::new(
@@ -422,7 +422,7 @@ macro_rules! create_typed_array_constructor {
                 }
 
                 let source_array_length = typed_array_length(&source_record);
-                let byte_length = source_array_length * element_size!();
+                let byte_length = Self::typed_array_byte_length(cx, source_array_length, element_size!())?;
 
                 if source_typed_array.kind() == TypedArrayKind::$kind {
                     // If arrays have the same type then directly copy array buffer
@@ -581,9 +581,9 @@ macro_rules! create_typed_array_constructor {
                     result_new_byte_length = Some(new_byte_length);
                     result_new_array_length = Some(new_byte_length / element_size!());
                 } else {
-                    let new_byte_length = new_length * element_size!();
+                    let new_byte_length = Self::typed_array_byte_length(cx, new_length, element_size!())?;
 
-                    if offset + new_byte_length as usize > byte_length {
+                    if offset.checked_add(new_byte_length).is_none_or(|end| end > byte_length) {
                         return range_error(
                             cx,
                             &format!(
@@ -661,6 +661,18 @@ macro_rules! create_typed_array_constructor {
                 }
 
                 Ok(typed_array_object.as_value())
+            }
+
+            #[inline]
+            fn typed_array_byte_length(
+                cx: Context,
+                length: usize,
+                element_size: usize,
+            ) -> EvalResult<usize> {
+                match length.checked_mul(element_size) {
+                    Some(byte_length) => Ok(byte_length),
+                    None => range_error(cx, "ArrayBuffer is too large"),
+                }
             }
         }
     };

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -670,10 +670,17 @@ pub fn to_index(cx: Context, value_handle: Handle<Value>) -> EvalResult<usize> {
     } else {
         let integer = to_integer_or_infinity(cx, value_handle)?;
         if !(0.0..=MAX_SAFE_INTEGER_F64).contains(&integer) {
-            range_error(cx, &format!("{integer} is out of range for an array index"))
-        } else {
-            Ok(integer as usize)
+            return range_error(cx, &format!("{integer} is out of range for an array index"));
         }
+
+        // An index larger than `isize::MAX` exceeds the largest possible allocation. This is only
+        // relevant on 32-bit platforms since `isize::MAX < MAX_SAFE_INTEGER_F64`.
+        #[cfg(target_pointer_width = "32")]
+        if integer > isize::MAX as f64 {
+            return range_error(cx, &format!("{integer} is out of range for an array index"));
+        }
+
+        Ok(integer as usize)
     }
 }
 

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -89,6 +89,9 @@ pub struct Value {
     raw_bits: NonZeroU64,
 }
 
+/// The raw representation of a value when stored directly as bytes.
+pub type ValueRepr = u64;
+
 const TAG_SHIFT: u64 = 48;
 
 // Only the top 16 bits need to be checked as a tag, allowing for a right shift and check
@@ -481,7 +484,7 @@ impl ToHandleContents for Value {
 
     #[inline]
     fn to_handle_contents(value: Value) -> HandleContents {
-        value.as_raw_bits() as usize
+        value.as_raw_bits()
     }
 }
 


### PR DESCRIPTION
## Summary

Add support for 32-bit builds. Mostly fixing a few places we were incorrectly using `usize` instead the fixed 64-bit `Value` size.

- Heap size limits are conservative: defaults range is 16MB to 128MB, and new max is 256MB.
- Note that `HeapVIsitor::visit_value` needs to explicitly convert between pointers/values instead of transmuting ref
- New max size for strings and array buffers on 32-bit platforms. Also added some overflow guards in `to_index` and typed array constructors.

## Tests

- New CI job which runs integration tests compiled for 32-bit linux (`i686-unknown-linux-gnu`)