### PR TITLE
[runtime] ObjectBuilder utility for creating JS objects

### DIFF
--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -16,7 +16,7 @@ use crate::{
         intrinsics::intrinsics::Intrinsic,
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{
-            object_create, ordinary_define_own_property, ordinary_delete, ordinary_get,
+            ObjectBuilder, ordinary_define_own_property, ordinary_delete, ordinary_get,
             ordinary_get_own_property, ordinary_set,
         },
         property::Property,
@@ -38,12 +38,11 @@ extend_object! {
 
 impl UnmappedArgumentsObject {
     pub fn new(cx: Context) -> AllocResult<Handle<ObjectValue>> {
-        Ok(object_create::<ObjectValue>(
-            cx,
-            HeapItemKind::UnmappedArgumentsObject,
-            Intrinsic::ObjectPrototype,
-        )?
-        .to_handle())
+        Ok(ObjectBuilder::<ObjectValue>::new(cx)
+            .kind(HeapItemKind::UnmappedArgumentsObject)
+            .intrinsic_proto(Intrinsic::ObjectPrototype)
+            .build()?
+            .to_handle())
     }
 }
 
@@ -75,11 +74,9 @@ impl MappedArgumentsObject {
     ) -> EvalResult<Handle<MappedArgumentsObject>> {
         let shadowed_name = InternedStrings::alloc_static_wtf8_str(cx, &SHADOWED_SCOPE_SLOT_NAME)?;
 
-        let mut object = object_create::<MappedArgumentsObject>(
-            cx,
-            HeapItemKind::MappedArgumentsObject,
-            Intrinsic::ObjectPrototype,
-        )?;
+        let mut object = ObjectBuilder::<MappedArgumentsObject>::new(cx)
+            .intrinsic_proto(Intrinsic::ObjectPrototype)
+            .build()?;
 
         set_uninit!(object.scope, *scope);
         // Placeholder before the bitmap is created

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -5,7 +5,7 @@ use brimstone_macros::wrap_ordinary_object;
 use crate::{
     extend_object, must, must_a,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Realm, Value,
+        Context, EvalResult, Handle, HeapPtr, Realm, Value,
         abstract_operations::{construct, create_data_property_or_throw, get_function_realm},
         alloc_error::AllocResult,
         error::{range_error, type_error},
@@ -14,7 +14,7 @@ use crate::{
         intrinsics::intrinsics::Intrinsic,
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{
-            object_create_with_proto, ordinary_define_own_property, ordinary_delete,
+            ObjectBuilder, ordinary_define_own_property, ordinary_delete,
             ordinary_filtered_own_indexed_property_keys, ordinary_get_own_property,
             ordinary_own_string_symbol_property_keys,
         },
@@ -40,8 +40,7 @@ impl ArrayObject {
     pub const VIRTUAL_OBJECT_VTABLE: *const () = extract_virtual_object_vtable::<Self>();
 
     pub fn new(cx: Context, proto: Handle<ObjectValue>) -> AllocResult<Handle<ArrayObject>> {
-        let mut array =
-            object_create_with_proto::<ArrayObject>(cx, HeapItemKind::ArrayObject, proto)?;
+        let mut array = ObjectBuilder::<ArrayObject>::new(cx).proto(proto).build()?;
 
         set_uninit!(array.is_length_writable, true);
 

--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         iterator::create_iter_result_object,
         object_value::ObjectValue,
-        ordinary_object::{get_prototype_from_constructor, object_create_with_proto},
+        ordinary_object::{ObjectBuilder, get_prototype_from_constructor},
         promise_object::{PromiseCapability, coerce_to_ordinary_promise},
         realm::Realm,
         shape::Shape,
@@ -116,11 +116,9 @@ impl AsyncGeneratorObject {
         // For GC safety do not initialize or link the stack frame until after allocations.
         let frame_array = StackFrameArray::new_uninit(cx, stack_frame.len())?.to_handle();
 
-        let mut generator = object_create_with_proto::<AsyncGeneratorObject>(
-            cx,
-            HeapItemKind::AsyncGeneratorObject,
-            prototype,
-        )?;
+        let mut generator = ObjectBuilder::<AsyncGeneratorObject>::new(cx)
+            .proto(prototype)
+            .build()?;
 
         set_uninit!(generator.state, AsyncGeneratorState::SuspendedStart);
         set_uninit!(generator.pc_to_resume_offset, pc_to_resume_offset);

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -20,9 +20,7 @@ use crate::{
         global_object::GlobalObject,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunctionId},
         object_value::ObjectValue,
-        ordinary_object::{
-            object_create, object_create_with_optional_proto, object_create_with_proto,
-        },
+        ordinary_object::ObjectBuilder,
         property::Property,
         scope::Scope,
         shape::Shape,
@@ -47,11 +45,9 @@ impl ClosureObject {
         function: Handle<BytecodeFunction>,
         scope: Handle<Scope>,
     ) -> AllocResult<Handle<ClosureObject>> {
-        let mut object = object_create::<ClosureObject>(
-            cx,
-            HeapItemKind::ClosureObject,
-            Intrinsic::FunctionPrototype,
-        )?;
+        let mut object = ObjectBuilder::<ClosureObject>::new(cx)
+            .intrinsic_proto(Intrinsic::FunctionPrototype)
+            .build()?;
 
         set_uninit!(object.function, *function);
         set_uninit!(object.scope, *scope);
@@ -68,8 +64,9 @@ impl ClosureObject {
         scope: Handle<Scope>,
         prototype: Handle<ObjectValue>,
     ) -> AllocResult<Handle<ClosureObject>> {
-        let mut object =
-            object_create_with_proto::<ClosureObject>(cx, HeapItemKind::ClosureObject, prototype)?;
+        let mut object = ObjectBuilder::<ClosureObject>::new(cx)
+            .proto(prototype)
+            .build()?;
 
         set_uninit!(object.function, *function);
         set_uninit!(object.scope, *scope);
@@ -87,8 +84,9 @@ impl ClosureObject {
         realm: Handle<Realm>,
     ) -> AllocResult<Handle<ClosureObject>> {
         let proto = realm.get_intrinsic(Intrinsic::FunctionPrototype);
-        let mut object =
-            object_create_with_proto::<ClosureObject>(cx, HeapItemKind::ClosureObject, proto)?;
+        let mut object = ObjectBuilder::<ClosureObject>::new(cx)
+            .proto(proto)
+            .build()?;
 
         set_uninit!(object.function, *function);
         set_uninit!(object.scope, *scope);
@@ -105,11 +103,9 @@ impl ClosureObject {
         scope: Handle<Scope>,
         prototype: Option<Handle<ObjectValue>>,
     ) -> AllocResult<Handle<ClosureObject>> {
-        let mut object = object_create_with_optional_proto::<ClosureObject>(
-            cx,
-            HeapItemKind::ClosureObject,
-            prototype,
-        )?;
+        let mut object = ObjectBuilder::<ClosureObject>::new(cx)
+            .optional_proto(prototype)
+            .build()?;
 
         set_uninit!(object.function, *function);
         set_uninit!(object.scope, *scope);
@@ -178,9 +174,10 @@ impl ClosureObject {
         // MakeConstructor (https://tc39.es/ecma262/#sec-makeconstructor)
         if function.is_constructor() {
             let proto = realm.get_intrinsic(Intrinsic::ObjectPrototype);
-            let prototype =
-                object_create_with_proto::<ObjectValue>(cx, HeapItemKind::OrdinaryObject, proto)?
-                    .to_handle();
+            let prototype = ObjectBuilder::<ObjectValue>::new(cx)
+                .proto(proto)
+                .build()?
+                .to_handle();
 
             let desc = PropertyDescriptor::data(closure.into(), true, false, true);
             must_a!(define_property_or_throw(cx, prototype, cx.names.constructor(), desc));

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -8,8 +8,8 @@ use crate::{
     common::numeric::Numeric,
     eval_err, handle_scope, handle_scope_guard, must,
     runtime::{
-        Arguments, BigIntValue, Context, EvalResult, Handle, HeapItemKind, HeapPtr,
-        PropertyDescriptor, PropertyKey, Realm, SymbolValue, Value,
+        Arguments, BigIntValue, Context, EvalResult, Handle, HeapPtr, PropertyDescriptor,
+        PropertyKey, Realm, SymbolValue, Value,
         abstract_operations::{
             call, call_object, copy_data_properties, create_data_property_or_throw,
             define_property_or_throw, get_method, get_v, has_property, private_get, private_set,
@@ -126,7 +126,7 @@ use crate::{
         iterator::{IteratorHint, get_iterator, iterator_complete, iterator_value},
         module::{execute::dynamic_import, source_text_module::SourceTextModule},
         object_value::{ObjectValue, VirtualObject},
-        ordinary_object::{object_create_from_constructor, ordinary_object_create},
+        ordinary_object::{ObjectBuilder, ordinary_object_create},
         promise_object::{PromiseObject, coerce_to_ordinary_promise, resolve},
         property::Property,
         proxy_object::ProxyObject,
@@ -2918,13 +2918,10 @@ impl VM {
         is_base: bool,
     ) -> EvalResult<Value> {
         if is_base {
-            let new_object: Value = object_create_from_constructor::<ObjectValue>(
-                self.cx(),
-                new_target,
-                HeapItemKind::OrdinaryObject,
-                Intrinsic::ObjectPrototype,
-            )?
-            .into();
+            let new_object: Value = ObjectBuilder::<ObjectValue>::new(self.cx())
+                .constructor_proto(new_target, Intrinsic::ObjectPrototype)?
+                .build()?
+                .into();
 
             Ok(new_object)
         } else {

--- a/src/js/runtime/class_names.rs
+++ b/src/js/runtime/class_names.rs
@@ -12,7 +12,7 @@ use crate::{
         get,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_with_optional_proto,
+        ordinary_object::ObjectBuilder,
         shape::Shape,
         string_value::FlatString,
         type_utilities::is_constructor_value,
@@ -194,12 +194,10 @@ pub fn new_class(
     };
 
     // Create the prototype and constructor for the class
-    let prototype = object_create_with_optional_proto::<ObjectValue>(
-        cx,
-        HeapItemKind::OrdinaryObject,
-        proto_parent,
-    )?
-    .to_handle();
+    let prototype = ObjectBuilder::<ObjectValue>::new(cx)
+        .optional_proto(proto_parent)
+        .build()?
+        .to_handle();
 
     let scope = cx.vm().scope().to_handle();
     let constructor =

--- a/src/js/runtime/generator_object.rs
+++ b/src/js/runtime/generator_object.rs
@@ -1,7 +1,7 @@
 use crate::{
     eval_err, extend_object,
     runtime::{
-        Context, Handle, HeapItemKind, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         bytecode::{
             ExtraWide, Register,
@@ -15,7 +15,7 @@ use crate::{
         intrinsics::intrinsics::Intrinsic,
         iterator::create_iter_result_object,
         object_value::ObjectValue,
-        ordinary_object::{get_prototype_from_constructor, object_create_with_optional_proto},
+        ordinary_object::{ObjectBuilder, get_prototype_from_constructor},
     },
     set_uninit,
 };
@@ -116,11 +116,9 @@ impl GeneratorObject {
         // For GC safety do not initialize or link the stack frame until after allocations.
         let frame_array = StackFrameArray::new_uninit(cx, stack_frame.len())?.to_handle();
 
-        let mut generator = object_create_with_optional_proto::<GeneratorObject>(
-            cx,
-            HeapItemKind::GeneratorObject,
-            prototype,
-        )?;
+        let mut generator = ObjectBuilder::<GeneratorObject>::new(cx)
+            .optional_proto(prototype)
+            .build()?;
 
         set_uninit!(generator.state, GeneratorState::SuspendedStart);
         set_uninit!(generator.pc_to_resume_offset, pc_to_resume_offset);

--- a/src/js/runtime/global_object.rs
+++ b/src/js/runtime/global_object.rs
@@ -11,9 +11,9 @@ use crate::{
         intrinsics::intrinsics::Intrinsic,
         object_value::VirtualObject,
         ordinary_object::{
-            PropertyStorage, object_create_with_proto, ordinary_define_own_property,
-            ordinary_delete, ordinary_filtered_own_indexed_property_keys,
-            ordinary_get_own_property, validate_and_apply_property_descriptor,
+            ObjectBuilder, PropertyStorage, ordinary_define_own_property, ordinary_delete,
+            ordinary_filtered_own_indexed_property_keys, ordinary_get_own_property,
+            validate_and_apply_property_descriptor,
         },
         property::{DEFAULT_DATA_PROPERTY_FLAGS, HeapProperty, Property, PropertyFlags},
         property_descriptor::PropertyDescriptor,
@@ -45,11 +45,9 @@ impl GlobalObject {
         let properties =
             GlobalPropertiesMap::new(cx, GlobalPropertiesMap::MIN_CAPACITY)?.to_handle();
 
-        let mut object = object_create_with_proto::<GlobalObject>(
-            cx,
-            HeapItemKind::GlobalObject,
-            object_prototype,
-        )?;
+        let mut object = ObjectBuilder::<GlobalObject>::new(cx)
+            .proto(object_prototype)
+            .build()?;
 
         set_uninit!(object.properties, *properties);
 

--- a/src/js/runtime/intrinsic_builder.rs
+++ b/src/js/runtime/intrinsic_builder.rs
@@ -1,14 +1,14 @@
 use crate::{
     handle_scope_guard,
     runtime::{
-        Context, Handle, HeapItemKind, Realm, Value,
+        Context, Handle, Realm, Value,
         accessor::Accessor,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
         global_object::GlobalObject,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
-        ordinary_object::{OrdinaryObject, PropertyStorage, object_create_with_proto},
+        ordinary_object::{ObjectBuilder, OrdinaryObject, PropertyStorage},
         property::Property,
         property_key::PropertyKey,
     },
@@ -47,12 +47,10 @@ impl IntrinsicBuilder {
         realm: Handle<Realm>,
         prototype: Intrinsic,
     ) -> AllocResult<Self> {
-        let object = object_create_with_proto::<OrdinaryObject>(
-            cx,
-            HeapItemKind::OrdinaryObject,
-            realm.get_intrinsic(prototype),
-        )?
-        .to_handle();
+        let object = ObjectBuilder::<OrdinaryObject>::new(cx)
+            .proto(realm.get_intrinsic(prototype))
+            .build()?
+            .to_handle();
 
         Ok(Self::ordinary(cx, realm, object.as_object()))
     }

--- a/src/js/runtime/intrinsics/array_buffer_object.rs
+++ b/src/js/runtime/intrinsics/array_buffer_object.rs
@@ -3,14 +3,14 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, Handle, HeapItemKind, HeapPtr,
+        Context, Handle, HeapPtr,
         collections::{ArrayInstance, array::ByteArray},
         error::range_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -46,12 +46,9 @@ impl ArrayBufferObject {
             }
         }
 
-        let mut object = object_create_from_constructor::<ArrayBufferObject>(
-            cx,
-            constructor,
-            HeapItemKind::ArrayBufferObject,
-            Intrinsic::ArrayBufferPrototype,
-        )?;
+        let mut object = ObjectBuilder::<ArrayBufferObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::ArrayBufferPrototype)?
+            .build()?;
 
         // Temporarily fill default values so object is fully initialized before GC may be triggered
         set_uninit!(object.byte_length, byte_length);

--- a/src/js/runtime/intrinsics/array_iterator_object.rs
+++ b/src/js/runtime/intrinsics/array_iterator_object.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapItemKind, HeapPtr,
+        Context, Handle, HeapPtr,
         abstract_operations::length_of_array_like,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
@@ -20,7 +20,7 @@ use crate::{
         },
         iterator::create_iter_result_object,
         object_value::ObjectValue,
-        ordinary_object::object_create,
+        ordinary_object::ObjectBuilder,
         property::Property,
         property_key::PropertyKey,
         realm::Realm,
@@ -51,11 +51,9 @@ impl ArrayIteratorObject {
         array: Handle<ObjectValue>,
         kind: ArrayIteratorKind,
     ) -> AllocResult<Handle<ArrayIteratorObject>> {
-        let mut object = object_create::<ArrayIteratorObject>(
-            cx,
-            HeapItemKind::ArrayIteratorObject,
-            Intrinsic::ArrayIteratorPrototype,
-        )?;
+        let mut object = ObjectBuilder::<ArrayIteratorObject>::new(cx)
+            .intrinsic_proto(Intrinsic::ArrayIteratorPrototype)
+            .build()?;
 
         set_uninit!(object.array, *array);
         set_uninit!(object.is_done, false);

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_object.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_object.rs
@@ -1,13 +1,13 @@
 use crate::{
     extend_object,
     runtime::{
-        Context, Handle, HeapItemKind, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         iterator::Iterator,
         object_value::ObjectValue,
-        ordinary_object::object_create,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -25,11 +25,9 @@ impl AsyncFromSyncIteratorObject {
         cx: Context,
         iterator: Iterator,
     ) -> AllocResult<Handle<AsyncFromSyncIteratorObject>> {
-        let mut object = object_create::<AsyncFromSyncIteratorObject>(
-            cx,
-            HeapItemKind::AsyncFromSyncIteratorObject,
-            Intrinsic::AsyncFromSyncIteratorPrototype,
-        )?;
+        let mut object = ObjectBuilder::<AsyncFromSyncIteratorObject>::new(cx)
+            .intrinsic_proto(Intrinsic::AsyncFromSyncIteratorPrototype)
+            .build()?;
 
         set_uninit!(object.iterator, *iterator.iterator);
         set_uninit!(object.next_method, *iterator.next_method);

--- a/src/js/runtime/intrinsics/async_generator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_generator_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     if_abrupt_reject_promise, intrinsic_methods, must,
     runtime::{
-        Context, Handle, HeapItemKind,
+        Context, Handle,
         abstract_operations::{call_object, define_property_or_throw},
         alloc_error::AllocResult,
         async_generator_object::{
@@ -15,7 +15,7 @@ use crate::{
         intrinsics::intrinsics::Intrinsic,
         iterator::create_iter_result_object,
         object_value::ObjectValue,
-        ordinary_object::object_create,
+        ordinary_object::ObjectBuilder,
         promise_object::PromiseCapability,
         property_descriptor::PropertyDescriptor,
         realm::Realm,
@@ -146,12 +146,10 @@ impl AsyncGeneratorPrototype {
         cx: Context,
         closure: Handle<ClosureObject>,
     ) -> EvalResult<()> {
-        let proto = object_create::<ObjectValue>(
-            cx,
-            HeapItemKind::OrdinaryObject,
-            Intrinsic::AsyncGeneratorPrototype,
-        )?
-        .to_handle();
+        let proto = ObjectBuilder::<ObjectValue>::new(cx)
+            .intrinsic_proto(Intrinsic::AsyncGeneratorPrototype)
+            .build()?
+            .to_handle();
 
         let proto_desc = PropertyDescriptor::data(proto.to_handle().into(), true, false, false);
         define_property_or_throw(cx, closure.into(), cx.names.prototype(), proto_desc)?;

--- a/src/js/runtime/intrinsics/bigint_object.rs
+++ b/src/js/runtime/intrinsics/bigint_object.rs
@@ -3,11 +3,11 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        BigIntValue, Context, HeapItemKind, HeapPtr,
+        BigIntValue, Context, HeapPtr,
         alloc_error::AllocResult,
         gc::{Handle, HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
-        ordinary_object::object_create,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -25,11 +25,9 @@ impl BigIntObject {
         cx: Context,
         bigint_data: Handle<BigIntValue>,
     ) -> AllocResult<Handle<BigIntObject>> {
-        let mut object = object_create::<BigIntObject>(
-            cx,
-            HeapItemKind::BigIntObject,
-            Intrinsic::BigIntPrototype,
-        )?;
+        let mut object = ObjectBuilder::<BigIntObject>::new(cx)
+            .intrinsic_proto(Intrinsic::BigIntPrototype)
+            .build()?;
 
         set_uninit!(object.bigint_data, *bigint_data);
 

--- a/src/js/runtime/intrinsics/boolean_object.rs
+++ b/src/js/runtime/intrinsics/boolean_object.rs
@@ -3,15 +3,13 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, HeapItemKind, HeapPtr,
+        Context, HeapPtr,
         alloc_error::AllocResult,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::{
-            object_create, object_create_from_constructor, object_create_with_proto,
-        },
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -26,11 +24,9 @@ extend_object! {
 
 impl BooleanObject {
     pub fn new(cx: Context, boolean_data: bool) -> AllocResult<Handle<BooleanObject>> {
-        let mut object = object_create::<BooleanObject>(
-            cx,
-            HeapItemKind::BooleanObject,
-            Intrinsic::BooleanPrototype,
-        )?;
+        let mut object = ObjectBuilder::<BooleanObject>::new(cx)
+            .intrinsic_proto(Intrinsic::BooleanPrototype)
+            .build()?;
 
         set_uninit!(object.boolean_data, boolean_data);
 
@@ -42,12 +38,9 @@ impl BooleanObject {
         constructor: Handle<ObjectValue>,
         boolean_data: bool,
     ) -> EvalResult<Handle<BooleanObject>> {
-        let mut object = object_create_from_constructor::<BooleanObject>(
-            cx,
-            constructor,
-            HeapItemKind::BooleanObject,
-            Intrinsic::BooleanPrototype,
-        )?;
+        let mut object = ObjectBuilder::<BooleanObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::BooleanPrototype)?
+            .build()?;
 
         set_uninit!(object.boolean_data, boolean_data);
 
@@ -59,8 +52,9 @@ impl BooleanObject {
         proto: Handle<ObjectValue>,
         boolean_data: bool,
     ) -> AllocResult<Handle<BooleanObject>> {
-        let mut object =
-            object_create_with_proto::<BooleanObject>(cx, HeapItemKind::BooleanObject, proto)?;
+        let mut object = ObjectBuilder::<BooleanObject>::new(cx)
+            .proto(proto)
+            .build()?;
 
         set_uninit!(object.boolean_data, boolean_data);
 

--- a/src/js/runtime/intrinsics/data_view_object.rs
+++ b/src/js/runtime/intrinsics/data_view_object.rs
@@ -3,12 +3,12 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, HeapItemKind, HeapPtr,
+        Context, HeapPtr,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
         intrinsics::{array_buffer_object::ArrayBufferObject, intrinsics::Intrinsic},
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
     },
 };
 
@@ -30,12 +30,9 @@ impl DataViewObject {
         byte_length: Option<usize>,
         byte_offset: usize,
     ) -> EvalResult<Handle<DataViewObject>> {
-        let mut object = object_create_from_constructor::<DataViewObject>(
-            cx,
-            constructor,
-            HeapItemKind::DataViewObject,
-            Intrinsic::DataViewPrototype,
-        )?;
+        let mut object = ObjectBuilder::<DataViewObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::DataViewPrototype)?
+            .build()?;
 
         let viewed_array_buffer = *viewed_array_buffer;
 

--- a/src/js/runtime/intrinsics/date_object.rs
+++ b/src/js/runtime/intrinsics/date_object.rs
@@ -4,11 +4,11 @@ use crate::{
     common::math::modulo,
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapPtr,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
         type_utilities::to_integer_or_infinity_f64,
     },
     set_uninit,
@@ -29,12 +29,9 @@ impl DateObject {
         constructor: Handle<ObjectValue>,
         date_value: f64,
     ) -> EvalResult<HeapPtr<DateObject>> {
-        let mut object = object_create_from_constructor::<DateObject>(
-            cx,
-            constructor,
-            HeapItemKind::DateObject,
-            Intrinsic::DatePrototype,
-        )?;
+        let mut object = ObjectBuilder::<DateObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::DatePrototype)?
+            .build()?;
 
         set_uninit!(object.date_value, date_value);
 

--- a/src/js/runtime/intrinsics/error_object.rs
+++ b/src/js/runtime/intrinsics/error_object.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     extend_object, must_a,
     runtime::{
-        Context, Handle, HeapItemKind, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         abstract_operations::{
             create_data_property_or_throw, create_non_enumerable_data_property_or_throw,
         },
@@ -12,7 +12,7 @@ use crate::{
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::{object_create, object_create_from_constructor},
+        ordinary_object::ObjectBuilder,
         source_file::SourceFile,
         stack_trace::{StackFrameInfoArray, create_current_stack_frame_info, create_stack_trace},
         string_value::FlatString,
@@ -57,8 +57,10 @@ impl ErrorObject {
         prototype: Intrinsic,
         skip_current_frame: bool,
     ) -> AllocResult<Handle<ErrorObject>> {
-        let mut error =
-            object_create::<ErrorObject>(cx, HeapItemKind::ErrorObject, prototype)?.to_handle();
+        let mut error = ObjectBuilder::<ErrorObject>::new(cx)
+            .intrinsic_proto(prototype)
+            .build()?
+            .to_handle();
 
         set_uninit!(error.is_stack_overflow, false);
 
@@ -73,13 +75,10 @@ impl ErrorObject {
         prototype: Intrinsic,
         skip_current_frame: bool,
     ) -> EvalResult<Handle<ErrorObject>> {
-        let mut error = object_create_from_constructor::<ErrorObject>(
-            cx,
-            constructor,
-            HeapItemKind::ErrorObject,
-            prototype,
-        )?
-        .to_handle();
+        let mut error = ObjectBuilder::<ErrorObject>::new(cx)
+            .constructor_proto(constructor, prototype)?
+            .build()?
+            .to_handle();
 
         set_uninit!(error.is_stack_overflow, false);
 

--- a/src/js/runtime/intrinsics/finalization_registry_object.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_object.rs
@@ -10,7 +10,7 @@ use crate::{
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
         shape::Shape,
         type_utilities::same_value_non_numeric_non_allocating,
     },
@@ -38,12 +38,9 @@ impl FinalizationRegistryObject {
     ) -> EvalResult<Handle<FinalizationRegistryObject>> {
         let cells = FinalizationRegistryCells::new(cx, FinalizationRegistryCells::MIN_CAPACITY)?
             .to_handle();
-        let mut object = object_create_from_constructor::<FinalizationRegistryObject>(
-            cx,
-            constructor,
-            HeapItemKind::FinalizationRegistryObject,
-            Intrinsic::FinalizationRegistryPrototype,
-        )?;
+        let mut object = ObjectBuilder::<FinalizationRegistryObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::FinalizationRegistryPrototype)?
+            .build()?;
 
         set_uninit!(object.cells, *cells);
         set_uninit!(object.cleanup_callback, *cleanup_callback);

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -16,7 +16,7 @@ use crate::{
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
-        ordinary_object::{init_object_fields, object_create_with_optional_proto},
+        ordinary_object::{ObjectBuilder, init_object_fields},
         property::Property,
         property_key::PropertyKey,
         realm::Realm,
@@ -34,11 +34,7 @@ impl FunctionPrototype {
     pub fn new_uninit(cx: Context) -> AllocResult<Handle<ObjectValue>> {
         // Initialized with correct values in initialize method, but set to default value
         // at first to be GC-safe until initialize method is called.
-        let mut object = object_create_with_optional_proto::<ClosureObject>(
-            cx,
-            HeapItemKind::ClosureObject,
-            None,
-        )?;
+        let mut object = ObjectBuilder::<ClosureObject>::new(cx).build()?;
         object.init_extra_fields(HeapPtr::uninit(), HeapPtr::uninit());
 
         Ok(object.to_handle().into())

--- a/src/js/runtime/intrinsics/generator_prototype.rs
+++ b/src/js/runtime/intrinsics/generator_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     intrinsic_methods,
     runtime::{
-        Context, Handle, HeapItemKind, PropertyDescriptor,
+        Context, Handle, PropertyDescriptor,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         bytecode::function::ClosureObject,
@@ -10,7 +10,7 @@ use crate::{
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create,
+        ordinary_object::ObjectBuilder,
         realm::Realm,
     },
     runtime_fn,
@@ -63,12 +63,10 @@ impl GeneratorPrototype {
         cx: Context,
         closure: Handle<ClosureObject>,
     ) -> EvalResult<()> {
-        let proto = object_create::<ObjectValue>(
-            cx,
-            HeapItemKind::OrdinaryObject,
-            Intrinsic::GeneratorPrototype,
-        )?
-        .to_handle();
+        let proto = ObjectBuilder::<ObjectValue>::new(cx)
+            .intrinsic_proto(Intrinsic::GeneratorPrototype)
+            .build()?
+            .to_handle();
 
         let proto_desc = PropertyDescriptor::data(proto.to_handle().into(), true, false, false);
         define_property_or_throw(cx, closure.into(), cx.names.prototype(), proto_desc)?;

--- a/src/js/runtime/intrinsics/iterator_constructor.rs
+++ b/src/js/runtime/intrinsics/iterator_constructor.rs
@@ -1,7 +1,7 @@
 use crate::{
     intrinsic_methods,
     runtime::{
-        Context, HeapItemKind, Value,
+        Context, Value,
         abstract_operations::{call, call_object, get_method, ordinary_has_instance},
         alloc_error::AllocResult,
         collections::array::ValueArray,
@@ -16,7 +16,7 @@ use crate::{
         },
         iterator::{create_iter_result_object, get_iterator_flattenable},
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
         realm::Realm,
     },
     runtime_fn,
@@ -59,12 +59,9 @@ impl IteratorConstructor {
             return type_error(cx, "Iterator is not a constructor");
         }
 
-        let object = object_create_from_constructor::<ObjectValue>(
-            cx,
-            new_target.unwrap(),
-            HeapItemKind::OrdinaryObject,
-            Intrinsic::IteratorPrototype,
-        )?;
+        let object = ObjectBuilder::<ObjectValue>::new(cx)
+            .constructor_proto(new_target.unwrap(), Intrinsic::IteratorPrototype)?
+            .build()?;
 
         Ok(object.to_handle().as_value())
     }}

--- a/src/js/runtime/intrinsics/iterator_helper_object.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_object.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
+        Context, EvalResult, Handle, HeapPtr, Value,
         abstract_operations::{call, call_object},
         alloc_error::AllocResult,
         collections::array::ValueArray,
@@ -16,7 +16,7 @@ use crate::{
             get_iterator_flattenable, iterator_close, iterator_step, iterator_step_value,
         },
         object_value::ObjectValue,
-        ordinary_object::object_create_with_proto,
+        ordinary_object::ObjectBuilder,
         type_utilities::to_boolean,
     },
     set_uninit,
@@ -91,11 +91,9 @@ impl IteratorHelperObject {
     /// state, which must be done by the caller.
     fn new(cx: Context, iterator: Option<&Iterator>) -> AllocResult<Handle<IteratorHelperObject>> {
         let prototype = cx.get_intrinsic(Intrinsic::IteratorHelperPrototype);
-        let mut object = object_create_with_proto::<IteratorHelperObject>(
-            cx,
-            HeapItemKind::IteratorHelperObject,
-            prototype,
-        )?;
+        let mut object = ObjectBuilder::<IteratorHelperObject>::new(cx)
+            .proto(prototype)
+            .build()?;
 
         set_uninit!(object.iterator, iterator.map(Iterator::to_heap));
         set_uninit!(object.generator_state, GeneratorState::SuspendedStart);

--- a/src/js/runtime/intrinsics/map_iterator_object.rs
+++ b/src/js/runtime/intrinsics/map_iterator_object.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapItemKind, HeapPtr,
+        Context, Handle, HeapPtr,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         collections::{
@@ -20,7 +20,7 @@ use crate::{
         },
         iterator::create_iter_result_object,
         object_value::ObjectValue,
-        ordinary_object::object_create,
+        ordinary_object::ObjectBuilder,
         property::Property,
         realm::Realm,
         value::{Value, ValueCollectionKey},
@@ -53,11 +53,9 @@ impl MapIteratorObject {
         map: Handle<MapObject>,
         kind: MapIteratorKind,
     ) -> AllocResult<Handle<MapIteratorObject>> {
-        let mut object = object_create::<MapIteratorObject>(
-            cx,
-            HeapItemKind::MapIteratorObject,
-            Intrinsic::MapIteratorPrototype,
-        )?;
+        let mut object = ObjectBuilder::<MapIteratorObject>::new(cx)
+            .intrinsic_proto(Intrinsic::MapIteratorPrototype)
+            .build()?;
 
         set_uninit!(object.map, map.map_data());
         set_uninit!(object.next_entry_index, 0);

--- a/src/js/runtime/intrinsics/map_object.rs
+++ b/src/js/runtime/intrinsics/map_object.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     extend_object, impl_index_map_instance,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
+        Context, EvalResult, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::{
             BsIndexMap, BsIndexMapField, HashDosResistantHasher, index_map::IndexMapInstance,
@@ -11,7 +11,7 @@ use crate::{
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
         value::{ValueCollectionKey, ValueCollectionKeyHandle},
     },
     set_uninit,
@@ -32,12 +32,9 @@ impl MapObject {
         // Allocate and place behind handle before allocating environment
         let map_data = ValueIndexMap::new(cx, ValueIndexMap::MIN_CAPACITY)?.to_handle();
 
-        let mut object = object_create_from_constructor::<MapObject>(
-            cx,
-            constructor,
-            HeapItemKind::MapObject,
-            Intrinsic::MapPrototype,
-        )?;
+        let mut object = ObjectBuilder::<MapObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::MapPrototype)?
+            .build()?;
 
         set_uninit!(object.map_data, *map_data);
 

--- a/src/js/runtime/intrinsics/number_object.rs
+++ b/src/js/runtime/intrinsics/number_object.rs
@@ -3,15 +3,13 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, HeapItemKind, HeapPtr,
+        Context, HeapPtr,
         alloc_error::AllocResult,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::{
-            object_create, object_create_from_constructor, object_create_with_proto,
-        },
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -26,11 +24,9 @@ extend_object! {
 
 impl NumberObject {
     pub fn new(cx: Context, number_data: f64) -> AllocResult<Handle<NumberObject>> {
-        let mut object = object_create::<NumberObject>(
-            cx,
-            HeapItemKind::NumberObject,
-            Intrinsic::NumberPrototype,
-        )?;
+        let mut object = ObjectBuilder::<NumberObject>::new(cx)
+            .intrinsic_proto(Intrinsic::NumberPrototype)
+            .build()?;
 
         set_uninit!(object.number_data, number_data);
 
@@ -42,12 +38,9 @@ impl NumberObject {
         constructor: Handle<ObjectValue>,
         number_data: f64,
     ) -> EvalResult<Handle<NumberObject>> {
-        let mut object = object_create_from_constructor::<NumberObject>(
-            cx,
-            constructor,
-            HeapItemKind::NumberObject,
-            Intrinsic::NumberPrototype,
-        )?;
+        let mut object = ObjectBuilder::<NumberObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::NumberPrototype)?
+            .build()?;
 
         set_uninit!(object.number_data, number_data);
 
@@ -59,8 +52,9 @@ impl NumberObject {
         proto: Handle<ObjectValue>,
         number_data: f64,
     ) -> AllocResult<Handle<NumberObject>> {
-        let mut object =
-            object_create_with_proto::<NumberObject>(cx, HeapItemKind::NumberObject, proto)?;
+        let mut object = ObjectBuilder::<NumberObject>::new(cx)
+            .proto(proto)
+            .build()?;
 
         set_uninit!(object.number_data, number_data);
 

--- a/src/js/runtime/intrinsics/object_constructor.rs
+++ b/src/js/runtime/intrinsics/object_constructor.rs
@@ -1,7 +1,7 @@
 use crate::{
     intrinsic_methods, must,
     runtime::{
-        Context, Handle, HeapItemKind, Value,
+        Context, Handle, Value,
         abstract_operations::{
             GroupByKeyCoercion, IntegrityLevel, KeyOrValue, create_data_property_or_throw,
             define_property_or_throw, enumerable_own_property_names, get, group_by,
@@ -18,8 +18,7 @@ use crate::{
         },
         object_value::ObjectValue,
         ordinary_object::{
-            object_create_from_constructor, object_create_with_optional_proto,
-            ordinary_object_create, ordinary_object_create_without_proto,
+            ObjectBuilder, ordinary_object_create, ordinary_object_create_without_proto,
         },
         property_descriptor::{from_property_descriptor, to_property_descriptor},
         property_key::PropertyKey,
@@ -79,12 +78,9 @@ impl ObjectConstructor {
     fn construct(cx, _, arguments) {
         if let Some(new_target) = cx.current_new_target() {
             if !cx.current_function().ptr_eq(&new_target) {
-                let new_object = object_create_from_constructor::<ObjectValue>(
-                    cx,
-                    new_target,
-                    HeapItemKind::OrdinaryObject,
-                    Intrinsic::ObjectPrototype,
-                )?;
+                let new_object = ObjectBuilder::<ObjectValue>::new(cx)
+                    .constructor_proto(new_target, Intrinsic::ObjectPrototype)?
+                    .build()?;
                 return Ok(new_object.to_handle().as_value());
             }
         }
@@ -144,12 +140,10 @@ impl ObjectConstructor {
             return type_error(cx, "Object.create prototype must be an object or null");
         };
 
-        let object = object_create_with_optional_proto::<ObjectValue>(
-            cx,
-            HeapItemKind::OrdinaryObject,
-            proto,
-        )?
-        .to_handle();
+        let object = ObjectBuilder::<ObjectValue>::new(cx)
+            .optional_proto(proto)
+            .build()?
+            .to_handle();
 
         let properties = arguments.get(cx, 1);
         if properties.is_undefined() {

--- a/src/js/runtime/intrinsics/raw_json_object.rs
+++ b/src/js/runtime/intrinsics/raw_json_object.rs
@@ -3,11 +3,11 @@ use std::mem::size_of;
 use crate::{
     extend_object, must_a,
     runtime::{
-        Context, HeapItemKind, HeapPtr,
+        Context, HeapPtr,
         abstract_operations::{IntegrityLevel, create_data_property_or_throw, set_integrity_level},
         alloc_error::AllocResult,
         gc::{Handle, HeapItem, HeapVisitor},
-        ordinary_object::object_create_with_optional_proto,
+        ordinary_object::ObjectBuilder,
         string_value::StringValue,
     },
 };
@@ -18,12 +18,7 @@ extend_object! {
 
 impl RawJSONObject {
     pub fn new(cx: Context, raw_json: Handle<StringValue>) -> AllocResult<Handle<RawJSONObject>> {
-        let object = object_create_with_optional_proto::<RawJSONObject>(
-            cx,
-            HeapItemKind::RawJSONObject,
-            None,
-        )?
-        .to_handle();
+        let object = ObjectBuilder::<RawJSONObject>::new(cx).build()?.to_handle();
 
         must_a!(create_data_property_or_throw(
             cx,

--- a/src/js/runtime/intrinsics/regexp_object.rs
+++ b/src/js/runtime/intrinsics/regexp_object.rs
@@ -4,14 +4,14 @@ use crate::{
     extend_object, must, must_a,
     parser::regexp::RegExpFlags,
     runtime::{
-        Context, HeapItemKind, HeapPtr, PropertyDescriptor,
+        Context, HeapPtr, PropertyDescriptor,
         abstract_operations::{define_property_or_throw, set},
         alloc_error::AllocResult,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
         regexp::compiled_regexp::CompiledRegExp,
         string_value::StringValue,
     },
@@ -30,12 +30,9 @@ impl RegExpObject {
         cx: Context,
         constructor: Handle<ObjectValue>,
     ) -> EvalResult<Handle<RegExpObject>> {
-        let mut object = object_create_from_constructor::<RegExpObject>(
-            cx,
-            constructor,
-            HeapItemKind::RegExpObject,
-            Intrinsic::RegExpPrototype,
-        )?;
+        let mut object = ObjectBuilder::<RegExpObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::RegExpPrototype)?
+            .build()?;
 
         // Initialize with default values as allocation may occur before real values are set, so
         // we must ensure the RegExpObject is in a valid state.
@@ -53,12 +50,11 @@ impl RegExpObject {
         compiled_regexp: Handle<CompiledRegExp>,
     ) -> EvalResult<Handle<RegExpObject>> {
         let regexp_constructor = cx.get_intrinsic(Intrinsic::RegExpConstructor);
-        let mut object = must!(object_create_from_constructor::<RegExpObject>(
-            cx,
-            regexp_constructor,
-            HeapItemKind::RegExpObject,
-            Intrinsic::RegExpPrototype
-        ));
+        let mut object = must!(
+            ObjectBuilder::<RegExpObject>::new(cx)
+                .constructor_proto(regexp_constructor, Intrinsic::RegExpPrototype)
+        )
+        .build()?;
 
         set_uninit!(object.compiled_regexp, *compiled_regexp);
 

--- a/src/js/runtime/intrinsics/regexp_string_iterator_object.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator_object.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapItemKind, HeapPtr, PropertyKey, Value,
+        Context, Handle, HeapPtr, PropertyKey, Value,
         abstract_operations::set,
         alloc_error::AllocResult,
         error::type_error,
@@ -17,7 +17,7 @@ use crate::{
         },
         iterator::create_iter_result_object,
         object_value::ObjectValue,
-        ordinary_object::object_create,
+        ordinary_object::ObjectBuilder,
         property::Property,
         realm::Realm,
         string_value::StringValue,
@@ -46,11 +46,9 @@ impl RegExpStringIteratorObject {
         is_global: bool,
         is_unicode: bool,
     ) -> AllocResult<Handle<RegExpStringIteratorObject>> {
-        let mut object = object_create::<RegExpStringIteratorObject>(
-            cx,
-            HeapItemKind::RegExpStringIteratorObject,
-            Intrinsic::RegExpStringIteratorPrototype,
-        )?;
+        let mut object = ObjectBuilder::<RegExpStringIteratorObject>::new(cx)
+            .intrinsic_proto(Intrinsic::RegExpStringIteratorPrototype)
+            .build()?;
 
         set_uninit!(object.regexp_object, *regexp_object);
         set_uninit!(object.target_string, *target_string);

--- a/src/js/runtime/intrinsics/set_iterator_object.rs
+++ b/src/js/runtime/intrinsics/set_iterator_object.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapItemKind, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
         collections::{
@@ -19,7 +19,7 @@ use crate::{
         },
         iterator::create_iter_result_object,
         object_value::ObjectValue,
-        ordinary_object::object_create,
+        ordinary_object::ObjectBuilder,
         property::Property,
         realm::Realm,
         value::ValueCollectionKey,
@@ -51,11 +51,9 @@ impl SetIteratorObject {
         set: Handle<SetObject>,
         kind: SetIteratorKind,
     ) -> AllocResult<Handle<SetIteratorObject>> {
-        let mut object = object_create::<SetIteratorObject>(
-            cx,
-            HeapItemKind::SetIteratorObject,
-            Intrinsic::SetIteratorPrototype,
-        )?;
+        let mut object = ObjectBuilder::<SetIteratorObject>::new(cx)
+            .intrinsic_proto(Intrinsic::SetIteratorPrototype)
+            .build()?;
 
         set_uninit!(object.set, set.set_data_ptr().cast());
         set_uninit!(object.next_entry_index, 0);

--- a/src/js/runtime/intrinsics/set_object.rs
+++ b/src/js/runtime/intrinsics/set_object.rs
@@ -3,13 +3,13 @@ use std::mem::size_of;
 use crate::{
     extend_object, impl_index_set_instance,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, Value,
+        Context, EvalResult, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::{BsIndexSet, BsIndexSetField, HashDosResistantHasher, IndexSetInstance},
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::{object_create, object_create_from_constructor},
+        ordinary_object::ObjectBuilder,
         value::{ValueCollectionKey, ValueCollectionKeyHandle},
     },
     set_uninit,
@@ -30,12 +30,9 @@ impl SetObject {
         // Allocate and place behind handle before allocating object
         let set_data = ValueIndexSet::new(cx, ValueIndexSet::MIN_CAPACITY)?.to_handle();
 
-        let mut object = object_create_from_constructor::<SetObject>(
-            cx,
-            constructor,
-            HeapItemKind::SetObject,
-            Intrinsic::SetPrototype,
-        )?;
+        let mut object = ObjectBuilder::<SetObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::SetPrototype)?
+            .build()?;
 
         set_uninit!(object.set_data, *set_data);
 
@@ -47,8 +44,9 @@ impl SetObject {
         cx: Context,
         set_data: Handle<ValueIndexSet>,
     ) -> AllocResult<Handle<SetObject>> {
-        let mut object =
-            object_create::<SetObject>(cx, HeapItemKind::SetObject, Intrinsic::SetPrototype)?;
+        let mut object = ObjectBuilder::<SetObject>::new(cx)
+            .intrinsic_proto(Intrinsic::SetPrototype)
+            .build()?;
 
         set_uninit!(object.set_data, *set_data);
 

--- a/src/js/runtime/intrinsics/string_iterator_object.rs
+++ b/src/js/runtime/intrinsics/string_iterator_object.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
-        Context, Handle, HeapItemKind, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         error::type_error,
         eval_result::EvalResult,
@@ -12,7 +12,7 @@ use crate::{
         intrinsics::intrinsics::Intrinsic,
         iterator::create_iter_result_object,
         object_value::ObjectValue,
-        ordinary_object::object_create,
+        ordinary_object::ObjectBuilder,
         property::Property,
         realm::Realm,
         string_value::{FlatString, SafeCodePointIterator},
@@ -32,11 +32,9 @@ impl StringIteratorObject {
         cx: Context,
         string: Handle<FlatString>,
     ) -> AllocResult<Handle<StringIteratorObject>> {
-        let mut object = object_create::<StringIteratorObject>(
-            cx,
-            HeapItemKind::StringIteratorObject,
-            Intrinsic::StringIteratorPrototype,
-        )?;
+        let mut object = ObjectBuilder::<StringIteratorObject>::new(cx)
+            .intrinsic_proto(Intrinsic::StringIteratorPrototype)
+            .build()?;
 
         set_uninit!(object.iter, string.iter_code_points_safe());
 

--- a/src/js/runtime/intrinsics/symbol_object.rs
+++ b/src/js/runtime/intrinsics/symbol_object.rs
@@ -3,11 +3,11 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, HeapItemKind, HeapPtr, SymbolValue,
+        Context, HeapPtr, SymbolValue,
         alloc_error::AllocResult,
         gc::{Handle, HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
-        ordinary_object::object_create,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -25,11 +25,9 @@ impl SymbolObject {
         cx: Context,
         symbol_data: Handle<SymbolValue>,
     ) -> AllocResult<Handle<SymbolObject>> {
-        let mut object = object_create::<SymbolObject>(
-            cx,
-            HeapItemKind::SymbolObject,
-            Intrinsic::SymbolPrototype,
-        )?;
+        let mut object = ObjectBuilder::<SymbolObject>::new(cx)
+            .intrinsic_proto(Intrinsic::SymbolPrototype)
+            .build()?;
 
         set_uninit!(object.symbol_data, *symbol_data);
 

--- a/src/js/runtime/intrinsics/temporal/duration_object.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_object.rs
@@ -3,11 +3,11 @@ use temporal_rs::Duration;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapPtr,
         gc::{HeapItem, HeapUnaligned, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -32,12 +32,9 @@ impl DurationObject {
         constructor: Handle<ObjectValue>,
         duration: Duration,
     ) -> EvalResult<Handle<DurationObject>> {
-        let mut object = object_create_from_constructor::<DurationObject>(
-            cx,
-            constructor,
-            HeapItemKind::DurationObject,
-            Intrinsic::DurationPrototype,
-        )?;
+        let mut object = ObjectBuilder::<DurationObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::DurationPrototype)?
+            .build()?;
 
         set_uninit!(object.duration, HeapUnaligned::new(duration));
 

--- a/src/js/runtime/intrinsics/temporal/instant_object.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_object.rs
@@ -3,11 +3,11 @@ use temporal_rs::Instant;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapPtr,
         gc::{HeapItem, HeapUnaligned, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -32,12 +32,9 @@ impl InstantObject {
         constructor: Handle<ObjectValue>,
         instant: Instant,
     ) -> EvalResult<Handle<InstantObject>> {
-        let mut object = object_create_from_constructor::<InstantObject>(
-            cx,
-            constructor,
-            HeapItemKind::InstantObject,
-            Intrinsic::InstantPrototype,
-        )?;
+        let mut object = ObjectBuilder::<InstantObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::InstantPrototype)?
+            .build()?;
 
         set_uninit!(object.instant, HeapUnaligned::new(instant));
 

--- a/src/js/runtime/intrinsics/temporal/plain_date_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_object.rs
@@ -3,11 +3,11 @@ use temporal_rs::PlainDate;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapPtr,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -30,12 +30,9 @@ impl PlainDateObject {
         constructor: Handle<ObjectValue>,
         date: PlainDate,
     ) -> EvalResult<Handle<PlainDateObject>> {
-        let mut object = object_create_from_constructor::<PlainDateObject>(
-            cx,
-            constructor,
-            HeapItemKind::PlainDateObject,
-            Intrinsic::PlainDatePrototype,
-        )?;
+        let mut object = ObjectBuilder::<PlainDateObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::PlainDatePrototype)?
+            .build()?;
 
         set_uninit!(object.date, date);
 

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_object.rs
@@ -3,11 +3,11 @@ use temporal_rs::PlainDateTime;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapPtr,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -30,12 +30,9 @@ impl PlainDateTimeObject {
         constructor: Handle<ObjectValue>,
         date_time: PlainDateTime,
     ) -> EvalResult<Handle<PlainDateTimeObject>> {
-        let mut object = object_create_from_constructor::<PlainDateTimeObject>(
-            cx,
-            constructor,
-            HeapItemKind::PlainDateTimeObject,
-            Intrinsic::PlainDateTimePrototype,
-        )?;
+        let mut object = ObjectBuilder::<PlainDateTimeObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::PlainDateTimePrototype)?
+            .build()?;
 
         set_uninit!(object.date_time, date_time);
 

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_object.rs
@@ -3,11 +3,11 @@ use temporal_rs::PlainMonthDay;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapPtr,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -30,12 +30,9 @@ impl PlainMonthDayObject {
         constructor: Handle<ObjectValue>,
         month_day: PlainMonthDay,
     ) -> EvalResult<Handle<PlainMonthDayObject>> {
-        let mut object = object_create_from_constructor::<PlainMonthDayObject>(
-            cx,
-            constructor,
-            HeapItemKind::PlainMonthDayObject,
-            Intrinsic::PlainMonthDayPrototype,
-        )?;
+        let mut object = ObjectBuilder::<PlainMonthDayObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::PlainMonthDayPrototype)?
+            .build()?;
 
         set_uninit!(object.month_day, month_day);
 

--- a/src/js/runtime/intrinsics/temporal/plain_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_object.rs
@@ -3,11 +3,11 @@ use temporal_rs::PlainTime;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapPtr,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -30,12 +30,9 @@ impl PlainTimeObject {
         constructor: Handle<ObjectValue>,
         time: PlainTime,
     ) -> EvalResult<Handle<PlainTimeObject>> {
-        let mut object = object_create_from_constructor::<PlainTimeObject>(
-            cx,
-            constructor,
-            HeapItemKind::PlainTimeObject,
-            Intrinsic::PlainTimePrototype,
-        )?;
+        let mut object = ObjectBuilder::<PlainTimeObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::PlainTimePrototype)?
+            .build()?;
 
         set_uninit!(object.time, time);
 

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_object.rs
@@ -3,11 +3,11 @@ use temporal_rs::PlainYearMonth;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapPtr,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -33,12 +33,9 @@ impl PlainYearMonthObject {
         constructor: Handle<ObjectValue>,
         year_month: PlainYearMonth,
     ) -> EvalResult<Handle<PlainYearMonthObject>> {
-        let mut object = object_create_from_constructor::<PlainYearMonthObject>(
-            cx,
-            constructor,
-            HeapItemKind::PlainYearMonthObject,
-            Intrinsic::PlainYearMonthPrototype,
-        )?;
+        let mut object = ObjectBuilder::<PlainYearMonthObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::PlainYearMonthPrototype)?
+            .build()?;
 
         set_uninit!(object.year_month, year_month);
 

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
@@ -3,11 +3,11 @@ use temporal_rs::ZonedDateTime;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr,
+        Context, EvalResult, Handle, HeapPtr,
         gc::{HeapItem, HeapUnaligned, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -35,12 +35,9 @@ impl ZonedDateTimeObject {
         constructor: Handle<ObjectValue>,
         zoned_date_time: ZonedDateTime,
     ) -> EvalResult<Handle<ZonedDateTimeObject>> {
-        let mut object = object_create_from_constructor::<ZonedDateTimeObject>(
-            cx,
-            constructor,
-            HeapItemKind::ZonedDateTimeObject,
-            Intrinsic::ZonedDateTimePrototype,
-        )?;
+        let mut object = ObjectBuilder::<ZonedDateTimeObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::ZonedDateTimePrototype)?
+            .build()?;
 
         set_uninit!(object.zoned_date_time, HeapUnaligned::new(zoned_date_time));
 

--- a/src/js/runtime/intrinsics/typed_array.rs
+++ b/src/js/runtime/intrinsics/typed_array.rs
@@ -9,7 +9,7 @@ use crate::{
     create_typed_array_constructor, create_typed_array_object, create_typed_array_prototype,
     extend_object, heap_trait_object,
     runtime::{
-        BigIntValue, Context, Handle, HeapItemKind, HeapPtr,
+        BigIntValue, Context, Handle, HeapPtr,
         abstract_operations::{get, get_method, length_of_array_like, set},
         alloc_error::AllocResult,
         error::{range_error, type_error},
@@ -30,7 +30,7 @@ use crate::{
         iterator::iter_iterator_method_values,
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{
-            get_prototype_from_constructor, object_create_with_proto, ordinary_define_own_property,
+            ObjectBuilder, get_prototype_from_constructor, ordinary_define_own_property,
             ordinary_delete, ordinary_get, ordinary_get_own_property, ordinary_has_property,
             ordinary_own_string_symbol_property_keys, ordinary_set,
         },

--- a/src/js/runtime/intrinsics/typed_array_object.rs
+++ b/src/js/runtime/intrinsics/typed_array_object.rs
@@ -45,11 +45,9 @@ macro_rules! create_typed_array_object {
                 byte_offset: usize,
                 array_length: Option<usize>,
             ) -> AllocResult<Handle<ObjectValue>> {
-                let mut object = object_create_with_proto::<$typed_array>(
-                    cx,
-                    HeapItemKind::$typed_array,
-                    proto,
-                )?;
+                let mut object = ObjectBuilder::<$typed_array>::new(cx)
+                    .proto(proto)
+                    .build()?;
 
                 set_uninit!(object.viewed_array_buffer, *viewed_array_buffer);
                 set_uninit!(object.byte_length, byte_length);

--- a/src/js/runtime/intrinsics/weak_map_object.rs
+++ b/src/js/runtime/intrinsics/weak_map_object.rs
@@ -3,14 +3,14 @@ use std::mem::size_of;
 use crate::{
     extend_object, impl_hash_map_instance,
     runtime::{
-        Context, Handle, HeapItemKind, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::{FastHasher, HashMapInstance, hash_map::BsHashMapField},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
         value::{ValueCollectionKey, ValueCollectionKeyHandle},
     },
     set_uninit,
@@ -34,12 +34,9 @@ impl WeakMapObject {
     ) -> EvalResult<Handle<WeakMapObject>> {
         let weak_map_data = WeakValueMap::new_initial(cx)?.to_handle();
 
-        let mut object = object_create_from_constructor::<WeakMapObject>(
-            cx,
-            constructor,
-            HeapItemKind::WeakMapObject,
-            Intrinsic::WeakMapPrototype,
-        )?;
+        let mut object = ObjectBuilder::<WeakMapObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::WeakMapPrototype)?
+            .build()?;
 
         set_uninit!(object.weak_map_data, *weak_map_data);
 

--- a/src/js/runtime/intrinsics/weak_ref_object.rs
+++ b/src/js/runtime/intrinsics/weak_ref_object.rs
@@ -3,12 +3,12 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, Handle, HeapItemKind, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -30,12 +30,9 @@ impl WeakRefObject {
         constructor: Handle<ObjectValue>,
         value: Handle<Value>,
     ) -> EvalResult<Handle<WeakRefObject>> {
-        let mut object = object_create_from_constructor::<WeakRefObject>(
-            cx,
-            constructor,
-            HeapItemKind::WeakRefObject,
-            Intrinsic::WeakRefPrototype,
-        )?;
+        let mut object = ObjectBuilder::<WeakRefObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::WeakRefPrototype)?
+            .build()?;
 
         set_uninit!(object.weak_ref_target, *value);
 

--- a/src/js/runtime/intrinsics/weak_set_object.rs
+++ b/src/js/runtime/intrinsics/weak_set_object.rs
@@ -3,14 +3,14 @@ use std::mem::size_of;
 use crate::{
     extend_object, impl_hash_set_instance,
     runtime::{
-        Context, Handle, HeapItemKind, HeapPtr, Value,
+        Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         collections::{BsHashSetField, FastHasher, HashSetInstance},
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_from_constructor,
+        ordinary_object::ObjectBuilder,
         value::{ValueCollectionKey, ValueCollectionKeyHandle},
     },
     set_uninit,
@@ -34,12 +34,9 @@ impl WeakSetObject {
     ) -> EvalResult<Handle<WeakSetObject>> {
         let weak_set_data = WeakValueSet::new_initial(cx)?.to_handle();
 
-        let mut object = object_create_from_constructor::<WeakSetObject>(
-            cx,
-            constructor,
-            HeapItemKind::WeakSetObject,
-            Intrinsic::WeakSetPrototype,
-        )?;
+        let mut object = ObjectBuilder::<WeakSetObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::WeakSetPrototype)?
+            .build()?;
 
         set_uninit!(object.weak_set_data, *weak_set_data);
 

--- a/src/js/runtime/intrinsics/wrapped_valid_iterator_object.rs
+++ b/src/js/runtime/intrinsics/wrapped_valid_iterator_object.rs
@@ -3,12 +3,12 @@ use std::mem::size_of;
 use crate::{
     extend_object,
     runtime::{
-        Context, HeapItemKind, HeapPtr, Value,
+        Context, HeapPtr, Value,
         alloc_error::AllocResult,
         gc::{Handle, HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::object_create_with_proto,
+        ordinary_object::ObjectBuilder,
     },
     set_uninit,
 };
@@ -27,11 +27,9 @@ impl WrappedValidIteratorObject {
         iterator: Handle<ObjectValue>,
         next_method: Handle<Value>,
     ) -> AllocResult<Handle<ObjectValue>> {
-        let mut object = object_create_with_proto::<WrappedValidIteratorObject>(
-            cx,
-            HeapItemKind::WrappedValidIteratorObject,
-            cx.get_intrinsic(Intrinsic::WrapForValidIteratorPrototype),
-        )?;
+        let mut object = ObjectBuilder::<WrappedValidIteratorObject>::new(cx)
+            .intrinsic_proto(Intrinsic::WrapForValidIteratorPrototype)
+            .build()?;
 
         set_uninit!(object.iterator, *iterator);
         set_uninit!(object.next_method, *next_method);

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -3,7 +3,7 @@ use brimstone_macros::wrap_ordinary_object;
 use crate::{
     extend_object,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyDescriptor, PropertyKey, Value,
+        Context, EvalResult, Handle, HeapPtr, PropertyDescriptor, PropertyKey, Value,
         alloc_error::AllocResult,
         boxed_value::BoxedValue,
         error::reference_error,
@@ -15,8 +15,8 @@ use crate::{
         },
         object_value::VirtualObject,
         ordinary_object::{
-            object_create_with_optional_proto, ordinary_define_own_property, ordinary_delete,
-            ordinary_get, ordinary_get_own_property, ordinary_has_property,
+            ObjectBuilder, ordinary_define_own_property, ordinary_delete, ordinary_get,
+            ordinary_get_own_property, ordinary_has_property,
             ordinary_own_string_symbol_property_keys,
         },
         property::Property,
@@ -44,11 +44,7 @@ impl ModuleNamespaceObject {
         // Module namespace object does not have a prototype. This satisfies:
         // - [[GetPrototypeOf]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getprototypeof)
         // - [[SetPrototypeOf]] (https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-setprototypeof-v)
-        let mut object = object_create_with_optional_proto::<ModuleNamespaceObject>(
-            cx,
-            HeapItemKind::ModuleNamespaceObject,
-            None,
-        )?;
+        let mut object = ObjectBuilder::<ModuleNamespaceObject>::new(cx).build()?;
 
         set_uninit!(object.module, *module.as_any());
 

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use crate::{
     extend_object, must, must_a,
     runtime::{
@@ -6,7 +8,7 @@ use crate::{
         accessor::Accessor,
         alloc_error::AllocResult,
         eval_result::EvalResult,
-        gc::{Handle, HeapItem, HeapPtr, HeapVisitor},
+        gc::{Handle, HeapItem, HeapPtr, HeapVisitor, WithHeapItemKind},
         intrinsics::{intrinsics::Intrinsic, object_prototype_object::ObjectPrototypeObject},
         object_value::{ObjectValue, VirtualObject},
         property::Property,
@@ -571,90 +573,102 @@ pub fn ordinary_own_string_symbol_property_keys(
 }
 
 pub fn ordinary_object_create(cx: Context) -> AllocResult<Handle<ObjectValue>> {
-    let proto = cx.get_intrinsic(Intrinsic::ObjectPrototype);
-    let shape =
-        ShapeRegistry::get_root_object_shape(cx, HeapItemKind::OrdinaryObject, Some(proto))?;
-
-    let object = cx.alloc_uninit::<ObjectValue>()?;
-    init_object_fields(cx, object, *shape);
-
-    Ok(object.to_handle())
+    Ok(ObjectBuilder::<ObjectValue>::new(cx)
+        .intrinsic_proto(Intrinsic::ObjectPrototype)
+        .build()?
+        .to_handle())
 }
 
 pub fn ordinary_object_create_without_proto(cx: Context) -> AllocResult<Handle<ObjectValue>> {
-    let shape = ShapeRegistry::get_root_object_shape(cx, HeapItemKind::OrdinaryObject, None)?;
-
-    let object = cx.alloc_uninit::<ObjectValue>()?;
-    init_object_fields(cx, object, *shape);
-
-    Ok(object.to_handle())
+    Ok(ObjectBuilder::<ObjectValue>::new(cx).build()?.to_handle())
 }
 
-pub fn object_create<T>(
-    cx: Context,
-    shape_kind: HeapItemKind,
-    intrinsic_proto: Intrinsic,
-) -> AllocResult<HeapPtr<T>>
-where
-    HeapPtr<T>: Into<HeapPtr<ObjectValue>>,
-{
-    let proto = cx.get_intrinsic(intrinsic_proto);
-    let shape = ShapeRegistry::get_root_object_shape(cx, shape_kind, Some(proto))?;
-
-    let object = cx.alloc_uninit::<T>()?;
-    init_object_fields(cx, object.into(), *shape);
-
-    Ok(object)
-}
-
-pub fn object_create_with_size<T>(
-    cx: Context,
-    size: usize,
-    shape_kind: HeapItemKind,
-    intrinsic_proto: Intrinsic,
-) -> AllocResult<HeapPtr<T>>
-where
-    HeapPtr<T>: Into<HeapPtr<ObjectValue>>,
-{
-    let proto = cx.get_intrinsic(intrinsic_proto);
-    let shape = ShapeRegistry::get_root_object_shape(cx, shape_kind, Some(proto))?;
-
-    let object = cx.alloc_uninit_with_size::<T>(size)?;
-    init_object_fields(cx, object.into(), *shape);
-
-    Ok(object)
-}
-
-pub fn object_create_with_proto<T>(
-    cx: Context,
-    shape_kind: HeapItemKind,
-    proto: Handle<ObjectValue>,
-) -> AllocResult<HeapPtr<T>>
-where
-    HeapPtr<T>: Into<HeapPtr<ObjectValue>>,
-{
-    let shape = ShapeRegistry::get_root_object_shape(cx, shape_kind, Some(proto))?;
-
-    let object = cx.alloc_uninit::<T>()?;
-    init_object_fields(cx, object.into(), *shape);
-
-    Ok(object)
-}
-
-pub fn object_create_with_optional_proto<T>(
+/// Builder for JS objects.
+pub struct ObjectBuilder<T> {
     cx: Context,
     shape_kind: HeapItemKind,
     proto: Option<Handle<ObjectValue>>,
-) -> AllocResult<HeapPtr<T>>
+    _phantom: PhantomData<T>,
+}
+
+impl<T> ObjectBuilder<T>
 where
     HeapPtr<T>: Into<HeapPtr<ObjectValue>>,
 {
-    let shape = ShapeRegistry::get_root_object_shape(cx, shape_kind, proto)?;
+    #[inline]
+    fn with_shape_kind(cx: Context, shape_kind: HeapItemKind) -> Self {
+        Self { cx, shape_kind, proto: None, _phantom: PhantomData }
+    }
 
-    let object = cx.alloc_uninit::<T>()?;
-    init_object_fields(cx, object.into(), *shape);
+    /// Override the shape kind (which defaults to `T`'s own kind).
+    #[inline]
+    pub fn kind(mut self, shape_kind: HeapItemKind) -> Self {
+        self.shape_kind = shape_kind;
+        self
+    }
 
-    Ok(object)
+    /// Set the prototype to an existing object.
+    #[inline]
+    pub fn proto(mut self, proto: Handle<ObjectValue>) -> Self {
+        self.proto = Some(proto);
+        self
+    }
+
+    /// Set the prototype to an existing object or null.
+    #[inline]
+    pub fn optional_proto(mut self, proto: Option<Handle<ObjectValue>>) -> Self {
+        self.proto = proto;
+        self
+    }
+
+    /// Set the prototype to the given intrinsic.
+    #[inline]
+    pub fn intrinsic_proto(mut self, proto: Intrinsic) -> Self {
+        self.proto = Some(self.cx.get_intrinsic(proto));
+        self
+    }
+
+    /// Set the prototype from `constructor.prototype`, falling back to `default`. Corresponds to:
+    /// OrdinaryCreateFromConstructor (https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor)
+    #[inline]
+    pub fn constructor_proto(
+        mut self,
+        constructor: Handle<ObjectValue>,
+        default: Intrinsic,
+    ) -> EvalResult<Self> {
+        self.proto = Some(get_prototype_from_constructor(self.cx, constructor, default)?);
+        Ok(self)
+    }
+
+    #[inline]
+    pub fn build(self) -> AllocResult<HeapPtr<T>> {
+        let shape = ShapeRegistry::get_root_object_shape(self.cx, self.shape_kind, self.proto)?;
+
+        let object = self.cx.alloc_uninit::<T>()?;
+        init_object_fields(self.cx, object.into(), *shape);
+
+        Ok(object)
+    }
+}
+
+impl<T> ObjectBuilder<T>
+where
+    HeapPtr<T>: Into<HeapPtr<ObjectValue>>,
+    T: WithHeapItemKind,
+{
+    /// Start a builder for an object of type `T`, using `T`'s own shape kind.
+    #[inline]
+    pub fn new(cx: Context) -> Self {
+        Self::with_shape_kind(cx, T::KIND)
+    }
+}
+
+impl ObjectBuilder<ObjectValue> {
+    /// Start a builder for an ordinary object, returning a generic ObjectValue.
+    #[inline]
+    pub fn new(cx: Context) -> Self {
+        Self::with_shape_kind(cx, HeapItemKind::OrdinaryObject)
+    }
 }
 
 pub fn init_object_fields(cx: Context, mut object: HeapPtr<ObjectValue>, shape: HeapPtr<Shape>) {
@@ -668,27 +682,6 @@ pub fn init_object_fields(cx: Context, mut object: HeapPtr<ObjectValue>, shape: 
 
     object.set_array_properties(cx.default_array_properties);
     object.set_uninit_hash_code();
-}
-
-/// OrdinaryCreateFromConstructor (https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor)
-/// Creates an object of type T, and initializes the standard object fields.
-pub fn object_create_from_constructor<T>(
-    cx: Context,
-    constructor: Handle<ObjectValue>,
-    shape_kind: HeapItemKind,
-    intrinsic_default_proto: Intrinsic,
-) -> EvalResult<HeapPtr<T>>
-where
-    HeapPtr<T>: Into<HeapPtr<ObjectValue>>,
-{
-    // May allocate, so call before allocating object
-    let proto = get_prototype_from_constructor(cx, constructor, intrinsic_default_proto)?;
-    let shape = ShapeRegistry::get_root_object_shape(cx, shape_kind, Some(proto))?;
-
-    let object = cx.alloc_uninit::<T>()?;
-    init_object_fields(cx, object.into(), *shape);
-
-    Ok(object)
 }
 
 /// GetPrototypeFromConstructor (https://tc39.es/ecma262/#sec-getprototypefromconstructor)

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -12,7 +12,7 @@ use crate::{
         get,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
         object_value::ObjectValue,
-        ordinary_object::{object_create, object_create_from_constructor},
+        ordinary_object::ObjectBuilder,
         shape::Shape,
         type_utilities::{is_callable, is_constructor_value, same_object_value, same_value},
         value::Value,
@@ -81,11 +81,9 @@ pub enum PromiseReactionKind {
 
 impl PromiseObject {
     pub fn new_pending(cx: Context) -> AllocResult<HeapPtr<PromiseObject>> {
-        let mut object = object_create::<PromiseObject>(
-            cx,
-            HeapItemKind::PromiseObject,
-            Intrinsic::PromisePrototype,
-        )?;
+        let mut object = ObjectBuilder::<PromiseObject>::new(cx)
+            .intrinsic_proto(Intrinsic::PromisePrototype)
+            .build()?;
 
         set_uninit!(
             object.state,
@@ -99,12 +97,9 @@ impl PromiseObject {
         cx: Context,
         constructor: Handle<ObjectValue>,
     ) -> EvalResult<Handle<PromiseObject>> {
-        let mut object = object_create_from_constructor::<PromiseObject>(
-            cx,
-            constructor,
-            HeapItemKind::PromiseObject,
-            Intrinsic::PromisePrototype,
-        )?;
+        let mut object = ObjectBuilder::<PromiseObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::PromisePrototype)?
+            .build()?;
 
         set_uninit!(
             object.state,

--- a/src/js/runtime/proxy_object.rs
+++ b/src/js/runtime/proxy_object.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, mem::size_of};
 use crate::{
     extend_object, must,
     runtime::{
-        Context, EvalResult, HeapItemKind, Realm, Value,
+        Context, EvalResult, Realm, Value,
         abstract_operations::{
             call_object, construct, get_method, is_extensible as is_extensible_,
             length_of_array_like,
@@ -15,7 +15,7 @@ use crate::{
         get,
         intrinsics::intrinsics::Intrinsic,
         object_value::{ObjectValue, VirtualObject},
-        ordinary_object::{is_compatible_property_descriptor, object_create},
+        ordinary_object::{ObjectBuilder, is_compatible_property_descriptor},
         property::Property,
         property_descriptor::{
             PropertyDescriptor, from_property_descriptor, to_property_descriptor,
@@ -50,11 +50,9 @@ impl ProxyObject {
         is_callable: bool,
         is_constructor: bool,
     ) -> AllocResult<Handle<ProxyObject>> {
-        let mut object = object_create::<ProxyObject>(
-            cx,
-            HeapItemKind::ProxyObject,
-            Intrinsic::ObjectPrototype,
-        )?;
+        let mut object = ObjectBuilder::<ProxyObject>::new(cx)
+            .intrinsic_proto(Intrinsic::ObjectPrototype)
+            .build()?;
 
         set_uninit!(object.proxy_handler, Some(*proxy_handler));
         set_uninit!(object.proxy_target, Some(*proxy_target));

--- a/src/js/runtime/string_object.rs
+++ b/src/js/runtime/string_object.rs
@@ -5,15 +5,14 @@ use brimstone_macros::wrap_ordinary_object;
 use crate::{
     extend_object,
     runtime::{
-        Context, HeapItemKind, PropertyKey,
+        Context, PropertyKey,
         alloc_error::AllocResult,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapPtr, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{
-            is_compatible_property_descriptor, object_create, object_create_from_constructor,
-            object_create_with_proto, ordinary_define_own_property,
+            ObjectBuilder, is_compatible_property_descriptor, ordinary_define_own_property,
             ordinary_filtered_own_indexed_property_keys, ordinary_get_own_property,
             ordinary_own_string_symbol_property_keys,
         },
@@ -42,11 +41,9 @@ impl StringObject {
         cx: Context,
         string_data_handle: Handle<StringValue>,
     ) -> AllocResult<Handle<StringObject>> {
-        let mut object = object_create::<StringObject>(
-            cx,
-            HeapItemKind::StringObject,
-            Intrinsic::StringPrototype,
-        )?;
+        let mut object = ObjectBuilder::<StringObject>::new(cx)
+            .intrinsic_proto(Intrinsic::StringPrototype)
+            .build()?;
 
         let string_data = *string_data_handle;
         let string_length = string_data.len();
@@ -65,12 +62,9 @@ impl StringObject {
         constructor: Handle<ObjectValue>,
         string_data_handle: Handle<StringValue>,
     ) -> EvalResult<Handle<StringObject>> {
-        let mut object = object_create_from_constructor::<StringObject>(
-            cx,
-            constructor,
-            HeapItemKind::StringObject,
-            Intrinsic::StringPrototype,
-        )?;
+        let mut object = ObjectBuilder::<StringObject>::new(cx)
+            .constructor_proto(constructor, Intrinsic::StringPrototype)?
+            .build()?;
 
         let string_data = *string_data_handle;
         let string_length = string_data.len();
@@ -89,8 +83,9 @@ impl StringObject {
         proto: Handle<ObjectValue>,
         string_data_handle: Handle<StringValue>,
     ) -> AllocResult<Handle<StringObject>> {
-        let mut object =
-            object_create_with_proto::<StringObject>(cx, HeapItemKind::StringObject, proto)?;
+        let mut object = ObjectBuilder::<StringObject>::new(cx)
+            .proto(proto)
+            .build()?;
 
         let string_data = *string_data_handle;
         let string_length = string_data.len();

--- a/src/js/runtime/test_shell.rs
+++ b/src/js/runtime/test_shell.rs
@@ -8,7 +8,7 @@ use crate::{
     must_a,
     parser::source::Source,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, PropertyDescriptor, PropertyKey, Realm, Value,
+        Context, EvalResult, Handle, PropertyDescriptor, PropertyKey, Realm, Value,
         abstract_operations::{create_data_property_or_throw, define_property_or_throw},
         alloc_error::AllocResult,
         array_object::array_create_in_realm,
@@ -23,7 +23,7 @@ use crate::{
             intrinsics::Intrinsic, rust_runtime::RuntimeFunctionPtr,
         },
         object_value::ObjectValue,
-        ordinary_object::object_create_with_proto,
+        ordinary_object::ObjectBuilder,
         to_string,
     },
     runtime_fn,
@@ -105,12 +105,10 @@ impl TestShell {
         realm: Handle<Realm>,
     ) -> AllocResult<Handle<ObjectValue>> {
         let object_proto = realm.get_intrinsic(Intrinsic::ObjectPrototype);
-        let performance_object = object_create_with_proto::<ObjectValue>(
-            cx,
-            HeapItemKind::OrdinaryObject,
-            object_proto,
-        )?
-        .to_handle();
+        let performance_object = ObjectBuilder::<ObjectValue>::new(cx)
+            .proto(object_proto)
+            .build()?
+            .to_handle();
 
         let name_key = PropertyKey::string_handle(cx, cx.alloc_static_string("performance")?)?;
         let desc = PropertyDescriptor::data(performance_object.as_value(), true, false, true);


### PR DESCRIPTION
## Summary

Unify the various JS-object creation utilities into an `ObjectBuilder` utility. Use in place of the old `object_create*` utilities.

## Tests

- CI