### PR TITLE
[runtime] Refactor property and property descriptor creation, replace descriptors with raw properties in most paths

### DIFF
--- a/src/js/runtime/abstract_operations.rs
+++ b/src/js/runtime/abstract_operations.rs
@@ -76,7 +76,7 @@ pub fn create_data_property(
     key: Handle<PropertyKey>,
     value: Handle<Value>,
 ) -> EvalResult<bool> {
-    let new_desc = PropertyDescriptor::data(value, true, true, true);
+    let new_desc = PropertyDescriptor::default_data(value);
     object.define_own_property(cx, key, new_desc)
 }
 
@@ -102,7 +102,7 @@ pub fn create_non_enumerable_data_property_or_throw(
     key: Handle<PropertyKey>,
     value: Handle<Value>,
 ) -> AllocResult<()> {
-    let new_desc = PropertyDescriptor::data(value, true, false, true);
+    let new_desc = PropertyDescriptor::non_enumerable_data(value);
     must_a!(define_property_or_throw(cx, object, key, new_desc));
 
     Ok(())
@@ -229,7 +229,7 @@ pub fn set_integrity_level(
 
             for key_value in keys {
                 key.replace(must!(PropertyKey::from_value(cx, key_value)));
-                let desc = PropertyDescriptor::attributes(None, None, Some(false));
+                let desc = PropertyDescriptor::attributes_only(None, None, Some(false));
                 define_property_or_throw(cx, object, key, desc)?;
             }
         }
@@ -242,9 +242,9 @@ pub fn set_integrity_level(
                 let current_prop = object.get_own_property(cx, key)?;
                 if let Some(current_prop) = current_prop {
                     let desc = if current_prop.is_accessor() {
-                        PropertyDescriptor::attributes(None, None, Some(false))
+                        PropertyDescriptor::attributes_only(None, None, Some(false))
                     } else {
-                        PropertyDescriptor::attributes(Some(false), None, Some(false))
+                        PropertyDescriptor::attributes_only(Some(false), None, Some(false))
                     };
 
                     define_property_or_throw(cx, object, key, desc)?;

--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -6,7 +6,7 @@ use crate::{
     extend_object, must,
     parser::scope_tree::SHADOWED_SCOPE_SLOT_NAME,
     runtime::{
-        Context, EvalResult, HeapItemKind, HeapPtr, Value,
+        Context, EvalResult, HeapItemKind, HeapPtr, PropertyFlags, Value,
         abstract_operations::{create_data_property_or_throw, define_property_or_throw},
         alloc_error::AllocResult,
         bitmap::ValueBitmap,
@@ -115,17 +115,17 @@ impl MappedArgumentsObject {
 
         // Set length property
         let length_value = cx.number(arguments.len());
-        let length_desc = PropertyDescriptor::data(length_value, true, false, true);
+        let length_desc = PropertyDescriptor::non_enumerable_data(length_value);
         must!(define_property_or_throw(cx, object.into(), cx.names.length(), length_desc));
 
         // Set @@iterator to Array.prototype.values
         let iterator_key = cx.symbols.iterator();
         let iterator_value = cx.get_intrinsic(Intrinsic::ArrayPrototypeValues);
-        let iterator_desc = PropertyDescriptor::data(iterator_value.into(), true, false, true);
+        let iterator_desc = PropertyDescriptor::non_enumerable_data(iterator_value.into());
         must!(define_property_or_throw(cx, object.into(), iterator_key, iterator_desc));
 
         // Set callee property to the enclosing function
-        let callee_desc = PropertyDescriptor::data(callee.into(), true, false, true);
+        let callee_desc = PropertyDescriptor::non_enumerable_data(callee.into());
         must!(define_property_or_throw(cx, object.into(), cx.names.callee(), callee_desc));
 
         Ok(())
@@ -276,7 +276,7 @@ pub fn create_unmapped_arguments_object(
 
     // Set length property
     let length_value = cx.number(arguments.len());
-    let length_desc = PropertyDescriptor::data(length_value, true, false, true);
+    let length_desc = PropertyDescriptor::non_enumerable_data(length_value);
     must!(define_property_or_throw(cx, object, cx.names.length(), length_desc));
 
     // Property key is shared between iterations
@@ -291,13 +291,16 @@ pub fn create_unmapped_arguments_object(
     // Set @@iterator to Array.prototype.values
     let iterator_key = cx.symbols.iterator();
     let iterator_value = cx.get_intrinsic(Intrinsic::ArrayPrototypeValues);
-    let iterator_desc = PropertyDescriptor::data(iterator_value.into(), true, false, true);
+    let iterator_desc = PropertyDescriptor::non_enumerable_data(iterator_value.into());
     must!(define_property_or_throw(cx, object, iterator_key, iterator_desc));
 
     // Set callee to throw a type error when accessed
     let throw_type_error = cx.get_intrinsic(Intrinsic::ThrowTypeError);
-    let callee_desc =
-        PropertyDescriptor::accessor(Some(throw_type_error), Some(throw_type_error), false, false);
+    let callee_desc = PropertyDescriptor::accessor(
+        Some(throw_type_error),
+        Some(throw_type_error),
+        PropertyFlags::empty(),
+    );
     must!(define_property_or_throw(cx, object, cx.names.callee(), callee_desc));
 
     Ok(object.into())

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -18,7 +18,7 @@ use crate::{
             ordinary_filtered_own_indexed_property_keys, ordinary_get_own_property,
             ordinary_own_string_symbol_property_keys,
         },
-        property::Property,
+        property::{Property, PropertyFlags},
         property_descriptor::PropertyDescriptor,
         property_key::PropertyKey,
         rust_vtables::extract_virtual_object_vtable,
@@ -84,7 +84,10 @@ impl VirtualObject for Handle<ArrayObject> {
     ) -> EvalResult<Option<Property>> {
         if key.is_string() && key.as_string().equals(&cx.names.length().as_string())? {
             let length_value = cx.number(self.as_object().array_properties_length());
-            return Ok(Some(Property::data(length_value, self.is_length_writable, false, false)));
+            return Ok(Some(Property::data(
+                length_value,
+                PropertyFlags::from_data_attributes(self.is_length_writable, false, false),
+            )));
         }
 
         Ok(ordinary_get_own_property(cx, self.as_object(), key))
@@ -139,7 +142,7 @@ pub fn array_create_in_realm(
     let mut array_object = ArrayObject::new(cx, proto)?;
 
     let length_value = cx.number(length);
-    let length_desc = PropertyDescriptor::data(length_value, true, false, false);
+    let length_desc = PropertyDescriptor::data(length_value, PropertyFlags::empty().writable());
     must!(array_object.define_own_property(cx, cx.names.length(), length_desc));
 
     Ok(array_object)

--- a/src/js/runtime/array_properties.rs
+++ b/src/js/runtime/array_properties.rs
@@ -67,7 +67,7 @@ impl HeapPtr<ArrayProperties> {
                 return None;
             }
 
-            Some(Property::data(value.to_handle(cx), true, true, true))
+            Some(Property::default_data(value.to_handle(cx)))
         } else {
             let sparse_properties = self.as_sparse();
             sparse_properties
@@ -198,7 +198,7 @@ impl ArrayProperties {
                 value_handle.replace(value);
                 sparse_properties.insert_without_growing(
                     index as u32,
-                    Property::data(value_handle, true, true, true).to_heap(),
+                    Property::default_data(value_handle).to_heap(),
                 );
             }
         }

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -21,7 +21,7 @@ use crate::{
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunctionId},
         object_value::ObjectValue,
         ordinary_object::ObjectBuilder,
-        property::Property,
+        property::{Property, PropertyFlags},
         scope::Scope,
         shape::Shape,
         source_file::SourceFile,
@@ -179,10 +179,11 @@ impl ClosureObject {
                 .build()?
                 .to_handle();
 
-            let desc = PropertyDescriptor::data(closure.into(), true, false, true);
+            let desc = PropertyDescriptor::non_enumerable_data(closure.into());
             must_a!(define_property_or_throw(cx, prototype, cx.names.constructor(), desc));
 
-            let desc = PropertyDescriptor::data(prototype.into(), true, false, false);
+            let desc =
+                PropertyDescriptor::data(prototype.into(), PropertyFlags::empty().writable());
             must_a!(define_property_or_throw(cx, closure.into(), cx.names.prototype(), desc));
         }
 
@@ -202,7 +203,7 @@ impl Handle<ClosureObject> {
         cx: Context,
         name: Handle<StringValue>,
     ) -> AllocResult<()> {
-        let property = Property::data(name.into(), false, false, true);
+        let property = Property::data(name.into(), PropertyFlags::empty().configurable());
         self.as_object().set_property(cx, cx.names.name(), property)
     }
 }

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -128,7 +128,7 @@ use crate::{
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{ObjectBuilder, ordinary_object_create},
         promise_object::{PromiseObject, coerce_to_ordinary_promise, resolve},
-        property::Property,
+        property::{DEFAULT_ACCESSOR_PROPERTY_FLAGS, Property},
         proxy_object::ProxyObject,
         regexp::compiled_regexp::CompiledRegExp,
         scope::Scope,
@@ -4304,10 +4304,16 @@ impl VM {
 
                 // Create special property descriptors for accessors
                 if flags.contains(DefinePropertyFlags::GETTER) {
-                    let desc = PropertyDescriptor::get_only(Some(closure.into()), true, true);
+                    let desc = PropertyDescriptor::getter(
+                        Some(closure.into()),
+                        DEFAULT_ACCESSOR_PROPERTY_FLAGS,
+                    );
                     return define_property_or_throw(self.cx(), object, property_key, desc);
                 } else if flags.contains(DefinePropertyFlags::SETTER) {
-                    let desc = PropertyDescriptor::set_only(Some(closure.into()), true, true);
+                    let desc = PropertyDescriptor::setter(
+                        Some(closure.into()),
+                        DEFAULT_ACCESSOR_PROPERTY_FLAGS,
+                    );
                     return define_property_or_throw(self.cx(), object, property_key, desc);
                 }
             }
@@ -4834,7 +4840,7 @@ impl VM {
 
         // May allocate
         let index = index.replace_into(must!(PropertyKey::from_value(self.cx(), index)));
-        let desc = Property::data(value, true, true, true);
+        let desc = Property::default_data(value);
         array.as_object().set_property(self.cx(), index, desc)?;
 
         Ok(())
@@ -5133,7 +5139,7 @@ impl VM {
                 array_key.replace(PropertyKey::array_index(self.cx(), i as u32)?);
                 value_handle.replace(*argument);
 
-                let array_property = Property::data(value_handle, true, true, true);
+                let array_property = Property::default_data(value_handle);
                 rest_array
                     .as_object()
                     .set_property(self.cx(), array_key, array_property)?;

--- a/src/js/runtime/class_names.rs
+++ b/src/js/runtime/class_names.rs
@@ -1,7 +1,8 @@
 use crate::{
     field_offset, must,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyDescriptor, PropertyKey, Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyDescriptor, PropertyFlags,
+        PropertyKey, Value,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         bytecode::function::{BytecodeFunction, ClosureObject},
@@ -204,11 +205,11 @@ pub fn new_class(
         ClosureObject::new_with_proto(cx, constructor_function, scope, constructor_parent)?;
 
     // Define a `constructor` property on the prototype
-    let desc = PropertyDescriptor::data(constructor.into(), true, false, true);
+    let desc = PropertyDescriptor::non_enumerable_data(constructor.into());
     must!(define_property_or_throw(cx, prototype, cx.names.constructor(), desc));
 
     // Define a `prototype` property on the constructor
-    let desc = PropertyDescriptor::data(prototype.into(), false, false, false);
+    let desc = PropertyDescriptor::frozen(prototype.into());
     define_property_or_throw(cx, constructor.into(), cx.names.prototype(), desc)?;
 
     // Store the prototype as the home object if needed
@@ -272,11 +273,14 @@ pub fn new_class(
 
         // Define the method on the prototype or constructor
         let desc = if method.is_getter {
-            PropertyDescriptor::get_only(Some(closure.into()), false, true)
+            PropertyDescriptor::getter(Some(closure.into()), PropertyFlags::empty().configurable())
         } else if method.is_setter {
-            PropertyDescriptor::set_only(Some(closure.into()), false, true)
+            PropertyDescriptor::setter(Some(closure.into()), PropertyFlags::empty().configurable())
         } else {
-            PropertyDescriptor::data(closure.into(), !method.is_private, false, true)
+            PropertyDescriptor::data(
+                closure.into(),
+                PropertyFlags::from_data_attributes(!method.is_private, false, true),
+            )
         };
 
         define_property_or_throw(cx, target, name, desc)?;

--- a/src/js/runtime/eval/eval.rs
+++ b/src/js/runtime/eval/eval.rs
@@ -269,7 +269,7 @@ fn eval_declaration_instantiation(mut cx: Context, program: &ast::Program) -> Ev
             )?;
         } else {
             // All functions are initialized to undefined, overwriting existing declarations
-            let desc = Property::data(cx.undefined(), true, true, true);
+            let desc = Property::default_data(cx.undefined());
             scope_object.set_property(cx, name.cast(), desc)?;
         }
     }
@@ -281,7 +281,7 @@ fn eval_declaration_instantiation(mut cx: Context, program: &ast::Program) -> Ev
         } else {
             // Vars only initialized to undefined if the do not have been declared yet
             if !scope_object.has_property(cx, name.cast())? {
-                let desc = Property::data(cx.undefined(), true, true, true);
+                let desc = Property::default_data(cx.undefined());
                 scope_object.set_property(cx, name.cast(), desc)?;
             }
         }

--- a/src/js/runtime/eval/expression.rs
+++ b/src/js/runtime/eval/expression.rs
@@ -18,6 +18,7 @@ use crate::{
         eval_result::EvalResult,
         numeric_operations::number_exponentiate,
         object_value::ObjectValue,
+        property::PropertyFlags,
         property_descriptor::PropertyDescriptor,
         property_key::PropertyKey,
         string_value::StringValue,
@@ -51,17 +52,19 @@ pub fn generate_template_object(
             None => cx.undefined(),
             Some(cooked) => alloc_wtf8_str_from_source(cx, cooked)?.as_value(),
         };
-        let cooked_desc = PropertyDescriptor::data(cooked_value, false, true, false);
+        let cooked_desc =
+            PropertyDescriptor::data(cooked_value, PropertyFlags::empty().enumerable());
         must_a!(define_property_or_throw(cx, template_object, index_key, cooked_desc));
 
         let raw_value = alloc_wtf8_str_from_source(cx, quasi.raw)?;
-        let raw_desc = PropertyDescriptor::data(raw_value.as_value(), false, true, false);
+        let raw_desc =
+            PropertyDescriptor::data(raw_value.as_value(), PropertyFlags::empty().enumerable());
         must_a!(define_property_or_throw(cx, raw_object, index_key, raw_desc));
     }
 
     must_a!(set_integrity_level(cx, raw_object, IntegrityLevel::Frozen));
 
-    let raw_object_desc = PropertyDescriptor::data(raw_object.into(), false, false, false);
+    let raw_object_desc = PropertyDescriptor::frozen(raw_object.into());
     must_a!(define_property_or_throw(cx, template_object, cx.names.raw(), raw_object_desc));
 
     must_a!(set_integrity_level(cx, template_object, IntegrityLevel::Frozen));

--- a/src/js/runtime/function.rs
+++ b/src/js/runtime/function.rs
@@ -1,7 +1,7 @@
 use crate::{
     must, must_a,
     runtime::{
-        Context, EvalResult, Handle, abstract_operations::define_property_or_throw,
+        Context, EvalResult, Handle, PropertyFlags, abstract_operations::define_property_or_throw,
         alloc_error::AllocResult, object_value::ObjectValue,
         property_descriptor::PropertyDescriptor, property_key::PropertyKey,
         string_value::StringValue,
@@ -13,7 +13,7 @@ pub fn set_simple_function_name(
     func: Handle<ObjectValue>,
     name: Handle<StringValue>,
 ) -> AllocResult<()> {
-    let desc = PropertyDescriptor::data(name.into(), false, false, true);
+    let desc = PropertyDescriptor::data(name.into(), PropertyFlags::empty().configurable());
     must_a!(define_property_or_throw(cx, func, cx.names.name(), desc));
 
     Ok(())
@@ -27,7 +27,7 @@ pub fn set_function_name(
     prefix: Option<&str>,
 ) -> EvalResult<()> {
     let name_string = build_function_name(cx, name, prefix)?;
-    let desc = PropertyDescriptor::data(name_string.into(), false, false, true);
+    let desc = PropertyDescriptor::data(name_string.into(), PropertyFlags::empty().configurable());
     must_a!(define_property_or_throw(cx, func, cx.names.name(), desc));
 
     Ok(())
@@ -69,7 +69,7 @@ pub fn build_function_name(
 /// SetFunctionLength (https://tc39.es/ecma262/#sec-setfunctionlength)
 pub fn set_function_length(cx: Context, func: Handle<ObjectValue>, length: u32) -> AllocResult<()> {
     let length_value = cx.number(length);
-    let desc = PropertyDescriptor::data(length_value, false, false, true);
+    let desc = PropertyDescriptor::data(length_value, PropertyFlags::empty().configurable());
     must_a!(define_property_or_throw(cx, func, cx.names.length(), desc));
 
     Ok(())
@@ -87,7 +87,7 @@ pub fn set_function_length_maybe_infinity(
         cx.number(f64::INFINITY)
     };
 
-    let desc = PropertyDescriptor::data(length, false, false, true);
+    let desc = PropertyDescriptor::data(length, PropertyFlags::empty().configurable());
     must!(define_property_or_throw(cx, func, cx.names.length(), desc));
 
     Ok(())

--- a/src/js/runtime/gc_object.rs
+++ b/src/js/runtime/gc_object.rs
@@ -30,7 +30,7 @@ impl GcObject {
     pub fn install(cx: Context, realm: Handle<Realm>) -> AllocResult<()> {
         handle_scope!(cx, {
             let gc_object = GcObject::new(cx, realm)?;
-            let desc = PropertyDescriptor::data(gc_object.as_value(), true, false, true);
+            let desc = PropertyDescriptor::non_enumerable_data(gc_object.as_value());
             let global_object = realm.global_object().as_object();
             must_a!(define_property_or_throw(cx, global_object, cx.names.gc(), desc));
 

--- a/src/js/runtime/global_names.rs
+++ b/src/js/runtime/global_names.rs
@@ -1,8 +1,8 @@
 use crate::{
     field_offset,
     runtime::{
-        Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyDescriptor, PropertyKey, Realm,
-        Value,
+        Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyDescriptor, PropertyFlags,
+        PropertyKey, Realm, Value,
         abstract_operations::{define_property_or_throw, has_own_property, is_extensible},
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -241,7 +241,10 @@ pub fn create_global_var_binding(
 
     if !has_property && is_extensible {
         // Inlined ObjectEnvironment::CreateMutableBinding from spec
-        let prop_desc = PropertyDescriptor::data(cx.undefined(), true, true, can_delete);
+        let prop_desc = PropertyDescriptor::data(
+            cx.undefined(),
+            PropertyFlags::from_data_attributes(true, true, can_delete),
+        );
         define_property_or_throw(cx, global_object, name_key, prop_desc)?;
 
         // No need for initialize_binding here since binding must already be undefined
@@ -266,7 +269,10 @@ pub fn create_global_function_binding(
 
     // Property will be set later by a StoreGlobal, for now write undefined
     let prop_desc = if is_writable {
-        PropertyDescriptor::data(cx.undefined(), true, true, can_delete)
+        PropertyDescriptor::data(
+            cx.undefined(),
+            PropertyFlags::from_data_attributes(true, true, can_delete),
+        )
     } else {
         PropertyDescriptor::data_value_only(cx.undefined())
     };

--- a/src/js/runtime/global_object.rs
+++ b/src/js/runtime/global_object.rs
@@ -89,9 +89,7 @@ impl VirtualObject for Handle<GlobalObject> {
         }
 
         // All named properties are intercepted by the global object
-        let current_desc = self
-            .get_own_property(cx, key)?
-            .map(|property| PropertyDescriptor::from_property(&property));
+        let current_prop = self.get_own_property(cx, key)?;
         let is_extensible = self.as_object().is_extensible(cx)?;
 
         Ok(validate_and_apply_property_descriptor(
@@ -100,7 +98,7 @@ impl VirtualObject for Handle<GlobalObject> {
             key,
             is_extensible,
             desc,
-            current_desc,
+            current_prop,
         )?)
     }
 

--- a/src/js/runtime/intrinsic_builder.rs
+++ b/src/js/runtime/intrinsic_builder.rs
@@ -1,7 +1,7 @@
 use crate::{
     handle_scope_guard,
     runtime::{
-        Context, Handle, Realm, Value,
+        Context, Handle, PropertyFlags, Realm, Value,
         accessor::Accessor,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -102,7 +102,7 @@ impl IntrinsicBuilder {
         handle_scope_guard!(self.cx);
 
         let func = BuiltinFunction::create(self.cx, func, length, name, self.realm, None)?.into();
-        let property = Property::data(func, true, false, true);
+        let property = Property::non_enumerable_data(func);
         self.property(name, property)
     }
 
@@ -110,7 +110,7 @@ impl IntrinsicBuilder {
     pub fn data(&mut self, name: Handle<PropertyKey>, value: Handle<Value>) -> AllocResult<()> {
         handle_scope_guard!(self.cx);
 
-        let property = Property::data(value, true, false, true);
+        let property = Property::non_enumerable_data(value);
         self.property(name, property)
     }
 
@@ -120,7 +120,8 @@ impl IntrinsicBuilder {
 
         let getter = BuiltinFunction::create(self.cx, func, 0, name, self.realm, Some("get"))?;
         let accessor_value = Accessor::new(self.cx, Some(getter), None)?;
-        let property = Property::accessor(accessor_value.into(), false, true);
+        let flags = PropertyFlags::empty().configurable();
+        let property = Property::accessor(accessor_value.into(), flags);
         self.property(name, property)
     }
 
@@ -136,7 +137,8 @@ impl IntrinsicBuilder {
         let getter = BuiltinFunction::create(self.cx, getter, 0, name, self.realm, Some("get"))?;
         let setter = BuiltinFunction::create(self.cx, setter, 1, name, self.realm, Some("set"))?;
         let accessor_value = Accessor::new(self.cx, Some(getter), Some(setter))?;
-        let property = Property::accessor(accessor_value.into(), false, true);
+        let flags = PropertyFlags::empty().configurable();
+        let property = Property::accessor(accessor_value.into(), flags);
         self.property(name, property)
     }
 
@@ -144,7 +146,7 @@ impl IntrinsicBuilder {
     pub fn frozen(&mut self, name: Handle<PropertyKey>, value: Handle<Value>) -> AllocResult<()> {
         handle_scope_guard!(self.cx);
 
-        let property = Property::data(value, false, false, false);
+        let property = Property::frozen(value);
         self.property(name, property)
     }
 
@@ -154,11 +156,31 @@ impl IntrinsicBuilder {
         self.frozen(self.cx.names.prototype(), value)
     }
 
-    /// Install @@toStringTag with a particular string value.
+    /// Install @@toStringTag with a particular string value (as a property key).
     pub fn to_string_tag(&mut self, tag: Handle<PropertyKey>) -> AllocResult<()> {
         let key = self.cx.symbols.to_string_tag();
         let value = tag.as_string().into();
-        self.property(key, Property::data(value, false, false, true))
+
+        self.property(key, Property::data(value, PropertyFlags::empty().configurable()))
+    }
+
+    /// Install @@toStringTag with a particular string value.
+    pub fn to_string_tag_str(&mut self, tag: &'static str) -> AllocResult<()> {
+        let key = self.cx.symbols.to_string_tag();
+        let value = self.cx.alloc_static_string(tag)?.into();
+
+        self.property(key, Property::data(value, PropertyFlags::empty().configurable()))
+    }
+
+    /// Install @@toPrimitive with a particular function.
+    pub fn to_primitive(&mut self, func: RuntimeFunction) -> AllocResult<()> {
+        let to_primitive_key = self.cx.symbols.to_primitive();
+        let to_primitive_func = self.function(func, 1, to_primitive_key)?;
+
+        self.property(
+            to_primitive_key,
+            Property::data(to_primitive_func.into(), PropertyFlags::empty().configurable()),
+        )
     }
 
     /// Create a builtin function without installing it on the object.

--- a/src/js/runtime/intrinsics/aggregate_error_constructor.rs
+++ b/src/js/runtime/intrinsics/aggregate_error_constructor.rs
@@ -80,7 +80,7 @@ impl AggregateErrorConstructor {
 
         let errors_array = create_array_from_list(cx, &errors_list)?.as_object();
 
-        let errors_desc = PropertyDescriptor::data(errors_array.into(), true, false, true);
+        let errors_desc = PropertyDescriptor::non_enumerable_data(errors_array.into());
         must!(define_property_or_throw(cx, object.into(), cx.names.errors(), errors_desc));
 
         Ok(object.as_value())

--- a/src/js/runtime/intrinsics/array_iterator_object.rs
+++ b/src/js/runtime/intrinsics/array_iterator_object.rs
@@ -21,7 +21,6 @@ use crate::{
         iterator::create_iter_result_object,
         object_value::ObjectValue,
         ordinary_object::ObjectBuilder,
-        property::Property,
         property_key::PropertyKey,
         realm::Realm,
         value::Value,
@@ -74,7 +73,7 @@ impl ArrayIteratorObject {
 pub struct ArrayIteratorPrototype;
 
 impl ArrayIteratorPrototype {
-    pub fn new(mut cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
+    pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
         let mut builder = IntrinsicBuilder::new_object(cx, realm, Intrinsic::IteratorPrototype)?;
 
         intrinsic_methods!(cx, builder, {
@@ -82,11 +81,7 @@ impl ArrayIteratorPrototype {
         });
 
         // %ArrayIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_value = cx.alloc_static_string("Array Iterator")?.into();
-        builder.property(
-            cx.symbols.to_string_tag(),
-            Property::data(to_string_tag_value, false, false, true),
-        )?;
+        builder.to_string_tag_str("Array Iterator")?;
 
         builder.build()
     }

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -4,7 +4,7 @@ use crate::{
     common::numeric::MAX_SAFE_INTEGER_U64,
     intrinsic_methods, must, must_a,
     runtime::{
-        Context, EvalResult, Handle, Value,
+        Context, EvalResult, Handle, PropertyFlags, Value,
         abstract_operations::{
             call, call_object, create_data_property_or_throw, delete_property_or_throw,
             has_property, invoke, length_of_array_like, set,
@@ -90,8 +90,11 @@ impl ArrayPrototype {
         builder.alias(cx.names.values(), cx.symbols.iterator())?;
 
         // Array.prototype [ @@unscopables ] (https://tc39.es/ecma262/#sec-array.prototype-%symbol.unscopables%)
-        let unscopables = Property::data(Self::create_unscopables(cx)?.into(), false, false, true);
-        builder.property(cx.symbols.unscopables(), unscopables)?;
+        let unscopables_property = Property::data(
+            Self::create_unscopables(cx)?.into(),
+            PropertyFlags::empty().configurable(),
+        );
+        builder.property(cx.symbols.unscopables(), unscopables_property)?;
 
         builder.build()
     }

--- a/src/js/runtime/intrinsics/async_generator_function_prototype.rs
+++ b/src/js/runtime/intrinsics/async_generator_function_prototype.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    Context, Handle, alloc_error::AllocResult, intrinsic_builder::IntrinsicBuilder,
+    Context, Handle, PropertyFlags, alloc_error::AllocResult, intrinsic_builder::IntrinsicBuilder,
     intrinsics::intrinsics::Intrinsic, object_value::ObjectValue, property::Property, realm::Realm,
 };
 
@@ -14,7 +14,10 @@ impl AsyncGeneratorFunctionPrototype {
 
         // AsyncGeneratorFunction.prototype.prototype (https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-prototype)
         let proto = realm.get_intrinsic(Intrinsic::AsyncGeneratorPrototype);
-        builder.property(cx.names.prototype(), Property::data(proto.into(), false, false, true))?;
+        builder.property(
+            cx.names.prototype(),
+            Property::data(proto.into(), PropertyFlags::empty().configurable()),
+        )?;
 
         // AsyncGeneratorFunction.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-%symbol.tostringtag%)
         builder.to_string_tag(cx.names.async_generator_function())?;

--- a/src/js/runtime/intrinsics/async_generator_prototype.rs
+++ b/src/js/runtime/intrinsics/async_generator_prototype.rs
@@ -17,6 +17,7 @@ use crate::{
         object_value::ObjectValue,
         ordinary_object::ObjectBuilder,
         promise_object::PromiseCapability,
+        property::PropertyFlags,
         property_descriptor::PropertyDescriptor,
         realm::Realm,
     },
@@ -151,7 +152,8 @@ impl AsyncGeneratorPrototype {
             .build()?
             .to_handle();
 
-        let proto_desc = PropertyDescriptor::data(proto.to_handle().into(), true, false, false);
+        let proto_desc =
+            PropertyDescriptor::data(proto.to_handle().into(), PropertyFlags::empty().writable());
         define_property_or_throw(cx, closure.into(), cx.names.prototype(), proto_desc)?;
 
         Ok(())

--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -21,7 +21,6 @@ use crate::{
             temporal::instant_constructor::create_temporal_instant,
         },
         object_value::ObjectValue,
-        property::Property,
         string_value::StringValue,
         type_utilities::{
             ToPrimitivePreferredType, ordinary_to_primitive, to_number, to_object, to_primitive,
@@ -86,13 +85,7 @@ impl DatePrototype {
         });
 
         // [Symbol.toPrimitive] property
-        let to_primitive_key = cx.symbols.to_primitive();
-        let to_primitive_func =
-            builder.function(RuntimeFunction::DatePrototype_to_primitive, 1, to_primitive_key)?;
-        builder.property(
-            to_primitive_key,
-            Property::data(to_primitive_func.into(), false, false, true),
-        )?;
+        builder.to_primitive(RuntimeFunction::DatePrototype_to_primitive)?;
 
         builder.build()
     }

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     intrinsic_methods, must,
     runtime::{
-        Context, Handle, HeapItemKind, HeapPtr, Value,
+        Context, Handle, HeapItemKind, HeapPtr, PropertyFlags, Value,
         abstract_operations::{
             call_object, create_list_from_array_like_arguments, has_own_property,
             ordinary_has_instance,
@@ -75,10 +75,16 @@ impl FunctionPrototype {
         let mut builder = IntrinsicBuilder::ordinary(cx, realm, object);
 
         // Function prototype is a function with the standard name and length properties
-        builder.property(cx.names.length(), Property::data(cx.smi(0), false, false, true))?;
+        builder.property(
+            cx.names.length(),
+            Property::data(cx.smi(0), PropertyFlags::empty().configurable()),
+        )?;
         builder.property(
             cx.names.name(),
-            Property::data(cx.names.empty_string().as_string().into(), false, false, true),
+            Property::data(
+                cx.names.empty_string().as_string().into(),
+                PropertyFlags::empty().configurable(),
+            ),
         )?;
 
         intrinsic_methods!(cx, builder, {

--- a/src/js/runtime/intrinsics/generator_function_prototype.rs
+++ b/src/js/runtime/intrinsics/generator_function_prototype.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    Context, Handle, alloc_error::AllocResult, intrinsic_builder::IntrinsicBuilder,
+    Context, Handle, PropertyFlags, alloc_error::AllocResult, intrinsic_builder::IntrinsicBuilder,
     intrinsics::intrinsics::Intrinsic, object_value::ObjectValue, property::Property, realm::Realm,
 };
 
@@ -14,7 +14,10 @@ impl GeneratorFunctionPrototype {
 
         // GeneratorFunction.prototype.prototype (https://tc39.es/ecma262/#sec-generatorfunction.prototype.prototype)
         let proto = realm.get_intrinsic(Intrinsic::GeneratorPrototype);
-        builder.property(cx.names.prototype(), Property::data(proto.into(), false, false, true))?;
+        builder.property(
+            cx.names.prototype(),
+            Property::data(proto.into(), PropertyFlags::empty().configurable()),
+        )?;
 
         // GeneratorFunction.prototype [ @@toStringTag ] (https://tc39.es/ecma262/#sec-generatorfunction.prototype-%symbol.tostringtag%)
         builder.to_string_tag(cx.names.generator_function())?;

--- a/src/js/runtime/intrinsics/generator_prototype.rs
+++ b/src/js/runtime/intrinsics/generator_prototype.rs
@@ -1,7 +1,7 @@
 use crate::{
     intrinsic_methods,
     runtime::{
-        Context, Handle, PropertyDescriptor,
+        Context, Handle, PropertyDescriptor, PropertyFlags,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         bytecode::function::ClosureObject,
@@ -68,7 +68,8 @@ impl GeneratorPrototype {
             .build()?
             .to_handle();
 
-        let proto_desc = PropertyDescriptor::data(proto.to_handle().into(), true, false, false);
+        let proto_desc =
+            PropertyDescriptor::data(proto.to_handle().into(), PropertyFlags::empty().writable());
         define_property_or_throw(cx, closure.into(), cx.names.prototype(), proto_desc)?;
 
         Ok(())

--- a/src/js/runtime/intrinsics/globals.rs
+++ b/src/js/runtime/intrinsics/globals.rs
@@ -21,6 +21,7 @@ use crate::{
         gc_object::GcObject,
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        property::PropertyFlags,
         property_descriptor::PropertyDescriptor,
         string_parsing::{StringLexer, parse_signed_decimal_literal, skip_string_whitespace},
         string_value::{FlatString, StringValue},
@@ -44,9 +45,11 @@ pub fn set_default_global_bindings(cx: Context, realm: Handle<Realm>) -> EvalRes
                     $name,
                     PropertyDescriptor::data(
                         $value,
-                        $is_writable,
-                        $is_enumerable,
-                        $is_configurable,
+                        PropertyFlags::from_data_attributes(
+                            $is_writable,
+                            $is_enumerable,
+                            $is_configurable,
+                        ),
                     ),
                 )?;
             }};
@@ -72,7 +75,7 @@ pub fn set_default_global_bindings(cx: Context, realm: Handle<Realm>) -> EvalRes
                     cx,
                     realm.global_object().as_object(),
                     $name,
-                    PropertyDescriptor::data(value.into(), true, false, true),
+                    PropertyDescriptor::non_enumerable_data(value.into()),
                 )?;
             }};
         }

--- a/src/js/runtime/intrinsics/intrinsics.rs
+++ b/src/js/runtime/intrinsics/intrinsics.rs
@@ -1,7 +1,7 @@
 use crate::{
     handle_scope, handle_scope_guard, must_a,
     runtime::{
-        Context, Handle, HeapPtr, Value,
+        Context, Handle, HeapPtr, PropertyFlags, Value,
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         builtin_function::BuiltinFunction,
@@ -547,8 +547,7 @@ impl Intrinsics {
         let mut prototype_object = realm.get_intrinsic(prototype);
         let constructor_object = realm.get_intrinsic(constructor);
 
-        let constructor_desc =
-            PropertyDescriptor::data(constructor_object.into(), true, false, true);
+        let constructor_desc = PropertyDescriptor::non_enumerable_data(constructor_object.into());
         must_a!(prototype_object.define_own_property(cx, cx.names.constructor(), constructor_desc));
 
         Ok(())
@@ -566,8 +565,10 @@ impl Intrinsics {
         let mut prototype_object = realm.get_intrinsic(prototype);
         let constructor_object = realm.get_intrinsic(constructor);
 
-        let constructor_desc =
-            PropertyDescriptor::data(constructor_object.into(), false, false, true);
+        let constructor_desc = PropertyDescriptor::data(
+            constructor_object.into(),
+            PropertyFlags::empty().configurable(),
+        );
         must_a!(prototype_object.define_own_property(cx, cx.names.constructor(), constructor_desc));
 
         Ok(())
@@ -600,7 +601,7 @@ fn create_throw_type_error_intrinsic(
             .into();
 
         let zero_value = cx.zero();
-        let length_desc = PropertyDescriptor::data(zero_value, false, false, false);
+        let length_desc = PropertyDescriptor::frozen(zero_value);
         must_a!(define_property_or_throw(
             cx,
             throw_type_error_func,
@@ -610,7 +611,7 @@ fn create_throw_type_error_intrinsic(
 
         // Is anonymous function so name is empty
         let name = cx.names.empty_string().as_string().into();
-        let name_desc = PropertyDescriptor::data(name, false, false, false);
+        let name_desc = PropertyDescriptor::frozen(name);
         must_a!(define_property_or_throw(cx, throw_type_error_func, cx.names.name(), name_desc,));
 
         must_a!(throw_type_error_func.prevent_extensions(cx));
@@ -629,12 +630,18 @@ fn add_restricted_function_properties(
 
     let thrower_func = realm.get_intrinsic(Intrinsic::ThrowTypeError);
 
-    let caller_desc =
-        PropertyDescriptor::accessor(Some(thrower_func), Some(thrower_func), false, true);
+    let caller_desc = PropertyDescriptor::accessor(
+        Some(thrower_func),
+        Some(thrower_func),
+        PropertyFlags::empty().configurable(),
+    );
     must_a!(define_property_or_throw(cx, func, cx.names.caller(), caller_desc));
 
-    let arguments_desc =
-        PropertyDescriptor::accessor(Some(thrower_func), Some(thrower_func), false, true);
+    let arguments_desc = PropertyDescriptor::accessor(
+        Some(thrower_func),
+        Some(thrower_func),
+        PropertyFlags::empty().configurable(),
+    );
     must_a!(define_property_or_throw(cx, func, cx.names.arguments(), arguments_desc));
 
     Ok(())

--- a/src/js/runtime/intrinsics/iterator_helper_prototype.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_prototype.rs
@@ -9,7 +9,6 @@ use crate::{
         intrinsics::{intrinsics::Intrinsic, iterator_helper_object::IteratorHelperObject},
         iterator::{create_iter_result_object, iterator_close},
         object_value::ObjectValue,
-        property::Property,
     },
     runtime_fn,
 };
@@ -18,7 +17,7 @@ use crate::{
 pub struct IteratorHelperPrototype;
 
 impl IteratorHelperPrototype {
-    pub fn new(mut cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
+    pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
         let mut builder = IntrinsicBuilder::new_object(cx, realm, Intrinsic::IteratorPrototype)?;
 
         intrinsic_methods!(cx, builder, {
@@ -27,11 +26,7 @@ impl IteratorHelperPrototype {
         });
 
         // %IteratorHelperPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%iteratorhelperprototype%-%symbol.tostringtag%)
-        let iterator_helper = cx.alloc_static_string("Iterator Helper")?;
-        builder.property(
-            cx.symbols.to_string_tag(),
-            Property::data(iterator_helper.as_value(), false, false, true),
-        )?;
+        builder.to_string_tag_str("Iterator Helper")?;
 
         builder.build()
     }

--- a/src/js/runtime/intrinsics/json_parser.rs
+++ b/src/js/runtime/intrinsics/json_parser.rs
@@ -318,7 +318,7 @@ impl JSONValue {
 
                 for (i, value) in elements.iter().enumerate() {
                     key.replace(PropertyKey::from_u64(cx, i as u64)?);
-                    let desc = Property::data(value.to_js_value(cx)?, true, true, true);
+                    let desc = Property::default_data(value.to_js_value(cx)?);
                     array.as_object().set_property(cx, key, desc)?;
                 }
 
@@ -379,7 +379,7 @@ impl JSONValue {
                     let value = parse_record.value;
                     record_elements.push(parse_record);
 
-                    let desc = Property::data(value, true, true, true);
+                    let desc = Property::default_data(value);
                     array.as_object().set_property(cx, key, desc)?;
                 }
 

--- a/src/js/runtime/intrinsics/map_iterator_object.rs
+++ b/src/js/runtime/intrinsics/map_iterator_object.rs
@@ -21,7 +21,6 @@ use crate::{
         iterator::create_iter_result_object,
         object_value::ObjectValue,
         ordinary_object::ObjectBuilder,
-        property::Property,
         realm::Realm,
         value::{Value, ValueCollectionKey},
     },
@@ -82,7 +81,7 @@ impl MapIteratorObject {
 pub struct MapIteratorPrototype;
 
 impl MapIteratorPrototype {
-    pub fn new(mut cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
+    pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
         let mut builder = IntrinsicBuilder::new_object(cx, realm, Intrinsic::IteratorPrototype)?;
 
         intrinsic_methods!(cx, builder, {
@@ -90,11 +89,7 @@ impl MapIteratorPrototype {
         });
 
         // %MapIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%mapiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_value = cx.alloc_static_string("Map Iterator")?.into();
-        builder.property(
-            cx.symbols.to_string_tag(),
-            Property::data(to_string_tag_value, false, false, true),
-        )?;
+        builder.to_string_tag_str("Map Iterator")?;
 
         builder.build()
     }

--- a/src/js/runtime/intrinsics/object_constructor.rs
+++ b/src/js/runtime/intrinsics/object_constructor.rs
@@ -1,7 +1,7 @@
 use crate::{
     intrinsic_methods, must,
     runtime::{
-        Context, Handle, Value,
+        Context, Handle, PropertyDescriptor, Value,
         abstract_operations::{
             GroupByKeyCoercion, IntegrityLevel, KeyOrValue, create_data_property_or_throw,
             define_property_or_throw, enumerable_own_property_names, get, group_by,
@@ -20,7 +20,7 @@ use crate::{
         ordinary_object::{
             ObjectBuilder, ordinary_object_create, ordinary_object_create_without_proto,
         },
-        property_descriptor::{from_property_descriptor, to_property_descriptor},
+        property_descriptor::to_property_descriptor_object,
         property_key::PropertyKey,
         realm::Realm,
         type_utilities::{require_object_coercible, same_value, to_object, to_property_key},
@@ -183,7 +183,7 @@ impl ObjectConstructor {
             if let Some(prop) = prop {
                 if prop.is_enumerable() {
                     let desc_object = get(cx, properties, key)?;
-                    let desc = to_property_descriptor(cx, desc_object)?;
+                    let desc = PropertyDescriptor::from_object(cx, desc_object)?;
 
                     descriptors.push((key, desc));
                 }
@@ -209,7 +209,7 @@ impl ObjectConstructor {
         let property_key = to_property_key(cx, property_arg)?;
 
         let desc_arg = arguments.get(cx, 2);
-        let desc = to_property_descriptor(cx, desc_arg)?;
+        let desc = PropertyDescriptor::from_object(cx, desc_arg)?;
 
         define_property_or_throw(cx, object.as_object(), property_key, desc)?;
 
@@ -264,9 +264,9 @@ impl ObjectConstructor {
         let property_arg = arguments.get(cx, 1);
         let property_key = to_property_key(cx, property_arg)?;
 
-        match object.get_own_property_descriptor(cx, property_key)? {
+        match object.get_own_property(cx, property_key)? {
             None => Ok(cx.undefined()),
-            Some(desc) => Ok(from_property_descriptor(cx, desc)?.as_value()),
+            Some(property) => Ok(to_property_descriptor_object(cx, property)?.as_value()),
         }
     }}
 
@@ -285,9 +285,9 @@ impl ObjectConstructor {
 
         for key_value in keys {
             key.replace(must!(PropertyKey::from_value(cx, key_value)));
-            let desc = object.get_own_property_descriptor(cx, key)?;
-            if let Some(desc) = desc {
-                let desc_object = from_property_descriptor(cx, desc)?;
+            let property = object.get_own_property(cx, key)?;
+            if let Some(property) = property {
+                let desc_object = to_property_descriptor_object(cx, property)?;
                 must!(create_data_property_or_throw(cx, descriptors, key, desc_object.into()));
             }
         }

--- a/src/js/runtime/intrinsics/object_prototype_object.rs
+++ b/src/js/runtime/intrinsics/object_prototype_object.rs
@@ -16,6 +16,7 @@ use crate::{
             rust_runtime::RuntimeFunction,
         },
         ordinary_object::{init_object_fields, ordinary_object_create_without_proto},
+        property::DEFAULT_ACCESSOR_PROPERTY_FLAGS,
         property_descriptor::PropertyDescriptor,
         realm::Realm,
         shape_registry::ShapeRegistry,
@@ -241,7 +242,8 @@ impl ObjectPrototypeObject {
 
         let key_arg = arguments.get(cx, 0);
         let key = to_property_key(cx, key_arg)?;
-        let desc = PropertyDescriptor::get_only(Some(getter.as_object()), true, true);
+        let desc =
+            PropertyDescriptor::getter(Some(getter.as_object()), DEFAULT_ACCESSOR_PROPERTY_FLAGS);
 
         define_property_or_throw(cx, object, key, desc)?;
 
@@ -260,7 +262,8 @@ impl ObjectPrototypeObject {
 
         let key_arg = arguments.get(cx, 0);
         let key = to_property_key(cx, key_arg)?;
-        let desc = PropertyDescriptor::set_only(Some(setter.as_object()), true, true);
+        let desc =
+            PropertyDescriptor::setter(Some(setter.as_object()), DEFAULT_ACCESSOR_PROPERTY_FLAGS);
 
         define_property_or_throw(cx, object, key, desc)?;
 

--- a/src/js/runtime/intrinsics/reflect_object.rs
+++ b/src/js/runtime/intrinsics/reflect_object.rs
@@ -1,7 +1,7 @@
 use crate::{
     intrinsic_methods,
     runtime::{
-        Context, Handle,
+        Context, Handle, PropertyDescriptor,
         abstract_operations::{call_object, construct, create_list_from_array_like_arguments},
         alloc_error::AllocResult,
         array_object::create_array_from_list,
@@ -9,7 +9,7 @@ use crate::{
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        property_descriptor::{from_property_descriptor, to_property_descriptor},
+        property_descriptor::to_property_descriptor_object,
         realm::Realm,
         type_utilities::{is_callable, is_constructor_value, to_property_key},
     },
@@ -103,7 +103,7 @@ impl ReflectObject {
         let key = to_property_key(cx, key_arg)?;
 
         let desc_arg = arguments.get(cx, 2);
-        let desc = to_property_descriptor(cx, desc_arg)?;
+        let desc = PropertyDescriptor::from_object(cx, desc_arg)?;
 
         let result = target.define_own_property(cx, key, desc)?;
         Ok(cx.bool(result))
@@ -157,10 +157,10 @@ impl ReflectObject {
         let key_arg = arguments.get(cx, 1);
         let key = to_property_key(cx, key_arg)?;
 
-        let desc = target.get_own_property_descriptor(cx, key)?;
+        let property = target.get_own_property(cx, key)?;
 
-        Ok(desc
-            .map(|desc| from_property_descriptor(cx, desc))
+        Ok(property
+            .map(|property| to_property_descriptor_object(cx, property))
             .transpose()?
             .map(|desc_object| desc_object.as_value())
             .unwrap_or(cx.undefined()))

--- a/src/js/runtime/intrinsics/regexp_object.rs
+++ b/src/js/runtime/intrinsics/regexp_object.rs
@@ -4,7 +4,7 @@ use crate::{
     extend_object, must, must_a,
     parser::regexp::RegExpFlags,
     runtime::{
-        Context, HeapPtr, PropertyDescriptor,
+        Context, HeapPtr, PropertyDescriptor, PropertyFlags,
         abstract_operations::{define_property_or_throw, set},
         alloc_error::AllocResult,
         eval_result::EvalResult,
@@ -73,7 +73,8 @@ impl RegExpObject {
         cx: Context,
         regexp_object: Handle<RegExpObject>,
     ) -> AllocResult<()> {
-        let last_index_desc = PropertyDescriptor::data(cx.undefined(), true, false, false);
+        let last_index_desc =
+            PropertyDescriptor::data(cx.undefined(), PropertyFlags::empty().writable());
         must_a!(define_property_or_throw(
             cx,
             regexp_object.into(),

--- a/src/js/runtime/intrinsics/regexp_string_iterator_object.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator_object.rs
@@ -18,7 +18,6 @@ use crate::{
         iterator::create_iter_result_object,
         object_value::ObjectValue,
         ordinary_object::ObjectBuilder,
-        property::Property,
         realm::Realm,
         string_value::StringValue,
         to_string,
@@ -76,7 +75,7 @@ impl RegExpStringIteratorObject {
 pub struct RegExpStringIteratorPrototype;
 
 impl RegExpStringIteratorPrototype {
-    pub fn new(mut cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
+    pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
         let mut builder = IntrinsicBuilder::new_object(cx, realm, Intrinsic::IteratorPrototype)?;
 
         intrinsic_methods!(cx, builder, {
@@ -84,11 +83,7 @@ impl RegExpStringIteratorPrototype {
         });
 
         // %RegExpStringIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%regexpstringiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_value = cx.alloc_static_string("RegExp String Iterator")?.into();
-        builder.property(
-            cx.symbols.to_string_tag(),
-            Property::data(to_string_tag_value, false, false, true),
-        )?;
+        builder.to_string_tag_str("RegExp String Iterator")?;
 
         builder.build()
     }

--- a/src/js/runtime/intrinsics/set_iterator_object.rs
+++ b/src/js/runtime/intrinsics/set_iterator_object.rs
@@ -20,7 +20,6 @@ use crate::{
         iterator::create_iter_result_object,
         object_value::ObjectValue,
         ordinary_object::ObjectBuilder,
-        property::Property,
         realm::Realm,
         value::ValueCollectionKey,
     },
@@ -84,7 +83,7 @@ impl SetIteratorObject {
 pub struct SetIteratorPrototype;
 
 impl SetIteratorPrototype {
-    pub fn new(mut cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
+    pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
         let mut builder = IntrinsicBuilder::new_object(cx, realm, Intrinsic::IteratorPrototype)?;
 
         intrinsic_methods!(cx, builder, {
@@ -92,11 +91,7 @@ impl SetIteratorPrototype {
         });
 
         // %SetIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%setiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_value = cx.alloc_static_string("Set Iterator")?.into();
-        builder.property(
-            cx.symbols.to_string_tag(),
-            Property::data(to_string_tag_value, false, false, true),
-        )?;
+        builder.to_string_tag_str("Set Iterator")?;
 
         builder.build()
     }

--- a/src/js/runtime/intrinsics/string_iterator_object.rs
+++ b/src/js/runtime/intrinsics/string_iterator_object.rs
@@ -13,7 +13,6 @@ use crate::{
         iterator::create_iter_result_object,
         object_value::ObjectValue,
         ordinary_object::ObjectBuilder,
-        property::Property,
         realm::Realm,
         string_value::{FlatString, SafeCodePointIterator},
     },
@@ -48,7 +47,7 @@ impl StringIteratorObject {
 pub struct StringIteratorPrototype;
 
 impl StringIteratorPrototype {
-    pub fn new(mut cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
+    pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
         let mut builder = IntrinsicBuilder::new_object(cx, realm, Intrinsic::IteratorPrototype)?;
 
         intrinsic_methods!(cx, builder, {
@@ -56,11 +55,7 @@ impl StringIteratorPrototype {
         });
 
         // %StringIteratorPrototype% [ @@toStringTag ] (https://tc39.es/ecma262/#sec-%stringiteratorprototype%-%symbol.tostringtag%)
-        let to_string_tag_value = cx.alloc_static_string("String Iterator")?.into();
-        builder.property(
-            cx.symbols.to_string_tag(),
-            Property::data(to_string_tag_value, false, false, true),
-        )?;
+        builder.to_string_tag_str("String Iterator")?;
 
         builder.build()
     }

--- a/src/js/runtime/intrinsics/symbol_prototype.rs
+++ b/src/js/runtime/intrinsics/symbol_prototype.rs
@@ -1,4 +1,3 @@
-use crate::runtime::intrinsics::symbol_object::SymbolObject;
 use crate::{
     intrinsic_methods,
     runtime::{
@@ -7,9 +6,10 @@ use crate::{
         error::type_error,
         eval_result::EvalResult,
         intrinsic_builder::IntrinsicBuilder,
-        intrinsics::{intrinsics::Intrinsic, rust_runtime::RuntimeFunction},
+        intrinsics::{
+            intrinsics::Intrinsic, rust_runtime::RuntimeFunction, symbol_object::SymbolObject,
+        },
         object_value::ObjectValue,
-        property::Property,
         realm::Realm,
         string_value::StringValue,
     },
@@ -32,13 +32,7 @@ impl SymbolPrototype {
         builder.getter(cx.names.description(), RuntimeFunction::SymbolPrototype_get_description)?;
 
         // [Symbol.toPrimitive] property
-        let to_primitive_key = cx.symbols.to_primitive();
-        let to_primitive_func =
-            builder.function(RuntimeFunction::SymbolPrototype_value_of, 1, to_primitive_key)?;
-        builder.property(
-            to_primitive_key,
-            Property::data(to_primitive_func.into(), false, false, true),
-        )?;
+        builder.to_primitive(RuntimeFunction::SymbolPrototype_value_of)?;
 
         // [Symbol.toStringTag] property
         builder.to_string_tag(cx.names.symbol())?;

--- a/src/js/runtime/intrinsics/typed_array_object.rs
+++ b/src/js/runtime/intrinsics/typed_array_object.rs
@@ -91,7 +91,7 @@ macro_rules! create_typed_array_object {
 
                         let value = self.read_element_value(cx, array_buffer_ptr, byte_index)?;
 
-                        Ok(Some(Property::data(value, true, true, true)))
+                        Ok(Some(Property::default_data(value)))
                     }
                 }
             }

--- a/src/js/runtime/mod.rs
+++ b/src/js/runtime/mod.rs
@@ -70,6 +70,7 @@ pub use error::BsResult;
 pub use eval_result::EvalResult;
 pub use gc::{AnyHeapItem, Handle, HeapItemKind, HeapPtr};
 pub use intrinsics::rust_runtime::Arguments;
+pub use property::PropertyFlags;
 pub use property_descriptor::PropertyDescriptor;
 pub use property_key::PropertyKey;
 pub use realm::Realm;

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -19,7 +19,7 @@ use crate::{
             ordinary_get_own_property, ordinary_has_property,
             ordinary_own_string_symbol_property_keys,
         },
-        property::Property,
+        property::{Property, PropertyFlags},
         rust_vtables::extract_virtual_object_vtable,
         type_utilities::same_value,
     },
@@ -55,7 +55,7 @@ impl ModuleNamespaceObject {
         object.as_object().set_property(
             cx,
             to_string_tag_key,
-            Property::data(cx.names.module().as_string().into(), false, false, false),
+            Property::frozen(cx.names.module().as_string().into()),
         )?;
 
         Ok(*object)
@@ -169,7 +169,7 @@ impl VirtualObject for Handle<ModuleNamespaceObject> {
             None => Ok(None),
             Some(value) => {
                 let value = value.to_handle(cx);
-                Ok(Some(Property::data(value, true, true, false)))
+                Ok(Some(Property::data(value, PropertyFlags::empty().writable().enumerable())))
             }
         }
     }

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -641,18 +641,6 @@ impl Handle<ObjectValue> {
         self.virtual_object().get_own_property(cx, key)
     }
 
-    /// [[GetOwnProperty]] which returns a full property descriptor matching the spec.
-    #[inline]
-    pub fn get_own_property_descriptor(
-        &self,
-        cx: Context,
-        key: Handle<PropertyKey>,
-    ) -> EvalResult<Option<PropertyDescriptor>> {
-        Ok(self
-            .get_own_property(cx, key)?
-            .map(|property| PropertyDescriptor::from_property(&property)))
-    }
-
     #[inline]
     pub fn define_own_property(
         &mut self,

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -11,14 +11,16 @@ use crate::{
         gc::{Handle, HeapItem, HeapPtr, HeapVisitor, WithHeapItemKind},
         intrinsics::{intrinsics::Intrinsic, object_prototype_object::ObjectPrototypeObject},
         object_value::{ObjectValue, VirtualObject},
-        property::Property,
+        property::{Property, PropertyFlags},
         property_descriptor::PropertyDescriptor,
         property_key::PropertyKey,
         proxy_object::ProxyObject,
         rust_vtables::extract_virtual_object_vtable,
         shape::{Shape, TransitionResult},
         shape_registry::ShapeRegistry,
-        type_utilities::{same_object_value_handles, same_opt_object_value, same_value},
+        type_utilities::{
+            same_object_value, same_object_value_handles, same_opt_object_value, same_value,
+        },
         value::Value,
     },
 };
@@ -190,7 +192,7 @@ pub fn ordinary_define_own_property(
     key: Handle<PropertyKey>,
     desc: PropertyDescriptor,
 ) -> EvalResult<bool> {
-    let current_desc = object.get_own_property_descriptor(cx, key)?;
+    let current_prop = object.get_own_property(cx, key)?;
     let is_extensible = object.is_extensible(cx)?;
 
     Ok(validate_and_apply_property_descriptor(
@@ -199,7 +201,7 @@ pub fn ordinary_define_own_property(
         key,
         is_extensible,
         desc,
-        current_desc,
+        current_prop,
     )?)
 }
 
@@ -208,7 +210,7 @@ pub fn is_compatible_property_descriptor(
     cx: Context,
     is_extensible: bool,
     desc: PropertyDescriptor,
-    current_desc: Option<PropertyDescriptor>,
+    current_prop: Option<Property>,
 ) -> AllocResult<bool> {
     validate_and_apply_property_descriptor::<Handle<ObjectValue>>(
         cx,
@@ -216,7 +218,7 @@ pub fn is_compatible_property_descriptor(
         cx.names.empty_string(),
         is_extensible,
         desc,
-        current_desc,
+        current_prop,
     )
 }
 
@@ -227,9 +229,9 @@ pub fn validate_and_apply_property_descriptor<S: PropertyStorage>(
     key: Handle<PropertyKey>,
     is_extensible: bool,
     desc: PropertyDescriptor,
-    current_desc: Option<PropertyDescriptor>,
+    current_prop: Option<Property>,
 ) -> AllocResult<bool> {
-    if current_desc.is_none() {
+    if current_prop.is_none() {
         if !is_extensible {
             return Ok(false);
         }
@@ -245,13 +247,16 @@ pub fn validate_and_apply_property_descriptor<S: PropertyStorage>(
 
         let property = if desc.is_accessor_descriptor() {
             let accessor_value = Accessor::new(cx, desc.get, desc.set)?;
+            let flags = PropertyFlags::from_accessor_attributes(is_enumerable, is_configurable);
 
-            Property::accessor(accessor_value.into(), is_enumerable, is_configurable)
+            Property::accessor(accessor_value.into(), flags)
         } else {
             let is_writable = desc.is_writable.unwrap_or(false);
             let value = desc.value.unwrap_or_else(|| cx.undefined());
+            let flags =
+                PropertyFlags::from_data_attributes(is_writable, is_enumerable, is_configurable);
 
-            Property::data(value, is_writable, is_enumerable, is_configurable)
+            Property::data(value, flags)
         };
 
         object.set_property(cx, key, property)?;
@@ -259,18 +264,18 @@ pub fn validate_and_apply_property_descriptor<S: PropertyStorage>(
         return Ok(true);
     }
 
-    let current_desc = current_desc.unwrap();
+    let current_prop = current_prop.unwrap();
     if desc.has_no_fields() {
         return Ok(true);
     }
 
-    if !current_desc.is_configurable() {
+    if !current_prop.is_configurable() {
         if let Some(true) = desc.is_configurable {
             return Ok(false);
         }
 
         match desc.is_enumerable {
-            Some(is_enumerable) if is_enumerable != current_desc.is_enumerable() => {
+            Some(is_enumerable) if is_enumerable != current_prop.is_enumerable() => {
                 return Ok(false);
             }
             _ => {}
@@ -279,8 +284,8 @@ pub fn validate_and_apply_property_descriptor<S: PropertyStorage>(
 
     if desc.is_generic_descriptor() {
         // No validation necessary
-    } else if current_desc.is_data_descriptor() != desc.is_data_descriptor() {
-        if !current_desc.is_configurable() {
+    } else if current_prop.is_data() != desc.is_data_descriptor() {
+        if !current_prop.is_configurable() {
             return Ok(false);
         }
 
@@ -305,14 +310,14 @@ pub fn validate_and_apply_property_descriptor<S: PropertyStorage>(
                 object.set_property(cx, key, property)?
             }
         }
-    } else if current_desc.is_data_descriptor() && desc.is_data_descriptor() {
-        if !current_desc.is_configurable() && !current_desc.is_writable() {
+    } else if current_prop.is_data() && desc.is_data_descriptor() {
+        if !current_prop.is_configurable() && !current_prop.is_writable() {
             if let Some(true) = desc.is_writable {
                 return Ok(false);
             }
 
             match desc.value {
-                Some(value) if !same_value(value, current_desc.value.unwrap())? => {
+                Some(value) if !same_value(value, current_prop.value())? => {
                     return Ok(false);
                 }
                 _ => {}
@@ -321,13 +326,11 @@ pub fn validate_and_apply_property_descriptor<S: PropertyStorage>(
             return Ok(true);
         }
     } else {
-        if !current_desc.is_configurable() {
+        if !current_prop.is_configurable() {
             // Error if a [[Get]] was provided but does not match the existing [[Get]]
             if desc.has_get {
-                match (desc.get, current_desc.get) {
-                    (Some(get), Some(current_get))
-                        if !same_object_value_handles(get, current_get) =>
-                    {
+                match (desc.get, current_prop.accessor_value().get) {
+                    (Some(get), Some(current_get)) if !same_object_value(*get, current_get) => {
                         return Ok(false);
                     }
                     (Some(_), None) | (None, Some(_)) => return Ok(false),
@@ -337,10 +340,8 @@ pub fn validate_and_apply_property_descriptor<S: PropertyStorage>(
 
             // Error if a [[Set]] was provided but does not match the existing [[Set]]
             if desc.has_set {
-                match (desc.set, current_desc.set) {
-                    (Some(set), Some(current_set))
-                        if !same_object_value_handles(set, current_set) =>
-                    {
+                match (desc.set, current_prop.accessor_value().set) {
+                    (Some(set), Some(current_set)) if !same_object_value(*set, current_set) => {
                         return Ok(false);
                     }
                     (Some(_), None) | (None, Some(_)) => return Ok(false),
@@ -448,7 +449,7 @@ pub fn ordinary_set(
         None => {
             let parent = object.get_prototype_of(cx)?;
             match parent {
-                None => Property::data(cx.undefined(), true, true, true),
+                None => Property::default_data(cx.undefined()),
                 Some(mut parent) => return parent.set(cx, key, value, receiver),
             }
         }

--- a/src/js/runtime/property.rs
+++ b/src/js/runtime/property.rs
@@ -16,7 +16,7 @@ use crate::runtime::{
 ///
 /// PrivateElements (https://tc39.es/ecma262/#sec-privateelement-specification-type) are represented
 /// as properties, with bitflags noting the private property kind.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct Property {
     value: Handle<Value>,
     flags: PropertyFlags,
@@ -43,9 +43,53 @@ bitflags! {
 }
 
 impl PropertyFlags {
+    /// Return these flags with the writable attribute added.
+    #[inline]
+    pub const fn writable(self) -> PropertyFlags {
+        self.union(PropertyFlags::IS_WRITABLE)
+    }
+
+    /// Return these flags with the enumerable attribute added.
+    #[inline]
+    pub const fn enumerable(self) -> PropertyFlags {
+        self.union(PropertyFlags::IS_ENUMERABLE)
+    }
+
+    /// Return these flags with the configurable attribute added.
+    #[inline]
+    pub const fn configurable(self) -> PropertyFlags {
+        self.union(PropertyFlags::IS_CONFIGURABLE)
+    }
+
+    #[inline]
+    pub fn from_data_attributes(
+        is_writable: bool,
+        is_enumerable: bool,
+        is_configurable: bool,
+    ) -> PropertyFlags {
+        let mut flags = PropertyFlags::empty();
+        flags.set(PropertyFlags::IS_WRITABLE, is_writable);
+        flags.set(PropertyFlags::IS_ENUMERABLE, is_enumerable);
+        flags.set(PropertyFlags::IS_CONFIGURABLE, is_configurable);
+        flags
+    }
+
+    #[inline]
+    pub fn from_accessor_attributes(is_enumerable: bool, is_configurable: bool) -> PropertyFlags {
+        let mut flags = PropertyFlags::IS_ACCESSOR;
+        flags.set(PropertyFlags::IS_ENUMERABLE, is_enumerable);
+        flags.set(PropertyFlags::IS_CONFIGURABLE, is_configurable);
+        flags
+    }
+
     #[inline]
     pub fn is_writable(&self) -> bool {
         self.contains(PropertyFlags::IS_WRITABLE)
+    }
+
+    #[inline]
+    pub fn is_enumerable(&self) -> bool {
+        self.contains(PropertyFlags::IS_ENUMERABLE)
     }
 
     #[inline]
@@ -72,49 +116,39 @@ pub const DEFAULT_DATA_PROPERTY_FLAGS: PropertyFlags = PropertyFlags::IS_WRITABL
     .union(PropertyFlags::IS_ENUMERABLE)
     .union(PropertyFlags::IS_CONFIGURABLE);
 
+pub const DEFAULT_ACCESSOR_PROPERTY_FLAGS: PropertyFlags = PropertyFlags::IS_ACCESSOR
+    .union(PropertyFlags::IS_ENUMERABLE)
+    .union(PropertyFlags::IS_CONFIGURABLE);
+
 pub const DENSE_ARRAY_PROPERTY_FLAGS: PropertyFlags = DEFAULT_DATA_PROPERTY_FLAGS;
 
 impl Property {
     #[inline]
-    pub fn data(
-        value: Handle<Value>,
-        is_writable: bool,
-        is_enumerable: bool,
-        is_configurable: bool,
-    ) -> Property {
-        let mut flags = PropertyFlags::empty();
-
-        if is_writable {
-            flags |= PropertyFlags::IS_WRITABLE;
-        }
-
-        if is_enumerable {
-            flags |= PropertyFlags::IS_ENUMERABLE;
-        }
-
-        if is_configurable {
-            flags |= PropertyFlags::IS_CONFIGURABLE;
-        }
-
+    pub fn data(value: Handle<Value>, flags: PropertyFlags) -> Property {
         Property { value, flags }
     }
 
+    /// An ordinary data property: writable, enumerable, and configurable.
     #[inline]
-    pub fn accessor(
-        accessor_value: Handle<Value>,
-        is_enumerable: bool,
-        is_configurable: bool,
-    ) -> Property {
-        let mut flags = PropertyFlags::IS_ACCESSOR;
+    pub fn default_data(value: Handle<Value>) -> Property {
+        Property::data(value, DEFAULT_DATA_PROPERTY_FLAGS)
+    }
 
-        if is_enumerable {
-            flags |= PropertyFlags::IS_ENUMERABLE;
-        }
+    /// A writable, configurable, non-enumerable data property.
+    #[inline]
+    pub fn non_enumerable_data(value: Handle<Value>) -> Property {
+        Property::data(value, PropertyFlags::empty().writable().configurable())
+    }
 
-        if is_configurable {
-            flags |= PropertyFlags::IS_CONFIGURABLE;
-        }
+    /// A frozen data property: non-writable, non-enumerable, and non-configurable.
+    #[inline]
+    pub fn frozen(value: Handle<Value>) -> Property {
+        Property::data(value, PropertyFlags::empty())
+    }
 
+    #[inline]
+    pub fn accessor(accessor_value: Handle<Value>, flags: PropertyFlags) -> Property {
+        let flags = flags | PropertyFlags::IS_ACCESSOR;
         Property { value: accessor_value, flags }
     }
 
@@ -152,8 +186,15 @@ impl Property {
         }
     }
 
+    /// Return the underlying raw value. For data properties this is the value itself, for accessor
+    /// properties this is the accessor value.
     pub fn value(&self) -> Handle<Value> {
         self.value
+    }
+
+    /// Return the underlying value as an accessor.
+    pub fn accessor_value(&self) -> Handle<Accessor> {
+        Accessor::from_value_handle(self.value)
     }
 
     pub fn flags(&self) -> PropertyFlags {
@@ -182,6 +223,10 @@ impl Property {
 
     pub fn is_private_accessor(&self) -> bool {
         self.flags.contains(PropertyFlags::IS_PRIVATE_ACCESSOR)
+    }
+
+    pub fn is_data(&self) -> bool {
+        !self.flags.contains(PropertyFlags::IS_ACCESSOR)
     }
 
     pub fn is_accessor(&self) -> bool {
@@ -228,7 +273,7 @@ impl Property {
         }
     }
 
-    pub fn to_heap(&self) -> HeapProperty {
+    pub fn to_heap(self) -> HeapProperty {
         HeapProperty { value: *self.value, flags: self.flags }
     }
 

--- a/src/js/runtime/property_descriptor.rs
+++ b/src/js/runtime/property_descriptor.rs
@@ -10,13 +10,13 @@ use crate::{
         gc::Handle,
         object_value::ObjectValue,
         ordinary_object::ordinary_object_create,
-        property::Property,
+        property::{DEFAULT_DATA_PROPERTY_FLAGS, Property, PropertyFlags},
         type_utilities::{is_callable, to_boolean},
     },
 };
 
 /// Property Descriptor (https://tc39.es/ecma262/#sec-property-descriptor-specification-type)
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct PropertyDescriptor {
     /// The [[Value]] field. None if [[Value]] field is not present.
     pub value: Option<Handle<Value>>,
@@ -37,140 +37,105 @@ pub struct PropertyDescriptor {
 }
 
 impl PropertyDescriptor {
-    pub fn data(
-        value: Handle<Value>,
-        is_writable: bool,
-        is_enumerable: bool,
-        is_configurable: bool,
-    ) -> PropertyDescriptor {
+    /// A data descriptor with all three attributes present.
+    pub fn data(value: Handle<Value>, flags: PropertyFlags) -> PropertyDescriptor {
         PropertyDescriptor {
             value: Some(value),
-            is_writable: Some(is_writable),
-            is_enumerable: Some(is_enumerable),
-            is_configurable: Some(is_configurable),
-            has_get: false,
-            has_set: false,
-            get: None,
-            set: None,
+            is_writable: Some(flags.is_writable()),
+            is_enumerable: Some(flags.is_enumerable()),
+            is_configurable: Some(flags.is_configurable()),
+            ..Default::default()
         }
     }
 
-    pub fn data_value_only(value: Handle<Value>) -> PropertyDescriptor {
-        PropertyDescriptor {
-            value: Some(value),
-            is_writable: None,
-            is_enumerable: None,
-            is_configurable: None,
-            has_get: false,
-            has_set: false,
-            get: None,
-            set: None,
-        }
+    /// An ordinary data property: writable, enumerable, and configurable.
+    pub fn default_data(value: Handle<Value>) -> PropertyDescriptor {
+        PropertyDescriptor::data(value, DEFAULT_DATA_PROPERTY_FLAGS)
     }
 
+    /// A writable, configurable, non-enumerable data property.
+    pub fn non_enumerable_data(value: Handle<Value>) -> PropertyDescriptor {
+        PropertyDescriptor::data(value, PropertyFlags::empty().writable().configurable())
+    }
+
+    /// A frozen data property: non-writable, non-enumerable, and non-configurable.
+    pub fn frozen(value: Handle<Value>) -> PropertyDescriptor {
+        PropertyDescriptor::data(value, PropertyFlags::empty())
+    }
+
+    /// An accessor descriptor with both a getter and setter.
     pub fn accessor(
         get: Option<Handle<ObjectValue>>,
         set: Option<Handle<ObjectValue>>,
-        is_enumerable: bool,
-        is_configurable: bool,
+        flags: PropertyFlags,
     ) -> PropertyDescriptor {
         PropertyDescriptor {
             get,
             set,
-            is_enumerable: Some(is_enumerable),
-            is_configurable: Some(is_configurable),
+            is_enumerable: Some(flags.is_enumerable()),
+            is_configurable: Some(flags.is_configurable()),
             has_get: true,
             has_set: true,
-            value: None,
-            is_writable: None,
+            ..Default::default()
         }
     }
 
-    pub fn get_only(
-        get: Option<Handle<ObjectValue>>,
-        is_enumerable: bool,
-        is_configurable: bool,
-    ) -> PropertyDescriptor {
+    /// An accessor descriptor with only a getter.
+    pub fn getter(get: Option<Handle<ObjectValue>>, flags: PropertyFlags) -> PropertyDescriptor {
         PropertyDescriptor {
             get,
-            set: None,
-            is_enumerable: Some(is_enumerable),
-            is_configurable: Some(is_configurable),
+            is_enumerable: Some(flags.is_enumerable()),
+            is_configurable: Some(flags.is_configurable()),
             has_get: true,
-            has_set: false,
-            value: None,
-            is_writable: None,
+            ..Default::default()
         }
     }
 
-    pub fn set_only(
-        set: Option<Handle<ObjectValue>>,
-        is_enumerable: bool,
-        is_configurable: bool,
-    ) -> PropertyDescriptor {
+    /// An accessor descriptor with only a setter.
+    pub fn setter(set: Option<Handle<ObjectValue>>, flags: PropertyFlags) -> PropertyDescriptor {
         PropertyDescriptor {
-            get: None,
             set,
-            is_enumerable: Some(is_enumerable),
-            is_configurable: Some(is_configurable),
-            has_get: false,
+            is_enumerable: Some(flags.is_enumerable()),
+            is_configurable: Some(flags.is_configurable()),
             has_set: true,
-            value: None,
-            is_writable: None,
+            ..Default::default()
         }
     }
 
-    pub fn attributes(
+    /// A data property descriptor with only the value set. No attributes are present.
+    pub fn data_value_only(value: Handle<Value>) -> PropertyDescriptor {
+        PropertyDescriptor { value: Some(value), ..Default::default() }
+    }
+
+    /// A property descriptor with only the attributes set. No value is present.
+    pub fn attributes_only(
         is_writable: Option<bool>,
         is_enumerable: Option<bool>,
         is_configurable: Option<bool>,
     ) -> PropertyDescriptor {
         PropertyDescriptor {
-            value: None,
             is_writable,
             is_enumerable,
             is_configurable,
-            has_get: false,
-            has_set: false,
-            get: None,
-            set: None,
-        }
-    }
-
-    pub fn from_property(property: &Property) -> PropertyDescriptor {
-        if property.is_accessor() {
-            let accessor = Accessor::from_value_handle(property.value());
-            PropertyDescriptor::accessor(
-                accessor.get.map(|f| f.to_handle()),
-                accessor.set.map(|f| f.to_handle()),
-                property.is_enumerable(),
-                property.is_configurable(),
-            )
-        } else {
-            PropertyDescriptor::data(
-                property.value(),
-                property.is_writable(),
-                property.is_enumerable(),
-                property.is_configurable(),
-            )
+            ..Default::default()
         }
     }
 
     pub fn to_property(&self, cx: Context) -> AllocResult<Property> {
         if self.is_accessor_descriptor() {
             let accessor = Accessor::new(cx, self.get, self.set)?;
-            Ok(Property::accessor(
-                accessor.into(),
+            let flags = PropertyFlags::from_accessor_attributes(
                 self.is_enumerable(),
                 self.is_configurable(),
-            ))
+            );
+            Ok(Property::accessor(accessor.into(), flags))
         } else {
-            Ok(Property::data(
-                self.value.unwrap(),
+            let flags = PropertyFlags::from_data_attributes(
                 self.is_writable(),
                 self.is_enumerable(),
                 self.is_configurable(),
-            ))
+            );
+            Ok(Property::data(self.value.unwrap(), flags))
         }
     }
 
@@ -232,143 +197,189 @@ impl PropertyDescriptor {
             self.is_configurable = Some(false);
         }
     }
+
+    /// Create a property descriptor from a JS object.
+    ///
+    /// ToPropertyDescriptor (https://tc39.es/ecma262/#sec-topropertydescriptor)
+    pub fn from_object(cx: Context, value: Handle<Value>) -> EvalResult<PropertyDescriptor> {
+        if !value.is_object() {
+            return type_error(cx, "property descriptor must be an object");
+        }
+
+        let object = value.as_object();
+
+        let mut desc = PropertyDescriptor::default();
+
+        if has_property(cx, object, cx.names.enumerable())? {
+            let enumerable = get(cx, object, cx.names.enumerable())?;
+            desc.is_enumerable = Some(to_boolean(*enumerable));
+        }
+
+        if has_property(cx, object, cx.names.configurable())? {
+            let configurable = get(cx, object, cx.names.configurable())?;
+            desc.is_configurable = Some(to_boolean(*configurable));
+        }
+
+        if has_property(cx, object, cx.names.value())? {
+            desc.value = Some(get(cx, object, cx.names.value())?);
+        }
+
+        if has_property(cx, object, cx.names.writable())? {
+            let writable = get(cx, object, cx.names.writable())?;
+            desc.is_writable = Some(to_boolean(*writable));
+        }
+
+        if has_property(cx, object, cx.names.get())? {
+            let get = get(cx, object, cx.names.get())?;
+            let is_function = is_callable(get);
+            if !is_function && !get.is_undefined() {
+                return type_error(cx, "getter must be a function");
+            }
+
+            desc.has_get = true;
+            desc.get = if is_function {
+                Some(get.as_object())
+            } else {
+                None
+            };
+        }
+
+        if has_property(cx, object, cx.names.set_())? {
+            let set = get(cx, object, cx.names.set_())?;
+            let is_function = is_callable(set);
+            if !is_function && !set.is_undefined() {
+                return type_error(cx, "setter must be a function");
+            }
+
+            desc.has_set = true;
+            desc.set = if is_function {
+                Some(set.as_object())
+            } else {
+                None
+            };
+        }
+
+        if (desc.has_get || desc.has_set) && (desc.value.is_some() || desc.is_writable.is_some()) {
+            return type_error(cx, "property descriptor must be data or accessor");
+        }
+
+        Ok(desc)
+    }
+
+    /// Create a partial property descriptor object from the fields set in a PropertyDescriptor.
+    ///
+    /// FromPropertyDescriptor (https://tc39.es/ecma262/#sec-frompropertydescriptor)
+    pub fn to_partial_object(&self, cx: Context) -> AllocResult<Handle<ObjectValue>> {
+        let object = ordinary_object_create(cx)?;
+
+        if let Some(value) = self.value {
+            must_a!(create_data_property_or_throw(cx, object, cx.names.value(), value,));
+        }
+
+        if let Some(is_writable) = self.is_writable {
+            let is_writable_value = cx.bool(is_writable);
+            must_a!(create_data_property_or_throw(
+                cx,
+                object,
+                cx.names.writable(),
+                is_writable_value,
+            ));
+        }
+
+        if self.has_get {
+            let get_value = if let Some(get) = self.get {
+                get.into()
+            } else {
+                cx.undefined()
+            };
+
+            must_a!(create_data_property_or_throw(cx, object, cx.names.get(), get_value));
+        }
+
+        if self.has_set {
+            let set_value = if let Some(set) = self.set {
+                set.into()
+            } else {
+                cx.undefined()
+            };
+
+            must_a!(create_data_property_or_throw(cx, object, cx.names.set_(), set_value));
+        }
+
+        if let Some(is_enumerable) = self.is_enumerable {
+            let is_enumerable_value = cx.bool(is_enumerable);
+            must_a!(create_data_property_or_throw(
+                cx,
+                object,
+                cx.names.enumerable(),
+                is_enumerable_value,
+            ));
+        }
+
+        if let Some(is_configurable) = self.is_configurable {
+            let is_configurable_value = cx.bool(is_configurable);
+            must_a!(create_data_property_or_throw(
+                cx,
+                object,
+                cx.names.configurable(),
+                is_configurable_value,
+            ));
+        }
+
+        Ok(object)
+    }
 }
 
+/// Create a complete property descriptor object from a property.
+///
+/// Specializes FromPropertyDescriptor for a complete descriptor.
+///
 /// FromPropertyDescriptor (https://tc39.es/ecma262/#sec-frompropertydescriptor)
-pub fn from_property_descriptor(
+pub fn to_property_descriptor_object(
     cx: Context,
-    desc: PropertyDescriptor,
+    property: Property,
 ) -> AllocResult<Handle<ObjectValue>> {
     let object = ordinary_object_create(cx)?;
 
-    if let Some(value) = desc.value {
-        must_a!(create_data_property_or_throw(cx, object, cx.names.value(), value,));
-    }
-
-    if let Some(is_writable) = desc.is_writable {
-        let is_writable_value = cx.bool(is_writable);
+    if property.is_data() {
+        must_a!(create_data_property_or_throw(cx, object, cx.names.value(), property.value()));
         must_a!(create_data_property_or_throw(
             cx,
             object,
             cx.names.writable(),
-            is_writable_value,
+            cx.bool(property.is_writable())
         ));
-    }
+    } else {
+        let accessor = property.accessor_value();
 
-    if desc.has_get {
-        let get_value = if let Some(get) = desc.get {
-            get.into()
+        let get_value = if let Some(get) = accessor.get {
+            get.as_value().to_handle(cx)
+        } else {
+            cx.undefined()
+        };
+
+        let set_value = if let Some(set) = accessor.set {
+            set.as_value().to_handle(cx)
         } else {
             cx.undefined()
         };
 
         must_a!(create_data_property_or_throw(cx, object, cx.names.get(), get_value));
-    }
-
-    if desc.has_set {
-        let set_value = if let Some(set) = desc.set {
-            set.into()
-        } else {
-            cx.undefined()
-        };
-
         must_a!(create_data_property_or_throw(cx, object, cx.names.set_(), set_value));
     }
 
-    if let Some(is_enumerable) = desc.is_enumerable {
-        let is_enumerable_value = cx.bool(is_enumerable);
-        must_a!(create_data_property_or_throw(
-            cx,
-            object,
-            cx.names.enumerable(),
-            is_enumerable_value,
-        ));
-    }
-
-    if let Some(is_configurable) = desc.is_configurable {
-        let is_configurable_value = cx.bool(is_configurable);
-        must_a!(create_data_property_or_throw(
-            cx,
-            object,
-            cx.names.configurable(),
-            is_configurable_value,
-        ));
-    }
+    must_a!(create_data_property_or_throw(
+        cx,
+        object,
+        cx.names.enumerable(),
+        cx.bool(property.is_enumerable())
+    ));
+    must_a!(create_data_property_or_throw(
+        cx,
+        object,
+        cx.names.configurable(),
+        cx.bool(property.is_configurable())
+    ));
 
     Ok(object)
-}
-
-/// ToPropertyDescriptor (https://tc39.es/ecma262/#sec-topropertydescriptor)
-pub fn to_property_descriptor(cx: Context, value: Handle<Value>) -> EvalResult<PropertyDescriptor> {
-    if !value.is_object() {
-        return type_error(cx, "property descriptor must be an object");
-    }
-
-    let object = value.as_object();
-
-    let mut desc = PropertyDescriptor {
-        value: None,
-        is_writable: None,
-        is_enumerable: None,
-        is_configurable: None,
-        has_get: false,
-        has_set: false,
-        get: None,
-        set: None,
-    };
-
-    if has_property(cx, object, cx.names.enumerable())? {
-        let enumerable = get(cx, object, cx.names.enumerable())?;
-        desc.is_enumerable = Some(to_boolean(*enumerable));
-    }
-
-    if has_property(cx, object, cx.names.configurable())? {
-        let configurable = get(cx, object, cx.names.configurable())?;
-        desc.is_configurable = Some(to_boolean(*configurable));
-    }
-
-    if has_property(cx, object, cx.names.value())? {
-        desc.value = Some(get(cx, object, cx.names.value())?);
-    }
-
-    if has_property(cx, object, cx.names.writable())? {
-        let writable = get(cx, object, cx.names.writable())?;
-        desc.is_writable = Some(to_boolean(*writable));
-    }
-
-    if has_property(cx, object, cx.names.get())? {
-        let get = get(cx, object, cx.names.get())?;
-        let is_function = is_callable(get);
-        if !is_function && !get.is_undefined() {
-            return type_error(cx, "getter must be a function");
-        }
-
-        desc.has_get = true;
-        desc.get = if is_function {
-            Some(get.as_object())
-        } else {
-            None
-        };
-    }
-
-    if has_property(cx, object, cx.names.set_())? {
-        let set = get(cx, object, cx.names.set_())?;
-        let is_function = is_callable(set);
-        if !is_function && !set.is_undefined() {
-            return type_error(cx, "setter must be a function");
-        }
-
-        desc.has_set = true;
-        desc.set = if is_function {
-            Some(set.as_object())
-        } else {
-            None
-        };
-    }
-
-    if (desc.has_get || desc.has_set) && (desc.value.is_some() || desc.is_writable.is_some()) {
-        return type_error(cx, "property descriptor must be data or accessor");
-    }
-
-    Ok(desc)
 }

--- a/src/js/runtime/proxy_object.rs
+++ b/src/js/runtime/proxy_object.rs
@@ -17,9 +17,7 @@ use crate::{
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{ObjectBuilder, is_compatible_property_descriptor},
         property::Property,
-        property_descriptor::{
-            PropertyDescriptor, from_property_descriptor, to_property_descriptor,
-        },
+        property_descriptor::PropertyDescriptor,
         property_key::PropertyKey,
         rust_vtables::extract_virtual_object_vtable,
         type_utilities::{
@@ -116,12 +114,12 @@ impl VirtualObject for Handle<ProxyObject> {
         let trap_result = call_object(cx, trap.unwrap(), handler, &trap_arguments)?;
 
         if trap_result.is_undefined() {
-            let target_desc = target.get_own_property_descriptor(cx, key)?;
-            if target_desc.is_none() {
+            let target_prop = target.get_own_property(cx, key)?;
+            if target_prop.is_none() {
                 return Ok(None);
             }
 
-            if let Some(false) = target_desc.unwrap().is_configurable {
+            if !target_prop.unwrap().is_configurable() {
                 return type_error(
                     cx,
                     &format!(
@@ -149,13 +147,13 @@ impl VirtualObject for Handle<ProxyObject> {
             );
         }
 
-        let target_desc = target.get_own_property_descriptor(cx, key)?;
+        let target_prop = target.get_own_property(cx, key)?;
         let is_target_extensible = is_extensible_(cx, target)?;
 
-        let mut result_desc = to_property_descriptor(cx, trap_result)?;
+        let mut result_desc = PropertyDescriptor::from_object(cx, trap_result)?;
         result_desc.complete_property_descriptor(cx);
 
-        if !is_compatible_property_descriptor(cx, is_target_extensible, result_desc, target_desc)? {
+        if !is_compatible_property_descriptor(cx, is_target_extensible, result_desc, target_prop)? {
             return type_error(
                 cx,
                 &format!(
@@ -166,8 +164,7 @@ impl VirtualObject for Handle<ProxyObject> {
         }
 
         if let Some(false) = result_desc.is_configurable {
-            if let None | Some(PropertyDescriptor { is_configurable: Some(true), .. }) = target_desc
-            {
+            if target_prop.is_none_or(|prop| prop.is_configurable()) {
                 return type_error(
                     cx,
                     &format!(
@@ -176,7 +173,7 @@ impl VirtualObject for Handle<ProxyObject> {
                     ),
                 );
             } else if let Some(false) = result_desc.is_writable {
-                if let Some(true) = target_desc.unwrap().is_writable {
+                if target_prop.unwrap().is_writable() {
                     return type_error(
                         cx,
                         &format!(
@@ -211,7 +208,7 @@ impl VirtualObject for Handle<ProxyObject> {
             return target.define_own_property(cx, key, desc);
         }
 
-        let desc_value = from_property_descriptor(cx, desc)?;
+        let desc_value = desc.to_partial_object(cx)?;
         let trap_arguments = [target.into(), key.to_value(cx)?, desc_value.into()];
         let trap_result = call_object(cx, trap.unwrap(), handler, &trap_arguments)?;
 
@@ -219,7 +216,7 @@ impl VirtualObject for Handle<ProxyObject> {
             return Ok(false);
         }
 
-        let target_desc = target.get_own_property_descriptor(cx, key)?;
+        let target_prop = target.get_own_property(cx, key)?;
         let is_target_extensible = is_extensible_(cx, target)?;
 
         let mut is_setting_non_configurable = false;
@@ -227,7 +224,7 @@ impl VirtualObject for Handle<ProxyObject> {
             is_setting_non_configurable = true;
         }
 
-        if target_desc.is_none() {
+        if target_prop.is_none() {
             if !is_target_extensible {
                 return type_error(
                     cx,
@@ -245,12 +242,12 @@ impl VirtualObject for Handle<ProxyObject> {
                     ),
                 );
             }
-        } else if let Some(target_desc) = target_desc {
+        } else if let Some(target_prop) = target_prop {
             if !is_compatible_property_descriptor(
                 cx,
                 is_target_extensible,
                 desc,
-                Some(target_desc),
+                Some(target_prop),
             )? {
                 return type_error(
                     cx,
@@ -262,7 +259,7 @@ impl VirtualObject for Handle<ProxyObject> {
             }
 
             if is_setting_non_configurable {
-                if let Some(true) = target_desc.is_configurable {
+                if target_prop.is_configurable() {
                     return type_error(
                         cx,
                         &format!(
@@ -273,19 +270,16 @@ impl VirtualObject for Handle<ProxyObject> {
                 }
             }
 
-            if target_desc.is_data_descriptor() {
-                if let Some(false) = target_desc.is_configurable {
-                    if let Some(true) = target_desc.is_writable {
-                        if let Some(false) = desc.is_writable {
-                            return type_error(
-                                cx,
-                                &format!(
-                                    "proxy cannot define an existing non-configurable writable property `{}` as non-writable",
-                                    key.format()?
-                                ),
-                            );
-                        }
-                    }
+            if target_prop.is_data() && !target_prop.is_configurable() && target_prop.is_writable()
+            {
+                if let Some(false) = desc.is_writable {
+                    return type_error(
+                        cx,
+                        &format!(
+                            "proxy cannot define an existing non-configurable writable property `{}` as non-writable",
+                            key.format()?
+                        ),
+                    );
                 }
             }
         }
@@ -313,9 +307,9 @@ impl VirtualObject for Handle<ProxyObject> {
         let trap_result = to_boolean(*trap_result);
 
         if !trap_result {
-            let target_desc = target.get_own_property_descriptor(cx, key)?;
-            if let Some(desc) = target_desc {
-                if let Some(false) = desc.is_configurable {
+            let target_prop = target.get_own_property(cx, key)?;
+            if let Some(target_prop) = target_prop {
+                if !target_prop.is_configurable() {
                     return type_error(
                         cx,
                         &format!(
@@ -363,32 +357,31 @@ impl VirtualObject for Handle<ProxyObject> {
         let trap_arguments = [target.into(), key.to_value(cx)?, receiver];
         let trap_result = call_object(cx, trap.unwrap(), handler, &trap_arguments)?;
 
-        let target_desc = target.get_own_property_descriptor(cx, key)?;
-        if let Some(target_desc) = target_desc {
-            if let Some(false) = target_desc.is_configurable {
-                if target_desc.is_data_descriptor() {
-                    if let Some(false) = target_desc.is_writable {
-                        if !same_value(trap_result, target_desc.value.unwrap())? {
-                            return type_error(
-                                cx,
-                                &format!(
-                                    "proxy must report the same value for the non-writable, non-configurable property `{}`",
-                                    key.format()?
-                                ),
-                            );
-                        }
+        let target_prop = target.get_own_property(cx, key)?;
+        if let Some(target_prop) = target_prop {
+            if !target_prop.is_configurable() {
+                if target_prop.is_data() {
+                    if !target_prop.is_writable() && !same_value(trap_result, target_prop.value())?
+                    {
+                        return type_error(
+                            cx,
+                            &format!(
+                                "proxy must report the same value for the non-writable, non-configurable property `{}`",
+                                key.format()?
+                            ),
+                        );
                     }
-                } else if target_desc.is_accessor_descriptor()
-                    && target_desc.get.is_none()
-                    && !trap_result.is_undefined()
-                {
-                    return type_error(
-                        cx,
-                        &format!(
-                            "proxy must report undefined for a non-configurable accessor property `{}` without a getter",
-                            key.format()?
-                        ),
-                    );
+                } else {
+                    let accessor = target_prop.accessor_value();
+                    if accessor.get.is_none() && !trap_result.is_undefined() {
+                        return type_error(
+                            cx,
+                            &format!(
+                                "proxy must report undefined for a non-configurable accessor property `{}` without a getter",
+                                key.format()?
+                            ),
+                        );
+                    }
                 }
             }
         }
@@ -424,29 +417,30 @@ impl VirtualObject for Handle<ProxyObject> {
             return Ok(false);
         }
 
-        let target_desc = target.get_own_property_descriptor(cx, key)?;
-        if let Some(target_desc) = target_desc {
-            if let Some(false) = target_desc.is_configurable {
-                if target_desc.is_data_descriptor() {
-                    if let Some(false) = target_desc.is_writable {
-                        if !same_value(value, target_desc.value.unwrap())? {
-                            return type_error(
-                                cx,
-                                &format!(
-                                    "proxy cannot successfully set a non-writable, non-configurable property `{}`",
-                                    key.format()?
-                                ),
-                            );
-                        }
+        let target_prop = target.get_own_property(cx, key)?;
+        if let Some(target_prop) = target_prop {
+            if !target_prop.is_configurable() {
+                if target_prop.is_data() {
+                    if !target_prop.is_writable() && !same_value(value, target_prop.value())? {
+                        return type_error(
+                            cx,
+                            &format!(
+                                "proxy cannot successfully set a non-writable, non-configurable property `{}`",
+                                key.format()?
+                            ),
+                        );
                     }
-                } else if target_desc.is_accessor_descriptor() && target_desc.set.is_none() {
-                    return type_error(
-                        cx,
-                        &format!(
-                            "proxy cannot successfully set an accessor property `{}` without a setter",
-                            key.format()?
-                        ),
-                    );
+                } else {
+                    let accessor = target_prop.accessor_value();
+                    if accessor.set.is_none() {
+                        return type_error(
+                            cx,
+                            &format!(
+                                "proxy cannot successfully set an accessor property `{}` without a setter",
+                                key.format()?
+                            ),
+                        );
+                    }
                 }
             }
         }
@@ -476,9 +470,9 @@ impl VirtualObject for Handle<ProxyObject> {
             return Ok(false);
         }
 
-        let target_desc = target.get_own_property_descriptor(cx, key)?;
-        if let Some(target_desc) = target_desc {
-            if let Some(false) = target_desc.is_configurable {
+        let target_prop = target.get_own_property(cx, key)?;
+        if let Some(target_prop) = target_prop {
+            if !target_prop.is_configurable() {
                 return type_error(
                     cx,
                     &format!(
@@ -571,9 +565,11 @@ impl VirtualObject for Handle<ProxyObject> {
 
         for key in target_keys {
             let property_key = must!(PropertyKey::from_value(cx, key)).to_handle(cx);
-            let desc = target.get_own_property_descriptor(cx, property_key)?;
+            let property = target.get_own_property(cx, property_key)?;
 
-            if let Some(PropertyDescriptor { is_configurable: Some(false), .. }) = desc {
+            if let Some(property) = property
+                && !property.is_configurable()
+            {
                 target_non_configurable_keys.push(property_key);
             } else {
                 target_configurable_keys.push(property_key);

--- a/src/js/runtime/string_object.rs
+++ b/src/js/runtime/string_object.rs
@@ -16,7 +16,7 @@ use crate::{
             ordinary_filtered_own_indexed_property_keys, ordinary_get_own_property,
             ordinary_own_string_symbol_property_keys,
         },
-        property::Property,
+        property::{Property, PropertyFlags},
         property_descriptor::PropertyDescriptor,
         rust_vtables::extract_virtual_object_vtable,
         string_value::{FlatString, StringValue},
@@ -106,11 +106,9 @@ impl StringObject {
     ) -> AllocResult<()> {
         // String objects have an immutable length property
         let length_value = cx.number(length);
-        string.as_object().set_property(
-            cx,
-            cx.names.length(),
-            Property::data(length_value, false, false, false),
-        )
+        string
+            .as_object()
+            .set_property(cx, cx.names.length(), Property::frozen(length_value))
     }
 
     pub fn string_data(&self) -> Handle<StringValue> {
@@ -124,7 +122,7 @@ impl StringObject {
         &self,
         cx: Context,
         key: Handle<PropertyKey>,
-    ) -> AllocResult<Option<PropertyDescriptor>> {
+    ) -> AllocResult<Option<Property>> {
         if key.is_symbol() {
             return Ok(None);
         }
@@ -137,7 +135,7 @@ impl StringObject {
         let code_unit = string.code_unit_at(index)?;
         let char_string = FlatString::from_code_unit(cx, code_unit)?.as_string();
 
-        Ok(Some(PropertyDescriptor::data(char_string.into(), false, true, false)))
+        Ok(Some(Property::data(char_string.into(), PropertyFlags::empty().enumerable())))
     }
 }
 
@@ -153,10 +151,7 @@ impl VirtualObject for Handle<StringObject> {
             return Ok(Some(property));
         }
 
-        match self.string_get_own_property(cx, key)? {
-            Some(desc) => Ok(Some(desc.to_property(cx)?)),
-            None => Ok(None),
-        }
+        Ok(self.string_get_own_property(cx, key)?)
     }
 
     /// [[DefineOwnProperty]] (https://tc39.es/ecma262/#sec-string-exotic-objects-defineownproperty-p-desc)
@@ -166,10 +161,10 @@ impl VirtualObject for Handle<StringObject> {
         key: Handle<PropertyKey>,
         desc: PropertyDescriptor,
     ) -> EvalResult<bool> {
-        let string_desc = self.string_get_own_property(cx, key)?;
-        if string_desc.is_some() {
+        let string_property = self.string_get_own_property(cx, key)?;
+        if string_property.is_some() {
             let is_extensible = self.shape_ptr().is_extensible();
-            Ok(is_compatible_property_descriptor(cx, is_extensible, desc, string_desc)?)
+            Ok(is_compatible_property_descriptor(cx, is_extensible, desc, string_property)?)
         } else {
             ordinary_define_own_property(cx, self.as_object(), key, desc)
         }

--- a/src/js/runtime/test_shell.rs
+++ b/src/js/runtime/test_shell.rs
@@ -94,7 +94,7 @@ impl TestShell {
         let fuzzilli_function =
             BuiltinFunction::create_custom(cx, function_id, length, name_key, realm, None)?;
 
-        let desc = PropertyDescriptor::data(fuzzilli_function.as_value(), true, false, true);
+        let desc = PropertyDescriptor::non_enumerable_data(fuzzilli_function.as_value());
         must_a!(define_property_or_throw(cx, object, name_key, desc));
 
         Ok(())
@@ -111,7 +111,7 @@ impl TestShell {
             .to_handle();
 
         let name_key = PropertyKey::string_handle(cx, cx.alloc_static_string("performance")?)?;
-        let desc = PropertyDescriptor::data(performance_object.as_value(), true, false, true);
+        let desc = PropertyDescriptor::non_enumerable_data(performance_object.as_value());
         must_a!(define_property_or_throw(cx, realm.global_object().as_object(), name_key, desc));
 
         Ok(performance_object)

--- a/tests/fuzz/src/main.rs
+++ b/tests/fuzz/src/main.rs
@@ -15,7 +15,7 @@ use brimstone_core::{
     runtime::{
         Arguments, Context, ContextBuilder, EvalResult, Handle, PropertyDescriptor, PropertyKey,
         Value, abstract_operations::define_property_or_throw, alloc_error::AllocResult,
-        builtin_function::BuiltinFunction, error::type_error,
+        builtin_function::BuiltinFunction, error::type_error, PropertyFlags,
     },
 };
 
@@ -111,7 +111,7 @@ fn install_fuzzilli_function(mut cx: Context) -> AllocResult<()> {
         let fuzzilli_function =
             BuiltinFunction::create_custom(cx, fuzzili_id, 2, fuzzilli_key, realm, None)?;
 
-        let desc = PropertyDescriptor::data(fuzzilli_function.as_value(), true, false, true);
+        let desc = PropertyDescriptor::data(fuzzilli_function.as_value(), PropertyFlags::empty().writable().configurable());
         let global_object = realm.global_object().as_object();
         must_a!(define_property_or_throw(cx, global_object, fuzzilli_key, desc));
 


### PR DESCRIPTION
## Summary

Make a number of changes to properties and property descriptors.

- Replace uses of property descriptors with uses of the raw property in virtually every place that an existing property was pulled off the object and immediately turned into a complete property descriptor. Notably we now pass the existing property directly through `validate_and_apply_property_descriptor`.
- Introduce utilities for all property and property descriptor creation, all of which take property flags as input instead of booleans
- Introduce utilities for constructing property flags
- Added `IntrinsicBuilder::{to_string_tag_str, to_primitive}` to further consolidate some shared patterns

## Tests

- CI