### PR TITLE
[runtime] Fast path for creating data properties on ordinary object

### DIFF
--- a/src/js/runtime/abstract_operations.rs
+++ b/src/js/runtime/abstract_operations.rs
@@ -76,8 +76,7 @@ pub fn create_data_property(
     key: Handle<PropertyKey>,
     value: Handle<Value>,
 ) -> EvalResult<bool> {
-    let new_desc = PropertyDescriptor::default_data(value);
-    object.define_own_property(cx, key, new_desc)
+    object.create_data_property(cx, key, value)
 }
 
 /// CreateDataPropertyOrThrow (https://tc39.es/ecma262/#sec-createdatapropertyorthrow)

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -653,6 +653,17 @@ impl Handle<ObjectValue> {
     }
 
     #[inline]
+    pub fn create_data_property(
+        &mut self,
+        cx: Context,
+        key: Handle<PropertyKey>,
+        value: Handle<Value>,
+    ) -> EvalResult<bool> {
+        self.virtual_object_mut()
+            .create_data_property(cx, key, value)
+    }
+
+    #[inline]
     pub fn has_property(&self, cx: Context, key: Handle<PropertyKey>) -> EvalResult<bool> {
         self.virtual_object().has_property(cx, key)
     }
@@ -774,6 +785,19 @@ pub trait VirtualObject {
         desc: PropertyDescriptor,
     ) -> EvalResult<bool> {
         self.as_ordinary_object().define_own_property(cx, key, desc)
+    }
+
+    /// Specialized version of [[DefineOwnProperty]] for defining an ordinary data property.
+    ///
+    /// CreateDataProperty (https://tc39.es/ecma262/#sec-createdataproperty)
+    fn create_data_property(
+        &mut self,
+        cx: Context,
+        key: Handle<PropertyKey>,
+        value: Handle<Value>,
+    ) -> EvalResult<bool> {
+        let desc = PropertyDescriptor::default_data(value);
+        self.define_own_property(cx, key, desc)
     }
 
     fn has_property(&self, cx: Context, key: Handle<PropertyKey>) -> EvalResult<bool> {

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -116,6 +116,16 @@ impl VirtualObject for Handle<OrdinaryObject> {
         ordinary_define_own_property(cx, self.as_object(), key, desc)
     }
 
+    /// CreateDataProperty (https://tc39.es/ecma262/#sec-createdataproperty)
+    fn create_data_property(
+        &mut self,
+        cx: Context,
+        key: Handle<PropertyKey>,
+        value: Handle<Value>,
+    ) -> EvalResult<bool> {
+        ordinary_create_data_property(cx, self.as_object(), key, value)
+    }
+
     /// [[HasProperty]] (https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p)
     fn has_property(&self, cx: Context, key: Handle<PropertyKey>) -> EvalResult<bool> {
         ordinary_has_property(cx, self.as_object(), key)
@@ -208,6 +218,36 @@ pub fn ordinary_define_own_property(
         desc,
         current_prop,
     )?)
+}
+
+/// Specialized CreateDataProperty for an ordinary object.
+fn ordinary_create_data_property(
+    cx: Context,
+    mut object: Handle<ObjectValue>,
+    key: Handle<PropertyKey>,
+    value: Handle<Value>,
+) -> EvalResult<bool> {
+    // Slow path if a property with that key already exists
+    if let Some(current_prop) = ordinary_get_own_property(cx, object, key) {
+        let desc = PropertyDescriptor::default_data(value);
+        return Ok(validate_and_apply_property_descriptor(
+            cx,
+            Some(object),
+            key,
+            true,
+            desc,
+            Some(current_prop),
+        )?);
+    }
+
+    // Fast path, simply create the property if the object is extensible
+    if !object.is_extensible(cx)? {
+        return Ok(false);
+    }
+
+    object.set_property(cx, key, Property::default_data(value))?;
+
+    Ok(true)
 }
 
 /// IsCompatiblePropertyDescriptor (https://tc39.es/ecma262/#sec-iscompatiblepropertydescriptor)


### PR DESCRIPTION
## Summary

The common case of adding a new data property to an ordinary object can be done without going through the full `validate_and_apply_property_descriptor`. Introduce a new `VirtualObject::create_data_property` which has a faster implementation for ordinary objects.

## Tests

- CI