### PR TITLE
[bytecode] Estimate number of properties in object literals and constructors

### DIFF
--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -337,6 +337,8 @@ pub struct BytecodeFunction {
     num_parameters: u32,
     /// Value of the `length` property
     function_length: u32,
+    /// Estimated number of own properties needed if this function is called as a constructor.
+    estimated_num_properties: u8,
     /// Whether this function is in strict mode.
     is_strict: bool,
     /// Whether this function is a constructor.
@@ -379,6 +381,7 @@ impl BytecodeFunction {
         num_registers: u32,
         num_parameters: u32,
         function_length: u32,
+        estimated_num_properties: u8,
         is_strict: bool,
         is_constructor: bool,
         is_class_constructor: bool,
@@ -401,6 +404,7 @@ impl BytecodeFunction {
         set_uninit!(object.num_registers, num_registers);
         set_uninit!(object.num_parameters, num_parameters);
         set_uninit!(object.function_length, function_length);
+        set_uninit!(object.estimated_num_properties, estimated_num_properties);
         set_uninit!(object.is_strict, is_strict);
         set_uninit!(object.is_constructor, is_constructor);
         set_uninit!(object.is_class_constructor, is_class_constructor);
@@ -445,6 +449,7 @@ impl BytecodeFunction {
         set_uninit!(object.num_registers, num_registers);
         set_uninit!(object.num_parameters, 0);
         set_uninit!(object.function_length, function_length);
+        set_uninit!(object.estimated_num_properties, 0);
         set_uninit!(object.is_strict, true);
         set_uninit!(object.is_constructor, is_constructor);
         set_uninit!(object.is_class_constructor, false);

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     error::Error,
     fmt,
     ops::Range,
@@ -1056,6 +1056,16 @@ pub struct BytecodeFunctionGenerator<'a> {
     /// before the first parameter with a default value or rest parameter.
     function_length: u32,
 
+    /// For constructors this is a loose set of property names, counting both fields and `this.prop`
+    /// assignment in the constructor body.
+    ///
+    /// - Combines properties and private properties (with the # prefix), can result in conflicts
+    constructor_property_names: HashSet<AstStr<'a>>,
+
+    /// For constructors this is an estimate of the number of computed properties, counting both
+    /// computed field names and `this[...]` assignment in the constructor body.
+    constructor_num_computed_properties: usize,
+
     /// Whether this function is in strict mode.
     is_strict: bool,
 
@@ -1150,6 +1160,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             finally_scopes: vec![],
             num_parameters,
             function_length,
+            constructor_property_names: HashSet::new(),
+            constructor_num_computed_properties: 0,
             is_strict,
             is_constructor,
             is_class_constructor,
@@ -2069,6 +2081,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         let is_async = self.is_async();
 
         let num_registers = self.register_allocator.max_allocated();
+        let estimated_num_properties = self.estimate_constructor_num_properties();
         let name = self
             .name
             .as_ref()
@@ -2088,6 +2101,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             num_registers,
             self.num_parameters,
             self.function_length,
+            estimated_num_properties,
             self.is_strict,
             self.is_constructor,
             self.is_class_constructor,
@@ -4146,7 +4160,9 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         let object = self.allocate_destination(object_dest)?;
 
-        self.writer.new_object_instruction(object);
+        let estimated_num_properties = Self::estimate_object_literal_num_properties(expr);
+        self.writer
+            .new_object_instruction(object, UInt::new(estimated_num_properties.into()));
 
         // If the body scope exists then the home object must have been used in a method, so store
         // the home object to the scope.
@@ -4174,11 +4190,16 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
             enum Property<'a> {
                 Computed(GenRegister),
-                Named {
-                    constant_index: GenConstantIndex,
-                    name: &'a Wtf8Str,
-                    is_proto: bool,
-                },
+                Named { constant_index: GenConstantIndex, name: &'a Wtf8Str },
+            }
+
+            // The `__proto__` property corresponds to a SetPrototypeOf instruction
+            if Self::is_prototype_setter_property(property) {
+                let prototype = self.gen_expression(property.value.as_ref().unwrap())?;
+                self.writer.set_prototype_of_instruction(object, prototype);
+                self.register_allocator.release(prototype);
+
+                continue;
             }
 
             // Evaluate property name
@@ -4189,17 +4210,15 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     ast::Expression::Id(id) => {
                         let constant_index = self.add_wtf8_string_property_key_constant(id.name)?;
                         let name = id.name;
-                        let is_proto = id.name == "__proto__";
 
-                        Property::Named { constant_index, name, is_proto }
+                        Property::Named { constant_index, name }
                     }
                     ast::Expression::String(string) => {
                         let constant_index =
                             self.add_wtf8_string_property_key_constant(string.value)?;
                         let name = string.value;
-                        let is_proto = string.value == "__proto__";
 
-                        Property::Named { constant_index, name, is_proto }
+                        Property::Named { constant_index, name }
                     }
                     ast::Expression::Number(_) | ast::Expression::BigInt(_) => {
                         Property::Computed(self.gen_expression(&property.key)?)
@@ -4274,13 +4293,6 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     );
 
                     method_value
-                } else if let Property::Named { is_proto: true, .. } = &key {
-                    // The __proto__ property corresponds to a SetPrototypeOf instruction
-                    let prototype = self.gen_expression(property_value)?;
-                    self.writer.set_prototype_of_instruction(object, prototype);
-                    self.register_allocator.release(prototype);
-
-                    continue;
                 } else {
                     // Regular key-value properties. Value is statically evaluated as named if the
                     // key is statically known, otherwise the DefinePropertyInstruction will handle
@@ -4334,6 +4346,49 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         self.gen_scope_end(body_scope);
 
         self.gen_mov_reg_to_dest(object, dest)
+    }
+
+    /// Whether an object literal property is the `__proto__: value` prototype setter.
+    fn is_prototype_setter_property(property: &ast::Property<'a>) -> bool {
+        if property.is_method || property.is_computed || property.value.is_none() {
+            return false;
+        }
+
+        match &property.key {
+            ast::Expression::Id(id) => id.name == "__proto__",
+            ast::Expression::String(string) => string.value == "__proto__",
+            _ => false,
+        }
+    }
+
+    /// An estimate of the number of properties in an object literal.
+    ///
+    /// - Counts each property that is not a spread element and not a `__proto__` prototype setter
+    /// - Assumes computed properties are distinct
+    /// - Overcounts getters and setters for the same property
+    /// - Caps at u8::MAX as an intentional underestimate.
+    fn estimate_object_literal_num_properties(object: &ast::ObjectExpression<'a>) -> u8 {
+        object
+            .properties
+            .iter()
+            .filter(|property| {
+                !matches!(property.kind, ast::PropertyKind::Spread(_))
+                    && !Self::is_prototype_setter_property(property)
+            })
+            .count()
+            .min(u8::MAX as usize) as u8
+    }
+
+    /// Estimate of the number of own properties created if this function is called as a
+    /// constructor. Caps at u8::MAX as an intentional underestimate.
+    fn estimate_constructor_num_properties(&self) -> u8 {
+        if !self.is_constructor {
+            return 0;
+        }
+
+        let count =
+            self.constructor_property_names.len() + self.constructor_num_computed_properties;
+        count.min(u8::MAX as usize) as u8
     }
 
     fn gen_store_captured_home_object(
@@ -4660,6 +4715,21 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 self.gen_mov_reg_to_dest(stored_value, dest)
             }
             member @ (ast::Pattern::Member(_) | ast::Pattern::SuperMember(_)) => {
+                // Track assignment to a property of `this` for the estimated number of properties
+                // if this function is called as a constructor.
+                if self.is_constructor
+                    && expr.operator == ast::AssignmentOperator::Equals
+                    && let ast::Pattern::Member(member) = member
+                    && matches!(member.object, ast::Expression::This(_))
+                {
+                    if member.is_computed {
+                        self.constructor_num_computed_properties += 1;
+                    } else {
+                        self.constructor_property_names
+                            .insert(member.property.to_id().name);
+                    }
+                }
+
                 enum Property {
                     Computed(GenRegister),
                     Named(GenConstantIndex),
@@ -5385,9 +5455,11 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         // Write the value to the temp value register
         self.write_mov_instruction(temp_value, value);
 
-        // Create an iterator result object that holds the yielded value
+        // Create an iterator result object that holds the yielded value. Always has exactly the
+        // `value` and `done` properties.
         let iter_result = self.register_allocator.allocate()?;
-        self.writer.new_object_instruction(iter_result);
+        self.writer
+            .new_object_instruction(iter_result, UInt::new(2));
 
         // Iterator result object holds the yielded value
         let value_constant_index = self.add_string_property_key_constant("value")?;
@@ -5945,6 +6017,25 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         // Check if a class field initializer is needed
         if initializer.scope.is_none() {
             return Ok(());
+        }
+
+        // Track each field for the constructor's estimated number of properties.
+        for field in &initializer.fields {
+            match field {
+                ClassField::Named { name, .. } => {
+                    self.constructor_property_names.insert(name);
+                }
+                ClassField::PrivateField { field } => {
+                    let private_id = field.as_ref().key.expr.to_id();
+                    self.constructor_property_names.insert(private_id.name);
+                }
+                ClassField::PrivateMethodOrAccessor { name, .. } => {
+                    self.constructor_property_names.insert(name.as_ref().name);
+                }
+                ClassField::Computed { .. } => {
+                    self.constructor_num_computed_properties += 1;
+                }
+            }
         }
 
         // Field initializer function is added to the pending functions queue
@@ -6551,8 +6642,10 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             self.register_allocator.release(scratch);
 
             // Create a new object and copy all data properties, except for the property keys saved
-            // to the stack.
-            self.writer.new_object_instruction(rest_element);
+            // to the stack. The number of properties copied is not statically known, and we use 0
+            // as the initial capacity.
+            self.writer
+                .new_object_instruction(rest_element, UInt::new(0));
             self.writer.copy_data_properties(
                 rest_element,
                 object_value,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1181,12 +1181,14 @@ define_instructions!(
         }
     }
 
-    /// Create a new empty object stored in dest.
+    /// Create a new empty object stored in dest. An estimated number of properties is provided.
+    /// TODO: Use as the number of inline properties
     NewObject {
         camel_case: NewObjectInstruction,
         snake_case: new_object_instruction,
         operands: {
             [0] dest: Register,
+            [1] num_properties: UInt,
         }
     }
 

--- a/tests/snapshot/bytecode/annex_b/assign_to_call_expression.exp
+++ b/tests/snapshot/bytecode/annex_b/assign_to_call_expression.exp
@@ -66,19 +66,19 @@
 
 [BytecodeFunction: forInInitializer] {
   Parameters: 0, Registers: 3
-     0: NewObject r0
-     2: JumpNullish r0, 26 (.L1)
-     5: NewForInIterator r0, r0
+     0: NewObject r0, 0
+     3: JumpNullish r0, 26 (.L1)
+     6: NewForInIterator r0, r0
   .L0:
-     8: ForInNext r1, r0
-    11: JumpNullish r1, 17 (.L1)
-    14: LoadGlobal r2, c0, k0
-    18: Call r2, r2, r2, 0
-    23: ThrowNewError 0, c1
-    26: Jump -18 (.L0)
+     9: ForInNext r1, r0
+    12: JumpNullish r1, 17 (.L1)
+    15: LoadGlobal r2, c0, k0
+    19: Call r2, r2, r2, 0
+    24: ThrowNewError 0, c1
+    27: Jump -18 (.L0)
   .L1:
-    28: LoadUndefined r0
-    30: Ret r0
+    29: LoadUndefined r0
+    31: Ret r0
   Constant Table:
     0: [String: f]
     1: [String: cannot assign to call expression]

--- a/tests/snapshot/bytecode/bytecode/assign_hazard.exp
+++ b/tests/snapshot/bytecode/bytecode/assign_hazard.exp
@@ -104,16 +104,16 @@
 
 [BytecodeFunction: inVarDeclarator] {
   Parameters: 1, Registers: 4
-     0: NewObject r1
-     2: GetNamedProperty r2, r1, c0, k0
-     7: JumpNotUndefined r2, 13 (.L0)
-    10: Mov r3, a0
-    13: LoadImmediate a0, 2
-    16: Add r2, r3, a0
+     0: NewObject r1, 0
+     3: GetNamedProperty r2, r1, c0, k0
+     8: JumpNotUndefined r2, 13 (.L0)
+    11: Mov r3, a0
+    14: LoadImmediate a0, 2
+    17: Add r2, r3, a0
   .L0:
-    20: Mov r0, r2
-    23: LoadUndefined r1
-    25: Ret r1
+    21: Mov r0, r2
+    24: LoadUndefined r1
+    26: Ret r1
   Constant Table:
     0: [String: x]
 }
@@ -138,20 +138,20 @@
 
 [BytecodeFunction: inForEachInit] {
   Parameters: 2, Registers: 3
-     0: NewObject r0
-     2: JumpNullish r0, 28 (.L1)
-     5: NewForInIterator r0, r0
+     0: NewObject r0, 0
+     3: JumpNullish r0, 28 (.L1)
+     6: NewForInIterator r0, r0
   .L0:
-     8: ForInNext r1, r0
-    11: JumpNullish r1, 19 (.L1)
-    14: Mov r2, a0
-    17: LoadImmediate a0, 2
-    20: Add r2, r2, a0
-    24: GetProperty a1, r1, r2
-    28: Jump -20 (.L0)
+     9: ForInNext r1, r0
+    12: JumpNullish r1, 19 (.L1)
+    15: Mov r2, a0
+    18: LoadImmediate a0, 2
+    21: Add r2, r2, a0
+    25: GetProperty a1, r1, r2
+    29: Jump -20 (.L0)
   .L1:
-    30: LoadUndefined r0
-    32: Ret r0
+    31: LoadUndefined r0
+    33: Ret r0
 }
 
 [BytecodeFunction: toplevelAssignExpressions] {
@@ -173,12 +173,12 @@
      3: Add a0, a1, r0
      7: NewClosure r0, c1
     10: Add a0, a1, r0
-    14: NewObject r0
-    16: NewClosure r1, c3
-    19: DefineNamedProperty r0, c2, r1
-    23: Add a0, a1, r0
-    27: LoadUndefined r0
-    29: Ret r0
+    14: NewObject r0, 1
+    17: NewClosure r1, c3
+    20: DefineNamedProperty r0, c2, r1
+    24: Add a0, a1, r0
+    28: LoadUndefined r0
+    30: Ret r0
   Constant Table:
     0: [BytecodeFunction: <anonymous>]
     1: [BytecodeFunction: <anonymous>]

--- a/tests/snapshot/bytecode/class/super_member.exp
+++ b/tests/snapshot/bytecode/class/super_member.exp
@@ -31,14 +31,14 @@
      95: PopScope 
      96: StoreToScope r0, 5, 0
     100: PushLexicalScope c22
-    102: NewObject r0
-    104: StoreToScope r0, 0, 0
-    108: NewClosure r1, c24
-    111: DefineNamedProperty r0, c23, r1
-    115: PopScope 
-    116: StoreToScope r0, 6, 0
-    120: LoadUndefined r0
-    122: Ret r0
+    102: NewObject r0, 1
+    105: StoreToScope r0, 0, 0
+    109: NewClosure r1, c24
+    112: DefineNamedProperty r0, c23, r1
+    116: PopScope 
+    117: StoreToScope r0, 6, 0
+    121: LoadUndefined r0
+    123: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: String]

--- a/tests/snapshot/bytecode/eval/completion.exp
+++ b/tests/snapshot/bytecode/eval/completion.exp
@@ -208,11 +208,11 @@
      2: StoreToScope <this>, 0, 0
      6: LoadConstant r0, c1
      9: LoadUndefined r0
-    11: NewObject r1
-    13: PushWithScope r1, c2
-    16: LoadImmediate r0, 1
-    19: PopScope 
-    20: Ret r0
+    11: NewObject r1, 0
+    14: PushWithScope r1, c2
+    17: LoadImmediate r0, 1
+    20: PopScope 
+    21: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: with completion]
@@ -238,17 +238,17 @@
   Parameters: 0, Registers: 3
      0: LoadConstant r0, c0
      3: LoadUndefined r0
-     5: NewObject r1
-     7: JumpNullish r1, 20 (.L1)
-    10: NewForInIterator r1, r1
+     5: NewObject r1, 0
+     8: JumpNullish r1, 20 (.L1)
+    11: NewForInIterator r1, r1
   .L0:
-    13: ForInNext r2, r1
-    16: JumpNullish r2, 11 (.L1)
-    19: StoreDynamic r2, c1
-    22: LoadImmediate r0, 1
-    25: Jump -12 (.L0)
+    14: ForInNext r2, r1
+    17: JumpNullish r2, 11 (.L1)
+    20: StoreDynamic r2, c1
+    23: LoadImmediate r0, 1
+    26: Jump -12 (.L0)
   .L1:
-    27: Ret r0
+    28: Ret r0
   Constant Table:
     0: [String: for-in completion]
     1: [String: x]

--- a/tests/snapshot/bytecode/expression/assign.exp
+++ b/tests/snapshot/bytecode/expression/assign.exp
@@ -29,15 +29,15 @@
      91: LoadImmediate r0, 1
      94: StoreGlobal r0, c26, k13
      98: PushLexicalScope c27
-    100: NewObject r0
-    102: StoreToScope r0, 0, 0
-    106: NewClosure r1, c29
-    109: DefineNamedProperty r0, c28, r1
-    113: NewClosure r1, c31
-    116: DefineNamedProperty r0, c30, r1
-    120: PopScope 
-    121: LoadUndefined r0
-    123: Ret r0
+    100: NewObject r0, 2
+    103: StoreToScope r0, 0, 0
+    107: NewClosure r1, c29
+    110: DefineNamedProperty r0, c28, r1
+    114: NewClosure r1, c31
+    117: DefineNamedProperty r0, c30, r1
+    121: PopScope 
+    122: LoadUndefined r0
+    124: Ret r0
   Constant Table:
     0: [BytecodeFunction: use]
     1: [String: use]

--- a/tests/snapshot/bytecode/expression/calls/super_member.exp
+++ b/tests/snapshot/bytecode/expression/calls/super_member.exp
@@ -1,15 +1,15 @@
 [BytecodeFunction: <global>] {
   Parameters: 0, Registers: 2
      0: PushLexicalScope c0
-     2: NewObject r0
-     4: StoreToScope r0, 0, 0
-     8: NewClosure r1, c2
-    11: DefineNamedProperty r0, c1, r1
-    15: NewClosure r1, c4
-    18: DefineNamedProperty r0, c3, r1
-    22: PopScope 
-    23: LoadUndefined r0
-    25: Ret r0
+     2: NewObject r0, 2
+     5: StoreToScope r0, 0, 0
+     9: NewClosure r1, c2
+    12: DefineNamedProperty r0, c1, r1
+    16: NewClosure r1, c4
+    19: DefineNamedProperty r0, c3, r1
+    23: PopScope 
+    24: LoadUndefined r0
+    26: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: namedSuperMemberCall]

--- a/tests/snapshot/bytecode/expression/chain.exp
+++ b/tests/snapshot/bytecode/expression/chain.exp
@@ -9,13 +9,13 @@
     21: NewClosure r0, c6
     24: StoreGlobal r0, c7, k3
     28: PushLexicalScope c8
-    30: NewObject r0
-    32: StoreToScope r0, 0, 0
-    36: NewClosure r1, c10
-    39: DefineNamedProperty r0, c9, r1
-    43: PopScope 
-    44: LoadUndefined r0
-    46: Ret r0
+    30: NewObject r0, 1
+    33: StoreToScope r0, 0, 0
+    37: NewClosure r1, c10
+    40: DefineNamedProperty r0, c9, r1
+    44: PopScope 
+    45: LoadUndefined r0
+    47: Ret r0
   Constant Table:
     0: [BytecodeFunction: namedMember]
     1: [String: namedMember]

--- a/tests/snapshot/bytecode/expression/delete.exp
+++ b/tests/snapshot/bytecode/expression/delete.exp
@@ -25,15 +25,15 @@
      77: LoadImmediate r0, 1
      80: StoreGlobal r0, c22, k11
      84: PushLexicalScope c23
-     86: NewObject r0
-     88: StoreToScope r0, 0, 0
-     92: NewClosure r1, c25
-     95: DefineNamedProperty r0, c24, r1
-     99: NewClosure r1, c27
-    102: DefineNamedProperty r0, c26, r1
-    106: PopScope 
-    107: LoadUndefined r0
-    109: Ret r0
+     86: NewObject r0, 2
+     89: StoreToScope r0, 0, 0
+     93: NewClosure r1, c25
+     96: DefineNamedProperty r0, c24, r1
+    100: NewClosure r1, c27
+    103: DefineNamedProperty r0, c26, r1
+    107: PopScope 
+    108: LoadUndefined r0
+    110: Ret r0
   Constant Table:
     0: [BytecodeFunction: deleteMember]
     1: [String: deleteMember]

--- a/tests/snapshot/bytecode/expression/object/accessor.exp
+++ b/tests/snapshot/bytecode/expression/object/accessor.exp
@@ -15,20 +15,20 @@
 
 [BytecodeFunction: getter] {
   Parameters: 0, Registers: 3
-     0: NewObject r0
-     2: LoadConstant r1, c0
-     5: NewClosure r2, c1
-     8: DefineProperty r0, r1, r2, 2
-    13: LoadConstant r1, c2
-    16: NewClosure r2, c3
-    19: DefineProperty r0, r1, r2, 2
-    24: LoadImmediate r1, 1
-    27: NewClosure r2, c4
-    30: DefineProperty r0, r1, r2, 3
-    35: LoadImmediate r1, 2
-    38: NewClosure r2, c5
-    41: DefineProperty r0, r1, r2, 3
-    46: Ret r0
+     0: NewObject r0, 4
+     3: LoadConstant r1, c0
+     6: NewClosure r2, c1
+     9: DefineProperty r0, r1, r2, 2
+    14: LoadConstant r1, c2
+    17: NewClosure r2, c3
+    20: DefineProperty r0, r1, r2, 2
+    25: LoadImmediate r1, 1
+    28: NewClosure r2, c4
+    31: DefineProperty r0, r1, r2, 3
+    36: LoadImmediate r1, 2
+    39: NewClosure r2, c5
+    42: DefineProperty r0, r1, r2, 3
+    47: Ret r0
   Constant Table:
     0: [String: a]
     1: [BytecodeFunction: get a]
@@ -64,20 +64,20 @@
 
 [BytecodeFunction: setter] {
   Parameters: 0, Registers: 3
-     0: NewObject r0
-     2: LoadConstant r1, c0
-     5: NewClosure r2, c1
-     8: DefineProperty r0, r1, r2, 4
-    13: LoadConstant r1, c2
-    16: NewClosure r2, c3
-    19: DefineProperty r0, r1, r2, 4
-    24: LoadImmediate r1, 1
-    27: NewClosure r2, c4
-    30: DefineProperty r0, r1, r2, 5
-    35: LoadImmediate r1, 2
-    38: NewClosure r2, c5
-    41: DefineProperty r0, r1, r2, 5
-    46: Ret r0
+     0: NewObject r0, 4
+     3: LoadConstant r1, c0
+     6: NewClosure r2, c1
+     9: DefineProperty r0, r1, r2, 4
+    14: LoadConstant r1, c2
+    17: NewClosure r2, c3
+    20: DefineProperty r0, r1, r2, 4
+    25: LoadImmediate r1, 1
+    28: NewClosure r2, c4
+    31: DefineProperty r0, r1, r2, 5
+    36: LoadImmediate r1, 2
+    39: NewClosure r2, c5
+    42: DefineProperty r0, r1, r2, 5
+    47: Ret r0
   Constant Table:
     0: [String: a]
     1: [BytecodeFunction: set a]

--- a/tests/snapshot/bytecode/expression/object/basic.exp
+++ b/tests/snapshot/bytecode/expression/object/basic.exp
@@ -50,19 +50,19 @@
 
 [BytecodeFunction: emptyObject] {
   Parameters: 0, Registers: 1
-    0: NewObject r0
-    2: Ret r0
+    0: NewObject r0, 0
+    3: Ret r0
 }
 
 [BytecodeFunction: shorthandProperties] {
   Parameters: 1, Registers: 3
      0: LoadImmediate r0, 1
-     3: NewObject r1
-     5: LoadGlobal r2, c0, k0
-     9: DefineNamedProperty r1, c0, r2
-    13: DefineNamedProperty r1, c1, r0
-    17: DefineNamedProperty r1, c2, a0
-    21: Ret r1
+     3: NewObject r1, 3
+     6: LoadGlobal r2, c0, k0
+    10: DefineNamedProperty r1, c0, r2
+    14: DefineNamedProperty r1, c1, r0
+    18: DefineNamedProperty r1, c2, a0
+    22: Ret r1
   Constant Table:
     0: [String: global]
     1: [String: local]
@@ -71,14 +71,14 @@
 
 [BytecodeFunction: initializedProperties] {
   Parameters: 0, Registers: 3
-     0: NewObject r0
-     2: LoadImmediate r1, 1
-     5: DefineNamedProperty r0, c0, r1
-     9: LoadImmediate r1, 2
-    12: LoadImmediate r2, 3
-    15: Add r1, r1, r2
-    19: DefineNamedProperty r0, c1, r1
-    23: Ret r0
+     0: NewObject r0, 2
+     3: LoadImmediate r1, 1
+     6: DefineNamedProperty r0, c0, r1
+    10: LoadImmediate r1, 2
+    13: LoadImmediate r2, 3
+    16: Add r1, r1, r2
+    20: DefineNamedProperty r0, c1, r1
+    24: Ret r0
   Constant Table:
     0: [String: a]
     1: [String: global]
@@ -86,12 +86,12 @@
 
 [BytecodeFunction: stringPropertyKeys] {
   Parameters: 0, Registers: 2
-     0: NewObject r0
-     2: LoadImmediate r1, 1
-     5: DefineNamedProperty r0, c0, r1
-     9: LoadImmediate r1, 2
-    12: DefineNamedProperty r0, c1, r1
-    16: Ret r0
+     0: NewObject r0, 2
+     3: LoadImmediate r1, 1
+     6: DefineNamedProperty r0, c0, r1
+    10: LoadImmediate r1, 2
+    13: DefineNamedProperty r0, c1, r1
+    17: Ret r0
   Constant Table:
     0: [String: a]
     1: [String: b]
@@ -99,63 +99,61 @@
 
 [BytecodeFunction: computedPropertyKeys] {
   Parameters: 0, Registers: 3
-     0: NewObject r0
-     2: LoadConstant r1, c0
-     5: LoadImmediate r2, 1
-     8: DefineProperty r0, r1, r2, 0
-    13: LoadImmediate r1, 2
-    16: LoadImmediate r2, 3
-    19: DefineProperty r0, r1, r2, 0
-    24: LoadImmediate r1, 4
-    27: LoadImmediate r2, 5
-    30: Add r1, r1, r2
-    34: LoadImmediate r2, 6
-    37: DefineProperty r0, r1, r2, 0
-    42: Ret r0
+     0: NewObject r0, 3
+     3: LoadConstant r1, c0
+     6: LoadImmediate r2, 1
+     9: DefineProperty r0, r1, r2, 0
+    14: LoadImmediate r1, 2
+    17: LoadImmediate r2, 3
+    20: DefineProperty r0, r1, r2, 0
+    25: LoadImmediate r1, 4
+    28: LoadImmediate r2, 5
+    31: Add r1, r1, r2
+    35: LoadImmediate r2, 6
+    38: DefineProperty r0, r1, r2, 0
+    43: Ret r0
   Constant Table:
     0: [String: a]
 }
 
 [BytecodeFunction: spread] {
   Parameters: 1, Registers: 3
-     0: NewObject r0
-     2: CopyDataProperties r0, a0, a0, 0
-     7: LoadImmediate r1, 1
-    10: LoadImmediate r2, 2
-    13: Add r1, r1, r2
-    17: CopyDataProperties r0, r1, r1, 0
-    22: Ret r0
+     0: NewObject r0, 0
+     3: CopyDataProperties r0, a0, a0, 0
+     8: LoadImmediate r1, 1
+    11: LoadImmediate r2, 2
+    14: Add r1, r1, r2
+    18: CopyDataProperties r0, r1, r1, 0
+    23: Ret r0
 }
 
 [BytecodeFunction: proto] {
   Parameters: 1, Registers: 3
-     0: NewObject r0
-     2: LoadImmediate r1, 1
-     5: LoadImmediate r2, 2
-     8: Add r1, r1, r2
-    12: SetPrototypeOf r0, r1
-    15: Ret r0
-  Constant Table:
-    0: [String: __proto__]
+     0: NewObject r0, 0
+     3: LoadImmediate r1, 1
+     6: LoadImmediate r2, 2
+     9: Add r1, r1, r2
+    13: SetPrototypeOf r0, r1
+    16: Ret r0
 }
 
 [BytecodeFunction: propertyNamesNotResolved] {
   Parameters: 0, Registers: 5
      0: LoadEmpty r1
      2: LoadEmpty r2
-     4: NewObject r3
-     6: LoadImmediate r4, 1
-     9: DefineNamedProperty r3, c0, r4
-    13: GetNamedProperty r0, r3, c0, k0
-    18: NewObject r3
-    20: CheckTdz r1, c1
-    23: DefineNamedProperty r3, c1, r1
-    27: CheckTdz r2, c3
-    30: DefineNamedProperty r3, c2, r2
-    34: GetNamedProperty r1, r3, c1, k1
-    39: GetNamedProperty r2, r3, c3, k2
-    44: LoadUndefined r3
-    46: Ret r3
+     4: NewObject r3, 1
+     7: LoadImmediate r4, 1
+    10: DefineNamedProperty r3, c0, r4
+    14: GetNamedProperty r0, r3, c0, k0
+    19: NewObject r3, 2
+    22: CheckTdz r1, c1
+    25: DefineNamedProperty r3, c1, r1
+    29: CheckTdz r2, c3
+    32: DefineNamedProperty r3, c2, r2
+    36: GetNamedProperty r1, r3, c1, k1
+    41: GetNamedProperty r2, r3, c3, k2
+    46: LoadUndefined r3
+    48: Ret r3
   Constant Table:
     0: [String: a]
     1: [String: b]
@@ -166,12 +164,12 @@
 [BytecodeFunction: temporaryRegisterToAvoidClobbering] {
   Parameters: 0, Registers: 3
      0: LoadImmediate r0, 1
-     3: NewObject r1
-     5: LoadImmediate r2, 2
-     8: DefineNamedProperty r1, c0, r2
-    12: Mov r0, r1
-    15: LoadUndefined r1
-    17: Ret r1
+     3: NewObject r1, 1
+     6: LoadImmediate r2, 2
+     9: DefineNamedProperty r1, c0, r2
+    13: Mov r0, r1
+    16: LoadUndefined r1
+    18: Ret r1
   Constant Table:
     0: [String: prop]
 }
@@ -179,7 +177,7 @@
 [BytecodeFunction: noTemporaryRegisterNeededForEmptyObject] {
   Parameters: 0, Registers: 2
     0: LoadImmediate r0, 1
-    3: NewObject r0
-    5: LoadUndefined r1
-    7: Ret r1
+    3: NewObject r0, 0
+    6: LoadUndefined r1
+    8: Ret r1
 }

--- a/tests/snapshot/bytecode/expression/object/estimated_num_properties.exp
+++ b/tests/snapshot/bytecode/expression/object/estimated_num_properties.exp
@@ -1,0 +1,152 @@
+[BytecodeFunction: <global>] {
+  Parameters: 0, Registers: 1
+     0: NewClosure r0, c0
+     3: StoreGlobal r0, c1, k0
+     7: NewClosure r0, c2
+    10: StoreGlobal r0, c3, k1
+    14: NewClosure r0, c4
+    17: StoreGlobal r0, c5, k2
+    21: NewClosure r0, c6
+    24: StoreGlobal r0, c7, k3
+    28: NewClosure r0, c8
+    31: StoreGlobal r0, c9, k4
+    35: NewClosure r0, c10
+    38: StoreGlobal r0, c11, k5
+    42: LoadUndefined r0
+    44: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: distinctNames]
+    1: [String: distinctNames]
+    2: [BytecodeFunction: duplicateNames]
+    3: [String: duplicateNames]
+    4: [BytecodeFunction: gettersAndSettersOvercounted]
+    5: [String: gettersAndSettersOvercounted]
+    6: [BytecodeFunction: computedPropertiesCounted]
+    7: [String: computedPropertiesCounted]
+    8: [BytecodeFunction: spreadIgnored]
+    9: [String: spreadIgnored]
+    10: [BytecodeFunction: prototypeSetterIgnored]
+    11: [String: prototypeSetterIgnored]
+}
+
+[BytecodeFunction: distinctNames] {
+  Parameters: 0, Registers: 2
+     0: NewObject r0, 4
+     3: LoadImmediate r1, 1
+     6: DefineNamedProperty r0, c0, r1
+    10: LoadImmediate r1, 2
+    13: DefineNamedProperty r0, c1, r1
+    17: NewClosure r1, c3
+    20: DefineNamedProperty r0, c2, r1
+    24: LoadImmediate r1, 4
+    27: DefineNamedProperty r0, c4, r1
+    31: LoadUndefined r0
+    33: Ret r0
+  Constant Table:
+    0: [String: a]
+    1: [String: b]
+    2: [String: c]
+    3: [BytecodeFunction: c]
+    4: [String: d]
+}
+
+[BytecodeFunction: c] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: duplicateNames] {
+  Parameters: 0, Registers: 2
+     0: NewObject r0, 4
+     3: LoadImmediate r1, 1
+     6: DefineNamedProperty r0, c0, r1
+    10: LoadImmediate r1, 2
+    13: DefineNamedProperty r0, c1, r1
+    17: LoadImmediate r1, 3
+    20: DefineNamedProperty r0, c0, r1
+    24: LoadImmediate r1, 4
+    27: DefineNamedProperty r0, c0, r1
+    31: LoadUndefined r0
+    33: Ret r0
+  Constant Table:
+    0: [String: a]
+    1: [String: b]
+}
+
+[BytecodeFunction: gettersAndSettersOvercounted] {
+  Parameters: 0, Registers: 3
+     0: NewObject r0, 3
+     3: LoadConstant r1, c0
+     6: NewClosure r2, c1
+     9: DefineProperty r0, r1, r2, 2
+    14: LoadConstant r1, c0
+    17: NewClosure r2, c2
+    20: DefineProperty r0, r1, r2, 4
+    25: LoadImmediate r1, 2
+    28: DefineNamedProperty r0, c3, r1
+    32: LoadUndefined r0
+    34: Ret r0
+  Constant Table:
+    0: [String: a]
+    1: [BytecodeFunction: get a]
+    2: [BytecodeFunction: set a]
+    3: [String: b]
+}
+
+[BytecodeFunction: get a] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: set a] {
+  Parameters: 1, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: computedPropertiesCounted] {
+  Parameters: 0, Registers: 3
+     0: NewObject r0, 2
+     3: LoadImmediate r1, 1
+     6: LoadImmediate r2, 1
+     9: DefineProperty r0, r1, r2, 0
+    14: LoadImmediate r1, 2
+    17: LoadImmediate r2, 2
+    20: DefineProperty r0, r1, r2, 0
+    25: LoadUndefined r0
+    27: Ret r0
+}
+
+[BytecodeFunction: spreadIgnored] {
+  Parameters: 0, Registers: 2
+     0: NewObject r0, 1
+     3: LoadGlobal r1, c0, k0
+     7: CopyDataProperties r0, r1, r1, 0
+    12: LoadImmediate r1, 2
+    15: DefineNamedProperty r0, c1, r1
+    19: LoadUndefined r0
+    21: Ret r0
+  Constant Table:
+    0: [String: a]
+    1: [String: b]
+}
+
+[BytecodeFunction: prototypeSetterIgnored] {
+  Parameters: 0, Registers: 2
+     0: NewObject r0, 1
+     3: LoadNull r1
+     5: SetPrototypeOf r0, r1
+     8: LoadImmediate r1, 2
+    11: DefineNamedProperty r0, c0, r1
+    15: NewObject r0, 1
+    18: LoadNull r1
+    20: SetPrototypeOf r0, r1
+    23: LoadImmediate r1, 2
+    26: DefineNamedProperty r0, c0, r1
+    30: LoadUndefined r0
+    32: Ret r0
+  Constant Table:
+    0: [String: b]
+}

--- a/tests/snapshot/bytecode/expression/object/estimated_num_properties.js
+++ b/tests/snapshot/bytecode/expression/object/estimated_num_properties.js
@@ -1,0 +1,24 @@
+function distinctNames() {
+  ({ a: 1, b: 2, c() {}, "d": 4 });
+}
+
+function duplicateNames() {
+  ({ a: 1, b: 2, a: 3, "a": 4 });
+}
+
+function gettersAndSettersOvercounted() {
+  ({ get a() {}, set a(x) {}, b: 2 });
+}
+
+function computedPropertiesCounted() {
+  ({ [1]: 1, [2]: 2 });
+}
+
+function spreadIgnored() {
+  ({ ...a, b: 2 });
+}
+
+function prototypeSetterIgnored() {
+  ({ __proto__: null, b: 2 });
+  ({ "__proto__": null, b: 2 });
+}

--- a/tests/snapshot/bytecode/expression/object/method.exp
+++ b/tests/snapshot/bytecode/expression/object/method.exp
@@ -15,12 +15,12 @@
 
 [BytecodeFunction: namedMethod] {
   Parameters: 0, Registers: 2
-     0: NewObject r0
-     2: NewClosure r1, c1
-     5: DefineNamedProperty r0, c0, r1
-     9: NewClosure r1, c3
-    12: DefineNamedProperty r0, c2, r1
-    16: Ret r0
+     0: NewObject r0, 2
+     3: NewClosure r1, c1
+     6: DefineNamedProperty r0, c0, r1
+    10: NewClosure r1, c3
+    13: DefineNamedProperty r0, c2, r1
+    17: Ret r0
   Constant Table:
     0: [String: a]
     1: [BytecodeFunction: a]
@@ -42,11 +42,11 @@
 
 [BytecodeFunction: computedMethod] {
   Parameters: 0, Registers: 3
-     0: NewObject r0
-     2: LoadImmediate r1, 1
-     5: NewClosure r2, c0
-     8: DefineProperty r0, r1, r2, 1
-    13: Ret r0
+     0: NewObject r0, 1
+     3: LoadImmediate r1, 1
+     6: NewClosure r2, c0
+     9: DefineProperty r0, r1, r2, 1
+    14: Ret r0
   Constant Table:
     0: [BytecodeFunction: <anonymous>]
 }

--- a/tests/snapshot/bytecode/expression/object/named_evalution.exp
+++ b/tests/snapshot/bytecode/expression/object/named_evalution.exp
@@ -23,14 +23,14 @@
 
 [BytecodeFunction: allNamedExpressions] {
   Parameters: 0, Registers: 2
-     0: NewObject r0
-     2: NewClosure r1, c1
-     5: DefineNamedProperty r0, c0, r1
-     9: NewClosure r1, c3
-    12: DefineNamedProperty r0, c2, r1
-    16: NewClosure r1, c5
-    19: DefineNamedProperty r0, c4, r1
-    23: Ret r0
+     0: NewObject r0, 3
+     3: NewClosure r1, c1
+     6: DefineNamedProperty r0, c0, r1
+    10: NewClosure r1, c3
+    13: DefineNamedProperty r0, c2, r1
+    17: NewClosure r1, c5
+    20: DefineNamedProperty r0, c4, r1
+    24: Ret r0
   Constant Table:
     0: [String: a]
     1: [BytecodeFunction: a]
@@ -61,10 +61,10 @@
 
 [BytecodeFunction: stringKey] {
   Parameters: 0, Registers: 2
-    0: NewObject r0
-    2: NewClosure r1, c1
-    5: DefineNamedProperty r0, c0, r1
-    9: Ret r0
+     0: NewObject r0, 1
+     3: NewClosure r1, c1
+     6: DefineNamedProperty r0, c0, r1
+    10: Ret r0
   Constant Table:
     0: [String: test]
     1: [BytecodeFunction: test]
@@ -78,16 +78,16 @@
 
 [BytecodeFunction: computedNeedsName] {
   Parameters: 0, Registers: 3
-     0: NewObject r0
-     2: LoadImmediate r1, 1
-     5: LoadImmediate r2, 2
-     8: Add r1, r1, r2
-    12: NewClosure r2, c0
-    15: DefineProperty r0, r1, r2, 1
-    20: LoadImmediate r1, 3
-    23: NewClosure r2, c1
-    26: DefineProperty r0, r1, r2, 1
-    31: Ret r0
+     0: NewObject r0, 2
+     3: LoadImmediate r1, 1
+     6: LoadImmediate r2, 2
+     9: Add r1, r1, r2
+    13: NewClosure r2, c0
+    16: DefineProperty r0, r1, r2, 1
+    21: LoadImmediate r1, 3
+    24: NewClosure r2, c1
+    27: DefineProperty r0, r1, r2, 1
+    32: Ret r0
   Constant Table:
     0: [BytecodeFunction: <anonymous>]
     1: [BytecodeFunction: <anonymous>]
@@ -107,11 +107,11 @@
 
 [BytecodeFunction: computedAlreadyNamed] {
   Parameters: 0, Registers: 3
-     0: NewObject r0
-     2: LoadImmediate r1, 1
-     5: NewClosure r2, c0
-     8: DefineProperty r0, r1, r2, 0
-    13: Ret r0
+     0: NewObject r0, 1
+     3: LoadImmediate r1, 1
+     6: NewClosure r2, c0
+     9: DefineProperty r0, r1, r2, 0
+    14: Ret r0
   Constant Table:
     0: [BytecodeFunction: alreadyNamed]
 }

--- a/tests/snapshot/bytecode/expression/super_member.exp
+++ b/tests/snapshot/bytecode/expression/super_member.exp
@@ -1,17 +1,17 @@
 [BytecodeFunction: <global>] {
   Parameters: 0, Registers: 2
      0: PushLexicalScope c0
-     2: NewObject r0
-     4: StoreToScope r0, 0, 0
-     8: NewClosure r1, c2
-    11: DefineNamedProperty r0, c1, r1
-    15: NewClosure r1, c4
-    18: DefineNamedProperty r0, c3, r1
-    22: NewClosure r1, c6
-    25: DefineNamedProperty r0, c5, r1
-    29: PopScope 
-    30: LoadUndefined r0
-    32: Ret r0
+     2: NewObject r0, 3
+     5: StoreToScope r0, 0, 0
+     9: NewClosure r1, c2
+    12: DefineNamedProperty r0, c1, r1
+    16: NewClosure r1, c4
+    19: DefineNamedProperty r0, c3, r1
+    23: NewClosure r1, c6
+    26: DefineNamedProperty r0, c5, r1
+    30: PopScope 
+    31: LoadUndefined r0
+    33: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: named]

--- a/tests/snapshot/bytecode/expression/update.exp
+++ b/tests/snapshot/bytecode/expression/update.exp
@@ -23,15 +23,15 @@
      70: LoadImmediate r0, 0
      73: StoreGlobal r0, c20, k10
      77: PushLexicalScope c21
-     79: NewObject r0
-     81: StoreToScope r0, 0, 0
-     85: NewClosure r1, c23
-     88: DefineNamedProperty r0, c22, r1
-     92: NewClosure r1, c25
-     95: DefineNamedProperty r0, c24, r1
-     99: PopScope 
-    100: LoadUndefined r0
-    102: Ret r0
+     79: NewObject r0, 2
+     82: StoreToScope r0, 0, 0
+     86: NewClosure r1, c23
+     89: DefineNamedProperty r0, c22, r1
+     93: NewClosure r1, c25
+     96: DefineNamedProperty r0, c24, r1
+    100: PopScope 
+    101: LoadUndefined r0
+    103: Ret r0
   Constant Table:
     0: [BytecodeFunction: use]
     1: [String: use]

--- a/tests/snapshot/bytecode/function/generator.exp
+++ b/tests/snapshot/bytecode/function/generator.exp
@@ -16,15 +16,15 @@
     45: StoreGlobal r0, c13, k6
     49: NewGenerator r0, c14
     52: NewGenerator r0, c15
-    55: NewObject r0
-    57: NewGenerator r1, c17
-    60: DefineNamedProperty r0, c16, r1
-    64: LoadEmpty r1
-    66: NewGenerator r2, c18
-    69: NewClass r0, c20, c19, r1, r2
-    75: StoreToScope r0, 1, 0
-    79: LoadUndefined r0
-    81: Ret r0
+    55: NewObject r0, 1
+    58: NewGenerator r1, c17
+    61: DefineNamedProperty r0, c16, r1
+    65: LoadEmpty r1
+    67: NewGenerator r2, c18
+    70: NewClass r0, c20, c19, r1, r2
+    76: StoreToScope r0, 1, 0
+    80: LoadUndefined r0
+    82: Ret r0
   Constant Table:
     0: [BytecodeFunction: empty]
     1: [String: empty]
@@ -76,20 +76,20 @@
      2: LoadImmediate r1, 1
      5: LoadUndefined r1
      7: Mov r2, r1
-    10: NewObject r3
-    12: SetNamedProperty r3, c0, r2, k0
-    17: LoadFalse r2
-    19: SetNamedProperty r3, c1, r2, k1
-    24: Yield r1, r2, r0, r3
-    29: JumpNotNullish r2, 10 (.L1)
-    32: JumpNotUndefined r2, 5 (.L0)
-    35: Ret r1
+    10: NewObject r3, 2
+    13: SetNamedProperty r3, c0, r2, k0
+    18: LoadFalse r2
+    20: SetNamedProperty r3, c1, r2, k1
+    25: Yield r1, r2, r0, r3
+    30: JumpNotNullish r2, 10 (.L1)
+    33: JumpNotUndefined r2, 5 (.L0)
+    36: Ret r1
   .L0:
-    37: Throw r1
+    38: Throw r1
   .L1:
-    39: LoadImmediate r1, 2
-    42: LoadUndefined r1
-    44: Ret r1
+    40: LoadImmediate r1, 2
+    43: LoadUndefined r1
+    45: Ret r1
   Constant Table:
     0: [String: value]
     1: [String: done]
@@ -101,20 +101,20 @@
      2: LoadImmediate r1, 1
      5: LoadImmediate r1, 2
      8: Mov r2, r1
-    11: NewObject r3
-    13: SetNamedProperty r3, c0, r2, k0
-    18: LoadFalse r2
-    20: SetNamedProperty r3, c1, r2, k1
-    25: Yield r1, r2, r0, r3
-    30: JumpNotNullish r2, 10 (.L1)
-    33: JumpNotUndefined r2, 5 (.L0)
-    36: Ret r1
+    11: NewObject r3, 2
+    14: SetNamedProperty r3, c0, r2, k0
+    19: LoadFalse r2
+    21: SetNamedProperty r3, c1, r2, k1
+    26: Yield r1, r2, r0, r3
+    31: JumpNotNullish r2, 10 (.L1)
+    34: JumpNotUndefined r2, 5 (.L0)
+    37: Ret r1
   .L0:
-    38: Throw r1
+    39: Throw r1
   .L1:
-    40: LoadImmediate r1, 3
-    43: LoadUndefined r1
-    45: Ret r1
+    41: LoadImmediate r1, 3
+    44: LoadUndefined r1
+    46: Ret r1
   Constant Table:
     0: [String: value]
     1: [String: done]
@@ -125,58 +125,58 @@
       0: GeneratorStart r0
       2: LoadUndefined r1
       4: Mov r2, r1
-      7: NewObject r3
-      9: SetNamedProperty r3, c0, r2, k0
-     14: LoadFalse r2
-     16: SetNamedProperty r3, c1, r2, k1
-     21: Yield r1, r2, r0, r3
-     26: JumpNotNullish r2, 10 (.L1)
-     29: JumpNotUndefined r2, 5 (.L0)
-     32: Ret r1
+      7: NewObject r3, 2
+     10: SetNamedProperty r3, c0, r2, k0
+     15: LoadFalse r2
+     17: SetNamedProperty r3, c1, r2, k1
+     22: Yield r1, r2, r0, r3
+     27: JumpNotNullish r2, 10 (.L1)
+     30: JumpNotUndefined r2, 5 (.L0)
+     33: Ret r1
   .L0:
-     34: Throw r1
+     35: Throw r1
   .L1:
-     36: LoadImmediate r1, 1
-     39: Mov r2, r1
-     42: NewObject r3
-     44: SetNamedProperty r3, c0, r2, k2
-     49: LoadFalse r2
-     51: SetNamedProperty r3, c1, r2, k3
-     56: Yield r1, r2, r0, r3
-     61: JumpNotNullish r2, 10 (.L3)
-     64: JumpNotUndefined r2, 5 (.L2)
-     67: Ret r1
+     37: LoadImmediate r1, 1
+     40: Mov r2, r1
+     43: NewObject r3, 2
+     46: SetNamedProperty r3, c0, r2, k2
+     51: LoadFalse r2
+     53: SetNamedProperty r3, c1, r2, k3
+     58: Yield r1, r2, r0, r3
+     63: JumpNotNullish r2, 10 (.L3)
+     66: JumpNotUndefined r2, 5 (.L2)
+     69: Ret r1
   .L2:
-     69: Throw r1
+     71: Throw r1
   .L3:
-     71: LoadUndefined r1
-     73: Mov r2, r1
-     76: NewObject r3
-     78: SetNamedProperty r3, c0, r2, k4
-     83: LoadFalse r2
-     85: SetNamedProperty r3, c1, r2, k5
-     90: Yield r1, r2, r0, r3
-     95: JumpNotNullish r2, 10 (.L5)
-     98: JumpNotUndefined r2, 5 (.L4)
-    101: Ret r1
+     73: LoadUndefined r1
+     75: Mov r2, r1
+     78: NewObject r3, 2
+     81: SetNamedProperty r3, c0, r2, k4
+     86: LoadFalse r2
+     88: SetNamedProperty r3, c1, r2, k5
+     93: Yield r1, r2, r0, r3
+     98: JumpNotNullish r2, 10 (.L5)
+    101: JumpNotUndefined r2, 5 (.L4)
+    104: Ret r1
   .L4:
-    103: Throw r1
+    106: Throw r1
   .L5:
-    105: LoadImmediate r1, 2
-    108: Mov r2, r1
-    111: NewObject r3
-    113: SetNamedProperty r3, c0, r2, k6
-    118: LoadFalse r2
-    120: SetNamedProperty r3, c1, r2, k7
-    125: Yield r1, r2, r0, r3
-    130: JumpNotNullish r2, 10 (.L7)
-    133: JumpNotUndefined r2, 5 (.L6)
-    136: Ret r1
+    108: LoadImmediate r1, 2
+    111: Mov r2, r1
+    114: NewObject r3, 2
+    117: SetNamedProperty r3, c0, r2, k6
+    122: LoadFalse r2
+    124: SetNamedProperty r3, c1, r2, k7
+    129: Yield r1, r2, r0, r3
+    134: JumpNotNullish r2, 10 (.L7)
+    137: JumpNotUndefined r2, 5 (.L6)
+    140: Ret r1
   .L6:
-    138: Throw r1
+    142: Throw r1
   .L7:
-    140: LoadUndefined r1
-    142: Ret r1
+    144: LoadUndefined r1
+    146: Ret r1
   Constant Table:
     0: [String: value]
     1: [String: done]
@@ -187,32 +187,32 @@
      0: GeneratorStart r0
      2: LoadUndefined r1
      4: Mov r2, r1
-     7: NewObject r3
-     9: SetNamedProperty r3, c0, r2, k0
-    14: LoadFalse r2
-    16: SetNamedProperty r3, c1, r2, k1
-    21: Yield r1, r2, r0, r3
-    26: JumpNotNullish r2, 10 (.L1)
-    29: JumpNotUndefined r2, 5 (.L0)
-    32: Ret r1
+     7: NewObject r3, 2
+    10: SetNamedProperty r3, c0, r2, k0
+    15: LoadFalse r2
+    17: SetNamedProperty r3, c1, r2, k1
+    22: Yield r1, r2, r0, r3
+    27: JumpNotNullish r2, 10 (.L1)
+    30: JumpNotUndefined r2, 5 (.L0)
+    33: Ret r1
   .L0:
-    34: Throw r1
+    35: Throw r1
   .L1:
-    36: LoadImmediate r2, 1
-    39: Mov r3, r2
-    42: NewObject r4
-    44: SetNamedProperty r4, c0, r3, k2
-    49: LoadFalse r3
-    51: SetNamedProperty r4, c1, r3, k3
-    56: Yield r2, r3, r0, r4
-    61: JumpNotNullish r3, 10 (.L3)
-    64: JumpNotUndefined r3, 5 (.L2)
-    67: Ret r2
+    37: LoadImmediate r2, 1
+    40: Mov r3, r2
+    43: NewObject r4, 2
+    46: SetNamedProperty r4, c0, r3, k2
+    51: LoadFalse r3
+    53: SetNamedProperty r4, c1, r3, k3
+    58: Yield r2, r3, r0, r4
+    63: JumpNotNullish r3, 10 (.L3)
+    66: JumpNotUndefined r3, 5 (.L2)
+    69: Ret r2
   .L2:
-    69: Throw r2
+    71: Throw r2
   .L3:
-    71: Add r1, r1, r2
-    75: Ret r1
+    73: Add r1, r1, r2
+    77: Ret r1
   Constant Table:
     0: [String: value]
     1: [String: done]
@@ -224,44 +224,44 @@
      2: Mov r3, <scope>
      5: LoadUndefined r4
      7: Mov r5, r4
-    10: NewObject r6
-    12: SetNamedProperty r6, c0, r5, k0
-    17: LoadFalse r5
-    19: SetNamedProperty r6, c1, r5, k1
-    24: Yield r4, r5, r0, r6
-    29: JumpNotNullish r5, 16 (.L1)
-    32: JumpNotUndefined r5, 11 (.L0)
-    35: LoadImmediate r1, 1
-    38: Mov r2, r4
-    41: Jump 12 (.L2)
+    10: NewObject r6, 2
+    13: SetNamedProperty r6, c0, r5, k0
+    18: LoadFalse r5
+    20: SetNamedProperty r6, c1, r5, k1
+    25: Yield r4, r5, r0, r6
+    30: JumpNotNullish r5, 16 (.L1)
+    33: JumpNotUndefined r5, 11 (.L0)
+    36: LoadImmediate r1, 1
+    39: Mov r2, r4
+    42: Jump 12 (.L2)
   .L0:
-    43: Throw r4
+    44: Throw r4
   .L1:
-    45: LoadImmediate r1, 2
-    48: Jump 5 (.L2)
-    50: LoadImmediate r1, 0
+    46: LoadImmediate r1, 2
+    49: Jump 5 (.L2)
+    51: LoadImmediate r1, 0
   .L2:
-    53: Mov <scope>, r3
-    56: LoadImmediate r3, 1
-    59: LoadImmediate r3, 0
-    62: StrictEqual r3, r1, r3
-    66: JumpFalse r3, 5 (.L3)
-    69: Rethrow r2
+    54: Mov <scope>, r3
+    57: LoadImmediate r3, 1
+    60: LoadImmediate r3, 0
+    63: StrictEqual r3, r1, r3
+    67: JumpFalse r3, 5 (.L3)
+    70: Rethrow r2
   .L3:
-    71: LoadImmediate r3, 2
-    74: StrictEqual r3, r1, r3
-    78: JumpFalse r3, 5 (.L4)
-    81: Jump 4 (.L5)
+    72: LoadImmediate r3, 2
+    75: StrictEqual r3, r1, r3
+    79: JumpFalse r3, 5 (.L4)
+    82: Jump 4 (.L5)
   .L4:
-    83: Ret r2
+    84: Ret r2
   .L5:
-    85: LoadUndefined r1
-    87: Ret r1
+    86: LoadUndefined r1
+    88: Ret r1
   Constant Table:
     0: [String: value]
     1: [String: done]
   Exception Handlers:
-    5-45 -> 50 (r2)
+    5-46 -> 51 (r2)
 }
 
 [BytecodeFunction: generatorExpression] {

--- a/tests/snapshot/bytecode/module/dynamic_import.exp
+++ b/tests/snapshot/bytecode/module/dynamic_import.exp
@@ -8,8 +8,8 @@
     16: LoadImmediate r1, 3
     19: Add r0, r0, r1
     23: LoadImmediate r1, 4
-    26: NewObject r2
-    28: DynamicImport r0, r1, r2
-    32: LoadUndefined r0
-    34: Ret r0
+    26: NewObject r2, 0
+    29: DynamicImport r0, r1, r2
+    33: LoadUndefined r0
+    35: Ret r0
 }

--- a/tests/snapshot/bytecode/pattern/basic.exp
+++ b/tests/snapshot/bytecode/pattern/basic.exp
@@ -16,17 +16,17 @@
     47: GetProperty r4, r0, r3
     51: StoreGlobal r4, c7, k6
     55: ToObject r5, r0
-    58: NewObject r4
-    60: CopyDataProperties r4, r0, r1, 3
-    65: StoreGlobal r4, c8, k7
-    69: PushLexicalScope c9
-    71: NewObject r0
-    73: StoreToScope r0, 0, 0
-    77: NewClosure r1, c11
-    80: DefineNamedProperty r0, c10, r1
-    84: PopScope 
-    85: LoadUndefined r0
-    87: Ret r0
+    58: NewObject r4, 0
+    61: CopyDataProperties r4, r0, r1, 3
+    66: StoreGlobal r4, c8, k7
+    70: PushLexicalScope c9
+    72: NewObject r0, 1
+    75: StoreToScope r0, 0, 0
+    79: NewClosure r1, c11
+    82: DefineNamedProperty r0, c10, r1
+    86: PopScope 
+    87: LoadUndefined r0
+    89: Ret r0
   Constant Table:
     0: [BytecodeFunction: constants]
     1: [String: constants]
@@ -53,10 +53,10 @@
     22: ToPropertyKey r7, r8
     25: GetProperty r2, r4, r7
     29: ToObject r8, r4
-    32: NewObject r3
-    34: CopyDataProperties r3, r4, r5, 3
-    39: LoadUndefined r4
-    41: Ret r4
+    32: NewObject r3, 0
+    35: CopyDataProperties r3, r4, r5, 3
+    40: LoadUndefined r4
+    42: Ret r4
   Constant Table:
     0: [String: a]
     1: [String: z]

--- a/tests/snapshot/bytecode/pattern/iterator_destructuring.exp
+++ b/tests/snapshot/bytecode/pattern/iterator_destructuring.exp
@@ -620,58 +620,58 @@
      17: JumpFalse r4, 5 (.L0)
      20: LoadUndefined r9
   .L0:
-     22: JumpNotUndefined r9, 40 (.L2)
+     22: JumpNotUndefined r9, 41 (.L2)
      25: LoadUndefined r10
-     27: NewObject r11
-     29: SetNamedProperty r11, c0, r10, k0
-     34: LoadFalse r10
-     36: SetNamedProperty r11, c1, r10, k1
-     41: Yield r9, r10, r1, r11
-     46: JumpNotNullish r10, 16 (.L2)
-     49: JumpNotUndefined r10, 11 (.L1)
-     52: LoadImmediate r5, 1
-     55: Mov r6, r9
-     58: Jump 18 (.L3)
+     27: NewObject r11, 2
+     30: SetNamedProperty r11, c0, r10, k0
+     35: LoadFalse r10
+     37: SetNamedProperty r11, c1, r10, k1
+     42: Yield r9, r10, r1, r11
+     47: JumpNotNullish r10, 16 (.L2)
+     50: JumpNotUndefined r10, 11 (.L1)
+     53: LoadImmediate r5, 1
+     56: Mov r6, r9
+     59: Jump 18 (.L3)
   .L1:
-     60: Throw r9
+     61: Throw r9
   .L2:
-     62: Mov r0, r9
-     65: JumpTrue r4, 62 (.L8)
-     68: LoadImmediate r5, 2
-     71: Jump 5 (.L3)
-     73: LoadImmediate r5, 0
+     63: Mov r0, r9
+     66: JumpTrue r4, 62 (.L8)
+     69: LoadImmediate r5, 2
+     72: Jump 5 (.L3)
+     74: LoadImmediate r5, 0
   .L3:
-     76: Mov <scope>, r7
-     79: JumpTrue r4, 22 (.L5)
-     82: IteratorClose r3
-     84: Jump 17 (.L5)
-     86: LoadImmediate r8, 0
-     89: StrictNotEqual r8, r8, r5
-     93: JumpTrue r8, 6 (.L4)
-     96: Mov r7, r6
+     77: Mov <scope>, r7
+     80: JumpTrue r4, 22 (.L5)
+     83: IteratorClose r3
+     85: Jump 17 (.L5)
+     87: LoadImmediate r8, 0
+     90: StrictNotEqual r8, r8, r5
+     94: JumpTrue r8, 6 (.L4)
+     97: Mov r7, r6
   .L4:
-     99: Rethrow r7
+    100: Rethrow r7
   .L5:
-    101: LoadImmediate r7, 0
-    104: StrictEqual r7, r5, r7
-    108: JumpFalse r7, 5 (.L6)
-    111: Rethrow r6
+    102: LoadImmediate r7, 0
+    105: StrictEqual r7, r5, r7
+    109: JumpFalse r7, 5 (.L6)
+    112: Rethrow r6
   .L6:
-    113: LoadImmediate r7, 2
-    116: StrictEqual r7, r5, r7
-    120: JumpFalse r7, 5 (.L7)
-    123: Jump 4 (.L8)
+    114: LoadImmediate r7, 2
+    117: StrictEqual r7, r5, r7
+    121: JumpFalse r7, 5 (.L7)
+    124: Jump 4 (.L8)
   .L7:
-    125: Ret r6
+    126: Ret r6
   .L8:
-    127: LoadUndefined r2
-    129: Ret r2
+    128: LoadUndefined r2
+    130: Ret r2
   Constant Table:
     0: [String: value]
     1: [String: done]
   Exception Handlers:
-    22-65 -> 73 (r6)
-    82-84 -> 86 (r7)
+    22-66 -> 74 (r6)
+    83-85 -> 87 (r7)
 }
 
 [BytecodeFunction: reassignIteratorSource] {

--- a/tests/snapshot/bytecode/pattern/object_destructuring.exp
+++ b/tests/snapshot/bytecode/pattern/object_destructuring.exp
@@ -221,30 +221,30 @@
   Parameters: 1, Registers: 10
      0: Mov r5, a0
      3: ToObject r6, r5
-     6: NewObject r0
-     8: CopyDataProperties r0, r5, r5, 0
-    13: Mov r5, a0
-    16: LoadConstant r6, c0
-    19: GetNamedProperty r0, r5, c0, k0
-    24: LoadConstant r7, c1
-    27: GetNamedProperty r1, r5, c1, k1
-    32: ToObject r8, r5
-    35: NewObject r2
-    37: CopyDataProperties r2, r5, r6, 2
-    42: Mov r5, a0
-    45: LoadConstant r6, c0
-    48: GetNamedProperty r0, r5, c0, k2
-    53: LoadImmediate r9, 1
-    56: ToPropertyKey r7, r9
-    59: GetProperty r1, r5, r7
-    63: LoadImmediate r9, 2
-    66: ToPropertyKey r8, r9
-    69: GetProperty r3, r5, r8
-    73: ToObject r9, r5
-    76: NewObject r4
-    78: CopyDataProperties r4, r5, r6, 3
-    83: LoadUndefined r5
-    85: Ret r5
+     6: NewObject r0, 0
+     9: CopyDataProperties r0, r5, r5, 0
+    14: Mov r5, a0
+    17: LoadConstant r6, c0
+    20: GetNamedProperty r0, r5, c0, k0
+    25: LoadConstant r7, c1
+    28: GetNamedProperty r1, r5, c1, k1
+    33: ToObject r8, r5
+    36: NewObject r2, 0
+    39: CopyDataProperties r2, r5, r6, 2
+    44: Mov r5, a0
+    47: LoadConstant r6, c0
+    50: GetNamedProperty r0, r5, c0, k2
+    55: LoadImmediate r9, 1
+    58: ToPropertyKey r7, r9
+    61: GetProperty r1, r5, r7
+    65: LoadImmediate r9, 2
+    68: ToPropertyKey r8, r9
+    71: GetProperty r3, r5, r8
+    75: ToObject r9, r5
+    78: NewObject r4, 0
+    81: CopyDataProperties r4, r5, r6, 3
+    86: LoadUndefined r5
+    88: Ret r5
   Constant Table:
     0: [String: a]
     1: [String: b]
@@ -309,11 +309,11 @@
     30: LoadGlobal r4, c3, k4
     34: Call r4, r4, r4, 0
     39: ToObject r5, r0
-    42: NewObject r2
-    44: CopyDataProperties r2, r0, r1, 1
-    49: SetProperty r3, r4, r2
-    53: LoadUndefined r0
-    55: Ret r0
+    42: NewObject r2, 0
+    45: CopyDataProperties r2, r0, r1, 1
+    50: SetProperty r3, r4, r2
+    54: LoadUndefined r0
+    56: Ret r0
   Constant Table:
     0: [String: d]
     1: [String: a]

--- a/tests/snapshot/bytecode/scope/for_in.exp
+++ b/tests/snapshot/bytecode/scope/for_in.exp
@@ -23,21 +23,21 @@
 
 [BytecodeFunction: startScope] {
   Parameters: 0, Registers: 4
-     0: NewObject r2
-     2: JumpNullish r2, 29 (.L1)
-     5: NewForInIterator r2, r2
+     0: NewObject r2, 0
+     3: JumpNullish r2, 29 (.L1)
+     6: NewForInIterator r2, r2
   .L0:
-     8: ForInNext r3, r2
-    11: JumpNullish r3, 20 (.L1)
-    14: Mov r0, r3
-    17: LoadEmpty r1
-    19: CheckTdz r1, c0
-    22: Add r3, r0, r1
-    26: LoadImmediate r1, 0
-    29: Jump -21 (.L0)
+     9: ForInNext r3, r2
+    12: JumpNullish r3, 20 (.L1)
+    15: Mov r0, r3
+    18: LoadEmpty r1
+    20: CheckTdz r1, c0
+    23: Add r3, r0, r1
+    27: LoadImmediate r1, 0
+    30: Jump -21 (.L0)
   .L1:
-    31: LoadUndefined r2
-    33: Ret r2
+    32: LoadUndefined r2
+    34: Ret r2
   Constant Table:
     0: [String: inner]
 }
@@ -47,30 +47,30 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 0, 0
-     8: NewObject r1
-    10: JumpNullish r1, 47 (.L1)
-    13: NewForInIterator r1, r1
-    16: PopScope 
+     8: NewObject r1, 0
+    11: JumpNullish r1, 47 (.L1)
+    14: NewForInIterator r1, r1
+    17: PopScope 
   .L0:
-    17: PushLexicalScope c0
-    19: LoadEmpty r2
-    21: StoreToScope r2, 0, 0
-    25: ForInNext r2, r1
-    28: JumpNullish r2, 29 (.L1)
-    31: StoreToScope r2, 0, 0
-    35: PushLexicalScope c1
-    37: LoadEmpty r2
-    39: StoreToScope r2, 0, 0
-    43: NewClosure r0, c2
-    46: LoadImmediate r2, 2
-    49: StoreToScope r2, 0, 0
-    53: PopScope 
+    18: PushLexicalScope c0
+    20: LoadEmpty r2
+    22: StoreToScope r2, 0, 0
+    26: ForInNext r2, r1
+    29: JumpNullish r2, 29 (.L1)
+    32: StoreToScope r2, 0, 0
+    36: PushLexicalScope c1
+    38: LoadEmpty r2
+    40: StoreToScope r2, 0, 0
+    44: NewClosure r0, c2
+    47: LoadImmediate r2, 2
+    50: StoreToScope r2, 0, 0
     54: PopScope 
-    55: Jump -38 (.L0)
+    55: PopScope 
+    56: Jump -38 (.L0)
   .L1:
-    57: PopScope 
-    58: LoadUndefined r1
-    60: Ret r1
+    58: PopScope 
+    59: LoadUndefined r1
+    61: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]

--- a/tests/snapshot/bytecode/scope/for_in_break.exp
+++ b/tests/snapshot/bytecode/scope/for_in_break.exp
@@ -26,50 +26,50 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 0, 0
-     8: NewObject r1
-    10: JumpNullish r1, 84 (.L3)
-    13: NewForInIterator r1, r1
-    16: PopScope 
+     8: NewObject r1, 0
+    11: JumpNullish r1, 84 (.L3)
+    14: NewForInIterator r1, r1
+    17: PopScope 
   .L0:
-    17: PushLexicalScope c0
-    19: LoadEmpty r2
-    21: StoreToScope r2, 0, 0
-    25: ForInNext r2, r1
-    28: JumpNullish r2, 66 (.L3)
-    31: StoreToScope r2, 0, 0
-    35: PushLexicalScope c1
-    37: LoadEmpty r2
-    39: StoreToScope r2, 0, 0
-    43: LoadImmediate r2, 1
-    46: StoreToScope r2, 0, 0
-    50: LoadImmediate r2, 2
-    53: JumpToBooleanFalse r2, 7 (.L1)
-    56: PopScope 
+    18: PushLexicalScope c0
+    20: LoadEmpty r2
+    22: StoreToScope r2, 0, 0
+    26: ForInNext r2, r1
+    29: JumpNullish r2, 66 (.L3)
+    32: StoreToScope r2, 0, 0
+    36: PushLexicalScope c1
+    38: LoadEmpty r2
+    40: StoreToScope r2, 0, 0
+    44: LoadImmediate r2, 1
+    47: StoreToScope r2, 0, 0
+    51: LoadImmediate r2, 2
+    54: JumpToBooleanFalse r2, 7 (.L1)
     57: PopScope 
-    58: Jump 37 (.L4)
+    58: PopScope 
+    59: Jump 37 (.L4)
   .L1:
-    60: PushLexicalScope c2
-    62: LoadEmpty r2
-    64: StoreToScope r2, 0, 0
-    68: NewClosure r0, c3
-    71: LoadImmediate r2, 3
-    74: StoreToScope r2, 0, 0
-    78: LoadImmediate r2, 4
-    81: JumpToBooleanFalse r2, 8 (.L2)
-    84: PopScope 
+    61: PushLexicalScope c2
+    63: LoadEmpty r2
+    65: StoreToScope r2, 0, 0
+    69: NewClosure r0, c3
+    72: LoadImmediate r2, 3
+    75: StoreToScope r2, 0, 0
+    79: LoadImmediate r2, 4
+    82: JumpToBooleanFalse r2, 8 (.L2)
     85: PopScope 
     86: PopScope 
-    87: Jump 8 (.L4)
+    87: PopScope 
+    88: Jump 8 (.L4)
   .L2:
-    89: PopScope 
     90: PopScope 
     91: PopScope 
-    92: Jump -75 (.L0)
+    92: PopScope 
+    93: Jump -75 (.L0)
   .L3:
-    94: PopScope 
+    95: PopScope 
   .L4:
-    95: LoadUndefined r1
-    97: Ret r1
+    96: LoadUndefined r1
+    98: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]
@@ -99,42 +99,42 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 0, 0
-     8: NewObject r1
-    10: JumpNullish r1, 66 (.L3)
-    13: NewForInIterator r1, r1
-    16: PopScope 
+     8: NewObject r1, 0
+    11: JumpNullish r1, 66 (.L3)
+    14: NewForInIterator r1, r1
+    17: PopScope 
   .L0:
-    17: PushLexicalScope c0
-    19: LoadEmpty r2
-    21: StoreToScope r2, 0, 0
-    25: ForInNext r2, r1
-    28: JumpNullish r2, 48 (.L3)
-    31: StoreToScope r2, 0, 0
-    35: LoadImmediate r2, 2
-    38: JumpToBooleanFalse r2, 6 (.L1)
-    41: PopScope 
-    42: Jump 35 (.L4)
+    18: PushLexicalScope c0
+    20: LoadEmpty r2
+    22: StoreToScope r2, 0, 0
+    26: ForInNext r2, r1
+    29: JumpNullish r2, 48 (.L3)
+    32: StoreToScope r2, 0, 0
+    36: LoadImmediate r2, 2
+    39: JumpToBooleanFalse r2, 6 (.L1)
+    42: PopScope 
+    43: Jump 35 (.L4)
   .L1:
-    44: PushLexicalScope c1
-    46: LoadEmpty r2
-    48: StoreToScope r2, 0, 0
-    52: NewClosure r0, c2
-    55: LoadImmediate r2, 3
-    58: StoreToScope r2, 0, 0
-    62: LoadImmediate r2, 4
-    65: JumpToBooleanFalse r2, 7 (.L2)
-    68: PopScope 
+    45: PushLexicalScope c1
+    47: LoadEmpty r2
+    49: StoreToScope r2, 0, 0
+    53: NewClosure r0, c2
+    56: LoadImmediate r2, 3
+    59: StoreToScope r2, 0, 0
+    63: LoadImmediate r2, 4
+    66: JumpToBooleanFalse r2, 7 (.L2)
     69: PopScope 
-    70: Jump 7 (.L4)
+    70: PopScope 
+    71: Jump 7 (.L4)
   .L2:
-    72: PopScope 
     73: PopScope 
-    74: Jump -57 (.L0)
+    74: PopScope 
+    75: Jump -57 (.L0)
   .L3:
-    76: PopScope 
+    77: PopScope 
   .L4:
-    77: LoadUndefined r1
-    79: Ret r1
+    78: LoadUndefined r1
+    80: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]
@@ -157,41 +157,41 @@
 [BytecodeFunction: noForCaptureButInnerCaptureWithBreak] {
   Parameters: 0, Registers: 3
      0: PushFunctionScope c0
-     2: NewObject r1
-     4: JumpNullish r1, 72 (.L3)
-     7: NewForInIterator r1, r1
+     2: NewObject r1, 0
+     5: JumpNullish r1, 72 (.L3)
+     8: NewForInIterator r1, r1
   .L0:
-    10: ForInNext r2, r1
-    13: JumpNullish r2, 63 (.L3)
-    16: StoreToScope r2, 0, 0
-    20: PushLexicalScope c1
-    22: LoadEmpty r2
-    24: StoreToScope r2, 0, 0
-    28: LoadImmediate r2, 1
-    31: StoreToScope r2, 0, 0
-    35: LoadImmediate r2, 2
-    38: JumpToBooleanFalse r2, 6 (.L1)
-    41: PopScope 
-    42: Jump 34 (.L3)
+    11: ForInNext r2, r1
+    14: JumpNullish r2, 63 (.L3)
+    17: StoreToScope r2, 0, 0
+    21: PushLexicalScope c1
+    23: LoadEmpty r2
+    25: StoreToScope r2, 0, 0
+    29: LoadImmediate r2, 1
+    32: StoreToScope r2, 0, 0
+    36: LoadImmediate r2, 2
+    39: JumpToBooleanFalse r2, 6 (.L1)
+    42: PopScope 
+    43: Jump 34 (.L3)
   .L1:
-    44: PushLexicalScope c2
-    46: LoadEmpty r2
-    48: StoreToScope r2, 0, 0
-    52: NewClosure r0, c3
-    55: LoadImmediate r2, 3
-    58: StoreToScope r2, 0, 0
-    62: LoadImmediate r2, 4
-    65: JumpToBooleanFalse r2, 7 (.L2)
-    68: PopScope 
+    45: PushLexicalScope c2
+    47: LoadEmpty r2
+    49: StoreToScope r2, 0, 0
+    53: NewClosure r0, c3
+    56: LoadImmediate r2, 3
+    59: StoreToScope r2, 0, 0
+    63: LoadImmediate r2, 4
+    66: JumpToBooleanFalse r2, 7 (.L2)
     69: PopScope 
-    70: Jump 6 (.L3)
+    70: PopScope 
+    71: Jump 6 (.L3)
   .L2:
-    72: PopScope 
     73: PopScope 
-    74: Jump -64 (.L0)
+    74: PopScope 
+    75: Jump -64 (.L0)
   .L3:
-    76: LoadUndefined r1
-    78: Ret r1
+    77: LoadUndefined r1
+    79: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]
@@ -217,35 +217,35 @@
 [BytecodeFunction: noForCaptureOrInnerCaptureWithBreak] {
   Parameters: 0, Registers: 3
      0: PushFunctionScope c0
-     2: NewObject r1
-     4: JumpNullish r1, 61 (.L3)
-     7: NewForInIterator r1, r1
+     2: NewObject r1, 0
+     5: JumpNullish r1, 61 (.L3)
+     8: NewForInIterator r1, r1
   .L0:
-    10: ForInNext r2, r1
-    13: JumpNullish r2, 52 (.L3)
-    16: StoreToScope r2, 0, 0
-    20: LoadImmediate r2, 1
-    23: StoreToScope r2, 1, 0
-    27: LoadImmediate r2, 2
-    30: JumpToBooleanFalse r2, 5 (.L1)
-    33: Jump 32 (.L3)
+    11: ForInNext r2, r1
+    14: JumpNullish r2, 52 (.L3)
+    17: StoreToScope r2, 0, 0
+    21: LoadImmediate r2, 1
+    24: StoreToScope r2, 1, 0
+    28: LoadImmediate r2, 2
+    31: JumpToBooleanFalse r2, 5 (.L1)
+    34: Jump 32 (.L3)
   .L1:
-    35: PushLexicalScope c1
-    37: LoadEmpty r2
-    39: StoreToScope r2, 0, 0
-    43: NewClosure r0, c2
-    46: LoadImmediate r2, 3
-    49: StoreToScope r2, 0, 0
-    53: LoadImmediate r2, 4
-    56: JumpToBooleanFalse r2, 6 (.L2)
-    59: PopScope 
-    60: Jump 5 (.L3)
+    36: PushLexicalScope c1
+    38: LoadEmpty r2
+    40: StoreToScope r2, 0, 0
+    44: NewClosure r0, c2
+    47: LoadImmediate r2, 3
+    50: StoreToScope r2, 0, 0
+    54: LoadImmediate r2, 4
+    57: JumpToBooleanFalse r2, 6 (.L2)
+    60: PopScope 
+    61: Jump 5 (.L3)
   .L2:
-    62: PopScope 
-    63: Jump -53 (.L0)
+    63: PopScope 
+    64: Jump -53 (.L0)
   .L3:
-    65: LoadUndefined r1
-    67: Ret r1
+    66: LoadUndefined r1
+    68: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]

--- a/tests/snapshot/bytecode/scope/for_in_continue.exp
+++ b/tests/snapshot/bytecode/scope/for_in_continue.exp
@@ -26,49 +26,49 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 0, 0
-     8: NewObject r1
-    10: JumpNullish r1, 84 (.L3)
-    13: NewForInIterator r1, r1
-    16: PopScope 
+     8: NewObject r1, 0
+    11: JumpNullish r1, 84 (.L3)
+    14: NewForInIterator r1, r1
+    17: PopScope 
   .L0:
-    17: PushLexicalScope c0
-    19: LoadEmpty r2
-    21: StoreToScope r2, 0, 0
-    25: ForInNext r2, r1
-    28: JumpNullish r2, 66 (.L3)
-    31: StoreToScope r2, 0, 0
-    35: PushLexicalScope c1
-    37: LoadEmpty r2
-    39: StoreToScope r2, 0, 0
-    43: LoadImmediate r2, 1
-    46: StoreToScope r2, 0, 0
-    50: LoadImmediate r2, 2
-    53: JumpToBooleanFalse r2, 7 (.L1)
-    56: PopScope 
+    18: PushLexicalScope c0
+    20: LoadEmpty r2
+    22: StoreToScope r2, 0, 0
+    26: ForInNext r2, r1
+    29: JumpNullish r2, 66 (.L3)
+    32: StoreToScope r2, 0, 0
+    36: PushLexicalScope c1
+    38: LoadEmpty r2
+    40: StoreToScope r2, 0, 0
+    44: LoadImmediate r2, 1
+    47: StoreToScope r2, 0, 0
+    51: LoadImmediate r2, 2
+    54: JumpToBooleanFalse r2, 7 (.L1)
     57: PopScope 
-    58: Jump -41 (.L0)
+    58: PopScope 
+    59: Jump -41 (.L0)
   .L1:
-    60: PushLexicalScope c2
-    62: LoadEmpty r2
-    64: StoreToScope r2, 0, 0
-    68: NewClosure r0, c3
-    71: LoadImmediate r2, 3
-    74: StoreToScope r2, 0, 0
-    78: LoadImmediate r2, 4
-    81: JumpToBooleanFalse r2, 8 (.L2)
-    84: PopScope 
+    61: PushLexicalScope c2
+    63: LoadEmpty r2
+    65: StoreToScope r2, 0, 0
+    69: NewClosure r0, c3
+    72: LoadImmediate r2, 3
+    75: StoreToScope r2, 0, 0
+    79: LoadImmediate r2, 4
+    82: JumpToBooleanFalse r2, 8 (.L2)
     85: PopScope 
     86: PopScope 
-    87: Jump -70 (.L0)
+    87: PopScope 
+    88: Jump -70 (.L0)
   .L2:
-    89: PopScope 
     90: PopScope 
     91: PopScope 
-    92: Jump -75 (.L0)
+    92: PopScope 
+    93: Jump -75 (.L0)
   .L3:
-    94: PopScope 
-    95: LoadUndefined r1
-    97: Ret r1
+    95: PopScope 
+    96: LoadUndefined r1
+    98: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]
@@ -98,41 +98,41 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 0, 0
-     8: NewObject r1
-    10: JumpNullish r1, 66 (.L3)
-    13: NewForInIterator r1, r1
-    16: PopScope 
+     8: NewObject r1, 0
+    11: JumpNullish r1, 66 (.L3)
+    14: NewForInIterator r1, r1
+    17: PopScope 
   .L0:
-    17: PushLexicalScope c0
-    19: LoadEmpty r2
-    21: StoreToScope r2, 0, 0
-    25: ForInNext r2, r1
-    28: JumpNullish r2, 48 (.L3)
-    31: StoreToScope r2, 0, 0
-    35: LoadImmediate r2, 2
-    38: JumpToBooleanFalse r2, 6 (.L1)
-    41: PopScope 
-    42: Jump -25 (.L0)
+    18: PushLexicalScope c0
+    20: LoadEmpty r2
+    22: StoreToScope r2, 0, 0
+    26: ForInNext r2, r1
+    29: JumpNullish r2, 48 (.L3)
+    32: StoreToScope r2, 0, 0
+    36: LoadImmediate r2, 2
+    39: JumpToBooleanFalse r2, 6 (.L1)
+    42: PopScope 
+    43: Jump -25 (.L0)
   .L1:
-    44: PushLexicalScope c1
-    46: LoadEmpty r2
-    48: StoreToScope r2, 0, 0
-    52: NewClosure r0, c2
-    55: LoadImmediate r2, 3
-    58: StoreToScope r2, 0, 0
-    62: LoadImmediate r2, 4
-    65: JumpToBooleanFalse r2, 7 (.L2)
-    68: PopScope 
+    45: PushLexicalScope c1
+    47: LoadEmpty r2
+    49: StoreToScope r2, 0, 0
+    53: NewClosure r0, c2
+    56: LoadImmediate r2, 3
+    59: StoreToScope r2, 0, 0
+    63: LoadImmediate r2, 4
+    66: JumpToBooleanFalse r2, 7 (.L2)
     69: PopScope 
-    70: Jump -53 (.L0)
+    70: PopScope 
+    71: Jump -53 (.L0)
   .L2:
-    72: PopScope 
     73: PopScope 
-    74: Jump -57 (.L0)
+    74: PopScope 
+    75: Jump -57 (.L0)
   .L3:
-    76: PopScope 
-    77: LoadUndefined r1
-    79: Ret r1
+    77: PopScope 
+    78: LoadUndefined r1
+    80: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]
@@ -155,41 +155,41 @@
 [BytecodeFunction: noForCaptureButInnerCaptureWithContinue] {
   Parameters: 0, Registers: 3
      0: PushFunctionScope c0
-     2: NewObject r1
-     4: JumpNullish r1, 72 (.L3)
-     7: NewForInIterator r1, r1
+     2: NewObject r1, 0
+     5: JumpNullish r1, 72 (.L3)
+     8: NewForInIterator r1, r1
   .L0:
-    10: ForInNext r2, r1
-    13: JumpNullish r2, 63 (.L3)
-    16: StoreToScope r2, 0, 0
-    20: PushLexicalScope c1
-    22: LoadEmpty r2
-    24: StoreToScope r2, 0, 0
-    28: LoadImmediate r2, 1
-    31: StoreToScope r2, 0, 0
-    35: LoadImmediate r2, 2
-    38: JumpToBooleanFalse r2, 6 (.L1)
-    41: PopScope 
-    42: Jump -32 (.L0)
+    11: ForInNext r2, r1
+    14: JumpNullish r2, 63 (.L3)
+    17: StoreToScope r2, 0, 0
+    21: PushLexicalScope c1
+    23: LoadEmpty r2
+    25: StoreToScope r2, 0, 0
+    29: LoadImmediate r2, 1
+    32: StoreToScope r2, 0, 0
+    36: LoadImmediate r2, 2
+    39: JumpToBooleanFalse r2, 6 (.L1)
+    42: PopScope 
+    43: Jump -32 (.L0)
   .L1:
-    44: PushLexicalScope c2
-    46: LoadEmpty r2
-    48: StoreToScope r2, 0, 0
-    52: NewClosure r0, c3
-    55: LoadImmediate r2, 3
-    58: StoreToScope r2, 0, 0
-    62: LoadImmediate r2, 4
-    65: JumpToBooleanFalse r2, 7 (.L2)
-    68: PopScope 
+    45: PushLexicalScope c2
+    47: LoadEmpty r2
+    49: StoreToScope r2, 0, 0
+    53: NewClosure r0, c3
+    56: LoadImmediate r2, 3
+    59: StoreToScope r2, 0, 0
+    63: LoadImmediate r2, 4
+    66: JumpToBooleanFalse r2, 7 (.L2)
     69: PopScope 
-    70: Jump -60 (.L0)
+    70: PopScope 
+    71: Jump -60 (.L0)
   .L2:
-    72: PopScope 
     73: PopScope 
-    74: Jump -64 (.L0)
+    74: PopScope 
+    75: Jump -64 (.L0)
   .L3:
-    76: LoadUndefined r1
-    78: Ret r1
+    77: LoadUndefined r1
+    79: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]
@@ -215,35 +215,35 @@
 [BytecodeFunction: noForCaptureOrInnerCaptureWithContinue] {
   Parameters: 0, Registers: 3
      0: PushFunctionScope c0
-     2: NewObject r1
-     4: JumpNullish r1, 61 (.L3)
-     7: NewForInIterator r1, r1
+     2: NewObject r1, 0
+     5: JumpNullish r1, 61 (.L3)
+     8: NewForInIterator r1, r1
   .L0:
-    10: ForInNext r2, r1
-    13: JumpNullish r2, 52 (.L3)
-    16: StoreToScope r2, 0, 0
-    20: LoadImmediate r2, 1
-    23: StoreToScope r2, 1, 0
-    27: LoadImmediate r2, 2
-    30: JumpToBooleanFalse r2, 5 (.L1)
-    33: Jump -23 (.L0)
+    11: ForInNext r2, r1
+    14: JumpNullish r2, 52 (.L3)
+    17: StoreToScope r2, 0, 0
+    21: LoadImmediate r2, 1
+    24: StoreToScope r2, 1, 0
+    28: LoadImmediate r2, 2
+    31: JumpToBooleanFalse r2, 5 (.L1)
+    34: Jump -23 (.L0)
   .L1:
-    35: PushLexicalScope c1
-    37: LoadEmpty r2
-    39: StoreToScope r2, 0, 0
-    43: NewClosure r0, c2
-    46: LoadImmediate r2, 3
-    49: StoreToScope r2, 0, 0
-    53: LoadImmediate r2, 4
-    56: JumpToBooleanFalse r2, 6 (.L2)
-    59: PopScope 
-    60: Jump -50 (.L0)
+    36: PushLexicalScope c1
+    38: LoadEmpty r2
+    40: StoreToScope r2, 0, 0
+    44: NewClosure r0, c2
+    47: LoadImmediate r2, 3
+    50: StoreToScope r2, 0, 0
+    54: LoadImmediate r2, 4
+    57: JumpToBooleanFalse r2, 6 (.L2)
+    60: PopScope 
+    61: Jump -50 (.L0)
   .L2:
-    62: PopScope 
-    63: Jump -53 (.L0)
+    63: PopScope 
+    64: Jump -53 (.L0)
   .L3:
-    65: LoadUndefined r1
-    67: Ret r1
+    66: LoadUndefined r1
+    68: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]

--- a/tests/snapshot/bytecode/statement/for_in.exp
+++ b/tests/snapshot/bytecode/statement/for_in.exp
@@ -36,120 +36,120 @@
 [BytecodeFunction: basicVar] {
   Parameters: 0, Registers: 3
      0: LoadImmediate r1, 1
-     3: NewObject r1
-     5: JumpNullish r1, 20 (.L1)
-     8: NewForInIterator r1, r1
+     3: NewObject r1, 0
+     6: JumpNullish r1, 20 (.L1)
+     9: NewForInIterator r1, r1
   .L0:
-    11: ForInNext r2, r1
-    14: JumpNullish r2, 11 (.L1)
-    17: Mov r0, r2
-    20: LoadImmediate r2, 2
-    23: Jump -12 (.L0)
+    12: ForInNext r2, r1
+    15: JumpNullish r2, 11 (.L1)
+    18: Mov r0, r2
+    21: LoadImmediate r2, 2
+    24: Jump -12 (.L0)
   .L1:
-    25: LoadImmediate r1, 3
-    28: LoadUndefined r1
-    30: Ret r1
+    26: LoadImmediate r1, 3
+    29: LoadUndefined r1
+    31: Ret r1
 }
 
 [BytecodeFunction: basicConstLet] {
   Parameters: 0, Registers: 4
      0: LoadImmediate r2, 1
-     3: NewObject r2
-     5: JumpNullish r2, 20 (.L1)
-     8: NewForInIterator r2, r2
+     3: NewObject r2, 0
+     6: JumpNullish r2, 20 (.L1)
+     9: NewForInIterator r2, r2
   .L0:
-    11: ForInNext r3, r2
-    14: JumpNullish r3, 11 (.L1)
-    17: Mov r1, r3
-    20: LoadImmediate r3, 2
-    23: Jump -12 (.L0)
+    12: ForInNext r3, r2
+    15: JumpNullish r3, 11 (.L1)
+    18: Mov r1, r3
+    21: LoadImmediate r3, 2
+    24: Jump -12 (.L0)
   .L1:
-    25: LoadImmediate r2, 3
-    28: NewObject r2
-    30: JumpNullish r2, 20 (.L3)
-    33: NewForInIterator r2, r2
+    26: LoadImmediate r2, 3
+    29: NewObject r2, 0
+    32: JumpNullish r2, 20 (.L3)
+    35: NewForInIterator r2, r2
   .L2:
-    36: ForInNext r3, r2
-    39: JumpNullish r3, 11 (.L3)
-    42: Mov r0, r3
-    45: LoadImmediate r3, 3
-    48: Jump -12 (.L2)
+    38: ForInNext r3, r2
+    41: JumpNullish r3, 11 (.L3)
+    44: Mov r0, r3
+    47: LoadImmediate r3, 3
+    50: Jump -12 (.L2)
   .L3:
-    50: LoadImmediate r2, 4
-    53: LoadUndefined r2
-    55: Ret r2
+    52: LoadImmediate r2, 4
+    55: LoadUndefined r2
+    57: Ret r2
 }
 
 [BytecodeFunction: testBreakAndContinue] {
   Parameters: 0, Registers: 3
      0: LoadImmediate r1, 1
-     3: NewObject r1
-     5: JumpNullish r1, 33 (.L3)
-     8: NewForInIterator r1, r1
+     3: NewObject r1, 0
+     6: JumpNullish r1, 33 (.L3)
+     9: NewForInIterator r1, r1
   .L0:
-    11: ForInNext r2, r1
-    14: JumpNullish r2, 24 (.L3)
-    17: Mov r0, r2
-    20: LoadImmediate r2, 2
-    23: JumpToBooleanFalse r2, 5 (.L1)
-    26: Jump 12 (.L3)
+    12: ForInNext r2, r1
+    15: JumpNullish r2, 24 (.L3)
+    18: Mov r0, r2
+    21: LoadImmediate r2, 2
+    24: JumpToBooleanFalse r2, 5 (.L1)
+    27: Jump 12 (.L3)
   .L1:
-    28: LoadImmediate r2, 3
-    31: JumpToBooleanFalse r2, 5 (.L2)
-    34: Jump -23 (.L0)
+    29: LoadImmediate r2, 3
+    32: JumpToBooleanFalse r2, 5 (.L2)
+    35: Jump -23 (.L0)
   .L2:
-    36: Jump -25 (.L0)
+    37: Jump -25 (.L0)
   .L3:
-    38: LoadImmediate r1, 4
-    41: LoadUndefined r1
-    43: Ret r1
+    39: LoadImmediate r1, 4
+    42: LoadUndefined r1
+    44: Ret r1
 }
 
 [BytecodeFunction: lhsIdentifier] {
   Parameters: 1, Registers: 2
      0: LoadImmediate r0, 1
-     3: NewObject r0
-     5: JumpNullish r0, 17 (.L1)
-     8: NewForInIterator r0, r0
+     3: NewObject r0, 0
+     6: JumpNullish r0, 17 (.L1)
+     9: NewForInIterator r0, r0
   .L0:
-    11: ForInNext r1, r0
-    14: JumpNullish r1, 8 (.L1)
-    17: Mov a0, r1
-    20: Jump -9 (.L0)
+    12: ForInNext r1, r0
+    15: JumpNullish r1, 8 (.L1)
+    18: Mov a0, r1
+    21: Jump -9 (.L0)
   .L1:
-    22: LoadImmediate r0, 2
-    25: LoadUndefined r0
-    27: Ret r0
+    23: LoadImmediate r0, 2
+    26: LoadUndefined r0
+    28: Ret r0
 }
 
 [BytecodeFunction: lhsMember] {
   Parameters: 1, Registers: 3
      0: LoadImmediate r0, 1
-     3: NewObject r0
-     5: JumpNullish r0, 22 (.L1)
-     8: NewForInIterator r0, r0
+     3: NewObject r0, 0
+     6: JumpNullish r0, 22 (.L1)
+     9: NewForInIterator r0, r0
   .L0:
-    11: ForInNext r1, r0
-    14: JumpNullish r1, 13 (.L1)
-    17: SetNamedProperty a0, c0, r1, k0
-    22: LoadImmediate r1, 2
-    25: Jump -14 (.L0)
+    12: ForInNext r1, r0
+    15: JumpNullish r1, 13 (.L1)
+    18: SetNamedProperty a0, c0, r1, k0
+    23: LoadImmediate r1, 2
+    26: Jump -14 (.L0)
   .L1:
-    27: LoadImmediate r0, 3
-    30: NewObject r0
-    32: JumpNullish r0, 24 (.L3)
-    35: NewForInIterator r0, r0
+    28: LoadImmediate r0, 3
+    31: NewObject r0, 0
+    34: JumpNullish r0, 24 (.L3)
+    37: NewForInIterator r0, r0
   .L2:
-    38: ForInNext r1, r0
-    41: JumpNullish r1, 15 (.L3)
-    44: LoadImmediate r2, 1
-    47: SetProperty a0, r2, r1
-    51: LoadImmediate r1, 4
-    54: Jump -16 (.L2)
+    40: ForInNext r1, r0
+    43: JumpNullish r1, 15 (.L3)
+    46: LoadImmediate r2, 1
+    49: SetProperty a0, r2, r1
+    53: LoadImmediate r1, 4
+    56: Jump -16 (.L2)
   .L3:
-    56: LoadImmediate r0, 5
-    59: LoadUndefined r0
-    61: Ret r0
+    58: LoadImmediate r0, 5
+    61: LoadUndefined r0
+    63: Ret r0
   Constant Table:
     0: [String: foo]
 }
@@ -157,42 +157,42 @@
 [BytecodeFunction: lhsDestructuring] {
   Parameters: 1, Registers: 6
      0: LoadImmediate r3, 1
-     3: NewObject r3
-     5: JumpNullish r3, 41 (.L2)
-     8: NewForInIterator r3, r3
+     3: NewObject r3, 0
+     6: JumpNullish r3, 41 (.L2)
+     9: NewForInIterator r3, r3
   .L0:
-    11: ForInNext r4, r3
-    14: JumpNullish r4, 32 (.L2)
-    17: GetNamedProperty r0, r4, c0, k0
-    22: GetNamedProperty r1, r4, c1, k1
-    27: GetNamedProperty r5, r4, c2, k2
-    32: JumpNotUndefined r5, 6 (.L1)
-    35: LoadImmediate r5, 1
+    12: ForInNext r4, r3
+    15: JumpNullish r4, 32 (.L2)
+    18: GetNamedProperty r0, r4, c0, k0
+    23: GetNamedProperty r1, r4, c1, k1
+    28: GetNamedProperty r5, r4, c2, k2
+    33: JumpNotUndefined r5, 6 (.L1)
+    36: LoadImmediate r5, 1
   .L1:
-    38: Mov r2, r5
-    41: LoadImmediate r4, 2
-    44: Jump -33 (.L0)
+    39: Mov r2, r5
+    42: LoadImmediate r4, 2
+    45: Jump -33 (.L0)
   .L2:
-    46: LoadImmediate r3, 3
-    49: NewObject r3
-    51: JumpNullish r3, 41 (.L5)
-    54: NewForInIterator r3, r3
+    47: LoadImmediate r3, 3
+    50: NewObject r3, 0
+    53: JumpNullish r3, 41 (.L5)
+    56: NewForInIterator r3, r3
   .L3:
-    57: ForInNext r4, r3
-    60: JumpNullish r4, 32 (.L5)
-    63: GetNamedProperty r0, r4, c0, k3
-    68: GetNamedProperty r1, r4, c1, k4
-    73: GetNamedProperty r5, r4, c2, k5
-    78: JumpNotUndefined r5, 6 (.L4)
-    81: LoadImmediate r5, 1
+    59: ForInNext r4, r3
+    62: JumpNullish r4, 32 (.L5)
+    65: GetNamedProperty r0, r4, c0, k3
+    70: GetNamedProperty r1, r4, c1, k4
+    75: GetNamedProperty r5, r4, c2, k5
+    80: JumpNotUndefined r5, 6 (.L4)
+    83: LoadImmediate r5, 1
   .L4:
-    84: Mov r2, r5
-    87: LoadImmediate r4, 4
-    90: Jump -33 (.L3)
+    86: Mov r2, r5
+    89: LoadImmediate r4, 4
+    92: Jump -33 (.L3)
   .L5:
-    92: LoadImmediate r3, 5
-    95: LoadUndefined r3
-    97: Ret r3
+    94: LoadImmediate r3, 5
+    97: LoadUndefined r3
+    99: Ret r3
   Constant Table:
     0: [String: a]
     1: [String: b]
@@ -207,38 +207,38 @@
      8: PushLexicalScope c1
     10: LoadEmpty r2
     12: StoreToScope r2, 0, 0
-    16: NewObject r2
-    18: JumpNullish r2, 31 (.L1)
-    21: NewForInIterator r2, r2
-    24: PopScope 
+    16: NewObject r2, 0
+    19: JumpNullish r2, 31 (.L1)
+    22: NewForInIterator r2, r2
+    25: PopScope 
   .L0:
-    25: PushLexicalScope c1
-    27: LoadEmpty r3
-    29: StoreToScope r3, 0, 0
-    33: ForInNext r3, r2
-    36: JumpNullish r3, 13 (.L1)
-    39: StoreToScope r3, 0, 0
-    43: NewClosure r1, c2
-    46: PopScope 
-    47: Jump -22 (.L0)
+    26: PushLexicalScope c1
+    28: LoadEmpty r3
+    30: StoreToScope r3, 0, 0
+    34: ForInNext r3, r2
+    37: JumpNullish r3, 13 (.L1)
+    40: StoreToScope r3, 0, 0
+    44: NewClosure r1, c2
+    47: PopScope 
+    48: Jump -22 (.L0)
   .L1:
-    49: PopScope 
-    50: LoadImmediate r2, 1
-    53: StoreToScope r2, 0, 0
-    57: NewObject r2
-    59: JumpNullish r2, 28 (.L3)
-    62: NewForInIterator r2, r2
+    50: PopScope 
+    51: LoadImmediate r2, 1
+    54: StoreToScope r2, 0, 0
+    58: NewObject r2, 0
+    61: JumpNullish r2, 28 (.L3)
+    64: NewForInIterator r2, r2
   .L2:
-    65: ForInNext r3, r2
-    68: JumpNullish r3, 19 (.L3)
-    71: LoadFromScope r4, 0, 0
-    75: CheckTdz r4, c3
-    78: StoreToScope r3, 0, 0
-    82: NewClosure r0, c4
-    85: Jump -20 (.L2)
+    67: ForInNext r3, r2
+    70: JumpNullish r3, 19 (.L3)
+    73: LoadFromScope r4, 0, 0
+    77: CheckTdz r4, c3
+    80: StoreToScope r3, 0, 0
+    84: NewClosure r0, c4
+    87: Jump -20 (.L2)
   .L3:
-    87: LoadUndefined r2
-    89: Ret r2
+    89: LoadUndefined r2
+    91: Ret r2
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]


### PR DESCRIPTION
## Summary

Estimate the number of properties in object literals and constructors during bytecode generation.

Object literals have the estimate baked directly into the resulting `NewObject` instruction. Assume that all keys are distinct.

Constructors are more involved. Track all assignments to a property of `this` as well as all fields (if this is a class constructor). Use these to store an estimate on each `BytecodeFunction` for the number of properties needed if the function is called as a constructor.

Not yet used, but will soon be used to allocate inline properties.

## Tests

- CI, no behavior has changed yet
- Added bytecode snapshot tests for the property estimate provided to the `NewObject` instruction
- Updated all bytecode snapshot tests that use `NewObject` to include the new property estimate