### PR TITLE
[runtime] Class field initializer stored in scope, fix super calls in eval

### DIFF
--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -89,8 +89,6 @@ struct FunctionStackEntry {
     is_derived_constructor: bool,
     is_static_initializer: bool,
     is_class_field_initializer: bool,
-    /// Whether this function represents the top level of an eval script.
-    is_eval_toplevel: bool,
 }
 
 enum AllowSuperStackEntry {
@@ -468,7 +466,7 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
             self.current_function(),
             Some(FunctionStackEntry { is_derived_constructor: true, .. })
         ) {
-            self.resolve_this_use(stmt.loc, |scope| stmt.this_scope = Some(scope));
+            self.resolve_this_use(stmt.loc, |scope| stmt.this_scope = scope);
         }
 
         default_visit_return_statement(self, stmt);
@@ -759,7 +757,7 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
                 expr.home_object_scope = def_scope;
 
                 // Also resolve `this` which may be used by the super member expression
-                self.resolve_this_use(expr.loc, |scope| expr.this_scope = Some(scope));
+                self.resolve_this_use(expr.loc, |scope| expr.this_scope = scope);
             }
             _ => self.emit_error(expr.loc, ParseError::SuperPropertyOutsideMethod),
         }
@@ -799,7 +797,7 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
     }
 
     fn visit_this_expression(&mut self, this: &mut ThisExpression<'a>) {
-        self.resolve_this_use(this.loc, |scope| this.scope = Some(scope));
+        self.resolve_this_use(this.loc, |scope| this.scope = scope);
     }
 
     fn visit_call_expression(&mut self, expr: &mut CallExpression<'a>) {
@@ -892,8 +890,10 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
         let private_names = self.collect_class_private_names(class);
         let num_private_names = private_names.len();
 
+        let is_derived = class.super_class.is_some();
+
         self.class_stack
-            .push(ClassStackEntry { private_names, is_derived: class.super_class.is_some() });
+            .push(ClassStackEntry { private_names, is_derived });
 
         // Mark the constructor if it is found, erroring if multiple are found
         let mut constructor = None;
@@ -1073,7 +1073,6 @@ impl<'a> Analyzer<'a> {
             is_derived_constructor,
             is_static_initializer,
             is_class_field_initializer: false,
-            is_eval_toplevel: false,
         });
 
         // Return is not allowed in static initializers, but is allowed in all other functions
@@ -1471,7 +1470,6 @@ impl<'a> Analyzer<'a> {
             is_derived_constructor: false,
             is_static_initializer: false,
             is_class_field_initializer: true,
-            is_eval_toplevel: false,
         });
 
         visit_opt!(self, prop.value, visit_outer_expression);
@@ -1681,34 +1679,20 @@ impl<'a> Analyzer<'a> {
         self.resolve_use(&mut id.scope, id.name, id.loc);
     }
 
-    fn resolve_this_use(&mut self, loc: Loc, mut set_scope: impl FnMut(AstPtr<AstScopeNode<'a>>)) {
+    fn resolve_this_use(&mut self, loc: Loc, mut set_scope: impl FnMut(TaggedResolvedScope<'a>)) {
         let current_scope = self.scope_stack.last().unwrap().as_ref().id();
         let (def_scope, is_capture) = self.scope_tree.resolve_use(current_scope, &THIS_NAME, loc);
 
         // Only set scope if this is a capture of a `this` binding or if `this` is for a derived
-        // constructor. Otherwise `this` does not need to resolve to a materialized binding.
-        let enclosing_non_arrow_function = self.enclosing_non_arrow_function();
+        // constructor. Otherwise `this` does not need to resolve to a materialized binding or will
+        // be looked up dynamically.
         let is_derived_constructor_this = matches!(
-            enclosing_non_arrow_function,
+            self.enclosing_non_arrow_function(),
             Some(FunctionStackEntry { is_derived_constructor: true, .. })
         );
 
-        if is_derived_constructor_this {
-            let scope = def_scope.unwrap_resolved();
-            let binding = scope.get_binding(&THIS_NAME);
-            let implicit_this = binding.kind().as_implicit_this().unwrap();
-
-            implicit_this.set_in_derived_constructor(true);
-
-            let is_eval_toplevel = matches!(
-                enclosing_non_arrow_function,
-                Some(FunctionStackEntry { is_eval_toplevel: true, .. })
-            );
-            implicit_this.set_in_derived_constructor_eval_toplevel(is_eval_toplevel);
-        }
-
         if is_capture || is_derived_constructor_this {
-            set_scope(AstPtr::from_ref(def_scope.unwrap_resolved()));
+            set_scope(def_scope);
         }
     }
 
@@ -1767,7 +1751,6 @@ pub fn analyze_for_eval<'a>(
     // If in function add a synthetic function entry
     if in_function {
         analyzer.function_stack.push(FunctionStackEntry {
-            is_eval_toplevel: true,
             is_arrow_function: false,
             is_method: in_method,
             is_static: in_static,

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -927,12 +927,16 @@ pub struct ReturnStatement<'a> {
     /// Reference to the scope that contains the binding for `this`. Similar to the scope in the
     /// `ThisExpression` node, but only set if this return is in a derived constructor (meaning the
     /// derived constructor's `this` may be implicitly returned).
-    pub this_scope: Option<AstPtr<AstScopeNode<'a>>>,
+    pub this_scope: TaggedResolvedScope<'a>,
 }
 
 impl<'a> ReturnStatement<'a> {
     pub fn new(loc: Loc, argument: Option<OuterExpression<'a>>) -> ReturnStatement<'a> {
-        ReturnStatement { loc, argument, this_scope: None }
+        ReturnStatement {
+            loc,
+            argument,
+            this_scope: TaggedResolvedScope::unresolved_global(),
+        }
     }
 }
 
@@ -1405,11 +1409,19 @@ pub enum PropertyKind<'a> {
 pub struct ThisExpression<'a> {
     pub loc: Loc,
     /// Reference to the scope that contains the binding for `this`, which may be a parent scope if
-    /// `this` is captured by an arrow function.
+    /// `this` is captured by an arrow function. Tagged as unresolved dynamic at the toplevel of a
+    /// direct eval in a derived constructor, where `this` must be looked up dynamically.
     ///
-    /// Starts out uninitialized during parsing and is set during analysis. Only set if resolved to
-    /// a captured `this` binding, or if referring to `this` of a derived constructor.
-    pub scope: Option<AstPtr<AstScopeNode<'a>>>,
+    /// Starts out unresolved during parsing and is set during analysis. Only set if resolved to
+    /// a captured `this` binding, or if referring to `this` of a derived constructor. Otherwise
+    /// remains unresolved global, meaning the current function's `this` is used directly.
+    pub scope: TaggedResolvedScope<'a>,
+}
+
+impl<'a> ThisExpression<'a> {
+    pub fn new(loc: Loc) -> ThisExpression<'a> {
+        ThisExpression { loc, scope: TaggedResolvedScope::unresolved_global() }
+    }
 }
 
 pub struct AwaitExpression<'a> {
@@ -1434,7 +1446,7 @@ pub struct SuperMemberExpression<'a> {
 
     /// Reference to the scope that contains the binding for `this`. Treated the same as the scope
     /// in the `ThisExpression` node.
-    pub this_scope: Option<AstPtr<AstScopeNode<'a>>>,
+    pub this_scope: TaggedResolvedScope<'a>,
 
     /// Reference to the scope that contains the binding for the home object referenced by this
     /// super expression, or tagged as unresolved dynamic if the scope could not be statically
@@ -1459,7 +1471,7 @@ impl<'a> SuperMemberExpression<'a> {
             property,
             is_computed,
             is_static: false,
-            this_scope: None,
+            this_scope: TaggedResolvedScope::unresolved_global(),
             home_object_scope: TaggedResolvedScope::unresolved_global(),
             operator_pos,
         }
@@ -1487,9 +1499,10 @@ pub struct SuperCallExpression<'a> {
     /// as unresolved dynamic if the scope could not be statically determined.
     pub new_target_scope: TaggedResolvedScope<'a>,
 
-    /// Reference to the scope that contains the binding for `this`. Similar to the scope in the
-    /// `ThisExpression` node, but is always set since it refers to a derived constructor's `this`.
-    pub this_scope: AstPtr<AstScopeNode<'a>>,
+    /// Reference to the scope that contains the binding for `this` of the containing derived
+    /// constructor. Similar to the scope in the `ThisExpression` node but is always either resolved
+    /// or tagged as unresolved dynamic.
+    pub this_scope: TaggedResolvedScope<'a>,
 }
 
 impl<'a> SuperCallExpression<'a> {
@@ -1500,7 +1513,7 @@ impl<'a> SuperCallExpression<'a> {
             arguments,
             constructor_scope: TaggedResolvedScope::unresolved_global(),
             new_target_scope: TaggedResolvedScope::unresolved_global(),
-            this_scope: AstPtr::uninit(),
+            this_scope: TaggedResolvedScope::unresolved_global(),
         }
     }
 }

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -945,13 +945,7 @@ impl<'a> Parser<'a> {
         // All non-arrow functions have a `this`, which should be treated as a var-scoped binding
         // when determining if it is captured by an arrow function.
         if !is_arrow {
-            let kind = BindingKind::new_implicit_this();
-
-            // Mark `this` bindings in derived constructors
-            kind.as_implicit_this()
-                .unwrap()
-                .set_in_derived_constructor(is_derived_constructor);
-
+            let kind = BindingKind::new_implicit_this(is_derived_constructor);
             self.scope_builder.add_binding(&THIS_NAME, kind).unwrap();
         }
 
@@ -2791,7 +2785,7 @@ impl<'a> Parser<'a> {
             Token::This => {
                 let loc = self.loc;
                 self.advance()?;
-                Ok(Expression::This(p!(self, ThisExpression { loc, scope: None })))
+                Ok(Expression::This(p!(self, ThisExpression::new(loc))))
             }
             Token::LeftParen => {
                 self.advance()?;
@@ -5088,12 +5082,13 @@ pub fn parse_script_for_eval(
     options: Rc<Options>,
     is_direct: bool,
     inherit_strict_mode: bool,
+    in_derived_constructor: bool,
 ) -> ParseResult<ParseProgramResult<'_>> {
     // Create and prime parser
     let alloc = pcx.alloc();
     let lexer = Lexer::new(pcx.source(), &options, alloc);
-    let mut parser =
-        Parser::new(lexer, ScopeTree::new_eval(options.clone(), is_direct, alloc), options, alloc);
+    let scope_tree = ScopeTree::new_eval(options.clone(), is_direct, in_derived_constructor, alloc);
+    let mut parser = Parser::new(lexer, scope_tree, options, alloc);
 
     // Inherit strict mode from context
     parser.set_in_strict_mode(inherit_strict_mode);

--- a/src/js/parser/scope_tree.rs
+++ b/src/js/parser/scope_tree.rs
@@ -49,25 +49,49 @@ impl<'a> ScopeTree<'a> {
         // Push the global scope node
         scope_tree.push_new_ast_scope_node(INITIAL_SCOPE_ID, kind, None);
 
-        // All root scopes start with an implicit `this` binding
-        scope_tree
-            .add_binding(&THIS_NAME, BindingKind::new_implicit_this())
-            .unwrap();
-
         scope_tree
     }
 
     pub fn new_global(options: Rc<Options>, alloc: AstAlloc<'a>) -> ScopeTree<'a> {
-        Self::new_with_root(options, ScopeNodeKind::Global, alloc)
+        let mut scope_tree = Self::new_with_root(options, ScopeNodeKind::Global, alloc);
+        scope_tree.add_implicit_this_binding();
+        scope_tree
     }
 
     pub fn new_module(options: Rc<Options>, alloc: AstAlloc<'a>) -> ScopeTree<'a> {
-        Self::new_with_root(options, ScopeNodeKind::Module, alloc)
+        let mut scope_tree = Self::new_with_root(options, ScopeNodeKind::Module, alloc);
+        scope_tree.add_implicit_this_binding();
+        scope_tree
     }
 
-    pub fn new_eval(options: Rc<Options>, is_direct: bool, alloc: AstAlloc<'a>) -> ScopeTree<'a> {
-        // Start off without setting the strict flag. This flag will be right away during parsing.
-        Self::new_with_root(options, ScopeNodeKind::Eval { is_direct, is_strict: false }, alloc)
+    pub fn new_eval(
+        options: Rc<Options>,
+        is_direct: bool,
+        in_derived_constructor: bool,
+        alloc: AstAlloc<'a>,
+    ) -> ScopeTree<'a> {
+        // Start off without setting the strict flag. This flag will be set right away during parsing.
+        let mut scope_tree = Self::new_with_root(
+            options,
+            ScopeNodeKind::Eval { is_direct, is_strict: false },
+            alloc,
+        );
+
+        // Direct eval in derived constructor has no `this` binding so that `this` is resolved to a
+        // dynamic lookup.
+        if !in_derived_constructor {
+            scope_tree.add_implicit_this_binding();
+        }
+
+        scope_tree
+    }
+
+    fn add_implicit_this_binding(&mut self) {
+        self.add_binding(
+            &THIS_NAME,
+            BindingKind::new_implicit_this(/* in_derived_constructor */ false),
+        )
+        .unwrap();
     }
 
     pub fn finish_ast_scope_tree(mut self) -> ScopeTree<'a> {
@@ -410,9 +434,9 @@ impl<'a> ScopeTree<'a> {
                         }
                     }
 
-                    // Home object bindings and class names in the scope body must always be stored
-                    // in a VM scope. Do not need to set this flag in other case since binding will
-                    // have been captured.
+                    // Home object bindings, class names in the scope body, and fields initializers
+                    // must always be stored in a VM scope. Do not need to set this flag in other
+                    // cases since binding will have been captured.
                     if matches!(
                         binding.kind(),
                         BindingKind::Class { in_body_scope: true, .. } | BindingKind::HomeObject
@@ -1041,7 +1065,10 @@ pub enum BindingKind<'a> {
         is_namespace: bool,
     },
     /// An implicit `this` binding introduced in a function or root scope.
-    ImplicitThis(ImplicitThisBinding),
+    ImplicitThis {
+        /// Whether this is the `this` value for a derived constructor.
+        in_derived_constructor: bool,
+    },
     /// An implicit `arguments` binding introduced in a function. Note that any var or var function
     /// is treated as an "explicit" `arguments` binding and will require an arguments object.
     ImplicitArguments,
@@ -1063,8 +1090,8 @@ impl<'a> BindingKind<'a> {
         BindingKind::FunctionParameter { init_pos: Cell::new(0), index }
     }
 
-    pub fn new_implicit_this() -> BindingKind<'a> {
-        BindingKind::ImplicitThis(ImplicitThisBinding::new())
+    pub fn new_implicit_this(in_derived_constructor: bool) -> BindingKind<'a> {
+        BindingKind::ImplicitThis { in_derived_constructor }
     }
 
     /// Whether this is a LexicallyScopedDeclaration from the spec.
@@ -1109,6 +1136,10 @@ impl<'a> BindingKind<'a> {
         matches!(self, BindingKind::ImplicitThis { .. })
     }
 
+    pub fn is_implicit_this_in_derived_constructor(&self) -> bool {
+        matches!(self, BindingKind::ImplicitThis { in_derived_constructor: true })
+    }
+
     pub fn is_implicit_arguments(&self) -> bool {
         matches!(self, BindingKind::ImplicitArguments)
     }
@@ -1131,14 +1162,6 @@ impl<'a> BindingKind<'a> {
 
     pub fn is_namespace_import(&self) -> bool {
         matches!(self, BindingKind::Import { is_namespace: true })
-    }
-
-    pub fn as_implicit_this(&self) -> Option<&ImplicitThisBinding> {
-        if let BindingKind::ImplicitThis(binding) = self {
-            Some(binding)
-        } else {
-            None
-        }
     }
 
     fn has_tdz(&self) -> bool {
@@ -1165,44 +1188,6 @@ impl<'a> BindingKind<'a> {
                 | BindingKind::Function { is_lexical: false, .. }
                 | BindingKind::ImplicitArguments
         )
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct ImplicitThisBinding {
-    /// Whether this is the `this` value for a derived constructor.
-    ///
-    /// Note that this is set during analysis not parsing.
-    in_derived_constructor: Cell<bool>,
-    /// Whether this is the `this` value for a derived constructor at the root scope of an eval.
-    ///
-    /// Note that this is set during analysis not parsing.
-    in_derived_constructor_eval_toplevel: Cell<bool>,
-}
-
-impl ImplicitThisBinding {
-    fn new() -> Self {
-        // Flags are set later during analysis
-        Self {
-            in_derived_constructor: Cell::new(false),
-            in_derived_constructor_eval_toplevel: Cell::new(false),
-        }
-    }
-
-    pub fn in_derived_constructor(&self) -> bool {
-        self.in_derived_constructor.get()
-    }
-
-    pub fn in_derived_constructor_eval_toplevel(&self) -> bool {
-        self.in_derived_constructor_eval_toplevel.get()
-    }
-
-    pub fn set_in_derived_constructor(&self, value: bool) {
-        self.in_derived_constructor.set(value);
-    }
-
-    pub fn set_in_derived_constructor_eval_toplevel(&self, value: bool) {
-        self.in_derived_constructor_eval_toplevel.set(value);
     }
 }
 

--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -655,6 +655,8 @@ builtin_symbols!(
     (to_primitive, "Symbol.toPrimitive"),
     (to_string_tag, "Symbol.toStringTag"),
     (unscopables, "Symbol.unscopables"),
+    // Symbols used for classes
+    (fields_initializer, "fieldsInitializer"),
     // Symbols used for private properties of bound functions
     (bound_target, ""),
     (bound_this, ""),

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -782,10 +782,10 @@ impl<'a> BytecodeProgramGenerator<'a> {
             None,
             self.source_file,
             /* source_range */ function.loc.to_range(),
-            ClassFieldsInitializer::none(),
             is_constructor,
             /* is_class_constructor */ false,
             /* is_base_constructor */ is_constructor,
+            /* constructor_fields_info */ None,
         )?;
 
         let emit_result = generator.generate(function)?;
@@ -805,7 +805,7 @@ impl<'a> BytecodeProgramGenerator<'a> {
     }
 
     fn gen_enqueued_function(&mut self, pending_function: PendingFunction<'a>) -> EmitResult<()> {
-        let PendingFunction { mut func_node, scope, patch } = pending_function;
+        let PendingFunction { func_node, scope, patch } = pending_function;
 
         let mut emit_result = EmitFunctionResult::empty();
 
@@ -814,8 +814,8 @@ impl<'a> BytecodeProgramGenerator<'a> {
             if let PendingFunctionNode::Constructor {
                 node: None,
                 name,
-                fields,
                 is_base,
+                fields_info,
                 source_range,
             } = func_node
             {
@@ -828,8 +828,8 @@ impl<'a> BytecodeProgramGenerator<'a> {
                     name,
                     self.source_file,
                     source_range,
-                    fields,
                     /* is_base_constructor */ is_base,
+                    fields_info,
                 )?;
 
                 emit_result = generator.generate_default_constructor(class_pos)?;
@@ -880,29 +880,26 @@ impl<'a> BytecodeProgramGenerator<'a> {
                 let is_constructor = func_node.is_constructor();
                 let is_class_constructor;
                 let is_base_constructor;
+                let fields_info;
                 let source_range;
 
                 if let PendingFunctionNode::Constructor {
                     is_base,
+                    fields_info: fields_info_,
                     source_range: source_range_,
                     ..
                 } = &func_node
                 {
                     is_class_constructor = true;
                     is_base_constructor = *is_base;
+                    fields_info = fields_info_.clone();
                     source_range = source_range_.clone();
                 } else {
                     is_class_constructor = false;
                     is_base_constructor = is_constructor;
+                    fields_info = None;
                     source_range = func.loc.to_range();
                 }
-
-                let class_fields = match &mut func_node {
-                    PendingFunctionNode::Constructor { fields, .. } => {
-                        std::mem::replace(fields, ClassFieldsInitializer::none())
-                    }
-                    _ => ClassFieldsInitializer::none(),
-                };
 
                 let default_name = func_node.default_name();
 
@@ -925,10 +922,10 @@ impl<'a> BytecodeProgramGenerator<'a> {
                     default_name,
                     self.source_file,
                     source_range,
-                    class_fields,
                     is_constructor,
                     is_class_constructor,
                     is_base_constructor,
+                    fields_info,
                 )?;
 
                 emit_result = generator.generate(func)?;
@@ -1101,9 +1098,9 @@ pub struct BytecodeFunctionGenerator<'a> {
     /// emit conservatively worse code to avoid assignment hazards.
     has_assign_expr: bool,
 
-    /// Class field initializer that must be called by this function. Only set if this is a
-    /// constructor.
-    class_fields: ClassFieldsInitializer<'a>,
+    /// Information about this function's fields. Only set if this function is a class constructor
+    /// with a field initializer.
+    constructor_fields_info: Option<ConstructorFieldsInfo<'a>>,
 
     /// End position of the derived constructor, if this is a derived constructor. Used to report
     /// errors if the super constructor was not called.
@@ -1130,7 +1127,6 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         source_file: Handle<SourceFile>,
         source_range: Range<Pos>,
         derived_constructor_end_pos: Option<Pos>,
-        class_fields: ClassFieldsInitializer<'a>,
         num_parameters: u32,
         function_length: u32,
         num_local_registers: u32,
@@ -1139,10 +1135,19 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         is_class_constructor: bool,
         is_base_constructor: bool,
         is_async: bool,
+        mut constructor_fields_info: Option<ConstructorFieldsInfo<'a>>,
     ) -> Self {
         // Source map begins with a header containing the entire source range of the function
         let mut writer = BytecodeWriter::new();
         writer.write_source_map_header(&source_range);
+
+        // Constructors initialize tracked property names from fields
+        let mut constructor_property_names = HashSet::new();
+        let mut constructor_num_computed_properties = 0;
+        if let Some(fields_info) = &mut constructor_fields_info {
+            std::mem::swap(&mut constructor_property_names, &mut fields_info.names);
+            constructor_num_computed_properties = fields_info.num_computed_names;
+        }
 
         Self {
             writer,
@@ -1160,8 +1165,9 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             finally_scopes: vec![],
             num_parameters,
             function_length,
-            constructor_property_names: HashSet::new(),
-            constructor_num_computed_properties: 0,
+            constructor_property_names,
+            constructor_num_computed_properties,
+            constructor_fields_info,
             is_strict,
             is_constructor,
             is_class_constructor,
@@ -1172,7 +1178,6 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             promise_index: None,
             statement_completion_dest: None,
             has_assign_expr: false,
-            class_fields,
             derived_constructor_end_pos,
             constant_table_builder: ConstantTableBuilder::new(),
             register_allocator: TemporaryRegisterAllocator::new(num_local_registers),
@@ -1191,10 +1196,10 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         default_name: Option<&Wtf8Str>,
         source_file: Handle<SourceFile>,
         source_range: Range<Pos>,
-        class_fields: ClassFieldsInitializer<'a>,
         is_constructor: bool,
         is_class_constructor: bool,
         is_base_constructor: bool,
+        constructor_fields_info: Option<ConstructorFieldsInfo<'a>>,
     ) -> EmitResult<Self> {
         // Stored number of parameters does not count the rest parameter
         let num_parameters = if let Some(ast::FunctionParam::Rest { .. }) = func.params.last() {
@@ -1250,7 +1255,6 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             source_file,
             source_range,
             derived_constructor_end_pos,
-            class_fields,
             num_parameters as u32,
             function_length as u32,
             num_local_registers as u32,
@@ -1259,6 +1263,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             is_class_constructor,
             is_base_constructor,
             func.is_async(),
+            constructor_fields_info,
         ))
     }
 
@@ -1290,7 +1295,6 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             source_file,
             program.loc.to_range(),
             /* derived_constructor_end_pos */ None,
-            ClassFieldsInitializer::none(),
             /* num_parameters */ 0,
             /* function_length */ 0,
             num_local_registers as u32,
@@ -1299,6 +1303,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             /* is_class_constructor */ false,
             /* is_base_constructor */ false,
             /* async */ program.has_top_level_await,
+            /* constructor_fields_info */ None,
         ))
     }
 
@@ -1310,8 +1315,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         name: &'a Wtf8Str,
         source_file: Handle<SourceFile>,
         source_range: Range<Pos>,
-        class_fields: ClassFieldsInitializer<'a>,
         is_base_constructor: bool,
+        constructor_fields_info: Option<ConstructorFieldsInfo<'a>>,
     ) -> EmitResult<Self> {
         // First local register used for new target in derived constructors
         let num_local_registers = if is_base_constructor { 0 } else { 1 };
@@ -1325,7 +1330,6 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             source_file,
             source_range,
             /* derived_constructor_end_pos */ None,
-            class_fields,
             /* num_parameters */ 0,
             /* function_length */ 0,
             num_local_registers,
@@ -1334,6 +1338,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             /* is_class_constructor */ true,
             is_base_constructor,
             /* is_async */ false,
+            constructor_fields_info,
         );
 
         if !is_base_constructor {
@@ -1372,7 +1377,6 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             source_file,
             source_range,
             /* derived_constructor_end_pos */ None,
-            ClassFieldsInitializer::none(),
             /* num_parameters */ 0,
             /* function_length */ 0,
             num_local_registers as u32,
@@ -1381,6 +1385,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             /* is_class_constructor */ false,
             /* is_base_constructor */ false,
             /* is_async */ false,
+            /* constructor_fields_info */ None,
         ))
     }
 
@@ -1740,6 +1745,19 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         );
     }
 
+    fn write_define_private_property_instruction(
+        &mut self,
+        object: GenRegister,
+        key: GenRegister,
+        value: GenRegister,
+        flags: DefinePrivatePropertyFlags,
+        pos: usize,
+    ) {
+        let flags = UInt::new(flags.bits() as u32);
+        self.writer
+            .define_private_property_instruction(object, key, value, flags, pos);
+    }
+
     fn get_cached_static_str(&mut self, str: &'static str) -> AllocResult<Handle<StringValue>> {
         InternedStrings::get_generator_cache_static_str(self.cx, str)
     }
@@ -1828,9 +1846,11 @@ impl<'a> BytecodeFunctionGenerator<'a> {
     fn generate(mut self, func: &'a ast::Function<'a>) -> EmitResult<EmitFunctionResult<'a>> {
         let func_pos = func.loc.start;
 
-        // Base constructors initialize class fields immediately
-        if !self.is_derived_constructor() {
-            self.gen_initialize_class_fields(Register::this(), func_pos)?;
+        // Base constructors first call the class fields initializer
+        if self.constructor_fields_info.is_some() && self.is_base_constructor {
+            let fields_initializer =
+                self.gen_load_fields_initializer_for_constructor(Register::closure())?;
+            self.gen_call_fields_initializer(fields_initializer, Register::this(), func_pos)?;
         }
 
         // Async functions reserve a register for the promise object
@@ -2024,7 +2044,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
                 let mut derived_constructor_scope = None;
                 if self.is_derived_constructor() {
-                    derived_constructor_scope = Some(func.scope);
+                    derived_constructor_scope = Some(TaggedResolvedScope::resolved(func.scope));
                 }
 
                 // If the body continues, meaning there was no return statement (or throw, break,
@@ -2130,8 +2150,12 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             self.writer.default_super_call_instruction(class_pos);
         }
 
-        // Initialize fields on the `this` value if any exist
-        self.gen_initialize_class_fields(Register::this(), class_pos)?;
+        // Initialize fields on the `this` value if necessary
+        if self.constructor_fields_info.is_some() {
+            let fields_initializer =
+                self.gen_load_fields_initializer_for_constructor(Register::closure())?;
+            self.gen_call_fields_initializer(fields_initializer, Register::this(), class_pos)?;
+        }
 
         // Return undefined for a base constructor and `this` for a derived constructor. No default
         // constructor scope is needed since it is only needed if `this` is captured.
@@ -3069,7 +3093,12 @@ impl<'a> BytecodeFunctionGenerator<'a> {
     }
 
     fn gen_store_captured_this(&mut self, scope: &AstScopeNode) -> EmitResult<()> {
-        match scope.get_binding(&THIS_NAME).vm_location() {
+        // Direct evals in derived constructors have no `this` binding of their own
+        let Some(binding) = scope.get_binding_opt(&THIS_NAME) else {
+            return Ok(());
+        };
+
+        match binding.vm_location() {
             // `this` is captured so it must be stored in the scope
             Some(VMLocation::Scope { scope_id, index }) => {
                 self.gen_store_scope_binding(scope_id, index, Register::this())
@@ -3090,40 +3119,39 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
     fn gen_load_this(
         &mut self,
-        scope: Option<AstPtr<AstScopeNode>>,
+        scope: TaggedResolvedScope,
         pos: Pos,
         dest: ExprDest,
         skip_init_check: bool,
     ) -> EmitResult<GenRegister> {
         let mut needs_init_check = false;
 
-        // If scope has been resolved this may be a captured `this`. Load from scope directly to
-        // the dest.
-        let this_value = if let Some(scope) = scope.as_ref() {
-            let binding = scope.as_ref().get_binding(&THIS_NAME);
-            let implicit_this = binding.kind().as_implicit_this().unwrap();
-
-            if implicit_this.in_derived_constructor()
-                || implicit_this.in_derived_constructor_eval_toplevel()
-            {
+        let this_value = match scope.kind() {
+            // If `this` was not resolved then it is the current function's `this`
+            ResolvedScope::UnresolvedGlobal => self.gen_mov_reg_to_dest(Register::this(), dest)?,
+            // Dynamic loads of this only occur in direct evals in derived constructors, so an init
+            // check is always needed.
+            ResolvedScope::UnresolvedDynamic => {
                 needs_init_check = true;
+                self.gen_load_dynamic_identifier(&THIS_NAME, pos, dest)?
             }
+            // If scope has been resolved this may be the current function's or a captured `this`
+            ResolvedScope::Resolved => {
+                let scope = scope.unwrap_resolved();
+                let binding = scope.get_binding(&THIS_NAME);
 
-            match binding.vm_location() {
-                // Captured `this`
-                Some(VMLocation::Scope { scope_id, index }) => {
-                    self.gen_load_scope_binding(scope_id, index, dest)?
+                if binding.kind().is_implicit_this_in_derived_constructor() {
+                    needs_init_check = true;
                 }
-                // In derived constructor eval `this` is stored in a captured scope outside the
-                // eval. Must be loaded/stored dynamically to support `this` initialization.
-                _ if implicit_this.in_derived_constructor_eval_toplevel() => {
-                    self.gen_load_dynamic_identifier(&THIS_NAME, pos, dest)?
+
+                match binding.vm_location() {
+                    // Captured `this`
+                    Some(VMLocation::Scope { scope_id, index }) => {
+                        self.gen_load_scope_binding(scope_id, index, dest)?
+                    }
+                    _ => self.gen_mov_reg_to_dest(Register::this(), dest)?,
                 }
-                _ => self.gen_mov_reg_to_dest(Register::this(), dest)?,
             }
-        } else {
-            // Otherwise `this` is for the current function
-            self.gen_mov_reg_to_dest(Register::this(), dest)?
         };
 
         // Check if this was initialized
@@ -3137,31 +3165,32 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
     fn gen_store_this(
         &mut self,
-        scope: AstPtr<AstScopeNode>,
+        scope: TaggedResolvedScope,
         pos: Pos,
         value: GenRegister,
     ) -> EmitResult<()> {
-        let binding = scope.as_ref().get_binding(&THIS_NAME);
-
-        let in_derived_constructor_eval_toplevel = binding
-            .kind()
-            .as_implicit_this()
-            .unwrap()
-            .in_derived_constructor_eval_toplevel();
-
-        match binding.vm_location() {
-            // Captured `this`
-            Some(VMLocation::Scope { scope_id, index }) => {
-                self.gen_store_scope_binding(scope_id, index, value)
-            }
-            // In derived constructor eval `this` is stored in a captured scope outside the
-            // eval. Must be loaded/stored dynamically to support `this` initialization.
-            _ if in_derived_constructor_eval_toplevel => {
-                self.gen_store_dynamic_identifier(&THIS_NAME, value, pos)
-            }
-            _ => {
+        match scope.kind() {
+            // If `this` was not resolved then it is the current function's `this`
+            ResolvedScope::UnresolvedGlobal => {
                 self.write_mov_instruction(Register::this(), value);
                 Ok(())
+            }
+            ResolvedScope::UnresolvedDynamic => {
+                self.gen_store_dynamic_identifier(&THIS_NAME, value, pos)
+            }
+            // If scope has been resolved this may be the current function's or a captured `this`
+            ResolvedScope::Resolved => {
+                let binding = scope.unwrap_resolved().get_binding(&THIS_NAME);
+
+                match binding.vm_location() {
+                    Some(VMLocation::Scope { scope_id, index }) => {
+                        self.gen_store_scope_binding(scope_id, index, value)
+                    }
+                    _ => {
+                        self.write_mov_instruction(Register::this(), value);
+                        Ok(())
+                    }
+                }
             }
         }
     }
@@ -5930,6 +5959,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         super_call: &'a ast::SuperCallExpression<'a>,
         dest: ExprDest,
     ) -> EmitResult<GenRegister> {
+        let this_result = self.allocate_destination(dest)?;
+
         let super_pos = super_call.loc.start;
 
         // Super calls implicitly use the surrounding derived constructor, so load it to register
@@ -5939,7 +5970,6 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             ExprDest::Any,
         )?;
 
-        self.register_allocator.release(derived_constructor);
         let super_constructor = self.register_allocator.allocate()?;
 
         self.writer
@@ -5960,12 +5990,10 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         self.register_allocator.release(super_constructor);
 
         // Generate the super call itself
-        let call_result = self.allocate_destination(dest)?;
-
         match args {
             CallArgs::Varargs { args, .. } => {
                 self.writer.construct_varargs_instruction(
-                    call_result,
+                    this_result,
                     super_constructor,
                     new_target,
                     args,
@@ -5974,7 +6002,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             }
             CallArgs::Normal { argv, argc } => {
                 self.writer.construct_instruction(
-                    call_result,
+                    this_result,
                     super_constructor,
                     new_target,
                     argv,
@@ -5987,7 +6015,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         // Load `this` value without init check, since initialization is checked by the following
         // CheckSuperAlreadyCalled instruction.
         let this_value = self.gen_load_this(
-            Some(super_call.this_scope),
+            super_call.this_scope,
             super_pos,
             ExprDest::Any,
             /* skip_init_check */ true,
@@ -6000,68 +6028,122 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         self.register_allocator.release(this_value);
 
         // Always store the result of the super call as the value of `this`
-        self.gen_store_this(super_call.this_scope, super_pos, call_result)?;
+        self.gen_store_this(super_call.this_scope, super_pos, this_result)?;
 
         // Derived constructors initialize fields after the super call
-        if self.is_derived_constructor() {
-            self.gen_initialize_class_fields(call_result, super_pos)?;
-        }
+        if self.constructor_fields_info.is_some() || !self.is_derived_constructor() {
+            let fields_initializer =
+                self.gen_load_fields_initializer_for_constructor(derived_constructor)?;
 
-        Ok(call_result)
-    }
-
-    /// Initialize class fields in a constructor, defining them on the `this` value.
-    fn gen_initialize_class_fields(&mut self, this_reg: GenRegister, pos: Pos) -> EmitResult<()> {
-        let initializer = std::mem::replace(&mut self.class_fields, ClassFieldsInitializer::none());
-
-        // Check if a class field initializer is needed
-        if initializer.scope.is_none() {
-            return Ok(());
-        }
-
-        // Track each field for the constructor's estimated number of properties.
-        for field in &initializer.fields {
-            match field {
-                ClassField::Named { name, .. } => {
-                    self.constructor_property_names.insert(name);
-                }
-                ClassField::PrivateField { field } => {
-                    let private_id = field.as_ref().key.expr.to_id();
-                    self.constructor_property_names.insert(private_id.name);
-                }
-                ClassField::PrivateMethodOrAccessor { name, .. } => {
-                    self.constructor_property_names.insert(name.as_ref().name);
-                }
-                ClassField::Computed { .. } => {
-                    self.constructor_num_computed_properties += 1;
-                }
+            if self.constructor_fields_info.is_some() {
+                // Super calls that are within their source derived constructor are only generated
+                // when the fields initializer exists.
+                self.gen_call_fields_initializer(fields_initializer, this_result, super_pos)?;
+            } else {
+                // Super calls that are not within their source derived constructor (e.g. in arrows
+                // or eval) must check whether the field initializer exists.
+                let join_block = self.new_block();
+                self.write_jump_nullish_instruction(fields_initializer, join_block)?;
+                self.gen_call_fields_initializer(fields_initializer, this_result, super_pos)?;
+                self.start_block(join_block);
             }
         }
 
+        self.register_allocator.release(derived_constructor);
+
+        Ok(this_result)
+    }
+
+    fn get_fields_initializer_symbol_constant_index(&mut self) -> EmitResult<GenConstantIndex> {
+        let constant_index = self
+            .constant_table_builder
+            .add_heap_item(self.cx.symbols.fields_initializer().as_symbol().cast())?;
+        Ok(ConstantIndex::new(constant_index))
+    }
+
+    /// Generate the fields initializer closure and store it in the class scope, enqueuing it for
+    /// generation.
+    fn gen_store_fields_initializer_closure(
+        &mut self,
+        constructor_reg: GenRegister,
+        class: &'a ast::Class<'a>,
+        fields: Vec<ClassField<'a>>,
+    ) -> EmitResult<()> {
         // Field initializer function is added to the pending functions queue
         let pending_node = PendingFunctionNode::ClassFieldsInitializer {
-            scope: initializer.scope.unwrap(),
-            fields: initializer.fields,
-            class: initializer.class,
+            scope: class.fields_initializer_scope.unwrap(),
+            fields,
+            class: AstPtr::from_ref(class),
         };
         let func_index = self.enqueue_function_to_generate(pending_node)?;
 
-        // Create the fields initializer closure itself
-        let fields_init_value = self.register_allocator.allocate()?;
+        // Create the fields initializer closure
+        let fields_initializer = self.register_allocator.allocate()?;
         self.writer
-            .new_closure_instruction(fields_init_value, ConstantIndex::new(func_index));
+            .new_closure_instruction(fields_initializer, ConstantIndex::new(func_index));
 
-        // Call the fields initializer function with the current `this` as the receiver
+        // Store fields initializer closure as an internal private property on the constructor
+        let fields_initializer_symbol = self.register_allocator.allocate()?;
+        let fields_initializer_symbol_constant_index =
+            self.get_fields_initializer_symbol_constant_index()?;
+        self.writer.load_constant_instruction(
+            fields_initializer_symbol,
+            fields_initializer_symbol_constant_index,
+        );
+
+        self.write_define_private_property_instruction(
+            constructor_reg,
+            fields_initializer_symbol,
+            fields_initializer,
+            DefinePrivatePropertyFlags::empty(),
+            NO_POS,
+        );
+
+        self.register_allocator.release(fields_initializer_symbol);
+        self.register_allocator.release(fields_initializer);
+
+        Ok(())
+    }
+
+    /// Load the fields intializer closure from a constructor.
+    fn gen_load_fields_initializer_for_constructor(
+        &mut self,
+        constructor_reg: GenRegister,
+    ) -> EmitResult<GenRegister> {
+        // Fields intializer is stored as an internal private property on the constructor. Use
+        // GetNamedProperty to load it so that undefined is returned if property does not exist
+        // (such as a `super()` call within an arrow function or eval that doesn't know if the
+        // constructor has a fields initializer).
+        let fields_initializer = self.register_allocator.allocate()?;
+        let fields_initializer_symbol_constant_index =
+            self.get_fields_initializer_symbol_constant_index()?;
+        self.write_get_named_property_instruction(
+            fields_initializer,
+            constructor_reg,
+            fields_initializer_symbol_constant_index,
+            NO_POS,
+        );
+
+        Ok(fields_initializer)
+    }
+
+    /// Call a fields intializer on the `this` value for a class constructor.
+    fn gen_call_fields_initializer(
+        &mut self,
+        fields_initializer: GenRegister,
+        this_reg: GenRegister,
+        pos: Pos,
+    ) -> EmitResult<()> {
         self.writer.call_with_receiver_instruction(
-            fields_init_value,
-            fields_init_value,
+            fields_initializer,
+            fields_initializer,
             this_reg,
-            /* dummy value */ fields_init_value,
+            /* dummy value */ fields_initializer,
             UInt::new(0),
             pos,
         );
 
-        self.register_allocator.release(fields_init_value);
+        self.register_allocator.release(fields_initializer);
 
         Ok(())
     }
@@ -7251,15 +7333,16 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         };
 
         // Create the constructor's static BytecodeFunction
-        let fields = ClassFieldsInitializer {
-            fields,
-            scope: class.fields_initializer_scope,
-            class: AstPtr::from_ref(class),
-        };
         let is_base = class.super_class.is_none();
+        let has_fields_initializer = class.fields_initializer_scope.is_some();
+        let fields_info = if has_fields_initializer {
+            Some(ConstructorFieldsInfo::new(&fields))
+        } else {
+            None
+        };
         let source_range = class.loc.to_range();
         let pending_constructor =
-            PendingFunctionNode::Constructor { node, name, fields, is_base, source_range };
+            PendingFunctionNode::Constructor { node, name, is_base, fields_info, source_range };
         let constructor_index = self.enqueue_function_to_generate(pending_constructor)?;
 
         // Find the scope locations for the home objects if they are needed
@@ -7301,6 +7384,13 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                     self.gen_initialize_binding(class_name, binding, constructor_reg)?;
                 }
             }
+        }
+
+        // Create the fields initializer function if one is needed. If the binding is needed at
+        // runtime but no fields initializer exists then binding remains undefined (needed for
+        // dynamic lookups).
+        if has_fields_initializer {
+            self.gen_store_fields_initializer_closure(constructor_reg, class, fields)?;
         }
 
         // Create the static initializer function if one exists
@@ -7487,10 +7577,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             if *is_setter {
                 flags |= DefinePrivatePropertyFlags::SETTER;
             }
-            let flags = UInt::new(flags.bits() as u32);
 
-            self.writer
-                .define_private_property_instruction(target, name, value, flags, name_pos);
+            self.write_define_private_property_instruction(target, name, value, flags, name_pos);
 
             self.register_allocator.release(value);
             self.register_allocator.release(name);
@@ -7559,10 +7647,11 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
                 // Define the private field using the private symbol
                 let name = self.gen_load_private_symbol(private_id)?;
-                let flags = UInt::new(DefinePrivatePropertyFlags::empty().bits() as u32);
+                let flags = DefinePrivatePropertyFlags::empty();
 
-                self.writer
-                    .define_private_property_instruction(target, name, value, flags, field_pos);
+                self.write_define_private_property_instruction(
+                    target, name, value, flags, field_pos,
+                );
 
                 self.register_allocator.release(name);
             }
@@ -7899,9 +7988,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
                 flags |= ScopeNameFlags::IS_IMPORT_BINDING;
             }
 
-            if let Some(implicit_this) = binding.kind().as_implicit_this()
-                && implicit_this.in_derived_constructor()
-            {
+            if binding.kind().is_implicit_this_in_derived_constructor() {
                 flags |= ScopeNameFlags::IS_DERIVED_CONSTRUCTOR_THIS;
             }
 
@@ -9161,7 +9248,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         let derived_constructor_scope = stmt.this_scope;
 
         if stmt.argument.is_none() {
-            self.gen_return(/* return_arg */ None, derived_constructor_scope)?;
+            self.gen_return(/* return_arg */ None, Some(derived_constructor_scope))?;
             return Ok(StmtCompletion::Abrupt);
         }
 
@@ -9173,7 +9260,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             return_arg = self.gen_await(return_arg, return_pos, ExprDest::Any)?;
         }
 
-        self.gen_return(Some(return_arg), derived_constructor_scope)?;
+        self.gen_return(Some(return_arg), Some(derived_constructor_scope))?;
         self.register_allocator.release(return_arg);
 
         Ok(StmtCompletion::Abrupt)
@@ -9185,7 +9272,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
     fn gen_return(
         &mut self,
         return_arg: Option<GenRegister>,
-        derived_constructor_scope: Option<AstPtr<AstScopeNode<'a>>>,
+        derived_constructor_scope: Option<TaggedResolvedScope<'a>>,
     ) -> EmitResult<()> {
         // If not in a finally scope we can return directly
         if self.finally_scopes.is_empty() {
@@ -9194,9 +9281,12 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             if self.is_derived_constructor() {
                 // This value may be loaded from a scope if captured
                 let gen_this_value = |this: &mut Self, dest: ExprDest| {
-                    if let Some(scope) = derived_constructor_scope {
+                    if let Some(derived_constructor_scope) = derived_constructor_scope
+                        && derived_constructor_scope.is_resolved()
+                    {
+                        let scope = derived_constructor_scope.unwrap_resolved();
                         if let Some(VMLocation::Scope { scope_id, index }) =
-                            scope.as_ref().get_binding(&THIS_NAME).vm_location()
+                            scope.get_binding(&THIS_NAME).vm_location()
                         {
                             return this.gen_load_scope_binding(scope_id, index, dest);
                         }
@@ -9693,8 +9783,8 @@ enum PendingFunctionNode<'a> {
     Constructor {
         node: Option<AstPtr<ast::Function<'a>>>,
         name: &'a Wtf8Str,
-        fields: ClassFieldsInitializer<'a>,
         is_base: bool,
+        fields_info: Option<ConstructorFieldsInfo<'a>>,
         source_range: Range<Pos>,
     },
     ClassFieldsInitializer {
@@ -9929,9 +10019,9 @@ struct FinallyScope<'a> {
     /// Set if the target block has a return statement, which must first continue to the finally
     /// block before performing the return.
     return_branch: Option<FinallyBranchId>,
-    /// The scope of the derived constructor that this finally scope is within, if any. Only set if
-    /// there is a return branch within a derived constructor.
-    derived_constructor_scope: Option<AstPtr<AstScopeNode<'a>>>,
+    /// The scope containing the `this` binding of the derived constructor that this finally scope
+    /// is within, if any. Only set if there is a return branch within a derived constructor.
+    derived_constructor_scope: Option<TaggedResolvedScope<'a>>,
     /// All break and continue statements in the target block, which must first continue to the
     /// finally block before performing the break or continue.
     jump_target_branches: Vec<JumpTargetBranch>,
@@ -10007,7 +10097,7 @@ impl<'a> FinallyScope<'a> {
 
     fn add_return_branch(
         &mut self,
-        derived_constructor_scope: Option<AstPtr<AstScopeNode<'a>>>,
+        derived_constructor_scope: Option<TaggedResolvedScope<'a>>,
     ) -> FinallyBranchId {
         if let Some(return_branch) = self.return_branch {
             return_branch
@@ -10074,15 +10164,37 @@ enum ClassField<'a> {
     },
 }
 
-struct ClassFieldsInitializer<'a> {
-    fields: Vec<ClassField<'a>>,
-    scope: Option<AstPtr<AstScopeNode<'a>>>,
-    class: AstPtr<ast::Class<'a>>,
+#[derive(Clone)]
+struct ConstructorFieldsInfo<'a> {
+    names: HashSet<AstStr<'a>>,
+    num_computed_names: usize,
 }
 
-impl ClassFieldsInitializer<'_> {
-    fn none() -> Self {
-        Self { fields: vec![], scope: None, class: AstPtr::uninit() }
+impl<'a> ConstructorFieldsInfo<'a> {
+    fn new(fields: &[ClassField<'a>]) -> Self {
+        let mut names = HashSet::new();
+        let mut num_computed_names = 0;
+
+        // Track each field for the constructor's estimated number of properties.
+        for field in fields {
+            match field {
+                ClassField::Named { name, .. } => {
+                    names.insert(*name);
+                }
+                ClassField::PrivateField { field } => {
+                    let private_id = field.as_ref().key.expr.to_id();
+                    names.insert(private_id.name);
+                }
+                ClassField::PrivateMethodOrAccessor { name, .. } => {
+                    names.insert(name.as_ref().name);
+                }
+                ClassField::Computed { .. } => {
+                    num_computed_names += 1;
+                }
+            }
+        }
+
+        ConstructorFieldsInfo { names, num_computed_names }
     }
 }
 

--- a/src/js/runtime/eval/eval.rs
+++ b/src/js/runtime/eval/eval.rs
@@ -57,7 +57,14 @@ pub fn perform_eval(
     };
     let pcx = ParseContext::new(source);
 
-    let parse_result = parse_script_for_eval(&pcx, cx.options.clone(), is_direct, is_strict_caller);
+    let in_derived_constructor = flags.contains(EvalFlags::IN_DERIVED_CONSTRUCTOR);
+    let parse_result = parse_script_for_eval(
+        &pcx,
+        cx.options.clone(),
+        is_direct,
+        is_strict_caller,
+        in_derived_constructor,
+    );
     let parse_result = match parse_result {
         Ok(parse_result) => parse_result,
         Err(error) => return syntax_parse_error(cx, &error),

--- a/tests/integration/language/class/derived_constructor_this_in_eval.js
+++ b/tests/integration/language/class/derived_constructor_this_in_eval.js
@@ -75,3 +75,40 @@ class C6 extends Base {
 
 const c6 = new C6();
 assert.sameValue(c6.fromEval, 5);
+
+// Super called in an arrow function within eval initializes `this`
+class C7 extends Base {
+  constructor() {
+    eval('(() => super())()');
+  }
+}
+
+assert.sameValue(new C7().method(), 7);
+
+// Super called within a nested direct eval initializes `this`
+class C8 extends Base {
+  constructor() {
+    eval('eval("super()")');
+  }
+}
+
+assert.sameValue(new C8().method(), 7);
+
+// Accessing `this` from an arrow function within eval without initialization errors
+class C9 extends Base {
+  constructor() {
+    eval('(() => this)()');
+  }
+}
+
+assert.throws(ReferenceError, () => new C9());
+
+// Successful access to `this` from an arrow function within eval after initialization
+class C10 extends Base {
+  constructor() {
+    eval('(() => super())()');
+    this.fromEval = eval('(() => this.method())()');
+  }
+}
+
+assert.sameValue(new C10().fromEval, 7);

--- a/tests/integration/language/class/super_call_fields_initialization.js
+++ b/tests/integration/language/class/super_call_fields_initialization.js
@@ -1,0 +1,230 @@
+/*---
+description: Fields are initialized at every super call site.
+---*/
+
+class Base {}
+
+// Multiple super() sites in branches all initialize fields
+class C1 extends Base {
+  x = 1;
+  constructor(cond) {
+    if (cond) {
+      super();
+    } else {
+      super();
+    }
+  }
+}
+
+assert.sameValue(new C1(true).x, 1);
+assert.sameValue(new C1(false).x, 1);
+
+// super() in an arrow function initializes fields
+class C2 extends Base {
+  x = 2;
+  constructor() {
+    const f = () => super();
+    f();
+  }
+}
+
+assert.sameValue(new C2().x, 2);
+
+// super() in a nested arrow function initializes fields
+class C3 extends Base {
+  x = 3;
+  constructor() {
+    const f = () => () => super();
+    f()();
+  }
+}
+
+assert.sameValue(new C3().x, 3);
+
+// super() in an async arrow function initializes fields synchronously
+class C4 extends Base {
+  x = 4;
+  constructor() {
+    const f = async () => super();
+    f();
+  }
+}
+
+assert.sameValue(new C4().x, 4);
+
+// super() within direct eval initializes fields
+class C5 extends Base {
+  x = 5;
+  constructor() {
+    eval('super()');
+  }
+}
+
+assert.sameValue(new C5().x, 5);
+
+// super() in an arrow within direct eval initializes fields
+class C6 extends Base {
+  x = 6;
+  constructor() {
+    eval('(() => super())()');
+  }
+}
+
+assert.sameValue(new C6().x, 6);
+
+// Private fields, private methods, and computed fields are initialized at every super() site
+const key = 'computed';
+class C7 extends Base {
+  [key] = 6;
+  #priv = 7;
+
+  #method() {
+    return this.#priv;
+  }
+  constructor(cond) {
+    if (cond) {
+      super();
+    } else {
+      super();
+    }
+  }
+  callPrivate() {
+    return this.#method();
+  }
+}
+
+assert.sameValue(new C7(true).computed, 6);
+assert.sameValue(new C7(true).callPrivate(), 7);
+assert.sameValue(new C7(false).computed, 6);
+assert.sameValue(new C7(false).callPrivate(), 7);
+
+// super() within a nested direct eval initializes fields
+class C8 extends Base {
+  x = 8;
+  constructor() {
+    eval('eval("super()")');
+  }
+}
+
+assert.sameValue(new C8().x, 8);
+
+// Classes without fields support super() in an arrow function
+class C9 extends Base {
+  constructor() {
+    (() => super())();
+  }
+}
+
+assert.sameValue(new C9() instanceof C9, true);
+
+// Calling super() a second time from an arrow throws, and fields are only initialized once
+let initCount = 0;
+class C10 extends Base {
+  x = ++initCount;
+  constructor() {
+    super();
+    let threw = false;
+    try {
+      (() => super())();
+    } catch (e) {
+      threw = e instanceof ReferenceError;
+    }
+    this.threw = threw;
+  }
+}
+
+const c10 = new C10();
+assert.sameValue(c10.x, 1);
+assert.sameValue(c10.threw, true);
+assert.sameValue(initCount, 1);
+
+// super() in a computed key of a nested class initializes the outer class's fields. The nested
+// derived class's scope must not shadow the outer fields initializer.
+class C11 extends Base {
+  x = 11;
+  constructor() {
+    class Inner extends Base {
+      [(super(), 'm')]() {}
+    }
+  }
+}
+
+assert.sameValue(new C11().x, 11);
+
+// super() in a static computed key of a nested class initializes the outer class's fields
+class C12 extends Base {
+  x = 12;
+  constructor() {
+    class Inner extends Base {
+      static [(super(), 'm')]() {}
+    }
+  }
+}
+
+assert.sameValue(new C12().x, 12);
+
+// super() in the heritage clause of a nested class initializes the outer class's fields
+class C13 extends Base {
+  x = 13;
+  constructor() {
+    class Inner extends (super(), Base) {}
+  }
+}
+
+assert.sameValue(new C13().x, 13);
+
+// super() in an arrow created in a nested class's computed key and called after the nested class
+// is defined initializes the outer class's fields, not the nested class's fields.
+class C14 extends Base {
+  x = 14;
+  constructor() {
+    let f;
+    class Inner {
+      [((f = () => super()), 'm')]() {}
+      innerField = 999;
+    }
+    f();
+  }
+}
+
+const c14 = new C14();
+assert.sameValue(c14.x, 14);
+assert.sameValue(Object.prototype.hasOwnProperty.call(c14, 'innerField'), false);
+
+// Same as above with an outer class without fields: the nested class's fields must not be
+// initialized on the outer instance.
+class C15 extends Base {
+  constructor() {
+    let f;
+    class Inner {
+      [((f = () => super()), 'm')]() {}
+      innerField = 999;
+    }
+    f();
+  }
+}
+
+assert.sameValue(Object.prototype.hasOwnProperty.call(new C15(), 'innerField'), false);
+
+// super() within direct eval in a nested class's computed key initializes the outer class's fields
+class C16 extends Base {
+  x = 16;
+  constructor() {
+    class Inner extends Base {
+      [(eval('super()'), 'm')]() {}
+    }
+  }
+}
+
+assert.sameValue(new C16().x, 16);
+
+// super() in the heritage clause of a nested class within direct eval initializes the outer
+// class's fields
+class C17 extends Base {
+  x = 17;
+  constructor() {
+    eval("class Inner extends (super(), Base) {}");
+  }
+}
+
+assert.sameValue(new C17().x, 17);

--- a/tests/snapshot/bytecode/class/constructor.exp
+++ b/tests/snapshot/bytecode/class/constructor.exp
@@ -84,11 +84,11 @@
 }
 
 [BytecodeFunction: ThisInDerivedConstructor] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: LoadEmpty <this>
      2: Mov r0, <closure>
-     5: GetSuperConstructor r2, r0
-     8: Construct r2, r2, r1, r1, 0
+     5: GetSuperConstructor r3, r0
+     8: Construct r2, r3, r1, r1, 0
     14: CheckSuperAlreadyCalled <this>
     16: Mov <this>, r2
     19: CheckThisInitialized <this>
@@ -106,8 +106,8 @@
   Parameters: 0, Registers: 4
      0: LoadEmpty <this>
      2: Mov r0, <closure>
-     5: GetSuperConstructor r2, r0
-     8: Construct r2, r2, r1, r1, 0
+     5: GetSuperConstructor r3, r0
+     8: Construct r2, r3, r1, r1, 0
     14: CheckSuperAlreadyCalled <this>
     16: Mov <this>, r2
     19: LoadImmediate r2, 1
@@ -120,11 +120,11 @@
 }
 
 [BytecodeFunction: DerivedConstructorWithNoArgReturn] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: LoadEmpty <this>
      2: Mov r0, <closure>
-     5: GetSuperConstructor r2, r0
-     8: Construct r2, r2, r1, r1, 0
+     5: GetSuperConstructor r3, r0
+     8: Construct r2, r3, r1, r1, 0
     14: CheckSuperAlreadyCalled <this>
     16: Mov <this>, r2
     19: CheckThisInitialized <this>
@@ -137,8 +137,8 @@
      2: LoadEmpty <this>
      4: StoreToScope <this>, 0, 0
      8: Mov r0, <closure>
-    11: GetSuperConstructor r2, r0
-    14: Construct r2, r2, r1, r1, 0
+    11: GetSuperConstructor r3, r0
+    14: Construct r2, r3, r1, r1, 0
     20: LoadFromScope r3, 0, 0
     24: CheckSuperAlreadyCalled r3
     26: StoreToScope r2, 0, 0
@@ -173,8 +173,8 @@
      2: LoadEmpty <this>
      4: StoreToScope <this>, 0, 0
      8: Mov r0, <closure>
-    11: GetSuperConstructor r2, r0
-    14: Construct r2, r2, r1, r1, 0
+    11: GetSuperConstructor r3, r0
+    14: Construct r2, r3, r1, r1, 0
     20: LoadFromScope r3, 0, 0
     24: CheckSuperAlreadyCalled r3
     26: StoreToScope r2, 0, 0
@@ -205,8 +205,8 @@
      2: LoadEmpty <this>
      4: StoreToScope <this>, 0, 0
      8: Mov r0, <closure>
-    11: GetSuperConstructor r2, r0
-    14: Construct r2, r2, r1, r1, 0
+    11: GetSuperConstructor r3, r0
+    14: Construct r2, r3, r1, r1, 0
     20: LoadFromScope r3, 0, 0
     24: CheckSuperAlreadyCalled r3
     26: StoreToScope r2, 0, 0
@@ -231,8 +231,8 @@
   Parameters: 0, Registers: 6
      0: LoadEmpty <this>
      2: Mov r0, <closure>
-     5: GetSuperConstructor r2, r0
-     8: Construct r2, r2, r1, r1, 0
+     5: GetSuperConstructor r3, r0
+     8: Construct r2, r3, r1, r1, 0
     14: CheckSuperAlreadyCalled <this>
     16: Mov <this>, r2
     19: Mov r4, <scope>
@@ -267,8 +267,8 @@
      2: LoadEmpty <this>
      4: StoreToScope <this>, 0, 0
      8: Mov r0, <closure>
-    11: GetSuperConstructor r2, r0
-    14: Construct r2, r2, r1, r1, 0
+    11: GetSuperConstructor r3, r0
+    14: Construct r2, r3, r1, r1, 0
     20: LoadFromScope r3, 0, 0
     24: CheckSuperAlreadyCalled r3
     26: StoreToScope r2, 0, 0

--- a/tests/snapshot/bytecode/class/fields.exp
+++ b/tests/snapshot/bytecode/class/fields.exp
@@ -70,37 +70,32 @@
 }
 
 [BytecodeFunction: named] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: LoadEmpty r1
      2: NewClass r0, c1, c0, r1, r0
      8: NewClosure r2, c2
-    11: CallWithReceiver r2, r2, r0, r2, 0
-    17: LoadUndefined r1
-    19: Ret r1
+    11: LoadConstant r3, c3
+    14: DefinePrivateProperty r0, r3, r2, 0
+    19: NewClosure r2, c4
+    22: CallWithReceiver r2, r2, r0, r2, 0
+    28: LoadUndefined r1
+    30: Ret r1
   Constant Table:
     0: [BytecodeFunction: C]
     1: [ClassNames]
-    2: [BytecodeFunction: staticInitializer]
+    2: [BytecodeFunction: fieldsInitializer]
+    3: [SymbolValue: fieldsInitializer]
+    4: [BytecodeFunction: staticInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 1
-    0: LoadImmediate r0, 3
-    3: DefineNamedProperty <this>, c0, r0
-    7: LoadUndefined r0
-    9: Ret r0
-  Constant Table:
-    0: [String: named2]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -111,6 +106,16 @@
     9: Ret r0
   Constant Table:
     0: [String: named1]
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 1
+    0: LoadImmediate r0, 3
+    3: DefineNamedProperty <this>, c0, r0
+    7: LoadUndefined r0
+    9: Ret r0
+  Constant Table:
+    0: [String: named2]
 }
 
 [BytecodeFunction: computed] {
@@ -129,34 +134,30 @@
     34: StoreToScope r2, 1, 0
     38: NewClass r0, c2, c1, r1, r0
     44: NewClosure r2, c3
-    47: CallWithReceiver r2, r2, r0, r2, 0
-    53: PopScope 
-    54: LoadUndefined r1
-    56: Ret r1
+    47: LoadConstant r3, c4
+    50: DefinePrivateProperty r0, r3, r2, 0
+    55: NewClosure r2, c5
+    58: CallWithReceiver r2, r2, r0, r2, 0
+    64: PopScope 
+    65: LoadUndefined r1
+    67: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [BytecodeFunction: C]
     2: [ClassNames]
-    3: [BytecodeFunction: staticInitializer]
+    3: [BytecodeFunction: fieldsInitializer]
+    4: [SymbolValue: fieldsInitializer]
+    5: [BytecodeFunction: staticInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadImmediate r0, 4
-     3: LoadFromScope r1, 1, 0
-     7: DefineProperty <this>, r1, r0, 0
-    12: LoadUndefined r0
-    14: Ret r0
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -168,8 +169,17 @@
     14: Ret r0
 }
 
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadImmediate r0, 4
+     3: LoadFromScope r1, 1, 0
+     7: DefineProperty <this>, r1, r0, 0
+    12: LoadUndefined r0
+    14: Ret r0
+}
+
 [BytecodeFunction: private] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: NewPrivateSymbol r2, c1
@@ -178,42 +188,47 @@
     14: StoreToScope r2, 3, 0
     18: NewClass r0, c4, c3, r1, r0
     24: NewClosure r2, c5
-    27: CallWithReceiver r2, r2, r0, r2, 0
-    33: PopScope 
-    34: LoadUndefined r1
-    36: Ret r1
+    27: LoadConstant r3, c6
+    30: DefinePrivateProperty r0, r3, r2, 0
+    35: NewClosure r2, c7
+    38: CallWithReceiver r2, r2, r0, r2, 0
+    44: PopScope 
+    45: LoadUndefined r1
+    47: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: private1]
     2: [String: private2]
     3: [BytecodeFunction: C]
     4: [ClassNames]
-    5: [BytecodeFunction: staticInitializer]
+    5: [BytecodeFunction: fieldsInitializer]
+    6: [SymbolValue: fieldsInitializer]
+    7: [BytecodeFunction: staticInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadImmediate r0, 2
-     3: LoadFromScope r1, 3, 0
-     7: DefinePrivateProperty <this>, r1, r0, 0
-    12: LoadUndefined r0
-    14: Ret r0
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
   Parameters: 0, Registers: 2
      0: LoadImmediate r0, 1
      3: LoadFromScope r1, 2, 0
+     7: DefinePrivateProperty <this>, r1, r0, 0
+    12: LoadUndefined r0
+    14: Ret r0
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadImmediate r0, 2
+     3: LoadFromScope r1, 3, 0
      7: DefinePrivateProperty <this>, r1, r0, 0
     12: LoadUndefined r0
     14: Ret r0
@@ -239,43 +254,32 @@
     48: StoreToScope r2, 1, 0
     52: NewClass r0, c4, c3, r1, r0
     58: NewClosure r2, c5
-    61: CallWithReceiver r2, r2, r0, r2, 0
-    67: PopScope 
-    68: LoadUndefined r1
-    70: Ret r1
+    61: LoadConstant r3, c6
+    64: DefinePrivateProperty r0, r3, r2, 0
+    69: NewClosure r2, c7
+    72: CallWithReceiver r2, r2, r0, r2, 0
+    78: PopScope 
+    79: LoadUndefined r1
+    81: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: private1]
     2: [String: private2]
     3: [BytecodeFunction: C]
     4: [ClassNames]
-    5: [BytecodeFunction: staticInitializer]
+    5: [BytecodeFunction: fieldsInitializer]
+    6: [SymbolValue: fieldsInitializer]
+    7: [BytecodeFunction: staticInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadUndefined r0
-     2: DefineNamedProperty <this>, c0, r0
-     6: LoadUndefined r0
-     8: LoadFromScope r1, 1, 0
-    12: DefineProperty <this>, r1, r0, 0
-    17: LoadUndefined r0
-    19: LoadFromScope r1, 5, 0
-    23: DefinePrivateProperty <this>, r1, r0, 0
-    28: LoadUndefined r0
-    30: Ret r0
-  Constant Table:
-    0: [String: named2]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -294,6 +298,22 @@
     0: [String: named1]
 }
 
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadUndefined r0
+     2: DefineNamedProperty <this>, c0, r0
+     6: LoadUndefined r0
+     8: LoadFromScope r1, 1, 0
+    12: DefineProperty <this>, r1, r0, 0
+    17: LoadUndefined r0
+    19: LoadFromScope r1, 5, 0
+    23: DefinePrivateProperty <this>, r1, r0, 0
+    28: LoadUndefined r0
+    30: Ret r0
+  Constant Table:
+    0: [String: named2]
+}
+
 [BytecodeFunction: withConstructor] {
   Parameters: 0, Registers: 4
      0: PushLexicalScope c0
@@ -304,27 +324,32 @@
     14: ToPropertyKey r2, r2
     17: StoreToScope r2, 0, 0
     21: NewClass r0, c2, c1, r1, r0
-    27: PopScope 
-    28: LoadUndefined r1
-    30: Ret r1
+    27: NewClosure r2, c3
+    30: LoadConstant r3, c4
+    33: DefinePrivateProperty r0, r3, r2, 0
+    38: PopScope 
+    39: LoadUndefined r1
+    41: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [BytecodeFunction: C]
     2: [ClassNames]
+    3: [BytecodeFunction: fieldsInitializer]
+    4: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: PushFunctionScope c1
-    11: LoadImmediate r0, 1
-    14: StoreToScope r0, 0, 0
-    18: NewClosure r0, c2
-    21: LoadUndefined r0
-    23: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: PushFunctionScope c1
+    13: LoadImmediate r0, 1
+    16: StoreToScope r0, 0, 0
+    20: NewClosure r0, c2
+    23: LoadUndefined r0
+    25: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
+    0: [SymbolValue: fieldsInitializer]
     1: [ScopeNames]
     2: [BytecodeFunction: <anonymous>]
 }
@@ -349,26 +374,31 @@
 }
 
 [BytecodeFunction: withImplicitDerivedConstructor] {
-  Parameters: 0, Registers: 2
+  Parameters: 0, Registers: 4
      0: LoadGlobal r1, c0, k0
      4: NewClass r0, c2, c1, r1, r0
-    10: LoadUndefined r1
-    12: Ret r1
+    10: NewClosure r2, c3
+    13: LoadConstant r3, c4
+    16: DefinePrivateProperty r0, r3, r2, 0
+    21: LoadUndefined r1
+    23: Ret r1
   Constant Table:
     0: [String: String]
     1: [BytecodeFunction: C]
     2: [ClassNames]
+    3: [BytecodeFunction: fieldsInitializer]
+    4: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 2
      0: DefaultSuperCall 
-     1: NewClosure r1, c0
-     4: CallWithReceiver r1, r1, <this>, r1, 0
-    10: CheckThisInitialized <this>
-    12: Ret <this>
+     1: GetNamedProperty r1, <closure>, c0, k0
+     6: CallWithReceiver r1, r1, <this>, r1, 0
+    12: CheckThisInitialized <this>
+    14: Ret <this>
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -382,15 +412,20 @@
 }
 
 [BytecodeFunction: withDerivedConstructor] {
-  Parameters: 0, Registers: 2
+  Parameters: 0, Registers: 4
      0: LoadGlobal r1, c0, k0
      4: NewClass r0, c2, c1, r1, r0
-    10: LoadUndefined r1
-    12: Ret r1
+    10: NewClosure r2, c3
+    13: LoadConstant r3, c4
+    16: DefinePrivateProperty r0, r3, r2, 0
+    21: LoadUndefined r1
+    23: Ret r1
   Constant Table:
     0: [String: String]
     1: [BytecodeFunction: C]
     2: [ClassNames]
+    3: [BytecodeFunction: fieldsInitializer]
+    4: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: C] {
@@ -398,17 +433,17 @@
      0: LoadEmpty <this>
      2: Mov r0, <closure>
      5: LoadImmediate r2, 2
-     8: GetSuperConstructor r2, r0
-    11: Construct r2, r2, r1, r1, 0
+     8: GetSuperConstructor r3, r0
+    11: Construct r2, r3, r1, r1, 0
     17: CheckSuperAlreadyCalled <this>
     19: Mov <this>, r2
-    22: NewClosure r3, c0
-    25: CallWithReceiver r3, r3, r2, r3, 0
-    31: LoadImmediate r2, 3
-    34: CheckThisInitialized <this>
-    36: Ret <this>
+    22: GetNamedProperty r3, r0, c0, k0
+    27: CallWithReceiver r3, r3, r2, r3, 0
+    33: LoadImmediate r2, 3
+    36: CheckThisInitialized <this>
+    38: Ret <this>
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -422,7 +457,7 @@
 }
 
 [BytecodeFunction: withMethods] {
-  Parameters: 0, Registers: 6
+  Parameters: 0, Registers: 7
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: NewPrivateSymbol r2, c1
@@ -443,9 +478,12 @@
     54: NewClosure r5, c5
     57: StoreToScope r5, 1, 0
     61: NewClass r0, c7, c6, r1, r2
-    67: PopScope 
-    68: LoadUndefined r1
-    70: Ret r1
+    67: NewClosure r5, c8
+    70: LoadConstant r6, c9
+    73: DefinePrivateProperty r0, r6, r5, 0
+    78: PopScope 
+    79: LoadUndefined r1
+    81: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: private1]
@@ -455,16 +493,18 @@
     5: [BytecodeFunction: #private2]
     6: [BytecodeFunction: C]
     7: [ClassNames]
+    8: [BytecodeFunction: fieldsInitializer]
+    9: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -505,7 +545,7 @@
 }
 
 [BytecodeFunction: withCapturedName] {
-  Parameters: 0, Registers: 4
+  Parameters: 0, Registers: 5
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 2, 0
@@ -522,9 +562,12 @@
     41: NewClosure r2, c3
     44: NewClass r0, c5, c4, r1, r2
     50: StoreToScope r0, 2, 0
-    54: PopScope 
-    55: LoadUndefined r1
-    57: Ret r1
+    54: NewClosure r3, c6
+    57: LoadConstant r4, c7
+    60: DefinePrivateProperty r0, r4, r3, 0
+    65: PopScope 
+    66: LoadUndefined r1
+    68: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: private1]
@@ -532,16 +575,18 @@
     3: [BytecodeFunction: method]
     4: [BytecodeFunction: C]
     5: [ClassNames]
+    6: [BytecodeFunction: fieldsInitializer]
+    7: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -636,46 +681,32 @@
     48: StoreToScope r2, 1, 0
     52: NewClass r0, c4, c3, r1, r0
     58: NewClosure r2, c5
-    61: CallWithReceiver r2, r2, r0, r2, 0
-    67: PopScope 
-    68: LoadUndefined r1
-    70: Ret r1
+    61: LoadConstant r3, c6
+    64: DefinePrivateProperty r0, r3, r2, 0
+    69: NewClosure r2, c7
+    72: CallWithReceiver r2, r2, r0, r2, 0
+    78: PopScope 
+    79: LoadUndefined r1
+    81: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: private1]
     2: [String: private2]
     3: [BytecodeFunction: C]
     4: [ClassNames]
-    5: [BytecodeFunction: staticInitializer]
+    5: [BytecodeFunction: fieldsInitializer]
+    6: [SymbolValue: fieldsInitializer]
+    7: [BytecodeFunction: staticInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: NewClosure r0, c0
-     3: DefineNamedProperty <this>, c1, r0
-     7: NewClosure r0, c2
-    10: LoadFromScope r1, 1, 0
-    14: DefineProperty <this>, r1, r0, 1
-    19: NewClosure r0, c3
-    22: LoadFromScope r1, 5, 0
-    26: DefinePrivateProperty <this>, r1, r0, 0
-    31: LoadUndefined r0
-    33: Ret r0
-  Constant Table:
-    0: [BytecodeFunction: named2]
-    1: [String: named2]
-    2: [BytecodeFunction: <anonymous>]
-    3: [BytecodeFunction: #private2]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -695,6 +726,25 @@
     1: [String: named1]
     2: [BytecodeFunction: <anonymous>]
     3: [BytecodeFunction: #private1]
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: NewClosure r0, c0
+     3: DefineNamedProperty <this>, c1, r0
+     7: NewClosure r0, c2
+    10: LoadFromScope r1, 1, 0
+    14: DefineProperty <this>, r1, r0, 1
+    19: NewClosure r0, c3
+    22: LoadFromScope r1, 5, 0
+    26: DefinePrivateProperty <this>, r1, r0, 0
+    31: LoadUndefined r0
+    33: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: named2]
+    1: [String: named2]
+    2: [BytecodeFunction: <anonymous>]
+    3: [BytecodeFunction: #private2]
 }
 
 [BytecodeFunction: named1] {
@@ -734,42 +784,35 @@
 }
 
 [BytecodeFunction: superMemberInFields] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: NewClass r0, c2, c1, r1, r0
     10: NewClosure r2, c3
-    13: CallWithReceiver r2, r2, r0, r2, 0
-    19: PopScope 
-    20: LoadUndefined r1
-    22: Ret r1
+    13: LoadConstant r3, c4
+    16: DefinePrivateProperty r0, r3, r2, 0
+    21: NewClosure r2, c5
+    24: CallWithReceiver r2, r2, r0, r2, 0
+    30: PopScope 
+    31: LoadUndefined r1
+    33: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [BytecodeFunction: C]
     2: [ClassNames]
-    3: [BytecodeFunction: staticInitializer]
+    3: [BytecodeFunction: fieldsInitializer]
+    4: [SymbolValue: fieldsInitializer]
+    5: [BytecodeFunction: staticInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 1
-     0: LoadFromScope r0, 1, 0
-     4: GetNamedSuperProperty r0, r0, <this>, c0
-     9: DefineNamedProperty <this>, c1, r0
-    13: LoadUndefined r0
-    15: Ret r0
-  Constant Table:
-    0: [String: foo]
-    1: [String: field2]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -784,37 +827,45 @@
     1: [String: field1]
 }
 
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 1
+     0: LoadFromScope r0, 1, 0
+     4: GetNamedSuperProperty r0, r0, <this>, c0
+     9: DefineNamedProperty <this>, c1, r0
+    13: LoadUndefined r0
+    15: Ret r0
+  Constant Table:
+    0: [String: foo]
+    1: [String: field2]
+}
+
 [BytecodeFunction: thisInFields] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: LoadEmpty r1
      2: NewClass r0, c1, c0, r1, r0
      8: NewClosure r2, c2
-    11: CallWithReceiver r2, r2, r0, r2, 0
-    17: LoadUndefined r1
-    19: Ret r1
+    11: LoadConstant r3, c3
+    14: DefinePrivateProperty r0, r3, r2, 0
+    19: NewClosure r2, c4
+    22: CallWithReceiver r2, r2, r0, r2, 0
+    28: LoadUndefined r1
+    30: Ret r1
   Constant Table:
     0: [BytecodeFunction: C]
     1: [ClassNames]
-    2: [BytecodeFunction: staticInitializer]
+    2: [BytecodeFunction: fieldsInitializer]
+    3: [SymbolValue: fieldsInitializer]
+    4: [BytecodeFunction: staticInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 1
-    0: DefineNamedProperty <this>, c0, <this>
-    4: LoadUndefined r0
-    6: Ret r0
-  Constant Table:
-    0: [String: field2]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -824,39 +875,44 @@
     6: Ret r0
   Constant Table:
     0: [String: field1]
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 1
+    0: DefineNamedProperty <this>, c0, <this>
+    4: LoadUndefined r0
+    6: Ret r0
+  Constant Table:
+    0: [String: field2]
 }
 
 [BytecodeFunction: newTargetInFields] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: LoadEmpty r1
      2: NewClass r0, c1, c0, r1, r0
      8: NewClosure r2, c2
-    11: CallWithReceiver r2, r2, r0, r2, 0
-    17: LoadUndefined r1
-    19: Ret r1
+    11: LoadConstant r3, c3
+    14: DefinePrivateProperty r0, r3, r2, 0
+    19: NewClosure r2, c4
+    22: CallWithReceiver r2, r2, r0, r2, 0
+    28: LoadUndefined r1
+    30: Ret r1
   Constant Table:
     0: [BytecodeFunction: C]
     1: [ClassNames]
-    2: [BytecodeFunction: staticInitializer]
+    2: [BytecodeFunction: fieldsInitializer]
+    3: [SymbolValue: fieldsInitializer]
+    4: [BytecodeFunction: staticInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-    0: DefineNamedProperty <this>, c0, r0
-    4: LoadUndefined r1
-    6: Ret r1
-  Constant Table:
-    0: [String: field2]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -866,40 +922,44 @@
     6: Ret r1
   Constant Table:
     0: [String: field1]
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+    0: DefineNamedProperty <this>, c0, r0
+    4: LoadUndefined r1
+    6: Ret r1
+  Constant Table:
+    0: [String: field2]
 }
 
 [BytecodeFunction: fieldNoInitializer] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: LoadEmpty r1
      2: NewClass r0, c1, c0, r1, r0
      8: NewClosure r2, c2
-    11: CallWithReceiver r2, r2, r0, r2, 0
-    17: LoadUndefined r1
-    19: Ret r1
+    11: LoadConstant r3, c3
+    14: DefinePrivateProperty r0, r3, r2, 0
+    19: NewClosure r2, c4
+    22: CallWithReceiver r2, r2, r0, r2, 0
+    28: LoadUndefined r1
+    30: Ret r1
   Constant Table:
     0: [BytecodeFunction: C]
     1: [ClassNames]
-    2: [BytecodeFunction: staticInitializer]
+    2: [BytecodeFunction: fieldsInitializer]
+    3: [SymbolValue: fieldsInitializer]
+    4: [BytecodeFunction: staticInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 1
-    0: LoadUndefined r0
-    2: DefineNamedProperty <this>, c0, r0
-    6: LoadUndefined r0
-    8: Ret r0
-  Constant Table:
-    0: [String: field2]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -912,8 +972,18 @@
     0: [String: field1]
 }
 
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: DefineNamedProperty <this>, c0, r0
+    6: LoadUndefined r0
+    8: Ret r0
+  Constant Table:
+    0: [String: field2]
+}
+
 [BytecodeFunction: privateFieldNoInitializer] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: NewPrivateSymbol r2, c1
@@ -922,42 +992,47 @@
     14: StoreToScope r2, 3, 0
     18: NewClass r0, c4, c3, r1, r0
     24: NewClosure r2, c5
-    27: CallWithReceiver r2, r2, r0, r2, 0
-    33: PopScope 
-    34: LoadUndefined r1
-    36: Ret r1
+    27: LoadConstant r3, c6
+    30: DefinePrivateProperty r0, r3, r2, 0
+    35: NewClosure r2, c7
+    38: CallWithReceiver r2, r2, r0, r2, 0
+    44: PopScope 
+    45: LoadUndefined r1
+    47: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: field1]
     2: [String: field2]
     3: [BytecodeFunction: C]
     4: [ClassNames]
-    5: [BytecodeFunction: staticInitializer]
+    5: [BytecodeFunction: fieldsInitializer]
+    6: [SymbolValue: fieldsInitializer]
+    7: [BytecodeFunction: staticInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
-  Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadUndefined r0
-     2: LoadFromScope r1, 3, 0
-     6: DefinePrivateProperty <this>, r1, r0, 0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
     11: LoadUndefined r0
     13: Ret r0
+  Constant Table:
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
   Parameters: 0, Registers: 2
      0: LoadUndefined r0
      2: LoadFromScope r1, 2, 0
+     6: DefinePrivateProperty <this>, r1, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadUndefined r0
+     2: LoadFromScope r1, 3, 0
      6: DefinePrivateProperty <this>, r1, r0, 0
     11: LoadUndefined r0
     13: Ret r0

--- a/tests/snapshot/bytecode/class/private_member.exp
+++ b/tests/snapshot/bytecode/class/private_member.exp
@@ -1,5 +1,5 @@
 [BytecodeFunction: <global>] {
-  Parameters: 0, Registers: 10
+  Parameters: 0, Registers: 12
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: NewPrivateSymbol r2, c1
@@ -15,10 +15,13 @@
     36: NewClosure r8, c9
     39: NewClosure r9, c10
     42: NewClass r0, c12, c11, r1, r2
-    48: PopScope 
-    49: StoreToScope r0, 1, 0
-    53: LoadUndefined r0
-    55: Ret r0
+    48: NewClosure r10, c13
+    51: LoadConstant r11, c14
+    54: DefinePrivateProperty r0, r11, r10, 0
+    59: PopScope 
+    60: StoreToScope r0, 1, 0
+    64: LoadUndefined r0
+    66: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: method]
@@ -33,16 +36,18 @@
     10: [BytecodeFunction: privateDestructure]
     11: [BytecodeFunction: C]
     12: [ClassNames]
+    13: [BytecodeFunction: fieldsInitializer]
+    14: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {

--- a/tests/snapshot/bytecode/class/private_properties.exp
+++ b/tests/snapshot/bytecode/class/private_properties.exp
@@ -18,7 +18,7 @@
 }
 
 [BytecodeFunction: methods] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: NewPrivateSymbol r2, c1
@@ -31,10 +31,13 @@
     28: StoreToScope r2, 1, 0
     32: NewClass r0, c6, c5, r1, r0
     38: NewClosure r2, c7
-    41: CallWithReceiver r2, r2, r0, r2, 0
-    47: PopScope 
-    48: LoadUndefined r1
-    50: Ret r1
+    41: LoadConstant r3, c8
+    44: DefinePrivateProperty r0, r3, r2, 0
+    49: NewClosure r2, c9
+    52: CallWithReceiver r2, r2, r0, r2, 0
+    58: PopScope 
+    59: LoadUndefined r1
+    61: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: method1]
@@ -43,32 +46,34 @@
     4: [BytecodeFunction: #method2]
     5: [BytecodeFunction: C]
     6: [ClassNames]
-    7: [BytecodeFunction: staticInitializer]
+    7: [BytecodeFunction: fieldsInitializer]
+    8: [SymbolValue: fieldsInitializer]
+    9: [BytecodeFunction: staticInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadFromScope r0, 3, 0
-     4: LoadFromScope r1, 1, 0
-     8: DefinePrivateProperty <this>, r0, r1, 1
-    13: LoadUndefined r0
-    15: Ret r0
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
   Parameters: 0, Registers: 2
      0: LoadFromScope r0, 2, 0
      4: LoadFromScope r1, 0, 0
+     8: DefinePrivateProperty <this>, r0, r1, 1
+    13: LoadUndefined r0
+    15: Ret r0
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r0, 3, 0
+     4: LoadFromScope r1, 1, 0
      8: DefinePrivateProperty <this>, r0, r1, 1
     13: LoadUndefined r0
     15: Ret r0
@@ -87,7 +92,7 @@
 }
 
 [BytecodeFunction: individualAccessors] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: NewPrivateSymbol r2, c1
@@ -108,10 +113,13 @@
     56: StoreToScope r2, 3, 0
     60: NewClass r0, c10, c9, r1, r0
     66: NewClosure r2, c11
-    69: CallWithReceiver r2, r2, r0, r2, 0
-    75: PopScope 
-    76: LoadUndefined r1
-    78: Ret r1
+    69: LoadConstant r3, c12
+    72: DefinePrivateProperty r0, r3, r2, 0
+    77: NewClosure r2, c13
+    80: CallWithReceiver r2, r2, r0, r2, 0
+    86: PopScope 
+    87: LoadUndefined r1
+    89: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: getter1]
@@ -124,29 +132,19 @@
     8: [BytecodeFunction: set #setter2]
     9: [BytecodeFunction: C]
     10: [ClassNames]
-    11: [BytecodeFunction: staticInitializer]
+    11: [BytecodeFunction: fieldsInitializer]
+    12: [SymbolValue: fieldsInitializer]
+    13: [BytecodeFunction: staticInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadFromScope r0, 6, 0
-     4: LoadFromScope r1, 2, 0
-     8: DefinePrivateProperty <this>, r0, r1, 2
-    13: LoadFromScope r0, 7, 0
-    17: LoadFromScope r1, 3, 0
-    21: DefinePrivateProperty <this>, r0, r1, 4
-    26: LoadUndefined r0
-    28: Ret r0
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -156,6 +154,18 @@
      8: DefinePrivateProperty <this>, r0, r1, 2
     13: LoadFromScope r0, 5, 0
     17: LoadFromScope r1, 1, 0
+    21: DefinePrivateProperty <this>, r0, r1, 4
+    26: LoadUndefined r0
+    28: Ret r0
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r0, 6, 0
+     4: LoadFromScope r1, 2, 0
+     8: DefinePrivateProperty <this>, r0, r1, 2
+    13: LoadFromScope r0, 7, 0
+    17: LoadFromScope r1, 3, 0
     21: DefinePrivateProperty <this>, r0, r1, 4
     26: LoadUndefined r0
     28: Ret r0
@@ -186,36 +196,39 @@
 }
 
 [BytecodeFunction: accessorPairs] {
-  Parameters: 0, Registers: 6
-     0: PushLexicalScope c0
-     2: LoadEmpty r1
-     4: NewPrivateSymbol r2, c1
-     7: StoreToScope r2, 3, 0
-    11: NewPrivateSymbol r2, c2
-    14: StoreToScope r2, 4, 0
-    18: NewPrivateSymbol r2, c3
-    21: StoreToScope r2, 5, 0
-    25: NewClosure r2, c4
-    28: NewClosure r3, c5
-    31: NewAccessor r2, r3, r2
-    35: StoreToScope r2, 0, 0
-    39: NewClosure r2, c6
-    42: NewClosure r3, c7
-    45: NewAccessor r2, r2, r3
-    49: StoreToScope r2, 1, 0
-    53: NewClosure r2, c8
-    56: NewClosure r3, c9
-    59: NewClosure r4, c10
-    62: NewClosure r5, c11
-    65: NewAccessor r4, r5, r4
-    69: StoreToScope r4, 2, 0
-    73: NewClosure r4, c12
-    76: NewClass r0, c14, c13, r1, r2
-    82: NewClosure r5, c15
-    85: CallWithReceiver r5, r5, r0, r5, 0
-    91: PopScope 
-    92: LoadUndefined r1
-    94: Ret r1
+  Parameters: 0, Registers: 7
+      0: PushLexicalScope c0
+      2: LoadEmpty r1
+      4: NewPrivateSymbol r2, c1
+      7: StoreToScope r2, 3, 0
+     11: NewPrivateSymbol r2, c2
+     14: StoreToScope r2, 4, 0
+     18: NewPrivateSymbol r2, c3
+     21: StoreToScope r2, 5, 0
+     25: NewClosure r2, c4
+     28: NewClosure r3, c5
+     31: NewAccessor r2, r3, r2
+     35: StoreToScope r2, 0, 0
+     39: NewClosure r2, c6
+     42: NewClosure r3, c7
+     45: NewAccessor r2, r2, r3
+     49: StoreToScope r2, 1, 0
+     53: NewClosure r2, c8
+     56: NewClosure r3, c9
+     59: NewClosure r4, c10
+     62: NewClosure r5, c11
+     65: NewAccessor r4, r5, r4
+     69: StoreToScope r4, 2, 0
+     73: NewClosure r4, c12
+     76: NewClass r0, c14, c13, r1, r2
+     82: NewClosure r5, c15
+     85: LoadConstant r6, c16
+     88: DefinePrivateProperty r0, r6, r5, 0
+     93: NewClosure r5, c17
+     96: CallWithReceiver r5, r5, r0, r5, 0
+    102: PopScope 
+    103: LoadUndefined r1
+    105: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: acc1]
@@ -232,26 +245,19 @@
     12: [BytecodeFunction: method3]
     13: [BytecodeFunction: C]
     14: [ClassNames]
-    15: [BytecodeFunction: staticInitializer]
+    15: [BytecodeFunction: fieldsInitializer]
+    16: [SymbolValue: fieldsInitializer]
+    17: [BytecodeFunction: staticInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
-}
-
-[BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadFromScope r0, 4, 0
-     4: LoadFromScope r1, 1, 0
-     8: DefinePrivateProperty <this>, r0, r1, 6
-    13: LoadUndefined r0
-    15: Ret r0
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {
@@ -264,6 +270,15 @@
     21: DefinePrivateProperty <this>, r0, r1, 6
     26: LoadUndefined r0
     28: Ret r0
+}
+
+[BytecodeFunction: staticInitializer] {
+  Parameters: 0, Registers: 2
+     0: LoadFromScope r0, 4, 0
+     4: LoadFromScope r1, 1, 0
+     8: DefinePrivateProperty <this>, r0, r1, 6
+    13: LoadUndefined r0
+    15: Ret r0
 }
 
 [BytecodeFunction: get #acc1] {

--- a/tests/snapshot/bytecode/class/super_call.exp
+++ b/tests/snapshot/bytecode/class/super_call.exp
@@ -27,11 +27,11 @@
 }
 
 [BytecodeFunction: C1] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: LoadEmpty <this>
      2: Mov r0, <closure>
-     5: GetSuperConstructor r2, r0
-     8: Construct r2, r2, r1, r1, 0
+     5: GetSuperConstructor r3, r0
+     8: Construct r2, r3, r1, r1, 0
     14: CheckSuperAlreadyCalled <this>
     16: Mov <this>, r2
     19: CheckThisInitialized <this>
@@ -58,15 +58,15 @@
 }
 
 [BytecodeFunction: C3] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: PushFunctionScope c0
      2: LoadEmpty <this>
      4: StoreToScope <this>, 0, 0
      8: StoreToScope r1, 1, 0
     12: Mov r0, <closure>
-    15: GetSuperConstructor r1, r0
-    18: LoadFromScope r2, 1, 0
-    22: Construct r1, r1, r2, r2, 0
+    15: GetSuperConstructor r2, r0
+    18: LoadFromScope r3, 1, 0
+    22: Construct r1, r2, r3, r3, 0
     28: LoadFromScope r2, 0, 0
     32: CheckSuperAlreadyCalled r2
     34: StoreToScope r1, 0, 0
@@ -110,13 +110,19 @@
 }
 
 [BytecodeFunction: <anonymous>] {
-  Parameters: 0, Registers: 2
-     0: LoadFromScope r0, 1, 0
-     4: GetSuperConstructor r0, r0
-     7: LoadFromScope r1, 2, 0
-    11: Construct r0, r0, r1, r1, 0
-    17: LoadFromScope r1, 0, 0
-    21: CheckSuperAlreadyCalled r1
+  Parameters: 0, Registers: 4
+     0: LoadFromScope r1, 1, 0
+     4: GetSuperConstructor r2, r1
+     7: LoadFromScope r3, 2, 0
+    11: Construct r0, r2, r3, r3, 0
+    17: LoadFromScope r2, 0, 0
+    21: CheckSuperAlreadyCalled r2
     23: StoreToScope r0, 0, 0
-    27: Ret r0
+    27: GetNamedProperty r2, r1, c0, k0
+    32: JumpNullish r2, 9 (.L0)
+    35: CallWithReceiver r2, r2, r0, r2, 0
+  .L0:
+    41: Ret r0
+  Constant Table:
+    0: [SymbolValue: fieldsInitializer]
 }

--- a/tests/snapshot/bytecode/class/super_member.exp
+++ b/tests/snapshot/bytecode/class/super_member.exp
@@ -68,11 +68,11 @@
 }
 
 [BytecodeFunction: C1] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: LoadEmpty <this>
      2: Mov r0, <closure>
-     5: GetSuperConstructor r2, r0
-     8: Construct r2, r2, r1, r1, 0
+     5: GetSuperConstructor r3, r0
+     8: Construct r2, r3, r1, r1, 0
     14: CheckSuperAlreadyCalled <this>
     16: Mov <this>, r2
     19: CheckThisInitialized <this>
@@ -124,15 +124,21 @@
 }
 
 [BytecodeFunction: <anonymous>] {
-  Parameters: 0, Registers: 2
-     0: LoadFromScope r0, 1, 0
-     4: GetSuperConstructor r0, r0
-     7: LoadFromScope r1, 2, 0
-    11: Construct r0, r0, r1, r1, 0
-    17: LoadFromScope r1, 0, 0
-    21: CheckSuperAlreadyCalled r1
+  Parameters: 0, Registers: 4
+     0: LoadFromScope r1, 1, 0
+     4: GetSuperConstructor r2, r1
+     7: LoadFromScope r3, 2, 0
+    11: Construct r0, r2, r3, r3, 0
+    17: LoadFromScope r2, 0, 0
+    21: CheckSuperAlreadyCalled r2
     23: StoreToScope r0, 0, 0
-    27: Ret r0
+    27: GetNamedProperty r2, r1, c0, k0
+    32: JumpNullish r2, 9 (.L0)
+    35: CallWithReceiver r2, r2, r0, r2, 0
+  .L0:
+    41: Ret r0
+  Constant Table:
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: C3] {

--- a/tests/snapshot/bytecode/eval/arrow_this.exp
+++ b/tests/snapshot/bytecode/eval/arrow_this.exp
@@ -82,7 +82,7 @@
 }
 
 [BytecodeFunction: Derived] {
-  Parameters: 0, Registers: 2
+  Parameters: 0, Registers: 4
      0: PushFunctionScope c0
      2: LoadEmpty <this>
      4: StoreToScope <this>, 0, 0
@@ -90,12 +90,12 @@
     12: StoreToScope <closure>, 1, 0
     16: NewUnmappedArguments r0
     18: StoreToScope r0, 3, 0
-    22: LoadFromScope r0, 1, 0
-    26: GetSuperConstructor r0, r0
-    29: LoadFromScope r1, 2, 0
-    33: Construct r0, r0, r1, r1, 0
-    39: LoadFromScope r1, 0, 0
-    43: CheckSuperAlreadyCalled r1
+    22: LoadFromScope r1, 1, 0
+    26: GetSuperConstructor r2, r1
+    29: LoadFromScope r3, 2, 0
+    33: Construct r0, r2, r3, r3, 0
+    39: LoadFromScope r2, 0, 0
+    43: CheckSuperAlreadyCalled r2
     45: StoreToScope r0, 0, 0
     49: NewClosure r0, c1
     52: Call r0, r0, r0, 0
@@ -186,18 +186,17 @@
 
 [BytecodeFunction: <eval>] {
   Parameters: 0, Registers: 1
-    0: PushLexicalScope c0
-    2: StoreToScope <this>, 0, 0
-    6: NewClosure r0, c1
-    9: Ret r0
+    0: NewClosure r0, c0
+    3: Ret r0
   Constant Table:
-    0: [ScopeNames]
-    1: [BytecodeFunction: <anonymous>]
+    0: [BytecodeFunction: <anonymous>]
 }
 
 [BytecodeFunction: <anonymous>] {
   Parameters: 0, Registers: 1
-    0: LoadFromScope r0, 0, 0
-    4: CheckThisInitialized r0
-    6: Ret r0
+    0: LoadDynamic r0, c0
+    3: CheckThisInitialized r0
+    5: Ret r0
+  Constant Table:
+    0: [String: this]
 }

--- a/tests/snapshot/bytecode/eval/derived_constructor_this.exp
+++ b/tests/snapshot/bytecode/eval/derived_constructor_this.exp
@@ -212,19 +212,24 @@
 }
 
 [BytecodeFunction: <eval>] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 4
      0: LoadDynamic r1, c0
-     3: GetSuperConstructor r1, r1
-     6: LoadDynamic r2, c1
-     9: Construct r0, r1, r2, r2, 0
-    15: LoadDynamic r1, c2
-    18: CheckSuperAlreadyCalled r1
+     3: GetSuperConstructor r2, r1
+     6: LoadDynamic r3, c1
+     9: Construct r0, r2, r3, r3, 0
+    15: LoadDynamic r2, c2
+    18: CheckSuperAlreadyCalled r2
     20: StoreDynamic r0, c2
-    23: Ret r0
+    23: GetNamedProperty r2, r1, c3, k0
+    28: JumpNullish r2, 9 (.L0)
+    31: CallWithReceiver r2, r2, r0, r2, 0
+  .L0:
+    37: Ret r0
   Constant Table:
     0: [String: %constructor]
     1: [String: %new.target]
     2: [String: this]
+    3: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: <eval>] {

--- a/tests/snapshot/bytecode/eval/flags.exp
+++ b/tests/snapshot/bytecode/eval/flags.exp
@@ -1,5 +1,5 @@
 [BytecodeFunction: <global>] {
-  Parameters: 0, Registers: 5
+  Parameters: 0, Registers: 6
      0: LoadGlobal r0, c0, k0
      4: LoadConstant r1, c1
      7: CallMaybeEval r0, r0, r1, 1, 0
@@ -12,19 +12,22 @@
     31: NewClass r0, c7, c6, r1, r2
     37: StoreToScope r0, 0, 0
     41: NewClosure r4, c8
-    44: CallWithReceiver r4, r4, r0, r4, 0
-    50: PopScope 
-    51: StoreToScope r0, 1, 0
-    55: PushLexicalScope c9
-    57: LoadEmpty r1
-    59: StoreToScope r1, 0, 0
-    63: LoadEmpty r1
-    65: NewClass r0, c11, c10, r1, r0
-    71: StoreToScope r0, 0, 0
-    75: PopScope 
-    76: StoreToScope r0, 2, 0
-    80: LoadUndefined r0
-    82: Ret r0
+    44: LoadConstant r5, c9
+    47: DefinePrivateProperty r0, r5, r4, 0
+    52: NewClosure r4, c10
+    55: CallWithReceiver r4, r4, r0, r4, 0
+    61: PopScope 
+    62: StoreToScope r0, 1, 0
+    66: PushLexicalScope c11
+    68: LoadEmpty r1
+    70: StoreToScope r1, 0, 0
+    74: LoadEmpty r1
+    76: NewClass r0, c13, c12, r1, r0
+    82: StoreToScope r0, 0, 0
+    86: PopScope 
+    87: StoreToScope r0, 2, 0
+    91: LoadUndefined r0
+    93: Ret r0
   Constant Table:
     0: [String: eval]
     1: [String: ]
@@ -34,14 +37,16 @@
     5: [BytecodeFunction: method2]
     6: [BytecodeFunction: C1]
     7: [ClassNames]
-    8: [BytecodeFunction: staticInitializer]
-    9: [ScopeNames]
-    10: [BytecodeFunction: C2]
-    11: [ClassNames]
+    8: [BytecodeFunction: fieldsInitializer]
+    9: [SymbolValue: fieldsInitializer]
+    10: [BytecodeFunction: staticInitializer]
+    11: [ScopeNames]
+    12: [BytecodeFunction: C2]
+    13: [ClassNames]
 }
 
 [BytecodeFunction: C1] {
-  Parameters: 0, Registers: 2
+  Parameters: 0, Registers: 4
      0: PushFunctionScope c0
      2: LoadEmpty <this>
      4: StoreToScope <this>, 0, 0
@@ -52,23 +57,42 @@
     22: LoadGlobal r0, c1, k0
     26: LoadConstant r1, c2
     29: CallMaybeEval r0, r0, r1, 1, 11
-    35: LoadFromScope r0, 1, 0
-    39: GetSuperConstructor r0, r0
-    42: LoadFromScope r1, 3, 0
-    46: Construct r0, r0, r1, r1, 0
-    52: LoadFromScope r1, 0, 0
-    56: CheckSuperAlreadyCalled r1
+    35: LoadFromScope r1, 1, 0
+    39: GetSuperConstructor r2, r1
+    42: LoadFromScope r3, 3, 0
+    46: Construct r0, r2, r3, r3, 0
+    52: LoadFromScope r2, 0, 0
+    56: CheckSuperAlreadyCalled r2
     58: StoreToScope r0, 0, 0
-    62: NewClosure r1, c3
-    65: CallWithReceiver r1, r1, r0, r1, 0
-    71: LoadFromScope r0, 0, 0
-    75: CheckThisInitialized r0
-    77: Ret r0
+    62: GetNamedProperty r2, r1, c3, k1
+    67: CallWithReceiver r2, r2, r0, r2, 0
+    73: LoadFromScope r0, 0, 0
+    77: CheckThisInitialized r0
+    79: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: eval]
     2: [String: ]
-    3: [BytecodeFunction: fieldsInitializer]
+    3: [SymbolValue: fieldsInitializer]
+}
+
+[BytecodeFunction: fieldsInitializer] {
+  Parameters: 0, Registers: 2
+     0: PushFunctionScope c0
+     2: StoreToScope <this>, 0, 0
+     6: StoreToScope r0, 2, 0
+    10: LoadGlobal r0, c1, k0
+    14: LoadConstant r1, c2
+    17: CallMaybeEval r0, r0, r1, 1, 35
+    23: DefineNamedProperty <this>, c3, r0
+    27: PopScope 
+    28: LoadUndefined r0
+    30: Ret r0
+  Constant Table:
+    0: [ScopeNames]
+    1: [String: eval]
+    2: [String: ]
+    3: [String: field1]
 }
 
 [BytecodeFunction: staticInitializer] {
@@ -91,25 +115,6 @@
     1: [String: eval]
     2: [String: ]
     3: [String: field2]
-}
-
-[BytecodeFunction: fieldsInitializer] {
-  Parameters: 0, Registers: 2
-     0: PushFunctionScope c0
-     2: StoreToScope <this>, 0, 0
-     6: StoreToScope r0, 2, 0
-    10: LoadGlobal r0, c1, k0
-    14: LoadConstant r1, c2
-    17: CallMaybeEval r0, r0, r1, 1, 35
-    23: DefineNamedProperty <this>, c3, r0
-    27: PopScope 
-    28: LoadUndefined r0
-    30: Ret r0
-  Constant Table:
-    0: [ScopeNames]
-    1: [String: eval]
-    2: [String: ]
-    3: [String: field1]
 }
 
 [BytecodeFunction: method1] {

--- a/tests/snapshot/bytecode/eval/private_names.exp
+++ b/tests/snapshot/bytecode/eval/private_names.exp
@@ -1,5 +1,5 @@
 [BytecodeFunction: <global>] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 5
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 1, 0
@@ -9,32 +9,37 @@
     17: NewClosure r2, c2
     20: NewClass r0, c4, c3, r1, r2
     26: StoreToScope r0, 1, 0
-    30: PopScope 
-    31: StoreToScope r0, 1, 0
-    35: LoadFromScope r0, 1, 0
-    39: CheckTdz r0, c5
-    42: GetNamedProperty r1, r0, c6, k0
-    47: CallWithReceiver r0, r1, r0, r1, 0
-    53: LoadUndefined r0
-    55: Ret r0
+    30: NewClosure r3, c5
+    33: LoadConstant r4, c6
+    36: DefinePrivateProperty r0, r4, r3, 0
+    41: PopScope 
+    42: StoreToScope r0, 1, 0
+    46: LoadFromScope r0, 1, 0
+    50: CheckTdz r0, c7
+    53: GetNamedProperty r1, r0, c8, k0
+    58: CallWithReceiver r0, r1, r0, r1, 0
+    64: LoadUndefined r0
+    66: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: field]
     2: [BytecodeFunction: method1]
     3: [BytecodeFunction: C1]
     4: [ClassNames]
-    5: [String: C1]
-    6: [String: method1]
+    5: [BytecodeFunction: fieldsInitializer]
+    6: [SymbolValue: fieldsInitializer]
+    7: [String: C1]
+    8: [String: method1]
 }
 
 [BytecodeFunction: C1] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {

--- a/tests/snapshot/bytecode/eval/super_members.exp
+++ b/tests/snapshot/bytecode/eval/super_members.exp
@@ -1,30 +1,33 @@
 [BytecodeFunction: <global>] {
-  Parameters: 0, Registers: 5
-     0: PushLexicalScope c0
-     2: LoadEmpty r1
-     4: StoreToScope r1, 0, 0
-     8: LoadGlobal r1, c1, k0
-    12: NewClosure r2, c2
-    15: NewClosure r3, c3
-    18: NewClass r0, c5, c4, r1, r2
-    24: StoreToScope r0, 0, 0
-    28: NewClosure r4, c6
-    31: CallWithReceiver r4, r4, r0, r4, 0
-    37: PopScope 
-    38: StoreToScope r0, 1, 0
-    42: LoadFromScope r0, 1, 0
-    46: CheckTdz r0, c7
-    49: Construct r0, r0, r0, r0, 0
-    55: StoreGlobal r0, c8, k1
-    59: LoadGlobal r0, c8, k2
-    63: GetNamedProperty r1, r0, c9, k3
-    68: CallWithReceiver r0, r1, r0, r1, 0
-    74: LoadFromScope r0, 1, 0
-    78: CheckTdz r0, c7
-    81: GetNamedProperty r1, r0, c10, k4
-    86: CallWithReceiver r0, r1, r0, r1, 0
-    92: LoadUndefined r0
-    94: Ret r0
+  Parameters: 0, Registers: 6
+      0: PushLexicalScope c0
+      2: LoadEmpty r1
+      4: StoreToScope r1, 0, 0
+      8: LoadGlobal r1, c1, k0
+     12: NewClosure r2, c2
+     15: NewClosure r3, c3
+     18: NewClass r0, c5, c4, r1, r2
+     24: StoreToScope r0, 0, 0
+     28: NewClosure r4, c6
+     31: LoadConstant r5, c7
+     34: DefinePrivateProperty r0, r5, r4, 0
+     39: NewClosure r4, c8
+     42: CallWithReceiver r4, r4, r0, r4, 0
+     48: PopScope 
+     49: StoreToScope r0, 1, 0
+     53: LoadFromScope r0, 1, 0
+     57: CheckTdz r0, c9
+     60: Construct r0, r0, r0, r0, 0
+     66: StoreGlobal r0, c10, k1
+     70: LoadGlobal r0, c10, k2
+     74: GetNamedProperty r1, r0, c11, k3
+     79: CallWithReceiver r0, r1, r0, r1, 0
+     85: LoadFromScope r0, 1, 0
+     89: CheckTdz r0, c9
+     92: GetNamedProperty r1, r0, c12, k4
+     97: CallWithReceiver r0, r1, r0, r1, 0
+    103: LoadUndefined r0
+    105: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: String]
@@ -32,32 +35,34 @@
     3: [BytecodeFunction: method2]
     4: [BytecodeFunction: C]
     5: [ClassNames]
-    6: [BytecodeFunction: staticInitializer]
-    7: [String: C]
-    8: [String: x]
-    9: [String: method1]
-    10: [String: method2]
+    6: [BytecodeFunction: fieldsInitializer]
+    7: [SymbolValue: fieldsInitializer]
+    8: [BytecodeFunction: staticInitializer]
+    9: [String: C]
+    10: [String: x]
+    11: [String: method1]
+    12: [String: method2]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 2
      0: DefaultSuperCall 
-     1: NewClosure r1, c0
-     4: CallWithReceiver r1, r1, <this>, r1, 0
-    10: CheckThisInitialized <this>
-    12: Ret <this>
+     1: GetNamedProperty r1, <closure>, c0, k0
+     6: CallWithReceiver r1, r1, <this>, r1, 0
+    12: CheckThisInitialized <this>
+    14: Ret <this>
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
+    0: [SymbolValue: fieldsInitializer]
 }
 
-[BytecodeFunction: staticInitializer] {
+[BytecodeFunction: fieldsInitializer] {
   Parameters: 0, Registers: 2
      0: PushFunctionScope c0
      2: StoreToScope <this>, 0, 0
      6: StoreToScope r0, 2, 0
     10: LoadGlobal r0, c1, k0
     14: LoadConstant r1, c2
-    17: CallMaybeEval r0, r0, r1, 1, 39
+    17: CallMaybeEval r0, r0, r1, 1, 35
     23: DefineNamedProperty <this>, c3, r0
     27: PopScope 
     28: LoadUndefined r0
@@ -69,14 +74,14 @@
     3: [String: field]
 }
 
-[BytecodeFunction: fieldsInitializer] {
+[BytecodeFunction: staticInitializer] {
   Parameters: 0, Registers: 2
      0: PushFunctionScope c0
      2: StoreToScope <this>, 0, 0
      6: StoreToScope r0, 2, 0
     10: LoadGlobal r0, c1, k0
     14: LoadConstant r1, c2
-    17: CallMaybeEval r0, r0, r1, 1, 35
+    17: CallMaybeEval r0, r0, r1, 1, 39
     23: DefineNamedProperty <this>, c3, r0
     27: PopScope 
     28: LoadUndefined r0

--- a/tests/snapshot/bytecode/expression/binary.exp
+++ b/tests/snapshot/bytecode/expression/binary.exp
@@ -45,32 +45,37 @@
 }
 
 [BytecodeFunction: privateIn] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 5
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: NewPrivateSymbol r2, c1
      7: StoreToScope r2, 1, 0
     11: NewClosure r2, c2
     14: NewClass r0, c4, c3, r1, r2
-    20: PopScope 
-    21: LoadUndefined r1
-    23: Ret r1
+    20: NewClosure r3, c5
+    23: LoadConstant r4, c6
+    26: DefinePrivateProperty r0, r4, r3, 0
+    31: PopScope 
+    32: LoadUndefined r1
+    34: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: field]
     2: [BytecodeFunction: method]
     3: [BytecodeFunction: C]
     4: [ClassNames]
+    5: [BytecodeFunction: fieldsInitializer]
+    6: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: C] {
   Parameters: 0, Registers: 1
-     0: NewClosure r0, c0
-     3: CallWithReceiver r0, r0, <this>, r0, 0
-     9: LoadUndefined r0
-    11: Ret r0
+     0: GetNamedProperty r0, <closure>, c0, k0
+     5: CallWithReceiver r0, r0, <this>, r0, 0
+    11: LoadUndefined r0
+    13: Ret r0
   Constant Table:
-    0: [BytecodeFunction: fieldsInitializer]
+    0: [SymbolValue: fieldsInitializer]
 }
 
 [BytecodeFunction: fieldsInitializer] {


### PR DESCRIPTION
## Summary

The previously implementation of field initializers did not work correctly for cases such as `super()` in an arrow or eval or multiple `super()` calls. This is because we were creating the class field initializer and then calling it when generating the constructor, using local state, and only doing so once.

Instead we should be creating the fields initializer closure when defining the class then storing it on the constructor closure itself. Then we can fetch it from the current closure and call it either at the start of a base or default constructor, or when `super()` is called (either in a derived constructor, captured in an arrow, or dynamically from an eval). This has the added benefit of only creating the field initializer closure once, at class creation time, instead of on every call to the constructor.

While here we also refactor how `this` is tracked in eval within derived constructors. We now use the standard `TaggedResolvedScope` which may be unresolved global (aka `this` for the current function, a dynamic lookup, or resolved and possibly captured). Then instead of tracking more complicated metadata, we simply don't add an implicit this binding at the top of an eval scope if within a derived constructor, forcing lookups to become dynamic. This let's us greatly simplify eval within derived constructor handling.

## Tests

- Added integration tests for the class fields initializer + `super()` fixes
- Updated bytecode snapshot tests, which already exercise all relevant patterns for `super()` calls with/without fields, including in arrows and direct eval.