### PR TITLE
[bytecode] Load this to temporary register before init check to avoid clobbering dest

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -3124,43 +3124,61 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         dest: ExprDest,
         skip_init_check: bool,
     ) -> EmitResult<GenRegister> {
-        let mut needs_init_check = false;
-
-        let this_value = match scope.kind() {
+        let needs_init_check = match scope.kind() {
             // If `this` was not resolved then it is the current function's `this`
-            ResolvedScope::UnresolvedGlobal => self.gen_mov_reg_to_dest(Register::this(), dest)?,
+            ResolvedScope::UnresolvedGlobal => false,
             // Dynamic loads of this only occur in direct evals in derived constructors, so an init
             // check is always needed.
+            ResolvedScope::UnresolvedDynamic => true,
+            // If scope has been resolved this may be the current function's or a captured `this`
+            ResolvedScope::Resolved => scope
+                .unwrap_resolved()
+                .get_binding(&THIS_NAME)
+                .kind()
+                .is_implicit_this_in_derived_constructor(),
+        };
+        let needs_init_check = needs_init_check && !skip_init_check;
+
+        // If an init check is needed we must first load `this` to a temporary register, so that if
+        // the init check fails we don't clobber the destination register.
+        let temporary_dest = if needs_init_check {
+            self.gen_ensure_dest_is_temporary(dest)
+        } else {
+            dest
+        };
+
+        // Load `this` to the dest. If scope has been resolved this may be a captured `this` which
+        // is loaded from the scope directly to the dest.
+        let this_value = match scope.kind() {
+            // If `this` was not resolved then it is the current function's `this`
+            ResolvedScope::UnresolvedGlobal => {
+                self.gen_mov_reg_to_dest(Register::this(), temporary_dest)?
+            }
+            // Dynamic loads of this only occur in direct evals in derived constructors
             ResolvedScope::UnresolvedDynamic => {
-                needs_init_check = true;
-                self.gen_load_dynamic_identifier(&THIS_NAME, pos, dest)?
+                self.gen_load_dynamic_identifier(&THIS_NAME, pos, temporary_dest)?
             }
             // If scope has been resolved this may be the current function's or a captured `this`
             ResolvedScope::Resolved => {
-                let scope = scope.unwrap_resolved();
-                let binding = scope.get_binding(&THIS_NAME);
-
-                if binding.kind().is_implicit_this_in_derived_constructor() {
-                    needs_init_check = true;
-                }
+                let binding = scope.unwrap_resolved().get_binding(&THIS_NAME);
 
                 match binding.vm_location() {
                     // Captured `this`
                     Some(VMLocation::Scope { scope_id, index }) => {
-                        self.gen_load_scope_binding(scope_id, index, dest)?
+                        self.gen_load_scope_binding(scope_id, index, temporary_dest)?
                     }
-                    _ => self.gen_mov_reg_to_dest(Register::this(), dest)?,
+                    _ => self.gen_mov_reg_to_dest(Register::this(), temporary_dest)?,
                 }
             }
         };
 
         // Check if this was initialized
-        if needs_init_check && !skip_init_check {
+        if needs_init_check {
             self.writer
                 .check_this_initialized_instruction(this_value, pos);
         }
 
-        Ok(this_value)
+        self.gen_mov_reg_to_dest(this_value, dest)
     }
 
     fn gen_store_this(

--- a/tests/integration/regression/000031.js
+++ b/tests/integration/regression/000031.js
@@ -1,0 +1,45 @@
+/*---
+description: >
+  Loading `this` before super() in a derived constructor should not write the uninitialized empty
+  value to the destination register before throwing the ReferenceError.
+---*/
+
+class Uncaptured extends Object {
+  constructor() {
+    let t = 1;
+    try {
+      t = this;
+    } catch {}
+    assert.sameValue(t, 1);
+    super();
+  }
+}
+new Uncaptured();
+
+class Captured extends Object {
+  constructor() {
+    let t = 1;
+    try {
+      t = this;
+    } catch {}
+    assert.sameValue(t, 1);
+    super();
+    // Force `this` to be captured
+    (() => this)();
+  }
+}
+new Captured();
+
+class InEval extends Object {
+  constructor() {
+    eval(`
+      let t = 1;
+      try {
+        t = this;
+      } catch {}
+      assert.sameValue(t, 1);
+    `);
+    super();
+  }
+}
+new InEval();

--- a/tests/snapshot/bytecode/class/this.exp
+++ b/tests/snapshot/bytecode/class/this.exp
@@ -1,0 +1,36 @@
+[BytecodeFunction: <global>] {
+  Parameters: 0, Registers: 2
+     0: LoadEmpty r1
+     2: NewClass r0, c1, c0, r1, r0
+     8: StoreToScope r0, 1, 0
+    12: LoadFromScope r1, 1, 0
+    16: CheckTdz r1, c2
+    19: NewClass r0, c4, c3, r1, r0
+    25: StoreToScope r0, 2, 0
+    29: LoadUndefined r0
+    31: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: Base]
+    1: [ClassNames]
+    2: [String: Base]
+    3: [BytecodeFunction: C1]
+    4: [ClassNames]
+}
+
+[BytecodeFunction: Base] {
+  Parameters: 0, Registers: 1
+    0: LoadUndefined r0
+    2: Ret r0
+}
+
+[BytecodeFunction: C1] {
+  Parameters: 0, Registers: 3
+     0: LoadEmpty <this>
+     2: Mov r0, <closure>
+     5: LoadUndefined r1
+     7: Mov r2, <this>
+    10: CheckThisInitialized r2
+    12: Mov r1, r2
+    15: CheckThisInitialized <this>
+    17: Ret <this>
+}

--- a/tests/snapshot/bytecode/class/this.js
+++ b/tests/snapshot/bytecode/class/this.js
@@ -1,0 +1,10 @@
+class Base {}
+
+class C1 extends Base{
+  constructor() {
+    let x;
+
+    // this must be loaded to temporary, perform init check, then be written to x
+    x = this;
+  }
+}


### PR DESCRIPTION
## Summary

Accessing `this` with an init check (in derived constructors) was clobbering the destination register if the init check failed and threw. This can be observable if the thrown error is caught.

Instead we must ensure that `this` is always loaded to a temporary register if an init check is needed and only moved to the final destination if the init check succeeds.

## Tests

- Added regression test and bytecode snapshot tests for this case