### PR TITLE
[runtime] Fix FinalizationRegistry cell array growth to account for deleted cells

### DIFF
--- a/src/js/runtime/intrinsics/finalization_registry_object.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_object.rs
@@ -111,7 +111,7 @@ impl FinalizationRegistryCells {
     #[inline]
     fn calculate_size_in_bytes(capacity: usize) -> usize {
         CELLS_BYTE_OFFSET
-            + InlineArray::<FinalizationRegistryCell>::calculate_size_in_bytes(capacity)
+            + InlineArray::<Option<FinalizationRegistryCell>>::calculate_size_in_bytes(capacity)
     }
 
     #[inline]
@@ -153,7 +153,7 @@ impl FinalizationRegistryCells {
         let mut new_cells = FinalizationRegistryCells::new(cx, new_capacity)?;
         let old_cells = *old_cells;
 
-        // Copy over occupied cells to new array
+        // Copy over occupied cells to new array, deleted cells are not copied over
         let mut new_cells_index = 0;
         for i in 0..num_cells_used {
             if let Some(cell) = old_cells.cells.get_unchecked(i) {
@@ -163,6 +163,9 @@ impl FinalizationRegistryCells {
                 new_cells_index += 1;
             }
         }
+
+        // Set the number of occupied cells to account for deleted cells
+        new_cells.num_occupied = new_cells_index;
 
         registry.cells = new_cells;
 

--- a/tests/integration/built-ins/FinalizationRegistry/grow_cells.js
+++ b/tests/integration/built-ins/FinalizationRegistry/grow_cells.js
@@ -1,0 +1,53 @@
+/*---
+description: FinalizationRegistry cell array grows correctly in the presence of deleted cells.
+flags: [async]
+---*/
+
+var called = [];
+var registry = new FinalizationRegistry((heldValue) => called.push(heldValue));
+
+// Must be large enough to force the cell array to grow well past its initial capacity.
+var NUM_CELLS = 20;
+
+// Number of cells that are deleted for each cell that is kept, so that deleted cells make up most
+// of the cell array when it grows.
+var NUM_DELETED_PER_CELL = 3;
+
+(() => {
+  // Keep every target alive until all registrations are done, otherwise a target may be collected
+  // before its cell is unregistered.
+  var targets = [];
+  var unregisterToken = {};
+
+  for (let i = 0; i < NUM_CELLS; i++) {
+    // Register cells then immediately unregister them, leaving deleted cells behind. Deleted cells
+    // must not be copied over by a grow, nor counted as occupied in the new cell array.
+    for (let j = 0; j < NUM_DELETED_PER_CELL; j++) {
+      let deletedTarget = {};
+      targets.push(deletedTarget);
+      registry.register(deletedTarget, "deleted", unregisterToken);
+      registry.unregister(unregisterToken);
+    }
+
+    // Register a cell that is kept, so that the array always holds a mix of occupied and deleted
+    // cells whenever it grows.
+    let target = {};
+    targets.push(target);
+    registry.register(target, i);
+  }
+})();
+
+// All targets are now unreachable so every cell that was not unregistered must have its finalizer
+// callback run.
+$262.gc();
+
+Promise.resolve().then(() => {
+  called.sort((a, b) => a - b);
+
+  var expected = [];
+  for (var i = 0; i < NUM_CELLS; i++) {
+    expected.push(i);
+  }
+
+  assert.compareArray(called, expected);
+}).then($DONE, $DONE);


### PR DESCRIPTION
## Summary

When the `FinalizationRegistry` was growing and copying cells to the new array we skip copying deleted cells. However we were failing to properly update the `num_occupied` field to account for this.

## Tests

- Added new LLM-generated integration test that hits this case