### PR TITLE
[runtime] Inline properties for objects

### DIFF
--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object, must, must_a,
     parser::scope_tree::SHADOWED_SCOPE_SLOT_NAME,
@@ -53,7 +51,7 @@ impl UnmappedArgumentsObject {
         let throw_type_error = cx.get_intrinsic(Intrinsic::ThrowTypeError);
         let callee = Accessor::new(cx, Some(throw_type_error), Some(throw_type_error))?;
 
-        object.init_properties(cx, &[length_value, iterator_value.into(), callee.into()])?;
+        object.init_inline_properties(&[length_value, iterator_value.into(), callee.into()]);
 
         // Set indexed argument properties
         let mut index_key = PropertyKey::uninit().to_handle(cx);
@@ -119,9 +117,11 @@ impl MappedArgumentsObject {
         let iterator_value = cx.get_intrinsic(Intrinsic::ArrayPrototypeValues);
 
         // Set callee property to the enclosing function
-        object
-            .as_object()
-            .init_properties(cx, &[length_value, iterator_value.into(), callee.into()])?;
+        object.as_object().init_inline_properties(&[
+            length_value,
+            iterator_value.into(),
+            callee.into(),
+        ]);
 
         // Set indexed argument properties, which go through the exotic [[DefineOwnProperty]] so they
         // are mapped to the enclosing scope.
@@ -275,8 +275,8 @@ impl VirtualObject for Handle<MappedArgumentsObject> {
 }
 
 impl HeapItem for MappedArgumentsObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<MappedArgumentsObject>()
+    fn byte_size(mapped_arguments_object: HeapPtr<Self>) -> usize {
+        mapped_arguments_object.object_byte_size()
     }
 
     fn visit_pointers(mut mapped_arguments_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
@@ -287,8 +287,8 @@ impl HeapItem for MappedArgumentsObject {
 }
 
 impl HeapItem for UnmappedArgumentsObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<UnmappedArgumentsObject>()
+    fn byte_size(unmapped_arguments_object: HeapPtr<Self>) -> usize {
+        unmapped_arguments_object.object_byte_size()
     }
 
     fn visit_pointers(

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object, must, must_a,
     runtime::{
@@ -283,8 +281,8 @@ pub fn create_array_from_list(
 }
 
 impl HeapItem for ArrayObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<ArrayObject>()
+    fn byte_size(array_object: HeapPtr<Self>) -> usize {
+        array_object.object_byte_size()
     }
 
     fn visit_pointers(mut array_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/async_generator_object.rs
+++ b/src/js/runtime/async_generator_object.rs
@@ -488,8 +488,8 @@ pub fn async_generator_drain_queue(
 }
 
 impl HeapItem for AsyncGeneratorObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        std::mem::size_of::<AsyncGeneratorObject>()
+    fn byte_size(async_generator_object: HeapPtr<Self>) -> usize {
+        async_generator_object.object_byte_size()
     }
 
     fn visit_pointers(mut async_generator_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/bytecode/cache.rs
+++ b/src/js/runtime/bytecode/cache.rs
@@ -79,6 +79,7 @@ pub enum GetNamedPropertyCacheResult {
 impl GetNamedPropertyCache {
     /// Match the cache against a receiver object and return the cached property if it is still
     /// valid. If the cache is invalid, returns a result indicating why it is invalid.
+    #[inline]
     pub fn try_match(&self, receiver: HeapPtr<ObjectValue>) -> GetNamedPropertyCacheResult {
         match *self {
             Self::Own { shape, location, is_accessor } if shape.ptr_eq(&receiver.shape_ptr()) => {
@@ -234,6 +235,7 @@ pub enum SetNamedPropertyCache {
         shape: HeapPtr<Shape>,
         guard: Option<ValidityGuard>,
         new_shape: HeapPtr<Shape>,
+        location: PropertyLocation,
     },
 }
 
@@ -241,7 +243,7 @@ pub enum SetNamedPropertyCacheResult {
     /// Property was successfully stored.
     Success,
     /// Property can be successfully stored after the receiver transitions to the new shape.
-    Transition { new_shape: HeapPtr<Shape> },
+    Transition { new_shape: HeapPtr<Shape>, location: PropertyLocation },
     /// Accessor property was found. Not guaranteed to contain a setter.
     Accessor(HeapPtr<Accessor>),
     /// Shape was the same but the validity guard was invalid.
@@ -253,6 +255,7 @@ pub enum SetNamedPropertyCacheResult {
 impl SetNamedPropertyCache {
     /// Match the cache against a receiver object and return the cached property location if it is
     /// still valid. If the cache is invalid, returns a result indicating why it is invalid.
+    #[inline]
     pub fn try_match(
         &self,
         mut receiver: HeapPtr<ObjectValue>,
@@ -280,11 +283,11 @@ impl SetNamedPropertyCache {
                     SetNamedPropertyCacheResult::InvalidGuard
                 }
             }
-            Self::TransitionStore { shape, guard, new_shape }
+            Self::TransitionStore { shape, guard, new_shape, location }
                 if shape.ptr_eq(&receiver.shape_ptr()) =>
             {
                 if guard.is_none() || matches!(guard, Some(guard) if guard.is_valid()) {
-                    SetNamedPropertyCacheResult::Transition { new_shape }
+                    SetNamedPropertyCacheResult::Transition { new_shape, location }
                 } else {
                     SetNamedPropertyCacheResult::InvalidGuard
                 }
@@ -418,12 +421,18 @@ impl SetNamedPropertyCache {
             return Ok(None);
         }
 
+        let location = new_property_definition.location;
         let new_shape = new_shape.to_handle();
 
         // May allocate
         let guard = receiver.request_prototype_validity_guard(cx)?;
 
-        Ok(Some(Self::TransitionStore { shape: *old_shape, guard, new_shape: *new_shape }))
+        Ok(Some(Self::TransitionStore {
+            shape: *old_shape,
+            guard,
+            new_shape: *new_shape,
+            location,
+        }))
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
@@ -436,7 +445,7 @@ impl SetNamedPropertyCache {
                 guard.visit_pointers(visitor);
                 visitor.visit_pointer(proto);
             }
-            Self::TransitionStore { shape, guard, new_shape } => {
+            Self::TransitionStore { shape, guard, new_shape, .. } => {
                 visitor.visit_pointer(shape);
                 if let Some(guard) = guard {
                     guard.visit_pointers(visitor);

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -1,4 +1,4 @@
-use std::{mem::size_of, ops::Range};
+use std::ops::Range;
 
 use crate::{
     common::graphviz::DotGraphBuilder,
@@ -82,9 +82,9 @@ impl ClosureObject {
             let prototype = Self::new_constructor_prototype_property_object(cx, closure, realm)?;
             closure
                 .as_object()
-                .init_properties(cx, &[length, name, prototype.as_value()])?;
+                .init_inline_properties(&[length, name, prototype.as_value()]);
         } else {
-            closure.as_object().init_properties(cx, &[length, name])?;
+            closure.as_object().init_inline_properties(&[length, name]);
         }
 
         Ok(closure)
@@ -100,7 +100,7 @@ impl ClosureObject {
             Self::new_with_common_shape(cx, function, scope, CommonShape::AsyncClosure, realm)?;
 
         let (length, name) = Self::create_common_properties(cx, function)?;
-        closure.as_object().init_properties(cx, &[length, name])?;
+        closure.as_object().init_inline_properties(&[length, name]);
 
         Ok(closure)
     }
@@ -118,7 +118,7 @@ impl ClosureObject {
         let prototype = GeneratorPrototype::new_prototype_property_object(cx)?.as_value();
         closure
             .as_object()
-            .init_properties(cx, &[length, name, prototype])?;
+            .init_inline_properties(&[length, name, prototype]);
 
         Ok(closure)
     }
@@ -141,7 +141,7 @@ impl ClosureObject {
         let prototype = AsyncGeneratorPrototype::new_prototype_property_object(cx)?.as_value();
         closure
             .as_object()
-            .init_properties(cx, &[length, name, prototype])?;
+            .init_inline_properties(&[length, name, prototype]);
 
         Ok(closure)
     }
@@ -252,7 +252,7 @@ impl ClosureObject {
             .shape(proto_shape)
             .build()?
             .to_handle();
-        prototype.init_properties(cx, &[constructor.as_value()])?;
+        prototype.init_inline_properties(&[constructor.as_value()]);
 
         Ok(prototype)
     }
@@ -306,8 +306,8 @@ impl Handle<ClosureObject> {
 }
 
 impl HeapItem for ClosureObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<ClosureObject>()
+    fn byte_size(closure: HeapPtr<Self>) -> usize {
+        closure.object_byte_size()
     }
 
     fn visit_pointers(mut closure: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {
@@ -515,6 +515,11 @@ impl BytecodeFunction {
     #[inline]
     pub fn num_registers(&self) -> u32 {
         self.num_registers
+    }
+
+    #[inline]
+    pub fn estimated_num_properties(&self) -> u8 {
+        self.estimated_num_properties
     }
 
     #[inline]

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -66,6 +66,7 @@ use crate::{
         regexp::compiler::compile_regexp,
         scope::Scope,
         scope_names::{ScopeFlags, ScopeNameFlags, ScopeNames},
+        shape::{EMPTY_OBJECT_LITERAL_INLINE_PROPERTIES_CAPACITY, MAX_ARRAY_PROPERTIES},
         source_file::SourceFile,
         string_value::{FlatString, StringValue},
     },
@@ -4413,21 +4414,26 @@ impl<'a> BytecodeFunctionGenerator<'a> {
     /// - Counts each property that is not a spread element and not a `__proto__` prototype setter
     /// - Assumes computed properties are distinct
     /// - Overcounts getters and setters for the same property
-    /// - Caps at u8::MAX as an intentional underestimate.
+    /// - If no explicit properties are present default to a small number of inline properties
     fn estimate_object_literal_num_properties(object: &ast::ObjectExpression<'a>) -> u8 {
-        object
+        let num_explicit_properties = object
             .properties
             .iter()
             .filter(|property| {
                 !matches!(property.kind, ast::PropertyKind::Spread(_))
                     && !Self::is_prototype_setter_property(property)
             })
-            .count()
-            .min(u8::MAX as usize) as u8
+            .count();
+
+        if num_explicit_properties == 0 {
+            return EMPTY_OBJECT_LITERAL_INLINE_PROPERTIES_CAPACITY;
+        }
+
+        num_explicit_properties.min(MAX_ARRAY_PROPERTIES as usize) as u8
     }
 
     /// Estimate of the number of own properties created if this function is called as a
-    /// constructor. Caps at u8::MAX as an intentional underestimate.
+    /// constructor.
     fn estimate_constructor_num_properties(&self) -> u8 {
         if !self.is_constructor {
             return 0;
@@ -4435,7 +4441,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
 
         let count =
             self.constructor_property_names.len() + self.constructor_num_computed_properties;
-        count.min(u8::MAX as usize) as u8
+        count.min(MAX_ARRAY_PROPERTIES as usize) as u8
     }
 
     fn gen_store_captured_home_object(
@@ -6742,10 +6748,12 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             self.register_allocator.release(scratch);
 
             // Create a new object and copy all data properties, except for the property keys saved
-            // to the stack. The number of properties copied is not statically known, and we use 0
-            // as the initial capacity.
-            self.writer
-                .new_object_instruction(rest_element, UInt::new(0));
+            // to the stack. The number of properties copied is not statically known but properties
+            // are likely, so use a small inline property capacity by default.
+            self.writer.new_object_instruction(
+                rest_element,
+                UInt::new(EMPTY_OBJECT_LITERAL_INLINE_PROPERTIES_CAPACITY as u32),
+            );
             self.writer.copy_data_properties(
                 rest_element,
                 object_value,

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1182,7 +1182,6 @@ define_instructions!(
     }
 
     /// Create a new empty object stored in dest. An estimated number of properties is provided.
-    /// TODO: Use as the number of inline properties
     NewObject {
         camel_case: NewObjectInstruction,
         snake_case: new_object_instruction,

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -124,17 +124,19 @@ use crate::{
         iterator::{IteratorHint, get_iterator, iterator_complete, iterator_value},
         module::{execute::dynamic_import, source_text_module::SourceTextModule},
         object_value::{ObjectValue, VirtualObject},
-        ordinary_object::{ObjectBuilder, ordinary_object_create},
+        ordinary_object::ObjectBuilder,
         promise_object::{PromiseObject, coerce_to_ordinary_promise, resolve},
         property::{DEFAULT_ACCESSOR_PROPERTY_FLAGS, Property},
         proxy_object::ProxyObject,
         regexp::compiled_regexp::CompiledRegExp,
         scope::Scope,
         scope_names::ScopeNames,
+        shape::MAX_ARRAY_PROPERTIES,
         source_file::SourceFile,
         stack_trace::{StackFrameInfoArray, create_current_stack_frame_info},
         string_value::FlatString,
         to_string,
+        transitions::PropertyLocation,
         type_utilities::{
             is_callable, is_callable_object, is_loosely_equal, is_loosely_not_equal,
             is_strictly_equal, is_strictly_not_equal, same_object_value, to_boolean, to_number,
@@ -2911,8 +2913,11 @@ impl VM {
         is_base: bool,
     ) -> EvalResult<Value> {
         if is_base {
+            let inline_properties_capacity = estimate_constructor_num_properties(*new_target);
+
             let new_object: Value = ObjectBuilder::<ObjectValue>::new(self.cx())
                 .constructor_proto(new_target, Intrinsic::ObjectPrototype)?
+                .inline_properties_capacity(inline_properties_capacity)
                 .build()?
                 .into();
 
@@ -4014,11 +4019,15 @@ impl VM {
         handle_scope_guard!(self.cx());
 
         let dest = instr.dest();
+        let num_properties = instr.num_properties().value().to_usize() as u8;
 
         // Allocates
-        let object = ordinary_object_create(self.cx())?;
+        let object = ObjectBuilder::<ObjectValue>::new(self.cx())
+            .intrinsic_proto(Intrinsic::ObjectPrototype)
+            .inline_properties_capacity(num_properties)
+            .build()?;
 
-        self.write_register(dest, *object.as_value());
+        self.write_register(dest, object.as_value());
 
         Ok(())
     }
@@ -4435,18 +4444,29 @@ impl VM {
                         SetNamedPropertyCacheResult::Success => return Ok(()),
                         // Cache hit where receiver must transition to the new shape, then data
                         // property can be stored.
-                        SetNamedPropertyCacheResult::Transition { new_shape } => {
+                        SetNamedPropertyCacheResult::Transition { new_shape, location } => {
                             object.set_shape(new_shape);
 
-                            // Fast path does not open handle scope when named properties array has
-                            // room to grow without allocating.
-                            let mut named_properties_array = object.named_properties_array();
-                            if !named_properties_array.is_full() {
-                                named_properties_array.push_without_growing(value);
-                                return Ok(());
-                            }
-
-                            return self.set_named_property_transition_grow(instr, object);
+                            return match location {
+                                // Inline properties can be directly stored on object
+                                PropertyLocation::Inline { byte_offset } => {
+                                    object
+                                        .set_inline_property_unchecked(byte_offset as usize, value);
+                                    Ok(())
+                                }
+                                // Fast path to directly add array properties if there is room
+                                // without allocating.
+                                PropertyLocation::ExternalArray { .. } => {
+                                    let mut named_properties_array =
+                                        object.named_properties_array();
+                                    if !named_properties_array.is_full() {
+                                        named_properties_array.push_without_growing(value);
+                                        Ok(())
+                                    } else {
+                                        self.set_named_property_transition_grow(instr, object)
+                                    }
+                                }
+                            };
                         }
                         // Cache hit for an accessor property
                         SetNamedPropertyCacheResult::Accessor(accessor) => {
@@ -5901,6 +5921,49 @@ impl VM {
         let new_instruction_address = unsafe { new_function_start.offset(offset) };
         set_instruction_address(new_instruction_address);
     }
+}
+
+/// Estimate the number of own properties needed for an object created by a constructor.
+///
+/// Walks the constructor chain summing the properties added by each constructor.
+fn estimate_constructor_num_properties(new_target: HeapPtr<ObjectValue>) -> u8 {
+    /// Cap the number of prototypes to walk when estimating.
+    const MAX_CONSTRUCTOR_CHAIN_LENGTH: usize = 8;
+
+    let Some(closure) = new_target.as_opt::<ClosureObject>() else {
+        return 0;
+    };
+
+    // Base constructors only get properties from their own constructor
+    let function = closure.function_ptr();
+    let mut total_num_properties = function.estimated_num_properties();
+
+    if function.is_base_constructor() {
+        return total_num_properties;
+    }
+
+    // Derived constructors must walk the prototype chain gathering properties added by each
+    // constructor.
+    let mut current = closure.as_object().prototype();
+
+    for _ in 0..MAX_CONSTRUCTOR_CHAIN_LENGTH {
+        match current {
+            Some(object) if object.is::<ClosureObject>() => {
+                let parent_function = object.cast::<ClosureObject>().function_ptr();
+                total_num_properties =
+                    total_num_properties.saturating_add(parent_function.estimated_num_properties());
+
+                // The chain above a base constructor contributes nothing
+                if parent_function.is_base_constructor() {
+                    break;
+                }
+                current = object.prototype();
+            }
+            _ => break,
+        }
+    }
+
+    total_num_properties.min(MAX_ARRAY_PROPERTIES)
 }
 
 enum ArgsSlice<'a> {

--- a/src/js/runtime/collections/vec.rs
+++ b/src/js/runtime/collections/vec.rs
@@ -198,8 +198,9 @@ pub trait BsVecField<I: VecInstance> {
         let new_capacity = (capacity * 2).max(I::MIN_CAPACITY);
         let mut new_vec = self.set_new(cx, new_capacity)?;
 
-        // Copy all values into new vec
-        new_vec.length = old_len;
+        // Copy all values into new vec. Must re-read old vec's length since it may have changed
+        // during GC (e.g. compressing weak vectors).
+        new_vec.length = old_vec.len();
         new_vec.as_mut_slice().copy_from_slice(old_vec.as_slice());
 
         Ok(new_vec)

--- a/src/js/runtime/common_shapes.rs
+++ b/src/js/runtime/common_shapes.rs
@@ -247,7 +247,14 @@ impl CommonShapes {
             };
 
         let proto = realm.get_intrinsic(intrinsic_proto);
-        let mut shape = ShapeRegistry::get_root_object_shape(cx, kind, Some(proto))?;
+        let inline_properties_capacity = properties.len() as u8;
+
+        let mut shape = ShapeRegistry::get_root_object_shape(
+            cx,
+            kind,
+            Some(proto),
+            inline_properties_capacity,
+        )?;
 
         for (key, attributes) in properties {
             let (next_shape, _) = shape.define_own_property(cx, *key, *attributes)?;

--- a/src/js/runtime/gc/garbage_collector.rs
+++ b/src/js/runtime/gc/garbage_collector.rs
@@ -4,7 +4,7 @@ use crate::runtime::{
     Context, HeapItemKind, PropertyKey, Value,
     gc::{
         AnyHeapItem, Heap, HeapItem, HeapPtr, HeapVisitor,
-        heap_item::{for_each_heap_item, visit_pointers_for_kind},
+        heap_item::{byte_size_for_kind, for_each_heap_item, visit_pointers_for_kind},
     },
     interned_strings::InternedStrings,
     intrinsics::{
@@ -175,8 +175,11 @@ impl GarbageCollector {
     fn visit_permanent_heap_roots(&mut self) {
         for_each_heap_item(self.new_permanent_space_bounds.clone(), |item| {
             let kind = item.shape().kind();
+            let byte_size = byte_size_for_kind(item, kind);
+
             visit_pointers_for_kind(item, self, kind);
-            kind
+
+            byte_size
         });
     }
 
@@ -216,10 +219,13 @@ impl GarbageCollector {
         let mut dest_ptr = self.new_permanent_space_bounds.start;
 
         for_each_heap_item(self.old_permanent_space_bounds.clone(), |mut item| {
-            // Read the kind before the shape is overwritten with a forwarding pointer
+            // Read the kind and byte size before the shape is overwritten with a forwarding pointer
             let kind = item.shape().kind();
+            let byte_size = byte_size_for_kind(item, kind);
+
             Self::move_heap_item(&mut item, &mut dest_ptr);
-            kind
+
+            byte_size
         });
 
         // Entire old permanent heap should have been copied 1:1 to the new permanent heap

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -156,6 +156,17 @@ macro_rules! register_heap_items {
 
         impl HeapItemKind {
             pub const COUNT: usize = <[()]>::len(&[$(unit!($name)),*]);
+
+            /// For all objects this is the offset of the inline properties array in bytes.
+            pub const INLINE_PROPERTIES_OFFSETS: [u8; Self::COUNT] = [
+                $(if (Self::$name as u8) < (Self::Shape as u8) {
+                    const OFFSET: usize = std::mem::size_of::<$name>();
+                    $crate::const_assert!(OFFSET <= (u8::MAX as usize));
+                    OFFSET as u8
+                } else {
+                    0
+                }),*
+            ];
         }
 
         pub fn byte_size_for_kind(item: HeapPtr<AnyHeapItem>, kind: HeapItemKind) -> usize {
@@ -343,18 +354,21 @@ impl<T> HeapUnaligned<T> {
 
 /// Call a function on each heap item in a contiguous, fully-allocated range of the heap.
 ///
-/// The function must return the kind of each visited heap item.
+/// The function must return the byte size of each visited heap item. Size must be computed by the
+/// caller at a point where the item's shape is still readable, since the function may re-encode
+/// the item's shape field (e.g. to a forwarding pointer when moving, or an offset when
+/// serializing) and object sizes are calculated through the shape.
 pub fn for_each_heap_item(
     space: Range<*const u8>,
-    mut f: impl FnMut(HeapPtr<AnyHeapItem>) -> HeapItemKind,
+    mut f: impl FnMut(HeapPtr<AnyHeapItem>) -> usize,
 ) {
     let mut current_ptr = space.start;
     while current_ptr < space.end {
         let item = HeapPtr::from_ptr(current_ptr.cast_mut()).cast::<AnyHeapItem>();
-        let kind = f(item);
+        let byte_size = f(item);
 
         // Increment pointer to the next heap item (accounting for alignment)
-        let alloc_size = Heap::alloc_size_for_request_size(byte_size_for_kind(item, kind));
+        let alloc_size = Heap::alloc_size_for_request_size(byte_size);
         current_ptr = unsafe { current_ptr.add(alloc_size) };
     }
 }

--- a/src/js/runtime/gc/heap_serializer.rs
+++ b/src/js/runtime/gc/heap_serializer.rs
@@ -19,7 +19,7 @@ use crate::{
         Context, Value,
         gc::{
             AnyHeapItem, GcType, Heap, HeapInfo, HeapPtr, HeapVisitor,
-            heap_item::{for_each_heap_item, visit_pointers_for_kind},
+            heap_item::{byte_size_for_kind, for_each_heap_item, visit_pointers_for_kind},
         },
         rust_vtables::{RustVtable, get_vtable, lookup_vtable_enum},
         shape::Shape,
@@ -103,10 +103,13 @@ impl HeapSerializer {
         let bounds = space.as_mut_ptr_range();
 
         for_each_heap_item(bounds.start.cast_const()..bounds.end.cast_const(), |item| {
-            // Read the kind before the shape pointer is rewritten to an offset
+            // Read the kind and byte size before the shape pointer is rewritten to an offset
             let kind = item.shape().kind();
+            let byte_size = byte_size_for_kind(item, kind);
+
             visit_pointers_for_kind(item, self, kind);
-            kind
+
+            byte_size
         });
     }
 
@@ -179,7 +182,10 @@ impl HeapSpaceDeserializer {
             let kind = unsafe { (*shape_ptr).kind() };
 
             visit_pointers_for_kind(item, &mut deserializer, kind);
-            kind
+
+            // Compute the byte size after visiting, at which point the item's shape field has been
+            // decoded back to a usable pointer.
+            byte_size_for_kind(item, kind)
         });
     }
 }
@@ -189,6 +195,12 @@ impl HeapVisitor for HeapSpaceDeserializer {
         // Decode by adding the heap base pointer to each stored offset
         let decoded_ptr = unsafe { self.base.add(ptr.as_ptr() as usize) };
         *ptr = HeapPtr::from_ptr(decoded_ptr as *mut AnyHeapItem);
+    }
+
+    /// Decode the shape field which was encoded as an offset.
+    fn resolve_shape(&mut self, shape: HeapPtr<Shape>) -> HeapPtr<Shape> {
+        let decoded_ptr = unsafe { self.base.add(shape.as_ptr() as usize) };
+        HeapPtr::from_ptr(decoded_ptr as *mut Shape)
     }
 
     fn visit_rust_vtable_pointer(&mut self, ptr: &mut *const ()) {

--- a/src/js/runtime/gc/heap_visitor.rs
+++ b/src/js/runtime/gc/heap_visitor.rs
@@ -3,6 +3,7 @@ use std::mem::transmute;
 use crate::runtime::{
     PropertyKey, Value,
     gc::{AnyHeapItem, HeapPtr},
+    shape::Shape,
 };
 
 pub trait HeapVisitor {
@@ -82,5 +83,13 @@ pub trait HeapVisitor {
     #[inline]
     fn visit_weak_property_key(&mut self, property_key: &mut PropertyKey) {
         unsafe { self.visit_weak_value(transmute::<&mut PropertyKey, &mut Value>(property_key)) };
+    }
+
+    /// Resolve an item's raw shape field to usable shape pointer. Visitors may modify fields to no
+    /// longer be usable pointers (e.g. converting them to offsets) so this method gives access
+    /// to the original shape pointer.
+    #[inline]
+    fn resolve_shape(&mut self, shape: HeapPtr<Shape>) -> HeapPtr<Shape> {
+        shape
     }
 }

--- a/src/js/runtime/generator_object.rs
+++ b/src/js/runtime/generator_object.rs
@@ -297,8 +297,8 @@ pub fn generator_resume_abrupt(
 }
 
 impl HeapItem for GeneratorObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<GeneratorObject>()
+    fn byte_size(generator_object: HeapPtr<Self>) -> usize {
+        generator_object.object_byte_size()
     }
 
     fn visit_pointers(mut generator_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/global_object.rs
+++ b/src/js/runtime/global_object.rs
@@ -188,8 +188,8 @@ impl PropertyStorage for Handle<GlobalObject> {
 }
 
 impl HeapItem for GlobalObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<GlobalObject>()
+    fn byte_size(object: HeapPtr<Self>) -> usize {
+        object.object_byte_size()
     }
 
     fn visit_pointers(mut object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/array_buffer_object.rs
+++ b/src/js/runtime/intrinsics/array_buffer_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object,
     runtime::{
@@ -143,8 +141,8 @@ impl ArrayBufferObject {
 }
 
 impl HeapItem for ArrayBufferObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<ArrayBufferObject>()
+    fn byte_size(array_buffer_object: HeapPtr<Self>) -> usize {
+        array_buffer_object.object_byte_size()
     }
 
     fn visit_pointers(mut array_buffer_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/array_iterator_object.rs
+++ b/src/js/runtime/intrinsics/array_iterator_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
@@ -143,8 +141,8 @@ impl ArrayIteratorPrototype {
 }
 
 impl HeapItem for ArrayIteratorObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<ArrayIteratorObject>()
+    fn byte_size(array_iterator: HeapPtr<Self>) -> usize {
+        array_iterator.object_byte_size()
     }
 
     fn visit_pointers(mut array_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/async_from_sync_iterator_object.rs
+++ b/src/js/runtime/intrinsics/async_from_sync_iterator_object.rs
@@ -45,8 +45,8 @@ impl AsyncFromSyncIteratorObject {
 }
 
 impl HeapItem for AsyncFromSyncIteratorObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        std::mem::size_of::<AsyncFromSyncIteratorObject>()
+    fn byte_size(async_from_sync_iterator: HeapPtr<Self>) -> usize {
+        async_from_sync_iterator.object_byte_size()
     }
 
     fn visit_pointers(mut async_from_sync_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/bigint_object.rs
+++ b/src/js/runtime/intrinsics/bigint_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object,
     runtime::{
@@ -40,8 +38,8 @@ impl BigIntObject {
 }
 
 impl HeapItem for BigIntObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<BigIntObject>()
+    fn byte_size(bigint_object: HeapPtr<Self>) -> usize {
+        bigint_object.object_byte_size()
     }
 
     fn visit_pointers(mut bigint_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/boolean_object.rs
+++ b/src/js/runtime/intrinsics/boolean_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object,
     runtime::{
@@ -71,8 +69,8 @@ impl BooleanObject {
 }
 
 impl HeapItem for BooleanObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<BooleanObject>()
+    fn byte_size(boolean_object: HeapPtr<Self>) -> usize {
+        boolean_object.object_byte_size()
     }
 
     fn visit_pointers(mut boolean_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/data_view_object.rs
+++ b/src/js/runtime/intrinsics/data_view_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object,
     runtime::{
@@ -61,8 +59,8 @@ impl DataViewObject {
 }
 
 impl HeapItem for DataViewObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<DataViewObject>()
+    fn byte_size(data_view_object: HeapPtr<Self>) -> usize {
+        data_view_object.object_byte_size()
     }
 
     fn visit_pointers(mut data_view_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/date_object.rs
+++ b/src/js/runtime/intrinsics/date_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     common::math::modulo,
     extend_object,
@@ -375,8 +373,8 @@ pub fn time_clip(time: f64) -> f64 {
 }
 
 impl HeapItem for DateObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<DateObject>()
+    fn byte_size(date_object: HeapPtr<Self>) -> usize {
+        date_object.object_byte_size()
     }
 
     fn visit_pointers(mut date_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/error_object.rs
+++ b/src/js/runtime/intrinsics/error_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object,
     runtime::{
@@ -67,7 +65,7 @@ impl ErrorObject {
 
         error_object
             .as_object()
-            .init_properties(cx, &[message.as_value()])?;
+            .init_inline_properties(&[message.as_value()]);
 
         Ok(error_object)
     }
@@ -101,7 +99,7 @@ impl ErrorObject {
 
         Self::initialize_stack_trace(cx, error_object, /* skip_current_frame */ true)?;
 
-        error_object.as_object().init_properties(cx, &[errors])?;
+        error_object.as_object().init_inline_properties(&[errors]);
 
         Ok(error_object)
     }
@@ -149,8 +147,8 @@ impl Handle<ErrorObject> {
 }
 
 impl HeapItem for ErrorObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<ErrorObject>()
+    fn byte_size(error_object: HeapPtr<Self>) -> usize {
+        error_object.object_byte_size()
     }
 
     fn visit_pointers(mut error_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/finalization_registry_object.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_object.rs
@@ -1,4 +1,4 @@
-use std::{mem::size_of, slice};
+use std::slice;
 
 use crate::{
     extend_object, field_offset,
@@ -209,8 +209,8 @@ impl FinalizationRegistryCells {
 }
 
 impl HeapItem for FinalizationRegistryObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<FinalizationRegistryObject>()
+    fn byte_size(finalization_registry_object: HeapPtr<Self>) -> usize {
+        finalization_registry_object.object_byte_size()
     }
 
     fn visit_pointers(

--- a/src/js/runtime/intrinsics/function_prototype.rs
+++ b/src/js/runtime/intrinsics/function_prototype.rs
@@ -54,6 +54,7 @@ impl FunctionPrototype {
             cx,
             HeapItemKind::ClosureObject,
             Some(object_proto),
+            /* inline_properties_capacity */ 0,
         )?;
         init_object_pointer_fields(cx, *object, *shape);
 

--- a/src/js/runtime/intrinsics/iterator_helper_object.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object,
     runtime::{
@@ -633,8 +631,8 @@ impl Handle<IteratorHelperObject> {
 }
 
 impl HeapItem for IteratorHelperObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<IteratorHelperObject>()
+    fn byte_size(iterator_helper_object: HeapPtr<Self>) -> usize {
+        iterator_helper_object.object_byte_size()
     }
 
     fn visit_pointers(mut iterator_helper_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/map_iterator_object.rs
+++ b/src/js/runtime/intrinsics/map_iterator_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
@@ -150,8 +148,8 @@ impl MapIteratorPrototype {
 }
 
 impl HeapItem for MapIteratorObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<MapIteratorObject>()
+    fn byte_size(map_iterator_object: HeapPtr<Self>) -> usize {
+        map_iterator_object.object_byte_size()
     }
 
     fn visit_pointers(mut map_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/map_object.rs
+++ b/src/js/runtime/intrinsics/map_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object, impl_index_map_instance,
     runtime::{
@@ -104,8 +102,8 @@ impl BsIndexMapField<ValueIndexMap> for MapObjectMapField {
 }
 
 impl HeapItem for MapObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<MapObject>()
+    fn byte_size(map_object: HeapPtr<Self>) -> usize {
+        map_object.object_byte_size()
     }
 
     fn visit_pointers(mut map_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/number_object.rs
+++ b/src/js/runtime/intrinsics/number_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object,
     runtime::{
@@ -71,8 +69,8 @@ impl NumberObject {
 }
 
 impl HeapItem for NumberObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<NumberObject>()
+    fn byte_size(number_object: HeapPtr<Self>) -> usize {
+        number_object.object_byte_size()
     }
 
     fn visit_pointers(mut number_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/object_prototype_object.rs
+++ b/src/js/runtime/intrinsics/object_prototype_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object, intrinsic_methods,
     runtime::{
@@ -50,8 +48,12 @@ impl ObjectPrototypeObject {
     ) -> AllocResult<()> {
         let object = object.as_object();
 
-        let shape =
-            ShapeRegistry::get_root_object_shape(cx, HeapItemKind::ObjectPrototypeObject, None)?;
+        let shape = ShapeRegistry::get_root_object_shape(
+            cx,
+            HeapItemKind::ObjectPrototypeObject,
+            None,
+            /* inline_properties_capacity */ 0,
+        )?;
         init_object_pointer_fields(cx, *object, *shape);
 
         let mut builder = IntrinsicBuilder::ordinary(cx, realm, object);
@@ -332,8 +334,8 @@ impl ObjectPrototypeObject {
 }
 
 impl HeapItem for ObjectPrototypeObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<ObjectPrototypeObject>()
+    fn byte_size(object_prototype: HeapPtr<Self>) -> usize {
+        object_prototype.object_byte_size()
     }
 
     fn visit_pointers(mut object_prototype: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/raw_json_object.rs
+++ b/src/js/runtime/intrinsics/raw_json_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object, must_a,
     runtime::{
@@ -34,8 +32,8 @@ impl RawJSONObject {
 }
 
 impl HeapItem for RawJSONObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<RawJSONObject>()
+    fn byte_size(raw_json_object: HeapPtr<Self>) -> usize {
+        raw_json_object.object_byte_size()
     }
 
     fn visit_pointers(mut raw_json_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/regexp_object.rs
+++ b/src/js/runtime/intrinsics/regexp_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object, must, must_a,
     parser::regexp::RegExpFlags,
@@ -112,8 +110,8 @@ impl RegExpObject {
 }
 
 impl HeapItem for RegExpObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<RegExpObject>()
+    fn byte_size(regexp_object: HeapPtr<Self>) -> usize {
+        regexp_object.object_byte_size()
     }
 
     fn visit_pointers(mut regexp_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -905,7 +905,7 @@ fn regexp_builtin_exec(
         cx.undefined()
     };
 
-    result_array.init_properties(cx, &[index_value, string_value.into(), named_groups_object])?;
+    result_array.init_inline_properties(&[index_value, string_value.into(), named_groups_object]);
 
     let mut matched_group_names = HashSet::new();
 

--- a/src/js/runtime/intrinsics/regexp_string_iterator_object.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
@@ -139,8 +137,8 @@ impl RegExpStringIteratorPrototype {
 }
 
 impl HeapItem for RegExpStringIteratorObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<RegExpStringIteratorObject>()
+    fn byte_size(regexp_string_iterator: HeapPtr<Self>) -> usize {
+        regexp_string_iterator.object_byte_size()
     }
 
     fn visit_pointers(mut regexp_string_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/set_iterator_object.rs
+++ b/src/js/runtime/intrinsics/set_iterator_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
@@ -147,8 +145,8 @@ impl SetIteratorPrototype {
 }
 
 impl HeapItem for SetIteratorObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<SetIteratorObject>()
+    fn byte_size(set_iterator: HeapPtr<Self>) -> usize {
+        set_iterator.object_byte_size()
     }
 
     fn visit_pointers(mut set_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/set_object.rs
+++ b/src/js/runtime/intrinsics/set_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object, impl_index_set_instance,
     runtime::{
@@ -116,8 +114,8 @@ impl BsIndexSetField<ValueIndexSet> for SetObjectSetField {
 }
 
 impl HeapItem for SetObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<SetObject>()
+    fn byte_size(set_object: HeapPtr<Self>) -> usize {
+        set_object.object_byte_size()
     }
 
     fn visit_pointers(mut set_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/string_iterator_object.rs
+++ b/src/js/runtime/intrinsics/string_iterator_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
@@ -77,8 +75,8 @@ impl StringIteratorPrototype {
 }
 
 impl HeapItem for StringIteratorObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<StringIteratorObject>()
+    fn byte_size(string_iterator: HeapPtr<Self>) -> usize {
+        string_iterator.object_byte_size()
     }
 
     fn visit_pointers(mut string_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/symbol_object.rs
+++ b/src/js/runtime/intrinsics/symbol_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object,
     runtime::{
@@ -40,8 +38,8 @@ impl SymbolObject {
 }
 
 impl HeapItem for SymbolObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<SymbolObject>()
+    fn byte_size(symbol_object: HeapPtr<Self>) -> usize {
+        symbol_object.object_byte_size()
     }
 
     fn visit_pointers(mut symbol_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/temporal/duration_object.rs
+++ b/src/js/runtime/intrinsics/temporal/duration_object.rs
@@ -47,8 +47,8 @@ impl DurationObject {
 }
 
 impl HeapItem for DurationObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<DurationObject>()
+    fn byte_size(duration_object: HeapPtr<Self>) -> usize {
+        duration_object.object_byte_size()
     }
 
     fn visit_pointers(mut duration_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/temporal/instant_object.rs
+++ b/src/js/runtime/intrinsics/temporal/instant_object.rs
@@ -47,8 +47,8 @@ impl InstantObject {
 }
 
 impl HeapItem for InstantObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<InstantObject>()
+    fn byte_size(instant_object: HeapPtr<Self>) -> usize {
+        instant_object.object_byte_size()
     }
 
     fn visit_pointers(mut instant_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/temporal/plain_date_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_object.rs
@@ -45,8 +45,8 @@ impl PlainDateObject {
 }
 
 impl HeapItem for PlainDateObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<PlainDateObject>()
+    fn byte_size(plain_date_object: HeapPtr<Self>) -> usize {
+        plain_date_object.object_byte_size()
     }
 
     fn visit_pointers(mut plain_date_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/temporal/plain_date_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_date_time_object.rs
@@ -45,8 +45,8 @@ impl PlainDateTimeObject {
 }
 
 impl HeapItem for PlainDateTimeObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<PlainDateTimeObject>()
+    fn byte_size(plain_date_time_object: HeapPtr<Self>) -> usize {
+        plain_date_time_object.object_byte_size()
     }
 
     fn visit_pointers(mut plain_date_time_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/temporal/plain_month_day_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_month_day_object.rs
@@ -45,8 +45,8 @@ impl PlainMonthDayObject {
 }
 
 impl HeapItem for PlainMonthDayObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<PlainMonthDayObject>()
+    fn byte_size(plain_month_day_object: HeapPtr<Self>) -> usize {
+        plain_month_day_object.object_byte_size()
     }
 
     fn visit_pointers(mut plain_month_day_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/temporal/plain_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_time_object.rs
@@ -45,8 +45,8 @@ impl PlainTimeObject {
 }
 
 impl HeapItem for PlainTimeObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<PlainTimeObject>()
+    fn byte_size(plain_time_object: HeapPtr<Self>) -> usize {
+        plain_time_object.object_byte_size()
     }
 
     fn visit_pointers(mut plain_time_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/temporal/plain_year_month_object.rs
+++ b/src/js/runtime/intrinsics/temporal/plain_year_month_object.rs
@@ -48,8 +48,8 @@ impl PlainYearMonthObject {
 }
 
 impl HeapItem for PlainYearMonthObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<PlainYearMonthObject>()
+    fn byte_size(plain_year_month_object: HeapPtr<Self>) -> usize {
+        plain_year_month_object.object_byte_size()
     }
 
     fn visit_pointers(mut plain_year_month_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
+++ b/src/js/runtime/intrinsics/temporal/zoned_date_time_object.rs
@@ -50,8 +50,8 @@ impl ZonedDateTimeObject {
 }
 
 impl HeapItem for ZonedDateTimeObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<ZonedDateTimeObject>()
+    fn byte_size(zoned_date_time_object: HeapPtr<Self>) -> usize {
+        zoned_date_time_object.object_byte_size()
     }
 
     fn visit_pointers(mut zoned_date_time_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/typed_array.rs
+++ b/src/js/runtime/intrinsics/typed_array.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use half::f16;
 use num_bigint::{BigInt, Sign};
 

--- a/src/js/runtime/intrinsics/typed_array_object.rs
+++ b/src/js/runtime/intrinsics/typed_array_object.rs
@@ -424,8 +424,8 @@ macro_rules! create_typed_array_object {
         }
 
         impl HeapItem for $typed_array {
-            fn byte_size(_: HeapPtr<Self>) -> usize {
-                size_of::<$typed_array>()
+            fn byte_size(typed_array: HeapPtr<Self>) -> usize {
+                typed_array.object_byte_size()
             }
 
             fn visit_pointers(mut typed_array: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/weak_map_object.rs
+++ b/src/js/runtime/intrinsics/weak_map_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object, impl_hash_map_instance,
     runtime::{
@@ -94,8 +92,8 @@ impl BsHashMapField<WeakValueMap> for WeakMapObjectMapField {
 }
 
 impl HeapItem for WeakMapObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<WeakMapObject>()
+    fn byte_size(weak_map_object: HeapPtr<Self>) -> usize {
+        weak_map_object.object_byte_size()
     }
 
     fn visit_pointers(mut weak_map_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/weak_ref_object.rs
+++ b/src/js/runtime/intrinsics/weak_ref_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object,
     runtime::{
@@ -57,8 +55,8 @@ impl WeakRefObject {
 }
 
 impl HeapItem for WeakRefObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<WeakRefObject>()
+    fn byte_size(weak_ref_object: HeapPtr<Self>) -> usize {
+        weak_ref_object.object_byte_size()
     }
 
     fn visit_pointers(mut weak_ref_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/weak_set_object.rs
+++ b/src/js/runtime/intrinsics/weak_set_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object, impl_hash_set_instance,
     runtime::{
@@ -89,8 +87,8 @@ impl BsHashSetField<WeakValueSet> for WeakSetObjectSetField {
 }
 
 impl HeapItem for WeakSetObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<WeakSetObject>()
+    fn byte_size(weak_set_object: HeapPtr<Self>) -> usize {
+        weak_set_object.object_byte_size()
     }
 
     fn visit_pointers(mut weak_set_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/intrinsics/wrapped_valid_iterator_object.rs
+++ b/src/js/runtime/intrinsics/wrapped_valid_iterator_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object,
     runtime::{
@@ -47,8 +45,8 @@ impl WrappedValidIteratorObject {
 }
 
 impl HeapItem for WrappedValidIteratorObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<WrappedValidIteratorObject>()
+    fn byte_size(wrapped_valid_iterator: HeapPtr<Self>) -> usize {
+        wrapped_valid_iterator.object_byte_size()
     }
 
     fn visit_pointers(mut wrapped_valid_iterator: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/iterator.rs
+++ b/src/js/runtime/iterator.rs
@@ -263,7 +263,7 @@ pub fn create_iter_result_object(
         .common_shape(CommonShape::IteratorResult)?
         .build()?
         .to_handle();
-    object.init_properties(cx, &[value, is_done_value])?;
+    object.init_inline_properties(&[value, is_done_value]);
 
     Ok(object.as_value())
 }

--- a/src/js/runtime/module/module_namespace_object.rs
+++ b/src/js/runtime/module/module_namespace_object.rs
@@ -302,8 +302,8 @@ impl VirtualObject for Handle<ModuleNamespaceObject> {
 }
 
 impl HeapItem for ModuleNamespaceObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<ModuleNamespaceObject>()
+    fn byte_size(module_namespace_object: HeapPtr<Self>) -> usize {
+        module_namespace_object.object_byte_size()
     }
 
     fn visit_pointers(mut module_namespace_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/object_value.rs
+++ b/src/js/runtime/object_value.rs
@@ -57,6 +57,9 @@ macro_rules! extend_object_without_conversions {
 
             // Child fields
             $($(#[$field_meta])* $field_vis $field_name: $field_type,)*
+
+            // Start of the inline properties array
+            inline_properties: [$crate::runtime::Value; 0],
         }
 
         impl $(<$($generics),*>)? $name $(<$($generics),*>)? {
@@ -76,6 +79,66 @@ macro_rules! extend_object_without_conversions {
             #[inline]
             pub fn set_shape(&mut self, shape: $crate::runtime::HeapPtr<$crate::runtime::shape::Shape>)  {
                 self.shape = shape
+            }
+
+            /// Pointer to the start of the inline properties array.
+            #[inline]
+            fn inline_properties_ptr(&mut self) -> *mut $crate::runtime::Value {
+                let inline_properties_offset = self.shape_ptr().inline_properties_offset() as usize;
+                unsafe {
+                    let self_ptr = self as *mut _ as *mut u8;
+                    self_ptr.add(inline_properties_offset) as *mut _
+                }
+            }
+
+            /// Get an inline property value at a precomputed byte offset from the start of the
+            /// object, without bounds checks.
+            #[inline]
+            pub fn get_inline_property_unchecked(
+                &self,
+                byte_offset: usize,
+            ) -> $crate::runtime::Value {
+                debug_assert!(byte_offset >= self.shape_ptr().inline_properties_offset() as usize
+                    && byte_offset + size_of::<$crate::runtime::Value>()
+                        <= self.shape_ptr().object_byte_size()
+                );
+
+                unsafe {
+                    let self_ptr = self as *const _ as *const u8;
+                    (self_ptr.add(byte_offset) as *const $crate::runtime::Value).read()
+                }
+            }
+
+            /// Set an inline property value at a precomputed byte offset from the start of the
+            /// object, without bounds checks.
+            #[inline]
+            pub fn set_inline_property_unchecked(
+                &mut self,
+                byte_offset: usize,
+                value: $crate::runtime::Value,
+            ) {
+                debug_assert!(byte_offset >= self.shape_ptr().inline_properties_offset() as usize
+                    && byte_offset + size_of::<$crate::runtime::Value>()
+                        <= self.shape_ptr().object_byte_size()
+                );
+
+                unsafe {
+                    let self_ptr = self as *mut _ as *mut u8;
+                    (self_ptr.add(byte_offset) as *mut $crate::runtime::Value).write(value)
+                }
+            }
+
+            #[inline]
+            pub fn inline_properties_as_slice_mut(
+                &mut self,
+            ) -> &mut [$crate::runtime::Value] {
+                let capacity = self.shape_ptr().inline_properties_capacity() as usize;
+                unsafe { std::slice::from_raw_parts_mut(self.inline_properties_ptr(), capacity) }
+            }
+
+            #[inline]
+            pub fn object_byte_size(&self) -> usize {
+                self.shape_ptr().object_byte_size()
             }
         }
 
@@ -143,12 +206,44 @@ macro_rules! extend_object {
             }
         }
 
+        impl $(<$($generics),*>)? $name $(<$($generics),*>)? {
+            /// Build the inline properties slice for this object, given the provided offset and
+            /// capacity for the inline properties array.
+            #[inline]
+            fn inline_properties_as_slice_mut_from_raw(
+                &mut self,
+                inline_properties_offset: usize,
+                inline_properties_capacity: usize,
+            ) -> &mut [$crate::runtime::Value] {
+                unsafe {
+                    let self_ptr = self as *mut _ as *mut u8;
+                    let inline_properties_ptr =
+                        self_ptr.add(inline_properties_offset) as *mut $crate::runtime::Value;
+                    std::slice::from_raw_parts_mut(inline_properties_ptr, inline_properties_capacity)
+                }
+            }
+        }
+
         impl $(<$($generics),*>)? $crate::runtime::HeapPtr<$name $(<$($generics),*>)?> {
             #[inline]
             pub fn visit_object_pointers(&mut self, visitor: &mut impl $crate::runtime::gc::HeapVisitor) {
+                // Capture the inline properties layout before visiting the shape field, since
+                // visiting may rewrite the field to an usable encoding (e.g. an offset).
+                let shape = visitor.resolve_shape(self.shape);
+                let inline_properties_offset = shape.inline_properties_offset() as usize;
+                let inline_properties_capacity = shape.inline_properties_capacity() as usize;
+
                 visitor.visit_pointer(&mut self.shape);
                 visitor.visit_pointer(&mut self.named_properties);
                 visitor.visit_pointer(&mut self.array_properties);
+
+                let inline_properties = self.inline_properties_as_slice_mut_from_raw(
+                    inline_properties_offset,
+                    inline_properties_capacity,
+                );
+                for value in inline_properties {
+                    visitor.visit_value(value);
+                }
             }
         }
     }
@@ -168,9 +263,13 @@ impl ObjectValue {
     /// Fetch a named property value from the object given its property location.
     ///
     /// Assumes the object is in array mode and the property location is valid.
+    #[inline]
     pub fn lookup_location_unchecked(&self, location: PropertyLocation) -> Value {
         match location {
-            PropertyLocation::PropertyArray { index } => *self
+            PropertyLocation::Inline { byte_offset } => {
+                self.get_inline_property_unchecked(byte_offset as usize)
+            }
+            PropertyLocation::ExternalArray { index } => *self
                 .named_properties
                 .cast::<ValueVec>()
                 .get_unchecked(index as usize),
@@ -180,9 +279,13 @@ impl ObjectValue {
     /// Set a named property value on the object given its property location.
     ///
     /// Assumes the object is in array mode and the property location is valid.
+    #[inline]
     pub fn set_location_unchecked(&mut self, location: PropertyLocation, value: Value) {
         match location {
-            PropertyLocation::PropertyArray { index } => {
+            PropertyLocation::Inline { byte_offset } => {
+                self.set_inline_property_unchecked(byte_offset as usize, value)
+            }
+            PropertyLocation::ExternalArray { index } => {
                 self.named_properties
                     .cast::<ValueVec>()
                     .set_unchecked(index as usize, value);
@@ -394,22 +497,15 @@ impl Handle<ObjectValue> {
         Ok(())
     }
 
-    /// Initialize the named properties of this object with the given values. Assumes the object
-    /// already has an array properties shape with the correct number of properties (e.g. a common
-    /// shape) and has no properties set yet.
-    pub fn init_properties(&mut self, cx: Context, values: &[Handle<Value>]) -> AllocResult<()> {
-        debug_assert!(values.len() == self.shape_ptr().num_properties() as usize);
-        debug_assert!(self.named_properties_array().len() == 0);
+    /// Initialize the inline named properties of this object with the given values. Assumes the
+    /// object has an array properties shape with the correct number of inline properties (e.g. a
+    /// common shape) and has no properties set yet.
+    pub fn init_inline_properties(&mut self, values: &[Handle<Value>]) {
+        debug_assert!(values.len() == self.shape_ptr().inline_properties_capacity() as usize);
 
-        let mut properties = ValueVec::new(cx, values.len())?;
-        properties.set_len(values.len());
-        for (slot, value) in properties.as_mut_slice().iter_mut().zip(values) {
+        for (slot, value) in self.inline_properties_as_slice_mut().iter_mut().zip(values) {
             *slot = **value;
         }
-
-        self.set_named_properties_array(properties);
-
-        Ok(())
     }
 
     fn set_named_property(
@@ -563,6 +659,11 @@ impl Handle<ObjectValue> {
             let value = self.lookup_location_unchecked(property_definition.location);
             let property = HeapProperty::new(value, property_definition.attributes);
             map.insert_without_growing(property_definition.key, property);
+        }
+
+        // Clear the inline properties to avoid leaking strong references
+        for slot in self.inline_properties_as_slice_mut() {
+            *slot = Value::undefined();
         }
 
         self.set_named_properties_map(*map);

--- a/src/js/runtime/ordinary_object.rs
+++ b/src/js/runtime/ordinary_object.rs
@@ -633,8 +633,13 @@ pub fn ordinary_object_create_without_proto(cx: Context) -> AllocResult<Handle<O
 /// Builder for JS objects.
 pub struct ObjectBuilder<T> {
     cx: Context,
+    /// The shape kind to use if a shape was not explicitly provided.
     shape_kind: HeapItemKind,
+    /// The number of inline properties needed if a shape was not explicitly provided.
+    inline_properties_capacity: u8,
+    /// The prototype to use for the object if a shape was not explicitly provided.
     proto: Option<Handle<ObjectValue>>,
+    /// The shape to use for the object.
     shape: Option<Handle<Shape>>,
     _phantom: PhantomData<T>,
 }
@@ -648,6 +653,7 @@ where
         Self {
             cx,
             shape_kind,
+            inline_properties_capacity: 0,
             proto: None,
             shape: None,
             _phantom: PhantomData,
@@ -707,15 +713,27 @@ where
     }
 
     #[inline]
+    pub fn inline_properties_capacity(mut self, capacity: u8) -> Self {
+        self.inline_properties_capacity = capacity;
+        self
+    }
+
+    #[inline]
     pub fn build(self) -> AllocResult<HeapPtr<T>> {
         let shape = if let Some(shape) = self.shape {
             shape
         } else {
-            ShapeRegistry::get_root_object_shape(self.cx, self.shape_kind, self.proto)?
+            ShapeRegistry::get_root_object_shape(
+                self.cx,
+                self.shape_kind,
+                self.proto,
+                self.inline_properties_capacity,
+            )?
         };
 
         // Allocate a new object with all fields initialized
-        let object = self.cx.alloc_uninit::<T>()?;
+        let byte_size = shape.object_byte_size();
+        let object = self.cx.alloc_uninit_with_size::<T>(byte_size)?;
 
         init_object_pointer_fields(self.cx, object.into(), *shape);
         object.into().set_uninit_hash_code();
@@ -744,6 +762,7 @@ impl ObjectBuilder<ObjectValue> {
     }
 }
 
+#[inline]
 pub fn init_object_pointer_fields(
     cx: Context,
     mut object: HeapPtr<ObjectValue>,
@@ -758,6 +777,11 @@ pub fn init_object_pointer_fields(
     }
 
     object.set_array_properties(cx.default_array_properties);
+
+    // All inline properties are initialized to undefined
+    for value in object.inline_properties_as_slice_mut() {
+        *value = Value::undefined();
+    }
 }
 
 /// GetPrototypeFromConstructor (https://tc39.es/ecma262/#sec-getprototypefromconstructor)
@@ -777,8 +801,8 @@ pub fn get_prototype_from_constructor(
 }
 
 impl HeapItem for OrdinaryObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<OrdinaryObject>()
+    fn byte_size(object: HeapPtr<Self>) -> usize {
+        object.object_byte_size()
     }
 
     fn visit_pointers(mut object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/promise_object.rs
+++ b/src/js/runtime/promise_object.rs
@@ -546,8 +546,8 @@ impl PromiseCapability {
 }
 
 impl HeapItem for PromiseObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<PromiseObject>()
+    fn byte_size(promise_object: HeapPtr<Self>) -> usize {
+        promise_object.object_byte_size()
     }
 
     fn visit_pointers(mut promise_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/property_descriptor.rs
+++ b/src/js/runtime/property_descriptor.rs
@@ -350,7 +350,7 @@ pub fn to_property_descriptor_object(
             .common_shape(CommonShape::DataPropertyDescriptor)?
             .build()?
             .to_handle();
-        object.init_properties(cx, &[property.value(), writable, enumerable, configurable])?;
+        object.init_inline_properties(&[property.value(), writable, enumerable, configurable]);
 
         Ok(object)
     } else {
@@ -370,7 +370,7 @@ pub fn to_property_descriptor_object(
             .common_shape(CommonShape::AccessorPropertyDescriptor)?
             .build()?
             .to_handle();
-        object.init_properties(cx, &[get_value, set_value, enumerable, configurable])?;
+        object.init_inline_properties(&[get_value, set_value, enumerable, configurable]);
 
         Ok(object)
     }

--- a/src/js/runtime/proxy_object.rs
+++ b/src/js/runtime/proxy_object.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, mem::size_of};
+use std::collections::HashSet;
 
 use crate::{
     extend_object, must,
@@ -868,8 +868,8 @@ pub fn proxy_create(
 }
 
 impl HeapItem for ProxyObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<ProxyObject>()
+    fn byte_size(proxy_object: HeapPtr<Self>) -> usize {
+        proxy_object.object_byte_size()
     }
 
     fn visit_pointers(mut proxy_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/shape.rs
+++ b/src/js/runtime/shape.rs
@@ -68,8 +68,18 @@ pub struct Shape {
     /// In array mode this is the number of properties in this shape. This is the size of the view
     /// into the `property_definitions` array.
     ///
+    /// Note this is the total number of both inline properties and properties in the external
+    /// property array.
+    ///
     /// Not used in map mode.
-    array_mode_property_count: u16,
+    array_mode_property_count: u8,
+
+    /// In array mode this is the maximum number of inline properties that can be stored in this
+    /// shape. A transition tree must share the same inline properties capacity for all shapes.
+    inline_properties_capacity: u8,
+
+    /// Start of the inline properties array in bytes.
+    inline_properties_offset: u8,
 
     /// The parent shape which links to this shape via a transition, if in the transition tree.
     parent_shape: Option<HeapPtr<Shape>>,
@@ -167,12 +177,17 @@ impl ObjectFlags {
     }
 }
 
-/// The maximum number of properties that can be stored in a shape before switching to map mode.
-const MAX_ARRAY_PROPERTIES: usize = 64;
-
 /// The maximum number of transitions that can be stored from a single shape. After this limit no
 /// new transitions are added and shapes that would need them enter map mode.
 const MAX_TRANSITIONS: usize = 256;
+
+/// The maximum number of properties that can be stored in a shape before switching to map mode.
+///
+/// Includes both inline and external array properties.
+pub const MAX_ARRAY_PROPERTIES: u8 = 64;
+
+/// The default number of inline properties to allocate for an empty object literal.
+pub const EMPTY_OBJECT_LITERAL_INLINE_PROPERTIES_CAPACITY: u8 = 4;
 
 enum StoredTransitions {
     None,
@@ -187,11 +202,14 @@ impl Shape {
         kind: HeapItemKind,
         flags: ObjectFlags,
         is_prototype_object: bool,
+        inline_properties_capacity: u8,
         property_definitions: Handle<PropertyDefinitionVec>,
     ) -> AllocResult<HeapPtr<Shape>>
     where
         Handle<T>: VirtualObject,
     {
+        debug_assert!(inline_properties_capacity <= MAX_ARRAY_PROPERTIES);
+
         let mut s = cx.alloc_uninit::<Shape>()?;
 
         set_uninit!(s.shape, *shape);
@@ -203,6 +221,11 @@ impl Shape {
         set_uninit!(s.prototype, None);
         set_uninit!(s.property_definitions, *property_definitions);
         set_uninit!(s.array_mode_property_count, 0);
+        set_uninit!(s.inline_properties_capacity, inline_properties_capacity);
+        set_uninit!(
+            s.inline_properties_offset,
+            HeapItemKind::INLINE_PROPERTIES_OFFSETS[kind as usize]
+        );
         set_uninit!(s.parent_shape, None);
         set_uninit!(s.transitions_or_next_shape, None);
         set_uninit!(s.validity_guard, None);
@@ -229,6 +252,7 @@ impl Shape {
             HeapItemKind::Shape,
             ObjectFlags::new_non_object(),
             /* is_prototype_object */ false,
+            /* inline_properties_capacity */ 0,
             default_property_definitions,
         )?;
 
@@ -292,12 +316,34 @@ impl Shape {
         self.flags.has_transitions_vec()
     }
 
+    #[inline]
     pub fn set_shape(&mut self, shape: HeapPtr<Shape>) {
         self.shape = shape;
     }
 
-    pub fn num_properties(&self) -> u16 {
+    #[inline]
+    pub fn num_properties(&self) -> u8 {
         self.array_mode_property_count
+    }
+
+    #[inline]
+    pub fn inline_properties_capacity(&self) -> u8 {
+        self.inline_properties_capacity
+    }
+
+    #[inline]
+    pub fn inline_properties_offset(&self) -> u8 {
+        self.inline_properties_offset
+    }
+
+    /// If this shape is for an object, returns the size of the object in bytes including the inline
+    /// properties array.
+    #[inline]
+    pub fn object_byte_size(&self) -> usize {
+        let inline_properties_size =
+            std::mem::size_of::<Value>() * (self.inline_properties_capacity() as usize);
+
+        (self.inline_properties_offset as usize) + inline_properties_size
     }
 
     pub fn transitions_or_next_shape(&self) -> Option<HeapPtr<AnyHeapItem>> {
@@ -471,9 +517,13 @@ impl Handle<Shape> {
         &self,
         cx: Context,
         prototype: Option<Handle<ObjectValue>>,
+        inline_properties_capacity: u8,
     ) -> AllocResult<HeapPtr<Shape>> {
+        debug_assert!(inline_properties_capacity <= MAX_ARRAY_PROPERTIES);
+
         let mut cloned = self.shallow_clone(cx)?;
         cloned.prototype = prototype.map(|p| *p);
+        cloned.inline_properties_capacity = inline_properties_capacity;
 
         Ok(cloned)
     }
@@ -512,6 +562,9 @@ impl Handle<Shape> {
             shape.flags.set_is_map_mode(true);
             shape.property_definitions = cx.shapes.default_property_definitions;
             shape.array_mode_property_count = 0;
+
+            // Note that inline properties offset and capacity are preserved so that the object's
+            // original size can still be calculated.
         }
 
         // Prototype shapes are always mutated in place, and are not part of the transition tree
@@ -572,21 +625,18 @@ impl Handle<Shape> {
 
                 DefinePropertyLocation::Location(property_definition.location)
             } else {
-                // Adding a new property. Ensure we have room for another property in array mode.
-                if self.array_mode_property_count as usize >= MAX_ARRAY_PROPERTIES {
+                // Switch to map mode if we do not have room for another property
+                let Some((define_location, location)) = self.next_property_location() else {
                     return Ok((**self, DefinePropertyLocation::EnterMapMode));
-                }
+                };
 
-                // Property is stored at the next open index
-                let index = self.array_mode_property_count;
-                let location = PropertyLocation::PropertyArray { index };
                 self.array_mode_property_count += 1;
 
                 self.property_definitions_vec_field()
                     .maybe_grow_for_push(cx)?
                     .push_without_growing(PropertyDefinition { key: *key, location, attributes });
 
-                DefinePropertyLocation::NewArrayProperty
+                define_location
             };
 
             // Any change invalidates all shapes with this shape in their prototype chain
@@ -616,7 +666,9 @@ impl Handle<Shape> {
             StoredTransitions::SimpleAddProperty(next_shape) => {
                 let property_definition = next_shape.get_last_property_definition();
                 if property_definition.key == *key && property_definition.attributes == attributes {
-                    return Ok((*next_shape, DefinePropertyLocation::NewArrayProperty));
+                    let define_location =
+                        Self::define_location_for_added_property(property_definition);
+                    return Ok((*next_shape, define_location));
                 }
             }
             // If there is a transition array then search for a matching DefineProperty transition
@@ -635,11 +687,11 @@ impl Handle<Shape> {
                             let added_property =
                                 self.num_properties() + 1 == new_shape.num_properties();
 
+                            let property_definition = new_shape.lookup_own_property(*key).unwrap();
+
                             let location = if added_property {
-                                DefinePropertyLocation::NewArrayProperty
+                                Self::define_location_for_added_property(property_definition)
                             } else {
-                                let property_definition =
-                                    new_shape.lookup_own_property(*key).unwrap();
                                 DefinePropertyLocation::Location(property_definition.location)
                             };
 
@@ -669,14 +721,10 @@ impl Handle<Shape> {
 
             DefinePropertyLocation::Location(property_definition.location)
         } else {
-            // Adding a new property. Ensure we have room for another property in array mode.
-            if self.array_mode_property_count as usize >= MAX_ARRAY_PROPERTIES {
+            // Switch to map mode if we do not have room for another property
+            let Some((define_location, location)) = new_shape.next_property_location() else {
                 return Ok((**self, DefinePropertyLocation::EnterMapMode));
-            }
-
-            // Property is stored at the next open index
-            let index = new_shape.array_mode_property_count;
-            let location = PropertyLocation::PropertyArray { index };
+            };
 
             // Property will be appended to shared array if the next slot hasn't already been used
             if new_shape.property_definitions.len() > new_shape.array_mode_property_count as usize {
@@ -691,7 +739,7 @@ impl Handle<Shape> {
                 .maybe_grow_for_push(cx)?
                 .push_without_growing(PropertyDefinition { key: *key, location, attributes });
 
-            DefinePropertyLocation::NewArrayProperty
+            define_location
         };
 
         match stored_transitions {
@@ -727,6 +775,42 @@ impl Handle<Shape> {
         }
 
         Ok((*new_shape, location))
+    }
+
+    /// Return the next property location for a new property added to this shape. Adds to available
+    /// inline properties if possible, otherwise adds to the external property array if possible.
+    ///
+    /// Returns None if the shape is full in array mode and must switch to map mode.
+    fn next_property_location(&self) -> Option<(DefinePropertyLocation, PropertyLocation)> {
+        if self.array_mode_property_count < self.inline_properties_capacity {
+            // Still room in the inline properties, store at the next open index. Precompute the
+            // byte offset of the slot property so it can be loaded directly.
+            let byte_offset = self.inline_properties_offset as u16
+                + (self.array_mode_property_count as u16) * (size_of::<Value>() as u16);
+            let location = PropertyLocation::Inline { byte_offset };
+
+            Some((DefinePropertyLocation::Location(location), location))
+        } else if self.array_mode_property_count < MAX_ARRAY_PROPERTIES {
+            // Still room in external array properties, store at the next open index
+            let index = self.array_mode_property_count - self.inline_properties_capacity;
+            let location = PropertyLocation::ExternalArray { index };
+
+            Some((DefinePropertyLocation::NewArrayProperty, location))
+        } else {
+            None
+        }
+    }
+
+    /// The define property location for an existing transition that adds the given property.
+    fn define_location_for_added_property(
+        property_definition: &PropertyDefinition,
+    ) -> DefinePropertyLocation {
+        match property_definition.location {
+            PropertyLocation::Inline { .. } => {
+                DefinePropertyLocation::Location(property_definition.location)
+            }
+            PropertyLocation::ExternalArray { .. } => DefinePropertyLocation::NewArrayProperty,
+        }
     }
 
     /// Set the prototype object for this shape.

--- a/src/js/runtime/shape_registry.rs
+++ b/src/js/runtime/shape_registry.rs
@@ -28,8 +28,9 @@ use crate::{
 /// Central registry for all shapes in a context.
 pub struct ShapeRegistry {
     /// Canonical shapes for all heap items, indexed by kind.
-    /// - For object items these are the initial shape for that kind without a prototype. They are
-    ///   not part of the transition tree nor are they used directly.
+    /// - For object items these are the initial shape for that kind without a prototype or inline
+    ///   properties. They are not part of the transition tree and are only used as a template for
+    ///   new root shapes (setting the prototype and inline properties capacity).
     /// - For non-object items these are the singleton shape for that kind
     canonical_shapes: Vec<HeapPtr<Shape>>,
 
@@ -100,6 +101,7 @@ impl ShapeRegistry {
                     $object_kind,
                     $flags,
                     /* is_prototype_object */ false,
+                    /* inline_properties_capacity */ 0,
                     default_property_definitions,
                 )?;
                 shapes[$object_kind as usize] = shape;
@@ -253,17 +255,24 @@ impl ShapeRegistry {
         self.canonical_shapes[kind as usize]
     }
 
-    /// Get the root shape in the transition tree for an object with the given prototype and kind.
+    /// Get the root shape in the transition tree for an object with the given prototype, kind, and
+    /// inline properties capacity. This tuple uniquely identifies a root shape in the tree.
+    ///
     /// Must only be called for object kinds.
     pub fn get_root_object_shape(
         cx: Context,
         kind: HeapItemKind,
         prototype: Option<Handle<ObjectValue>>,
+        inline_properties_capacity: u8,
     ) -> AllocResult<Handle<Shape>> {
         debug_assert!(kind.is_object_kind());
 
         // Use the root shape for this prototype and kind, if one already exists
-        let key = PrototypeAndKind { prototype: prototype.map(|p| *p), kind };
+        let key = PrototypeAndKind {
+            prototype: prototype.map(|p| *p),
+            kind,
+            inline_properties_capacity,
+        };
         if let Some(root_shape) = cx.shapes.transition_tree_roots.get(&key) {
             return Ok(root_shape.to_handle());
         }
@@ -271,13 +280,17 @@ impl ShapeRegistry {
         // Otherwise none exists yet, so create a new root shape for this prototype and kind
         let canonical_shape = cx.shapes.canonical_shapes[kind as usize].to_handle();
         let new_root_shape = canonical_shape
-            .clone_for_transition_tree_root(cx, prototype)?
+            .clone_for_transition_tree_root(cx, prototype, inline_properties_capacity)?
             .to_handle();
 
         TransitionTreeRootsMapField
             .maybe_grow_for_insertion(cx)?
             .insert_without_growing(
-                PrototypeAndKind { prototype: prototype.map(|p| *p), kind },
+                PrototypeAndKind {
+                    prototype: prototype.map(|p| *p),
+                    kind,
+                    inline_properties_capacity,
+                },
                 *new_root_shape,
             );
 
@@ -344,12 +357,14 @@ impl BsHashMapField<TransitionTreeRootsMap> for TransitionTreeRootsMapField {
 pub struct PrototypeAndKind {
     pub prototype: Option<HeapPtr<ObjectValue>>,
     pub kind: HeapItemKind,
+    pub inline_properties_capacity: u8,
 }
 
 impl PartialEq for PrototypeAndKind {
     fn eq(&self, other: &Self) -> bool {
         self.prototype.map(|p| p.as_ptr()) == other.prototype.map(|p| p.as_ptr())
             && self.kind == other.kind
+            && self.inline_properties_capacity == other.inline_properties_capacity
     }
 }
 
@@ -364,5 +379,6 @@ impl Hash for PrototypeAndKind {
         }
 
         state.write_u8(self.kind as u8);
+        state.write_u8(self.inline_properties_capacity);
     }
 }

--- a/src/js/runtime/string_object.rs
+++ b/src/js/runtime/string_object.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 use crate::{
     extend_object,
     runtime::{
@@ -53,7 +51,7 @@ impl StringObject {
 
         object
             .as_object()
-            .init_properties(cx, &[cx.number(string_length)])?;
+            .init_inline_properties(&[cx.number(string_length)]);
 
         Ok(object)
     }
@@ -195,8 +193,8 @@ impl VirtualObject for Handle<StringObject> {
 }
 
 impl HeapItem for StringObject {
-    fn byte_size(_: HeapPtr<Self>) -> usize {
-        size_of::<StringObject>()
+    fn byte_size(string_object: HeapPtr<Self>) -> usize {
+        string_object.object_byte_size()
     }
 
     fn visit_pointers(mut string_object: HeapPtr<Self>, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/transitions.rs
+++ b/src/js/runtime/transitions.rs
@@ -20,8 +20,11 @@ impl PropertyDefinition {
 #[derive(Clone, Copy)]
 /// Where a property is stored on an object.
 pub enum PropertyLocation {
+    /// Inline property stored directly on the object at this byte offset from the start of the
+    /// object.
+    Inline { byte_offset: u16 },
     /// Property is stored in the named properties array at this index.
-    PropertyArray { index: u16 },
+    ExternalArray { index: u8 },
 }
 
 #[derive(Clone, Copy)]

--- a/tests/snapshot/bytecode/annex_b/assign_to_call_expression.exp
+++ b/tests/snapshot/bytecode/annex_b/assign_to_call_expression.exp
@@ -66,7 +66,7 @@
 
 [BytecodeFunction: forInInitializer] {
   Parameters: 0, Registers: 3
-     0: NewObject r0, 0
+     0: NewObject r0, 4
      3: JumpNullish r0, 26 (.L1)
      6: NewForInIterator r0, r0
   .L0:

--- a/tests/snapshot/bytecode/bytecode/assign_hazard.exp
+++ b/tests/snapshot/bytecode/bytecode/assign_hazard.exp
@@ -104,7 +104,7 @@
 
 [BytecodeFunction: inVarDeclarator] {
   Parameters: 1, Registers: 4
-     0: NewObject r1, 0
+     0: NewObject r1, 4
      3: GetNamedProperty r2, r1, c0, k0
      8: JumpNotUndefined r2, 13 (.L0)
     11: Mov r3, a0
@@ -138,7 +138,7 @@
 
 [BytecodeFunction: inForEachInit] {
   Parameters: 2, Registers: 3
-     0: NewObject r0, 0
+     0: NewObject r0, 4
      3: JumpNullish r0, 28 (.L1)
      6: NewForInIterator r0, r0
   .L0:

--- a/tests/snapshot/bytecode/eval/completion.exp
+++ b/tests/snapshot/bytecode/eval/completion.exp
@@ -208,7 +208,7 @@
      2: StoreToScope <this>, 0, 0
      6: LoadConstant r0, c1
      9: LoadUndefined r0
-    11: NewObject r1, 0
+    11: NewObject r1, 4
     14: PushWithScope r1, c2
     17: LoadImmediate r0, 1
     20: PopScope 
@@ -238,7 +238,7 @@
   Parameters: 0, Registers: 3
      0: LoadConstant r0, c0
      3: LoadUndefined r0
-     5: NewObject r1, 0
+     5: NewObject r1, 4
      8: JumpNullish r1, 20 (.L1)
     11: NewForInIterator r1, r1
   .L0:

--- a/tests/snapshot/bytecode/expression/object/basic.exp
+++ b/tests/snapshot/bytecode/expression/object/basic.exp
@@ -50,7 +50,7 @@
 
 [BytecodeFunction: emptyObject] {
   Parameters: 0, Registers: 1
-    0: NewObject r0, 0
+    0: NewObject r0, 4
     3: Ret r0
 }
 
@@ -118,7 +118,7 @@
 
 [BytecodeFunction: spread] {
   Parameters: 1, Registers: 3
-     0: NewObject r0, 0
+     0: NewObject r0, 4
      3: CopyDataProperties r0, a0, a0, 0
      8: LoadImmediate r1, 1
     11: LoadImmediate r2, 2
@@ -129,7 +129,7 @@
 
 [BytecodeFunction: proto] {
   Parameters: 1, Registers: 3
-     0: NewObject r0, 0
+     0: NewObject r0, 4
      3: LoadImmediate r1, 1
      6: LoadImmediate r2, 2
      9: Add r1, r1, r2
@@ -177,7 +177,7 @@
 [BytecodeFunction: noTemporaryRegisterNeededForEmptyObject] {
   Parameters: 0, Registers: 2
     0: LoadImmediate r0, 1
-    3: NewObject r0, 0
+    3: NewObject r0, 4
     6: LoadUndefined r1
     8: Ret r1
 }

--- a/tests/snapshot/bytecode/module/dynamic_import.exp
+++ b/tests/snapshot/bytecode/module/dynamic_import.exp
@@ -8,7 +8,7 @@
     16: LoadImmediate r1, 3
     19: Add r0, r0, r1
     23: LoadImmediate r1, 4
-    26: NewObject r2, 0
+    26: NewObject r2, 4
     29: DynamicImport r0, r1, r2
     33: LoadUndefined r0
     35: Ret r0

--- a/tests/snapshot/bytecode/pattern/basic.exp
+++ b/tests/snapshot/bytecode/pattern/basic.exp
@@ -16,7 +16,7 @@
     47: GetProperty r4, r0, r3
     51: StoreGlobal r4, c7, k6
     55: ToObject r5, r0
-    58: NewObject r4, 0
+    58: NewObject r4, 4
     61: CopyDataProperties r4, r0, r1, 3
     66: StoreGlobal r4, c8, k7
     70: PushLexicalScope c9
@@ -53,7 +53,7 @@
     22: ToPropertyKey r7, r8
     25: GetProperty r2, r4, r7
     29: ToObject r8, r4
-    32: NewObject r3, 0
+    32: NewObject r3, 4
     35: CopyDataProperties r3, r4, r5, 3
     40: LoadUndefined r4
     42: Ret r4

--- a/tests/snapshot/bytecode/pattern/object_destructuring.exp
+++ b/tests/snapshot/bytecode/pattern/object_destructuring.exp
@@ -221,7 +221,7 @@
   Parameters: 1, Registers: 10
      0: Mov r5, a0
      3: ToObject r6, r5
-     6: NewObject r0, 0
+     6: NewObject r0, 4
      9: CopyDataProperties r0, r5, r5, 0
     14: Mov r5, a0
     17: LoadConstant r6, c0
@@ -229,7 +229,7 @@
     25: LoadConstant r7, c1
     28: GetNamedProperty r1, r5, c1, k1
     33: ToObject r8, r5
-    36: NewObject r2, 0
+    36: NewObject r2, 4
     39: CopyDataProperties r2, r5, r6, 2
     44: Mov r5, a0
     47: LoadConstant r6, c0
@@ -241,7 +241,7 @@
     68: ToPropertyKey r8, r9
     71: GetProperty r3, r5, r8
     75: ToObject r9, r5
-    78: NewObject r4, 0
+    78: NewObject r4, 4
     81: CopyDataProperties r4, r5, r6, 3
     86: LoadUndefined r5
     88: Ret r5
@@ -309,7 +309,7 @@
     30: LoadGlobal r4, c3, k4
     34: Call r4, r4, r4, 0
     39: ToObject r5, r0
-    42: NewObject r2, 0
+    42: NewObject r2, 4
     45: CopyDataProperties r2, r0, r1, 1
     50: SetProperty r3, r4, r2
     54: LoadUndefined r0

--- a/tests/snapshot/bytecode/scope/for_in.exp
+++ b/tests/snapshot/bytecode/scope/for_in.exp
@@ -23,7 +23,7 @@
 
 [BytecodeFunction: startScope] {
   Parameters: 0, Registers: 4
-     0: NewObject r2, 0
+     0: NewObject r2, 4
      3: JumpNullish r2, 29 (.L1)
      6: NewForInIterator r2, r2
   .L0:
@@ -47,7 +47,7 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 0, 0
-     8: NewObject r1, 0
+     8: NewObject r1, 4
     11: JumpNullish r1, 47 (.L1)
     14: NewForInIterator r1, r1
     17: PopScope 

--- a/tests/snapshot/bytecode/scope/for_in_break.exp
+++ b/tests/snapshot/bytecode/scope/for_in_break.exp
@@ -26,7 +26,7 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 0, 0
-     8: NewObject r1, 0
+     8: NewObject r1, 4
     11: JumpNullish r1, 84 (.L3)
     14: NewForInIterator r1, r1
     17: PopScope 
@@ -99,7 +99,7 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 0, 0
-     8: NewObject r1, 0
+     8: NewObject r1, 4
     11: JumpNullish r1, 66 (.L3)
     14: NewForInIterator r1, r1
     17: PopScope 
@@ -157,7 +157,7 @@
 [BytecodeFunction: noForCaptureButInnerCaptureWithBreak] {
   Parameters: 0, Registers: 3
      0: PushFunctionScope c0
-     2: NewObject r1, 0
+     2: NewObject r1, 4
      5: JumpNullish r1, 72 (.L3)
      8: NewForInIterator r1, r1
   .L0:
@@ -217,7 +217,7 @@
 [BytecodeFunction: noForCaptureOrInnerCaptureWithBreak] {
   Parameters: 0, Registers: 3
      0: PushFunctionScope c0
-     2: NewObject r1, 0
+     2: NewObject r1, 4
      5: JumpNullish r1, 61 (.L3)
      8: NewForInIterator r1, r1
   .L0:

--- a/tests/snapshot/bytecode/scope/for_in_continue.exp
+++ b/tests/snapshot/bytecode/scope/for_in_continue.exp
@@ -26,7 +26,7 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 0, 0
-     8: NewObject r1, 0
+     8: NewObject r1, 4
     11: JumpNullish r1, 84 (.L3)
     14: NewForInIterator r1, r1
     17: PopScope 
@@ -98,7 +98,7 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 0, 0
-     8: NewObject r1, 0
+     8: NewObject r1, 4
     11: JumpNullish r1, 66 (.L3)
     14: NewForInIterator r1, r1
     17: PopScope 
@@ -155,7 +155,7 @@
 [BytecodeFunction: noForCaptureButInnerCaptureWithContinue] {
   Parameters: 0, Registers: 3
      0: PushFunctionScope c0
-     2: NewObject r1, 0
+     2: NewObject r1, 4
      5: JumpNullish r1, 72 (.L3)
      8: NewForInIterator r1, r1
   .L0:
@@ -215,7 +215,7 @@
 [BytecodeFunction: noForCaptureOrInnerCaptureWithContinue] {
   Parameters: 0, Registers: 3
      0: PushFunctionScope c0
-     2: NewObject r1, 0
+     2: NewObject r1, 4
      5: JumpNullish r1, 61 (.L3)
      8: NewForInIterator r1, r1
   .L0:

--- a/tests/snapshot/bytecode/statement/for_in.exp
+++ b/tests/snapshot/bytecode/statement/for_in.exp
@@ -36,7 +36,7 @@
 [BytecodeFunction: basicVar] {
   Parameters: 0, Registers: 3
      0: LoadImmediate r1, 1
-     3: NewObject r1, 0
+     3: NewObject r1, 4
      6: JumpNullish r1, 20 (.L1)
      9: NewForInIterator r1, r1
   .L0:
@@ -54,7 +54,7 @@
 [BytecodeFunction: basicConstLet] {
   Parameters: 0, Registers: 4
      0: LoadImmediate r2, 1
-     3: NewObject r2, 0
+     3: NewObject r2, 4
      6: JumpNullish r2, 20 (.L1)
      9: NewForInIterator r2, r2
   .L0:
@@ -65,7 +65,7 @@
     24: Jump -12 (.L0)
   .L1:
     26: LoadImmediate r2, 3
-    29: NewObject r2, 0
+    29: NewObject r2, 4
     32: JumpNullish r2, 20 (.L3)
     35: NewForInIterator r2, r2
   .L2:
@@ -83,7 +83,7 @@
 [BytecodeFunction: testBreakAndContinue] {
   Parameters: 0, Registers: 3
      0: LoadImmediate r1, 1
-     3: NewObject r1, 0
+     3: NewObject r1, 4
      6: JumpNullish r1, 33 (.L3)
      9: NewForInIterator r1, r1
   .L0:
@@ -108,7 +108,7 @@
 [BytecodeFunction: lhsIdentifier] {
   Parameters: 1, Registers: 2
      0: LoadImmediate r0, 1
-     3: NewObject r0, 0
+     3: NewObject r0, 4
      6: JumpNullish r0, 17 (.L1)
      9: NewForInIterator r0, r0
   .L0:
@@ -125,7 +125,7 @@
 [BytecodeFunction: lhsMember] {
   Parameters: 1, Registers: 3
      0: LoadImmediate r0, 1
-     3: NewObject r0, 0
+     3: NewObject r0, 4
      6: JumpNullish r0, 22 (.L1)
      9: NewForInIterator r0, r0
   .L0:
@@ -136,7 +136,7 @@
     26: Jump -14 (.L0)
   .L1:
     28: LoadImmediate r0, 3
-    31: NewObject r0, 0
+    31: NewObject r0, 4
     34: JumpNullish r0, 24 (.L3)
     37: NewForInIterator r0, r0
   .L2:
@@ -157,7 +157,7 @@
 [BytecodeFunction: lhsDestructuring] {
   Parameters: 1, Registers: 6
      0: LoadImmediate r3, 1
-     3: NewObject r3, 0
+     3: NewObject r3, 4
      6: JumpNullish r3, 41 (.L2)
      9: NewForInIterator r3, r3
   .L0:
@@ -174,7 +174,7 @@
     45: Jump -33 (.L0)
   .L2:
     47: LoadImmediate r3, 3
-    50: NewObject r3, 0
+    50: NewObject r3, 4
     53: JumpNullish r3, 41 (.L5)
     56: NewForInIterator r3, r3
   .L3:
@@ -207,7 +207,7 @@
      8: PushLexicalScope c1
     10: LoadEmpty r2
     12: StoreToScope r2, 0, 0
-    16: NewObject r2, 0
+    16: NewObject r2, 4
     19: JumpNullish r2, 31 (.L1)
     22: NewForInIterator r2, r2
     25: PopScope 
@@ -225,7 +225,7 @@
     50: PopScope 
     51: LoadImmediate r2, 1
     54: StoreToScope r2, 0, 0
-    58: NewObject r2, 0
+    58: NewObject r2, 4
     61: JumpNullish r2, 28 (.L3)
     64: NewForInIterator r2, r2
   .L2:


### PR DESCRIPTION
## Summary

Switch to storing properties inline - directly on objects themselves - instead of the external properties array when possible. Each object shape now has an inline property capacity used to determine the object's overall size and how many inline properties it supports. This capacity is shared by an entire transition tree causing each transition root to additionally be keyed by this capacity.

The inline properties capacity is set a number of different ways:
- Object literals use the estimated property count added to the `NewObject` instruction
- Constructors store the estimated property count on `BytecodeFunctions` and must sum the counts from the entire constructor chain when an object is constructed.
- Empty object literals default to having room for 4 inline properties
- Common shapes have the exact number of inline properties hardcoded

Notes:
- For efficient lookup/size calculation we store the `inline_properties_offset` in bytes on the shape itself
- Similarly inline caches store the precise byte offset of an inline property from the start of the object
- All object size calculations now require reading the shape and calculating based off the number of inline properties. This also means heap traversal now needs a way to reconstruct the shape pointer so the object size can be calculated (e.g. in the case pointers were converted to offsets).
- Needed to add some more `#[inline]`s to prevent regressions in inline across module boundaries, most notably for named property cache's `try_match` methods.

Seeing a ~2% increase to Octane scores. Most of the increase is in the GC-heavy splay benchmarks, likely due reduced GC pressure as property allocation can often be avoided.

| Benchmark | (base) | (PR) | Change |
|---|---|---|---|
| Richards | 2,014 med 1,982 ±24.0 n=4 | 2,079 med 2,073 ±5.1 n=4 | +3.2% |
| DeltaBlue | 1,627 med 1,615 ±9.2 n=4 | 1,641 med 1,641 ±7.8 n=4 | +0.9% |
| Crypto | 1,524 med 1,489 ±28.7 n=4 | 1,513 med 1,500 ±28.5 n=4 | -0.7% |
| RayTrace | 2,792 med 2,786 ±9.4 n=4 | 2,770 med 2,765 ±7.2 n=4 | -0.8% |
| EarleyBoyer | 4,802 med 4,778 ±13.5 n=4 | 4,891 med 4,879 ±17.9 n=4 | +1.9% |
| RegExp | 429 med 428 ±3.2 n=4 | 428 med 427 ±1.0 n=4 | -0.2% |
| Splay | 3,245 med 3,197 ±25.4 n=4 | 3,794 med 3,739 ±41.9 n=4 | +16.9% |
| SplayLatency | 6,005 med 5,825 ±109 n=4 | 7,217 med 7,082 ±99.5 n=4 | +20.2% |
| NavierStokes | 1,251 med 1,243 ±4.8 n=4 | 1,249 med 1,239 ±5.7 n=4 | -0.2% |
| PdfJS | 4,594 med 4,581 ±11.9 n=4 | 4,606 med 4,596 ±9.5 n=4 | +0.3% |
| Mandreel | 1,092 med 1,091 ±1.3 n=4 | 1,083 med 1,078 ±13.2 n=4 | -0.8% |
| MandreelLatency | 7,081 med 7,056 ±23.8 n=4 | 7,002 med 6,973 ±41.8 n=4 | -1.1% |
| Gameboy | 4,247 med 4,203 ±34.1 n=4 | 4,230 med 4,190 ±38.4 n=4 | -0.4% |
| CodeLoad | 39,760 med 39,632 ±119 n=4 | 39,897 med 39,852 ±49.3 n=4 | +0.3% |
| Box2D | 7,327 med 7,244 ±44.7 n=4 | 7,169 med 7,159 ±16.7 n=4 | -2.2% |
| zlib | 2,384 med 2,364 ±20.2 n=4 | 2,359 med 2,348 ±11.1 n=4 | -1.0% |
| Typescript | 17,258 med 17,207 ±76.5 n=4 | 17,369 med 17,334 ±28.6 n=4 | +0.6% |
| Total (octane) | 3,421 med 3,400 ±13.1 n=4 | 3,489 med 3,480 ±11.1 n=4 | +2.0% |

## Tests

- CI
- Updated bytecode snapshots now that empty object literals have an estimate of 4 properties
