### PR TITLE
[bytecode] Add polymorphic inline caches for named property loads and stores

### DIFF
--- a/src/js/runtime/bytecode/cache.rs
+++ b/src/js/runtime/bytecode/cache.rs
@@ -2,6 +2,7 @@ use crate::runtime::{
     Context, Handle, HeapItemKind, HeapPtr, PropertyKey, Realm, Value,
     accessor::Accessor,
     alloc_error::AllocResult,
+    bytecode::function::CacheArray,
     gc::HeapVisitor,
     global_object::GlobalProperty,
     object_value::ObjectValue,
@@ -11,6 +12,10 @@ use crate::runtime::{
     transitions::PropertyLocation,
 };
 
+/// The maximum number of entries in a polymorphic cache. Once more shapes than this are seen the
+/// cache is considered megamorphic and caching fails.
+pub const MAX_POLYMORPHIC_ENTRIES: usize = 4;
+
 /// A generic cache with multiple specific cache types.
 ///
 /// Note that caches currently hold onto cached heap items strongly.
@@ -19,27 +24,99 @@ use crate::runtime::{
 pub enum Cache {
     /// A cache that has not yet been used. This is the initial value when a cache is allocated.
     Uninitialized,
-    /// Caching has failed and is no longer occurring (e.g. due to too many types).
+    /// Caching has failed and is no longer occurring (e.g. due to too many shapes or an
+    /// uncacheable property access).
     Failed,
     GetNamedProperty(GetNamedPropertyCache),
     SetNamedProperty(SetNamedPropertyCache),
+    /// A polymorphic cache holding an entry for each shape that has been seen, up to
+    /// `MAX_POLYMORPHIC_ENTRIES`. Entries are always `GetNamedProperty` or `SetNamedProperty`
+    /// and are packed at the front of the array, with `Uninitialized` in all unused slots.
+    Polymorphic(HeapPtr<CacheArray>),
     GlobalProperty(GlobalPropertyCache),
 }
 
 impl Cache {
-    #[inline]
-    pub fn get_named_property(cache: Option<GetNamedPropertyCache>) -> Self {
-        match cache {
-            Some(cache) => Self::GetNamedProperty(cache),
-            None => Self::Failed,
+    /// Insert a newly filled entry into the cache at the given index, promoting to a polymorphic
+    /// cache when multiple shapes are seen. A `new_entry` of `None` means the property access was
+    /// not cacheable, which stops caching at this site entirely.
+    ///
+    /// Must not allocate since `new_entry` contains unrooted heap pointers. Promoting to a
+    /// polymorphic cache requires an entry array, so callers must preallocate one whenever
+    /// promotion is possible.
+    ///
+    /// Reads the current state of the cache itself since the property access that preceded this
+    /// insert may have run arbitrary code (e.g. a getter) that re-entered the same instruction
+    /// and modified the cache.
+    pub fn insert(
+        mut caches: HeapPtr<CacheArray>,
+        cache_index: usize,
+        new_entry: Option<Cache>,
+        preallocated_entries: Option<Handle<CacheArray>>,
+    ) {
+        let Some(new_entry) = new_entry else {
+            // Uncacheable property accesses stop caching at this site entirely, even if valid
+            // polymorphic entries exist.
+            caches.set(cache_index, Cache::Failed);
+            return;
+        };
+
+        debug_assert!(matches!(new_entry, Cache::GetNamedProperty(_) | Cache::SetNamedProperty(_)));
+
+        match caches.get(cache_index) {
+            // Once caching has failed at this site it is never resumed
+            Cache::Failed => {}
+            Cache::Uninitialized => caches.set(cache_index, new_entry),
+            existing @ (Cache::GetNamedProperty(_) | Cache::SetNamedProperty(_)) => {
+                if existing
+                    .receiver_shape()
+                    .ptr_eq(&new_entry.receiver_shape())
+                {
+                    // Replace entries with the same shape, e.g. when refilling after a guard
+                    // was invalidated.
+                    caches.set(cache_index, new_entry);
+                } else if let Some(mut entries) = preallocated_entries {
+                    // A second shape was seen, promote to a polymorphic cache with both entries
+                    entries.set(0, existing);
+                    entries.set(1, new_entry);
+                    caches.set(cache_index, Cache::Polymorphic(*entries));
+                } else {
+                    // Cannot promote without a preallocated entry array, so replace the entry
+                    caches.set(cache_index, new_entry);
+                }
+            }
+            Cache::Polymorphic(mut entries) => {
+                for i in 0..entries.len() {
+                    match entries.get(i) {
+                        // Entries are packed at the front of the array, so reaching an
+                        // uninitialized slot means the new entry's shape is not present. Add the
+                        // new entry.
+                        Cache::Uninitialized => {
+                            entries.set(i, new_entry);
+                            return;
+                        }
+                        // Replace entries with the same shape
+                        entry if entry.receiver_shape().ptr_eq(&new_entry.receiver_shape()) => {
+                            entries.set(i, new_entry);
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+
+                // All entries are filled with other shapes, cache is now megamorphic
+                caches.set(cache_index, Cache::Failed);
+            }
+            Cache::GlobalProperty(_) => unreachable!("wrong cache kind for insert"),
         }
     }
 
-    #[inline]
-    pub fn set_named_property(cache: Option<SetNamedPropertyCache>) -> Self {
-        match cache {
-            Some(cache) => Self::SetNamedProperty(cache),
-            None => Self::Failed,
+    /// The receiver shape checked by a monomorphic cache entry.
+    fn receiver_shape(&self) -> HeapPtr<Shape> {
+        match self {
+            Self::GetNamedProperty(cache) => cache.receiver_shape(),
+            Self::SetNamedProperty(cache) => cache.receiver_shape(),
+            _ => unreachable!("only monomorphic entries have a receiver shape"),
         }
     }
 }
@@ -77,6 +154,15 @@ pub enum GetNamedPropertyCacheResult {
 }
 
 impl GetNamedPropertyCache {
+    /// The receiver shape checked by this cache.
+    fn receiver_shape(&self) -> HeapPtr<Shape> {
+        match self {
+            Self::Own { shape, .. } | Self::Proto { shape, .. } | Self::NotFound { shape, .. } => {
+                *shape
+            }
+        }
+    }
+
     /// Match the cache against a receiver object and return the cached property if it is still
     /// valid. If the cache is invalid, returns a result indicating why it is invalid.
     pub fn try_match(&self, receiver: HeapPtr<ObjectValue>) -> GetNamedPropertyCacheResult {
@@ -251,6 +337,15 @@ pub enum SetNamedPropertyCacheResult {
 }
 
 impl SetNamedPropertyCache {
+    /// The receiver shape checked by this cache.
+    fn receiver_shape(&self) -> HeapPtr<Shape> {
+        match self {
+            Self::Own { shape, .. }
+            | Self::ProtoAccessor { shape, .. }
+            | Self::TransitionStore { shape, .. } => *shape,
+        }
+    }
+
     /// Match the cache against a receiver object and return the cached property location if it is
     /// still valid. If the cache is invalid, returns a result indicating why it is invalid.
     pub fn try_match(
@@ -572,6 +667,7 @@ impl Cache {
             Self::Uninitialized | Self::Failed => {}
             Self::GetNamedProperty(cache) => cache.visit_pointers(visitor),
             Self::SetNamedProperty(cache) => cache.visit_pointers(visitor),
+            Self::Polymorphic(entries) => visitor.visit_pointer(entries),
             Self::GlobalProperty(cache) => cache.visit_pointers(visitor),
         }
     }

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -9,8 +9,11 @@ use crate::{
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         bytecode::{
-            cache::Cache, constant_table::ConstantTable, exception_handlers::ExceptionHandlers,
-            graphviz::bytecode_function_to_dot_graph, instruction::debug_format_instructions,
+            cache::{Cache, MAX_POLYMORPHIC_ENTRIES},
+            constant_table::ConstantTable,
+            exception_handlers::ExceptionHandlers,
+            graphviz::bytecode_function_to_dot_graph,
+            instruction::debug_format_instructions,
             source_map::BytecodeSourceMap,
         },
         collections::{ArrayInstance, InlineArray, array::ByteArray},
@@ -651,6 +654,14 @@ impl CacheArray {
         let caches = <Self as ArrayInstance>::new(cx, num_caches as usize, Cache::Uninitialized)?;
 
         Ok(Some(caches.to_handle()))
+    }
+
+    /// Create the entry array for a polymorphic cache, with all entries uninitialized.
+    pub fn new_polymorphic(cx: Context) -> AllocResult<Handle<Self>> {
+        let entries =
+            <Self as ArrayInstance>::new(cx, MAX_POLYMORPHIC_ENTRIES, Cache::Uninitialized)?;
+
+        Ok(entries.to_handle())
     }
 
     #[inline]

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -4341,13 +4341,44 @@ impl VM {
                         return self
                             .execute_get_named_property_slow(instr, /* fill_cache */ true);
                     }
-                    // Polymorphic access not yet supported, stop caching
+                    // A second shape was seen, promote to a polymorphic cache
                     GetNamedPropertyCacheResult::DifferentShape => {
-                        self.set_cache(cache_index, Cache::Failed);
                         return self
-                            .execute_get_named_property_slow(instr, /* fill_cache */ false);
+                            .execute_get_named_property_slow(instr, /* fill_cache */ true);
                     }
                 },
+                Cache::Polymorphic(entries) => {
+                    for entry in entries.as_slice() {
+                        // Entries are packed at the front of the array, so an uninitialized slot
+                        // means there are no more entries to check.
+                        let Cache::GetNamedProperty(cache) = entry else {
+                            break;
+                        };
+
+                        match cache.try_match(object) {
+                            // Cache hit for data property, simply return cached value
+                            GetNamedPropertyCacheResult::Data(value) => {
+                                self.write_register(instr.dest(), value);
+                                return Ok(());
+                            }
+                            // Cache hit for accessor property, call the cached getter
+                            GetNamedPropertyCacheResult::Accessor(getter) => {
+                                return self.get_named_property_accessor(instr, object, getter);
+                            }
+                            // The prototype chain changed, refill the entry for this shape
+                            GetNamedPropertyCacheResult::InvalidGuard => {
+                                return self.execute_get_named_property_slow(
+                                    instr, /* fill_cache */ true,
+                                );
+                            }
+                            // Otherwise check the next entry
+                            GetNamedPropertyCacheResult::DifferentShape => {}
+                        }
+                    }
+
+                    // No entry matched, so add an entry for the new shape
+                    return self.execute_get_named_property_slow(instr, /* fill_cache */ true);
+                }
                 _ => unreachable!("wrong cache for GetNamedProperty"),
             }
         }
@@ -4408,9 +4439,20 @@ impl VM {
             self.write_register(dest, *result);
 
             if fill_cache {
+                // If promotion to a polymorphic cache is possible then preallocate the entry
+                // array, since the entry holds unrooted heap pointers once filled.
+                let preallocated_entries = match self.get_cache(cache_index) {
+                    Cache::GetNamedProperty(_) => Some(CacheArray::new_polymorphic(self.cx())?),
+                    _ => None,
+                };
+
                 let cache = GetNamedPropertyCache::fill(self.cx(), coerced_object, property_key)?;
-                let cache = Cache::get_named_property(cache);
-                self.set_cache(cache_index, cache);
+                Cache::insert(
+                    self.caches(),
+                    cache_index.value().to_usize(),
+                    cache.map(Cache::GetNamedProperty),
+                    preallocated_entries,
+                );
             }
 
             Ok(())
@@ -4458,14 +4500,59 @@ impl VM {
                                 instr, /* fill_cache */ true,
                             );
                         }
-                        // Polymorphic access not yet supported, stop caching
+                        // A second shape was seen, promote to a polymorphic cache
                         SetNamedPropertyCacheResult::DifferentShape => {
-                            self.set_cache(cache_index, Cache::Failed);
                             return self.execute_set_named_property_slow(
-                                instr, /* fill_cache */ false,
+                                instr, /* fill_cache */ true,
                             );
                         }
                     }
+                }
+                Cache::Polymorphic(entries) => {
+                    let value = self.read_register(instr.value());
+
+                    for entry in entries.as_slice() {
+                        // Entries are packed at the front of the array, so an uninitialized slot
+                        // means there are no more entries to check.
+                        let Cache::SetNamedProperty(cache) = entry else {
+                            break;
+                        };
+
+                        match cache.try_match(object, value) {
+                            // Cache hit which stores data property
+                            SetNamedPropertyCacheResult::Success => return Ok(()),
+                            // Cache hit where receiver must transition to the new shape, then
+                            // data property can be stored.
+                            SetNamedPropertyCacheResult::Transition { new_shape } => {
+                                object.set_shape(new_shape);
+
+                                // Fast path does not open handle scope when named properties
+                                // array has room to grow without allocating.
+                                let mut named_properties_array = object.named_properties_array();
+                                if !named_properties_array.is_full() {
+                                    named_properties_array.push_without_growing(value);
+                                    return Ok(());
+                                }
+
+                                return self.set_named_property_transition_grow(instr, object);
+                            }
+                            // Cache hit for an accessor property
+                            SetNamedPropertyCacheResult::Accessor(accessor) => {
+                                return self.set_named_property_accessor(instr, object, accessor);
+                            }
+                            // The prototype chain changed, refill the entry for this shape
+                            SetNamedPropertyCacheResult::InvalidGuard => {
+                                return self.execute_set_named_property_slow(
+                                    instr, /* fill_cache */ true,
+                                );
+                            }
+                            // Otherwise check the next entry
+                            SetNamedPropertyCacheResult::DifferentShape => {}
+                        }
+                    }
+
+                    // No entry matched, so add an entry for the new shape
+                    return self.execute_set_named_property_slow(instr, /* fill_cache */ true);
                 }
                 Cache::Uninitialized => {
                     return self.execute_set_named_property_slow(instr, /* fill_cache */ true);
@@ -4570,14 +4657,25 @@ impl VM {
             }
 
             if let Some(old_shape) = old_shape {
+                // If promotion to a polymorphic cache is possible then preallocate the entry
+                // array, since the entry holds unrooted heap pointers once filled.
+                let preallocated_entries = match self.get_cache(cache_index) {
+                    Cache::SetNamedProperty(_) => Some(CacheArray::new_polymorphic(self.cx())?),
+                    _ => None,
+                };
+
                 let cache = SetNamedPropertyCache::fill(
                     self.cx(),
                     coerced_object,
                     property_key,
                     old_shape,
                 )?;
-                let cache = Cache::set_named_property(cache);
-                self.set_cache(cache_index, cache);
+                Cache::insert(
+                    self.caches(),
+                    cache_index.value().to_usize(),
+                    cache.map(Cache::SetNamedProperty),
+                    preallocated_entries,
+                );
             }
 
             Ok(())


### PR DESCRIPTION
## Summary

Promotes `GetNamedProperty`/`SetNamedProperty` cache sites to a **polymorphic cache** when a second shape is seen, instead of immediately failing the site. A polymorphic cache holds up to **4** monomorphic entries; past that the site becomes megamorphic (`Failed`) as before.

## Design

- **`Cache::Polymorphic(HeapPtr<CacheArray>)` reuses `CacheArray`** as the entry array — its element type is already `Cache`, so no new heap kind, shape-registry entry, or GC machinery is needed. Entries are always monomorphic `Get/SetNamedProperty` variants, packed at the front with `Uninitialized` in unused slots.
- **`Cache::insert` is the single mutation point** for both get and set sites. Its contract: it must **not allocate**, because the freshly filled entry holds unrooted `HeapPtr`s. The entry array needed for mono→poly promotion is therefore **preallocated by the slow path** (only when the site is currently monomorphic, so the first fill and steady states pay nothing) and held as a `Handle` across `fill()`.
- **Insert re-reads the cache slot** rather than trusting the state observed at dispatch: the property access that precedes it can run arbitrary JS (getters/setters) that re-enters the same instruction and changes the slot.
- **Same-shape entries are replaced in place** (guard-invalidation refills), so the array never holds duplicate shapes; a `Failed` site is never resurrected.
- The polymorphic dispatch loop in the interpreter stops at the first `Uninitialized` slot (front-packing) and falls through to the slow path + insert when no entry matches.

## Tradeoffs (deliberate, kept for simplicity)

- **Uncacheable access nukes the whole site to `Failed`**, even if valid polymorphic entries exist. Keeping the entries would help mixed proxy/plain sites but complicates the insert contract.
- **No move-to-front on hits** — entries are probed in insertion order. With max 4 entries the linear scan is cheap; reordering would require writes on the fast path.
- **Guard-invalidated entries are only replaced when their shape recurs**; a poly cache can carry a stale entry that costs one guard check per miss.
- **Strong retention**: up to 4 shapes/protos/guards are held strongly per site (same policy as the existing monomorphic caches, just ×4).
- **One extra slow fill before going megamorphic**: a 5th shape triggers a slow-path fill whose insert then marks the site `Failed`.

## Results

2M-iteration microbenchmark, 4-shape site: **loads −16%, stores −43%**. Monomorphic fast paths are unchanged.

## Testing

- `cargo btest --release -- --ignore-unimplemented`: **0 failures** (148 integration, 44867 test262).
- 12-scenario differential test vs Node (byte-identical output): poly get/set, megamorphic overflow, accessors in poly entries, transition stores, proto-guard invalidation + refill, re-entrant getters that mutate the same cache site, NotFound entries, proxy/plain mixes, strict-mode frozen receivers.
- Same differential test passes under `--features gc_stress_test` (validates tracing of the new `Polymorphic` variant and rooting of the preallocated array).