### PR TITLE
[runtime] Polymorphic caches for GetNamedProperty and SetNamedProperty

### DIFF
--- a/src/js/runtime/bytecode/cache.rs
+++ b/src/js/runtime/bytecode/cache.rs
@@ -2,6 +2,7 @@ use crate::runtime::{
     Context, Handle, HeapItemKind, HeapPtr, PropertyKey, Realm, Value,
     accessor::Accessor,
     alloc_error::AllocResult,
+    bytecode::function::CacheArray,
     gc::HeapVisitor,
     global_object::GlobalProperty,
     object_value::ObjectValue,
@@ -10,6 +11,9 @@ use crate::runtime::{
     string_value::FlatString,
     transitions::PropertyLocation,
 };
+
+/// The maximum number of entries in a polymorphic cache.
+pub const POLYMORPHIC_CACHE_SIZE: usize = 4;
 
 /// A generic cache with multiple specific cache types.
 ///
@@ -24,22 +28,82 @@ pub enum Cache {
     GetNamedProperty(GetNamedPropertyCache),
     SetNamedProperty(SetNamedPropertyCache),
     GlobalProperty(GlobalPropertyCache),
+    Polymorphic(HeapPtr<CacheArray>),
 }
 
 impl Cache {
-    #[inline]
-    pub fn get_named_property(cache: Option<GetNamedPropertyCache>) -> Self {
-        match cache {
-            Some(cache) => Self::GetNamedProperty(cache),
-            None => Self::Failed,
+    /// Insert a new cache entry into the cache at the given index. Replaces an existing entry or
+    /// promotes to a polymorphic cache when possible.
+    ///
+    /// An entry of `None` means caching has failed and we stop caching at this site entirely.
+    ///
+    /// Only supported for GetNamedProperty and SetNamedProperty caches.
+    pub fn insert(
+        mut caches: HeapPtr<CacheArray>,
+        cache_index: usize,
+        new_entry: Option<Cache>,
+        new_polymorphic_cache: Option<Handle<CacheArray>>,
+    ) {
+        // An uncachable result:
+        // - If monomorphic, stop caching at this site entirely
+        // - If polymorphic, keep the existing cache
+        let Some(new_entry) = new_entry else {
+            if !(matches!(caches.get(cache_index), Cache::Polymorphic(_))) {
+                caches.set(cache_index, Cache::Failed);
+            }
+            return;
+        };
+
+        match caches.get(cache_index) {
+            // Once caching has failed at this site it is never resumed
+            Cache::Failed => {}
+            // First time cache is filled, so just insert the (monomorphic) entry
+            Cache::Uninitialized => caches.set(cache_index, new_entry),
+            // Monomorphic cache already exists, so either replace or promote to polymorphic
+            existing @ (Cache::GetNamedProperty(_) | Cache::SetNamedProperty(_)) => {
+                if Self::same_receiver_shapes(existing, new_entry) {
+                    caches.set(cache_index, new_entry);
+                } else {
+                    // A second shape was seen, promote to a polymorphic cache with both entries
+                    let mut new_polymorphic_cache = new_polymorphic_cache.unwrap();
+                    new_polymorphic_cache.set(0, existing);
+                    new_polymorphic_cache.set(1, new_entry);
+                    caches.set(cache_index, Cache::Polymorphic(*new_polymorphic_cache));
+                }
+            }
+            Cache::Polymorphic(mut entries) => {
+                for i in 0..entries.len() {
+                    match entries.get(i) {
+                        // New entry can be inserted into the first uninitialized slot
+                        Cache::Uninitialized => {
+                            entries.set(i, new_entry);
+                            return;
+                        }
+                        // Replace entries with the same shape
+                        entry if Self::same_receiver_shapes(entry, new_entry) => {
+                            entries.set(i, new_entry);
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+
+                // Polymorphic cache is full, stop caching at this site
+                caches.set(cache_index, Cache::Failed);
+            }
+            Cache::GlobalProperty(_) => unreachable!("wrong cache kind for insert"),
         }
     }
 
-    #[inline]
-    pub fn set_named_property(cache: Option<SetNamedPropertyCache>) -> Self {
-        match cache {
-            Some(cache) => Self::SetNamedProperty(cache),
-            None => Self::Failed,
+    fn same_receiver_shapes(cache_a: Cache, cache_b: Cache) -> bool {
+        cache_a.receiver_shape().ptr_eq(&cache_b.receiver_shape())
+    }
+
+    fn receiver_shape(&self) -> HeapPtr<Shape> {
+        match self {
+            Self::GetNamedProperty(cache) => cache.receiver_shape(),
+            Self::SetNamedProperty(cache) => cache.receiver_shape(),
+            _ => unreachable!("cache does not have a receiver shape"),
         }
     }
 }
@@ -190,6 +254,14 @@ impl GetNamedPropertyCache {
         let guard = receiver.request_prototype_validity_guard(cx)?;
 
         Ok(Some(Self::NotFound { shape: receiver.shape_ptr(), guard }))
+    }
+
+    pub fn receiver_shape(&self) -> HeapPtr<Shape> {
+        match self {
+            Self::Own { shape, .. } | Self::Proto { shape, .. } | Self::NotFound { shape, .. } => {
+                *shape
+            }
+        }
     }
 
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
@@ -435,6 +507,14 @@ impl SetNamedPropertyCache {
         }))
     }
 
+    pub fn receiver_shape(&self) -> HeapPtr<Shape> {
+        match self {
+            Self::Own { shape, .. }
+            | Self::ProtoAccessor { shape, .. }
+            | Self::TransitionStore { shape, .. } => *shape,
+        }
+    }
+
     fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
         match self {
             Self::Own { shape, .. } => {
@@ -581,6 +661,7 @@ impl Cache {
             Self::Uninitialized | Self::Failed => {}
             Self::GetNamedProperty(cache) => cache.visit_pointers(visitor),
             Self::SetNamedProperty(cache) => cache.visit_pointers(visitor),
+            Self::Polymorphic(entries) => visitor.visit_pointer(entries),
             Self::GlobalProperty(cache) => cache.visit_pointers(visitor),
         }
     }

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -9,8 +9,11 @@ use crate::{
         abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
         bytecode::{
-            cache::Cache, constant_table::ConstantTable, exception_handlers::ExceptionHandlers,
-            graphviz::bytecode_function_to_dot_graph, instruction::debug_format_instructions,
+            cache::{Cache, POLYMORPHIC_CACHE_SIZE},
+            constant_table::ConstantTable,
+            exception_handlers::ExceptionHandlers,
+            graphviz::bytecode_function_to_dot_graph,
+            instruction::debug_format_instructions,
             source_map::BytecodeSourceMap,
         },
         collections::{ArrayInstance, InlineArray, array::ByteArray},
@@ -656,6 +659,13 @@ impl CacheArray {
         let caches = <Self as ArrayInstance>::new(cx, num_caches as usize, Cache::Uninitialized)?;
 
         Ok(Some(caches.to_handle()))
+    }
+
+    pub fn new_polymorphic(cx: Context) -> AllocResult<Handle<Self>> {
+        let entries =
+            <Self as ArrayInstance>::new(cx, POLYMORPHIC_CACHE_SIZE, Cache::Uninitialized)?;
+
+        Ok(entries.to_handle())
     }
 
     #[inline]

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -4327,7 +4327,11 @@ impl VM {
             let object = object_value.as_object();
             let cache_index = instr.cache_index();
 
-            match self.get_cache(cache_index) {
+            let result = match self.get_cache(cache_index) {
+                Cache::GetNamedProperty(cache) => cache.try_match(object),
+                Cache::Polymorphic(entries) => {
+                    Self::try_match_get_named_property_polymorphic(entries, object)
+                }
                 Cache::Uninitialized => {
                     return self.execute_get_named_property_slow(instr, /* fill_cache */ true);
                 }
@@ -4335,33 +4339,48 @@ impl VM {
                     return self
                         .execute_get_named_property_slow(instr, /* fill_cache */ false);
                 }
-                Cache::GetNamedProperty(cache) => match cache.try_match(object) {
-                    // Cache hit for data property, simply return cached value
-                    GetNamedPropertyCacheResult::Data(value) => {
-                        self.write_register(instr.dest(), value);
-                        return Ok(());
-                    }
-                    // Cache hit for accessor property, call the cached getter
-                    GetNamedPropertyCacheResult::Accessor(getter) => {
-                        return self.get_named_property_accessor(instr, object, getter);
-                    }
-                    // The prototype chain changed, refill the cache
-                    GetNamedPropertyCacheResult::InvalidGuard => {
-                        return self
-                            .execute_get_named_property_slow(instr, /* fill_cache */ true);
-                    }
-                    // Polymorphic access not yet supported, stop caching
-                    GetNamedPropertyCacheResult::DifferentShape => {
-                        self.set_cache(cache_index, Cache::Failed);
-                        return self
-                            .execute_get_named_property_slow(instr, /* fill_cache */ false);
-                    }
-                },
                 _ => unreachable!("wrong cache for GetNamedProperty"),
+            };
+
+            match result {
+                GetNamedPropertyCacheResult::Data(value) => {
+                    self.write_register(instr.dest(), value);
+                    return Ok(());
+                }
+                GetNamedPropertyCacheResult::Accessor(getter) => {
+                    return self.get_named_property_accessor(instr, object, getter);
+                }
+                // Either the prototype chain changed or a new shape was seen. Refill the cache,
+                // promoting to a polymorphic cache if necessary.
+                GetNamedPropertyCacheResult::InvalidGuard
+                | GetNamedPropertyCacheResult::DifferentShape => {
+                    return self.execute_get_named_property_slow(instr, /* fill_cache */ true);
+                }
             }
         }
 
         self.execute_get_named_property_slow(instr, /* fill_cache */ false)
+    }
+
+    /// Return the result of matching a polymorphic GetNamedPropertyCache.
+    #[inline(always)]
+    fn try_match_get_named_property_polymorphic(
+        entries: HeapPtr<CacheArray>,
+        object: HeapPtr<ObjectValue>,
+    ) -> GetNamedPropertyCacheResult {
+        for entry in entries.as_slice() {
+            // First uninitialized slot signals there are no more entries to check
+            let Cache::GetNamedProperty(cache) = entry else {
+                break;
+            };
+
+            match cache.try_match(object) {
+                GetNamedPropertyCacheResult::DifferentShape => {}
+                result => return result,
+            }
+        }
+
+        GetNamedPropertyCacheResult::DifferentShape
     }
 
     #[inline(never)]
@@ -4417,9 +4436,24 @@ impl VM {
             self.write_register(dest, *result);
 
             if fill_cache {
+                // Preallocate the polymorphic cache if promotion is possible
+                let new_polymorphic_cache = match self.get_cache(cache_index) {
+                    Cache::GetNamedProperty(cache)
+                        if !cache.receiver_shape().ptr_eq(&coerced_object.shape_ptr()) =>
+                    {
+                        Some(CacheArray::new_polymorphic(self.cx())?)
+                    }
+                    _ => None,
+                };
+
                 let cache = GetNamedPropertyCache::fill(self.cx(), coerced_object, property_key)?;
-                let cache = Cache::get_named_property(cache);
-                self.set_cache(cache_index, cache);
+
+                Cache::insert(
+                    self.caches(),
+                    cache_index.value().to_usize(),
+                    cache.map(Cache::GetNamedProperty),
+                    new_polymorphic_cache,
+                );
             }
 
             Ok(())
@@ -4434,58 +4468,13 @@ impl VM {
         let object_value = self.read_register(instr.object());
         if object_value.is_object() {
             let mut object = object_value.as_object();
+            let value = self.read_register(instr.value());
             let cache_index = instr.cache_index();
 
-            match self.get_cache(cache_index) {
-                Cache::SetNamedProperty(cache) => {
-                    let value = self.read_register(instr.value());
-                    match cache.try_match(object, value) {
-                        // Cache hit which stores data property
-                        SetNamedPropertyCacheResult::Success => return Ok(()),
-                        // Cache hit where receiver must transition to the new shape, then data
-                        // property can be stored.
-                        SetNamedPropertyCacheResult::Transition { new_shape, location } => {
-                            object.set_shape(new_shape);
-
-                            return match location {
-                                // Inline properties can be directly stored on object
-                                PropertyLocation::Inline { byte_offset } => {
-                                    object
-                                        .set_inline_property_unchecked(byte_offset as usize, value);
-                                    Ok(())
-                                }
-                                // Fast path to directly add array properties if there is room
-                                // without allocating.
-                                PropertyLocation::ExternalArray { .. } => {
-                                    let mut named_properties_array =
-                                        object.named_properties_array();
-                                    if !named_properties_array.is_full() {
-                                        named_properties_array.push_without_growing(value);
-                                        Ok(())
-                                    } else {
-                                        self.set_named_property_transition_grow(instr, object)
-                                    }
-                                }
-                            };
-                        }
-                        // Cache hit for an accessor property
-                        SetNamedPropertyCacheResult::Accessor(accessor) => {
-                            return self.set_named_property_accessor(instr, object, accessor);
-                        }
-                        // The prototype chain changed, refill the cache
-                        SetNamedPropertyCacheResult::InvalidGuard => {
-                            return self.execute_set_named_property_slow(
-                                instr, /* fill_cache */ true,
-                            );
-                        }
-                        // Polymorphic access not yet supported, stop caching
-                        SetNamedPropertyCacheResult::DifferentShape => {
-                            self.set_cache(cache_index, Cache::Failed);
-                            return self.execute_set_named_property_slow(
-                                instr, /* fill_cache */ false,
-                            );
-                        }
-                    }
+            let result = match self.get_cache(cache_index) {
+                Cache::SetNamedProperty(cache) => cache.try_match(object, value),
+                Cache::Polymorphic(entries) => {
+                    Self::try_match_set_named_property_polymorphic(entries, object, value)
                 }
                 Cache::Uninitialized => {
                     return self.execute_set_named_property_slow(instr, /* fill_cache */ true);
@@ -4495,10 +4484,71 @@ impl VM {
                         .execute_set_named_property_slow(instr, /* fill_cache */ false);
                 }
                 _ => unreachable!("wrong cache for SetNamedProperty"),
+            };
+
+            match result {
+                // Cache hit which stores data property
+                SetNamedPropertyCacheResult::Success => return Ok(()),
+                // Cache hit where receiver must transition to the new shape, then data property can
+                // be stored.
+                SetNamedPropertyCacheResult::Transition { new_shape, location } => {
+                    object.set_shape(new_shape);
+
+                    return match location {
+                        // Inline properties can be directly stored on object
+                        PropertyLocation::Inline { byte_offset } => {
+                            object.set_inline_property_unchecked(byte_offset as usize, value);
+                            Ok(())
+                        }
+                        // Fast path to directly add array properties if there is room without
+                        // allocating.
+                        PropertyLocation::ExternalArray { .. } => {
+                            let mut named_properties_array = object.named_properties_array();
+                            if !named_properties_array.is_full() {
+                                named_properties_array.push_without_growing(value);
+                                Ok(())
+                            } else {
+                                self.set_named_property_transition_grow(instr, object)
+                            }
+                        }
+                    };
+                }
+                // Cache hit for an accessor property
+                SetNamedPropertyCacheResult::Accessor(accessor) => {
+                    return self.set_named_property_accessor(instr, object, accessor);
+                }
+                // Either the prototype chain changed or a new shape was seen. Refill the cache,
+                // promoting to a polymorphic cache if necessary.
+                SetNamedPropertyCacheResult::InvalidGuard
+                | SetNamedPropertyCacheResult::DifferentShape => {
+                    return self.execute_set_named_property_slow(instr, /* fill_cache */ true);
+                }
             }
         }
 
         self.execute_set_named_property_slow(instr, /* fill_cache */ false)
+    }
+
+    /// Return the result of matching a polymorphic SetNamedPropertyCache.
+    #[inline(always)]
+    fn try_match_set_named_property_polymorphic(
+        entries: HeapPtr<CacheArray>,
+        object: HeapPtr<ObjectValue>,
+        value: Value,
+    ) -> SetNamedPropertyCacheResult {
+        for entry in entries.as_slice() {
+            // First uninitialized slot signals there are no more entries to check
+            let Cache::SetNamedProperty(cache) = entry else {
+                break;
+            };
+
+            match cache.try_match(object, value) {
+                SetNamedPropertyCacheResult::DifferentShape => {}
+                result => return result,
+            }
+        }
+
+        SetNamedPropertyCacheResult::DifferentShape
     }
 
     #[inline(never)]
@@ -4590,14 +4640,29 @@ impl VM {
             }
 
             if let Some(old_shape) = old_shape {
+                // Preallocate the polymorphic cache if promotion is possible
+                let new_polymorphic_cache = match self.get_cache(cache_index) {
+                    Cache::SetNamedProperty(cache)
+                        if !cache.receiver_shape().ptr_eq(&old_shape) =>
+                    {
+                        Some(CacheArray::new_polymorphic(self.cx())?)
+                    }
+                    _ => None,
+                };
+
                 let cache = SetNamedPropertyCache::fill(
                     self.cx(),
                     coerced_object,
                     property_key,
                     old_shape,
                 )?;
-                let cache = Cache::set_named_property(cache);
-                self.set_cache(cache_index, cache);
+
+                Cache::insert(
+                    self.caches(),
+                    cache_index.value().to_usize(),
+                    cache.map(Cache::SetNamedProperty),
+                    new_polymorphic_cache,
+                );
             }
 
             Ok(())

--- a/tests/integration/language/expression/member/get_named_property_cache/invalidation.js
+++ b/tests/integration/language/expression/member/get_named_property_cache/invalidation.js
@@ -54,7 +54,7 @@ description: GetNamedProperty cache misses and refills on shape transitions, pro
   assert.sameValue(get(o), 1);
 })();
 
-// One callsite, many shapes: the cache fails and uses the slow path.
+// One callsite, many shapes: the cache goes polymorphic and stays correct for each shape.
 (function () {
   function get(o) { return o.x; }
   assert.sameValue(get({ x: 1 }), 1);

--- a/tests/integration/language/expression/member/get_named_property_cache/polymorphic.js
+++ b/tests/integration/language/expression/member/get_named_property_cache/polymorphic.js
@@ -1,0 +1,364 @@
+/*---
+description: >
+  GetNamedProperty cache promotes to a polymorphic cache when a callsite sees several receiver
+  shapes, and stays correct for every shape it holds.
+---*/
+
+// Two shapes at one callsite: both are cached and read the property from their own location.
+(function () {
+  function get(o) { return o.x; }
+  var a = { x: 1 };
+  var b = { pad: 0, x: 2 };
+  for (var i = 0; i < 5; i++) {
+    assert.sameValue(get(a), 1);
+    assert.sameValue(get(b), 2);
+  }
+  a.x = 10;
+  b.x = 20;
+  assert.sameValue(get(a), 10);
+  assert.sameValue(get(b), 20);
+})();
+
+// Four shapes fill the polymorphic cache exactly, in both fill order and reverse order.
+(function () {
+  function get(o) { return o.x; }
+  var os = [
+    { x: 1 },
+    { p1: 0, x: 2 },
+    { p1: 0, p2: 0, x: 3 },
+    { p1: 0, p2: 0, p3: 0, x: 4 },
+  ];
+  for (var i = 0; i < os.length; i++) {
+    assert.sameValue(get(os[i]), i + 1);
+  }
+  for (var round = 0; round < 3; round++) {
+    for (var j = os.length - 1; j >= 0; j--) {
+      assert.sameValue(get(os[j]), j + 1);
+    }
+  }
+})();
+
+// A fifth shape overflows the polymorphic cache. Caching stops but every shape still reads
+// correctly, including the four that were cached before the overflow.
+(function () {
+  function get(o) { return o.x; }
+  var four = [
+    { x: 1 },
+    { p1: 0, x: 2 },
+    { p1: 0, p2: 0, x: 3 },
+    { p1: 0, p2: 0, p3: 0, x: 4 },
+  ];
+  var fifth = { p1: 0, p2: 0, p3: 0, p4: 0, x: 5 };
+
+  // Warm every entry of the polymorphic cache first.
+  for (var round = 0; round < 2; round++) {
+    for (var i = 0; i < four.length; i++) {
+      assert.sameValue(get(four[i]), i + 1);
+    }
+  }
+
+  // The fifth shape does not fit, so caching stops at this callsite.
+  assert.sameValue(get(fifth), 5);
+
+  for (var round2 = 0; round2 < 2; round2++) {
+    for (var j = 0; j < four.length; j++) {
+      assert.sameValue(get(four[j]), j + 1);
+    }
+    assert.sameValue(get(fifth), 5);
+  }
+
+  four[0].x = 100;
+  assert.sameValue(get(four[0]), 100);
+})();
+
+// A single polymorphic cache holds entries of every kind at once: an own data property, an own
+// accessor, a prototype data property and an absent property.
+(function () {
+  var ownData = { x: 1 };
+  var ownAccessor = { pad: 0, get x() { return 2; } };
+  var protoData = Object.create({ x: 3 });
+  var absent = { pad: 0, other: 0 };
+
+  function get(o) { return o.x; }
+
+  for (var i = 0; i < 4; i++) {
+    assert.sameValue(get(ownData), 1);
+    assert.sameValue(get(ownAccessor), 2);
+    assert.sameValue(get(protoData), 3);
+    assert.sameValue(get(absent), undefined);
+  }
+})();
+
+// Each polymorphic entry tracks its own property location, including properties that live in the
+// external property array rather than the object's inline slots.
+(function () {
+  function make(n) {
+    var o = {};
+    for (var i = 0; i < n; i++) {
+      o["f" + i] = i;
+    }
+    o.x = n;
+    return o;
+  }
+  function get(o) { return o.x; }
+
+  var os = [make(0), make(2), make(6), make(9)];
+  for (var round = 0; round < 3; round++) {
+    for (var i = 0; i < os.length; i++) {
+      assert.sameValue(get(os[i]), [0, 2, 6, 9][i]);
+    }
+  }
+})();
+
+// A polymorphic accessor entry calls the getter of the matching shape with the correct receiver.
+(function () {
+  var seen = [];
+  var a = { tag: "a", get x() { seen.push(this.tag); return this.tag; } };
+  var b = { pad: 0, tag: "b", get x() { seen.push(this.tag); return this.tag; } };
+  var c = Object.create({ get x() { seen.push(this.tag); return this.tag; } });
+  c.tag = "c";
+
+  function get(o) { return o.x; }
+
+  assert.sameValue(get(a), "a");
+  assert.sameValue(get(b), "b");
+  assert.sameValue(get(c), "c");
+  assert.sameValue(get(a), "a");
+  assert.sameValue(get(b), "b");
+  assert.sameValue(get(c), "c");
+  assert.sameValue(seen.join(), "a,b,c,a,b,c");
+})();
+
+// Instances of different classes at one callsite each resolve the method from their own
+// prototype, and redefining a method on one prototype only affects that class.
+(function () {
+  class A { m() { return "A"; } }
+  class B { m() { return "B"; } }
+  class C extends A {}
+  class D extends A { m() { return "D"; } }
+
+  function get(o) { return o.m; }
+  var a = new A(), b = new B(), c = new C(), d = new D();
+
+  for (var i = 0; i < 3; i++) {
+    assert.sameValue(get(a).call(a), "A");
+    assert.sameValue(get(b).call(b), "B");
+    assert.sameValue(get(c).call(c), "A");
+    assert.sameValue(get(d).call(d), "D");
+  }
+
+  // A.prototype is on the prototype chain of A, C and D instances, so this invalidates those
+  // three entries even though D shadows the method with its own.
+  A.prototype.m = function () { return "A2"; };
+  assert.sameValue(get(a).call(a), "A2");
+  assert.sameValue(get(c).call(c), "A2");
+  assert.sameValue(get(b).call(b), "B");
+  assert.sameValue(get(d).call(d), "D");
+  assert.sameValue(get(a).call(a), "A2");
+})();
+
+// Two receivers whose properties were added in different orders have different shapes, so the
+// callsite becomes polymorphic even though the objects look alike.
+(function () {
+  function get(o) { return o.x; }
+  var a = {};
+  a.x = 1;
+  a.y = 2;
+  var b = {};
+  b.y = 2;
+  b.x = 1;
+  assert.sameValue(get(a), 1);
+  assert.sameValue(get(b), 1);
+  assert.sameValue(get(a), 1);
+  a.x = 3;
+  b.x = 4;
+  assert.sameValue(get(a), 3);
+  assert.sameValue(get(b), 4);
+})();
+
+// A prototype mutation invalidates the guard of one polymorphic entry. That entry is refilled
+// while the other entries keep working.
+(function () {
+  var proto = { x: "proto" };
+  var viaProto = Object.create(proto);
+  var own = { x: "own" };
+
+  function get(o) { return o.x; }
+
+  assert.sameValue(get(own), "own");
+  assert.sameValue(get(viaProto), "proto");
+  assert.sameValue(get(own), "own");
+
+  // Move the property one level further up the chain, invalidating the Proto entry's guard.
+  Object.setPrototypeOf(proto, { x: "grandproto" });
+  delete proto.x;
+  assert.sameValue(get(viaProto), "grandproto");
+  assert.sameValue(get(own), "own");
+  assert.sameValue(get(viaProto), "grandproto");
+})();
+
+// An entry for an absent property is replaced in place, at the same shape, once the property
+// appears on the prototype chain.
+(function () {
+  var proto = {};
+  var absent = Object.create(proto);
+  var other = { x: "other" };
+
+  function get(o) { return o.x; }
+
+  assert.sameValue(get(absent), undefined);
+  assert.sameValue(get(other), "other");
+  assert.sameValue(get(absent), undefined);
+
+  proto.x = "found";
+  assert.sameValue(get(absent), "found");
+  assert.sameValue(get(absent), "found");
+  assert.sameValue(get(other), "other");
+})();
+
+// A receiver that cannot be cached at all does not disturb the entries already in a polymorphic
+// cache: the uncacheable receiver keeps taking the slow path while the others stay correct.
+(function () {
+  var traps = 0;
+  var a = { x: 1 };
+  var b = { pad: 0, x: 2 };
+  var proxy = new Proxy({}, { get: function () { return ++traps; } });
+
+  function get(o) { return o.x; }
+
+  assert.sameValue(get(a), 1);
+  assert.sameValue(get(b), 2);
+
+  for (var i = 0; i < 3; i++) {
+    assert.sameValue(get(proxy), i + 1);
+    assert.sameValue(get(a), 1);
+    assert.sameValue(get(b), 2);
+  }
+  assert.sameValue(traps, 3);
+
+  a.x = 11;
+  assert.sameValue(get(a), 11);
+})();
+
+// A dictionary (map mode) receiver is also uncacheable and mixes safely into a polymorphic
+// callsite.
+(function () {
+  var dict = {};
+  for (var i = 0; i < 80; i++) {
+    dict["k" + i] = i;
+  }
+  dict.x = "dict";
+  var a = { x: "a" };
+  var b = { pad: 0, x: "b" };
+
+  function get(o) { return o.x; }
+
+  assert.sameValue(get(a), "a");
+  assert.sameValue(get(b), "b");
+  for (var j = 0; j < 3; j++) {
+    assert.sameValue(get(dict), "dict");
+    assert.sameValue(get(a), "a");
+  }
+  dict.x = "dict2";
+  assert.sameValue(get(dict), "dict2");
+  assert.sameValue(get(b), "b");
+})();
+
+// Array length is exotic and never cached, but mixing arrays into a polymorphic callsite must
+// still report live lengths.
+(function () {
+  function get(o) { return o.length; }
+  var a = { length: 1 };
+  var b = { pad: 0, length: 2 };
+  var arr = [0, 0, 0];
+
+  assert.sameValue(get(a), 1);
+  assert.sameValue(get(b), 2);
+  assert.sameValue(get(arr), 3);
+  arr.push(0);
+  assert.sameValue(get(arr), 4);
+  assert.sameValue(get(a), 1);
+  assert.sameValue(get(b), 2);
+  assert.sameValue(get(arr), 4);
+})();
+
+// A receiver that cannot be cached arriving while the callsite is still monomorphic stops
+// caching there entirely. Later shapes never reach the polymorphic cache but still read
+// correctly.
+(function () {
+  var traps = 0;
+  function get(o) { return o.x; }
+  var a = { x: 1 };
+  var b = { pad: 0, x: 2 };
+  var proxy = new Proxy({}, { get: function () { return ++traps; } });
+
+  assert.sameValue(get(a), 1);
+  assert.sameValue(get(proxy), 1);
+  for (var i = 0; i < 3; i++) {
+    assert.sameValue(get(a), 1);
+    assert.sameValue(get(b), 2);
+  }
+  assert.sameValue(get(proxy), 2);
+  assert.sameValue(traps, 2);
+
+  b.x = 22;
+  assert.sameValue(get(b), 22);
+})();
+
+// A getter that re-enters the same callsite with a different shape leaves both reads correct.
+(function () {
+  var plain = { pad: 0, x: "plain" };
+  var reentrant = {
+    get x() { return "re:" + get(plain); },
+  };
+
+  function get(o) { return o.x; }
+
+  assert.sameValue(get(plain), "plain");
+  assert.sameValue(get(reentrant), "re:plain");
+  assert.sameValue(get(reentrant), "re:plain");
+  assert.sameValue(get(plain), "plain");
+})();
+
+// A polymorphic cache survives garbage collection with all of its entries intact.
+(function () {
+  function get(o) { return o.x; }
+  var a = { x: 1 };
+  var b = { p1: 0, x: 2 };
+  var c = Object.create({ x: 3 });
+  var d = { p1: 0, p2: 0, other: 0 };
+
+  assert.sameValue(get(a), 1);
+  assert.sameValue(get(b), 2);
+  assert.sameValue(get(c), 3);
+  assert.sameValue(get(d), undefined);
+
+  $262.gc();
+
+  assert.sameValue(get(a), 1);
+  assert.sameValue(get(b), 2);
+  assert.sameValue(get(c), 3);
+  assert.sameValue(get(d), undefined);
+
+  $262.gc();
+
+  a.x = 4;
+  assert.sameValue(get(a), 4);
+})();
+
+// Receivers from another realm have different shapes, so a shared callsite goes polymorphic
+// across realm boundaries.
+(function () {
+  var other = $262.createRealm();
+  other.evalScript("globalThis.make = function () { return { x: 'other' }; };");
+
+  function get(o) { return o.x; }
+
+  var mine = { x: "mine" };
+  var theirs = other.global.make();
+
+  assert.sameValue(get(mine), "mine");
+  assert.sameValue(get(theirs), "other");
+  assert.sameValue(get(mine), "mine");
+  assert.sameValue(get(theirs), "other");
+})();

--- a/tests/integration/language/expression/member/set_named_property_cache/polymorphic.js
+++ b/tests/integration/language/expression/member/set_named_property_cache/polymorphic.js
@@ -1,0 +1,422 @@
+/*---
+description: >
+  SetNamedProperty cache promotes to a polymorphic cache when a callsite sees several receiver
+  shapes, and stays correct for every shape it holds.
+flags: [noStrict]
+---*/
+
+// Two shapes at one callsite: each stores into its own property location.
+(function () {
+  function set(o, v) { o.x = v; }
+  var a = { x: 0 };
+  var b = { pad: 0, x: 0 };
+  for (var i = 0; i < 5; i++) {
+    set(a, i);
+    set(b, i * 10);
+  }
+  assert.sameValue(a.x, 4);
+  assert.sameValue(b.x, 40);
+  assert.sameValue(a.pad, undefined);
+  assert.sameValue(b.pad, 0);
+})();
+
+// Four shapes fill the polymorphic cache exactly, and stay correct in reverse order too.
+(function () {
+  function set(o, v) { o.x = v; }
+  var os = [
+    { x: 0 },
+    { p1: 0, x: 0 },
+    { p1: 0, p2: 0, x: 0 },
+    { p1: 0, p2: 0, p3: 0, x: 0 },
+  ];
+  for (var i = 0; i < os.length; i++) {
+    set(os[i], i);
+  }
+  for (var round = 0; round < 3; round++) {
+    for (var j = os.length - 1; j >= 0; j--) {
+      set(os[j], j * 100 + round);
+      assert.sameValue(os[j].x, j * 100 + round);
+    }
+  }
+})();
+
+// A fifth shape overflows the polymorphic cache. Caching stops but every shape still stores
+// correctly, including the four that were cached before the overflow.
+(function () {
+  function set(o, v) { o.x = v; }
+  var four = [
+    { x: 0 },
+    { p1: 0, x: 0 },
+    { p1: 0, p2: 0, x: 0 },
+    { p1: 0, p2: 0, p3: 0, x: 0 },
+  ];
+  var fifth = { p1: 0, p2: 0, p3: 0, p4: 0, x: 0 };
+
+  // Warm every entry of the polymorphic cache first.
+  for (var round = 0; round < 2; round++) {
+    for (var i = 0; i < four.length; i++) {
+      set(four[i], i * 10 + round);
+      assert.sameValue(four[i].x, i * 10 + round);
+    }
+  }
+
+  // The fifth shape does not fit, so caching stops at this callsite.
+  set(fifth, 50);
+  assert.sameValue(fifth.x, 50);
+
+  for (var round2 = 2; round2 < 4; round2++) {
+    for (var j = 0; j < four.length; j++) {
+      set(four[j], j * 10 + round2);
+      assert.sameValue(four[j].x, j * 10 + round2);
+    }
+    set(fifth, 50 + round2);
+    assert.sameValue(fifth.x, 50 + round2);
+  }
+})();
+
+// A single polymorphic cache holds entries of every kind at once: an own data property, an own
+// setter, a prototype setter and a store that adds a new property via a shape transition.
+(function () {
+  var ownSetterValues = [];
+  var protoSetterValues = [];
+  var protoReceivers = [];
+
+  var accessorProto = {};
+  Object.defineProperty(accessorProto, "x", {
+    set: function (v) { protoSetterValues.push(v); protoReceivers.push(this); },
+    configurable: true,
+  });
+
+  var ownData = { x: 0 };
+  var ownSetter = { pad: 0, set x(v) { ownSetterValues.push(v); } };
+  var viaProto = Object.create(accessorProto);
+  function makeFresh() { return { q: 0 }; }
+
+  function set(o, v) { o.x = v; }
+
+  for (var i = 0; i < 4; i++) {
+    set(ownData, i);
+    set(ownSetter, i);
+    set(viaProto, i);
+
+    var fresh = makeFresh();
+    set(fresh, i);
+    assert.sameValue(fresh.x, i);
+    assert.sameValue(fresh.q, 0);
+  }
+
+  assert.sameValue(ownData.x, 3);
+  assert.sameValue(ownSetterValues.join(), "0,1,2,3");
+  assert.sameValue(protoSetterValues.join(), "0,1,2,3");
+  assert.sameValue(protoReceivers[0], viaProto);
+  assert.sameValue(protoReceivers[3], viaProto);
+  assert.sameValue(viaProto.hasOwnProperty("x"), false);
+})();
+
+// Transition stores from several different source shapes each append the new property in the
+// right place, including when the new property lands in the external property array.
+(function () {
+  function make(n) {
+    var o = {};
+    for (var i = 0; i < n; i++) {
+      o["f" + i] = i;
+    }
+    return o;
+  }
+  function set(o, v) { o.x = v; }
+
+  var counts = [0, 3, 7, 10];
+  for (var round = 0; round < 3; round++) {
+    for (var i = 0; i < counts.length; i++) {
+      var o = make(counts[i]);
+      set(o, "v" + i);
+      assert.sameValue(o.x, "v" + i);
+      assert.sameValue(Object.keys(o).length, counts[i] + 1);
+      if (counts[i] > 0) {
+        assert.sameValue(o.f0, 0);
+        assert.sameValue(o["f" + (counts[i] - 1)], counts[i] - 1);
+      }
+    }
+  }
+})();
+
+// The property added by a polymorphic transition store has the attributes of a plain store.
+(function () {
+  function set(o, v) { o.x = v; }
+  var a = { p1: 0 };
+  var b = { p2: 0, p3: 0 };
+  set(a, 1);
+  set(b, 2);
+  var a2 = { p1: 0 };
+  var b2 = { p2: 0, p3: 0 };
+  set(a2, 3);
+  set(b2, 4);
+  [a2, b2].forEach(function (o) {
+    var desc = Object.getOwnPropertyDescriptor(o, "x");
+    assert.sameValue(desc.writable, true);
+    assert.sameValue(desc.enumerable, true);
+    assert.sameValue(desc.configurable, true);
+  });
+})();
+
+// A prototype setter added after the callsite is polymorphic must intercept later stores for the
+// shape it applies to, without disturbing the other cached shapes.
+(function () {
+  var calls = 0;
+  var proto = {};
+  function make() { var o = Object.create(proto); o.pad = 0; return o; }
+  function set(o, v) { o.x = v; }
+
+  var plain = { x: 0 };
+  set(plain, 1);
+  set(make(), 1);
+  set(plain, 2);
+
+  Object.defineProperty(proto, "x", { set: function (v) { calls++; }, configurable: true });
+
+  var late = make();
+  set(late, 3);
+  assert.sameValue(calls, 1);
+  assert.sameValue(late.hasOwnProperty("x"), false);
+
+  set(plain, 4);
+  assert.sameValue(plain.x, 4);
+})();
+
+// A non-writable prototype data property blocks stores for one shape of a polymorphic callsite.
+// The store cannot be cached, but the other entries keep working.
+(function () {
+  var proto = {};
+  Object.defineProperty(proto, "x", { value: 99, writable: false, configurable: true });
+  function make() { var o = Object.create(proto); o.pad = 0; return o; }
+
+  function set(o, v) { o.x = v; }
+
+  var a = { x: 0 };
+  var b = { p1: 0, x: 0 };
+  set(a, 1);
+  set(b, 2);
+
+  for (var i = 0; i < 3; i++) {
+    var blocked = make();
+    set(blocked, 5);
+    assert.sameValue(blocked.hasOwnProperty("x"), false);
+    assert.sameValue(blocked.x, 99);
+
+    set(a, 10 + i);
+    set(b, 20 + i);
+    assert.sameValue(a.x, 10 + i);
+    assert.sameValue(b.x, 20 + i);
+  }
+})();
+
+// The blocked store above throws in strict mode, while the other shapes still store.
+(function () {
+  "use strict";
+  var proto = {};
+  Object.defineProperty(proto, "x", { value: 99, writable: false, configurable: true });
+  function make() { var o = Object.create(proto); o.pad = 0; return o; }
+
+  function set(o, v) { o.x = v; }
+
+  var a = { x: 0 };
+  var b = { p1: 0, x: 0 };
+  set(a, 1);
+  set(b, 2);
+
+  for (var i = 0; i < 3; i++) {
+    assert.throws(TypeError, function () { set(make(), 5); });
+    set(a, 10 + i);
+    set(b, 20 + i);
+  }
+  assert.sameValue(a.x, 12);
+  assert.sameValue(b.x, 22);
+})();
+
+// A non-writable own data property is not cacheable and mixes safely into a polymorphic callsite.
+(function () {
+  function set(o, v) { o.x = v; }
+  var a = { x: 0 };
+  var b = { p1: 0, x: 0 };
+  var frozen = { p1: 0, p2: 0, x: 7 };
+  Object.defineProperty(frozen, "x", { writable: false });
+
+  set(a, 1);
+  set(b, 2);
+  for (var i = 0; i < 3; i++) {
+    set(frozen, 100);
+    assert.sameValue(frozen.x, 7);
+    set(a, 10 + i);
+    set(b, 20 + i);
+  }
+  assert.sameValue(a.x, 12);
+  assert.sameValue(b.x, 22);
+})();
+
+// A proxy receiver is never cacheable and must run its trap on every store, leaving the other
+// polymorphic entries intact.
+(function () {
+  var traps = [];
+  function set(o, v) { o.x = v; }
+  var a = { x: 0 };
+  var b = { p1: 0, x: 0 };
+  var proxy = new Proxy({}, {
+    set: function (t, k, v) { traps.push(v); return true; },
+  });
+
+  set(a, 1);
+  set(b, 2);
+  for (var i = 0; i < 3; i++) {
+    set(proxy, i);
+    set(a, 10 + i);
+    set(b, 20 + i);
+  }
+  assert.sameValue(traps.join(), "0,1,2");
+  assert.sameValue(a.x, 12);
+  assert.sameValue(b.x, 22);
+})();
+
+// A receiver that cannot be cached arriving while the callsite is still monomorphic stops
+// caching there entirely. Later shapes never reach a polymorphic cache but still store
+// correctly.
+(function () {
+  var traps = [];
+  function set(o, v) { o.x = v; }
+  var a = { x: 0 };
+  var b = { pad: 0, x: 0 };
+  var proxy = new Proxy({}, {
+    set: function (t, k, v) { traps.push(v); return true; },
+  });
+
+  set(a, 1);
+  set(proxy, 2);
+  for (var i = 0; i < 3; i++) {
+    set(a, 10 + i);
+    set(b, 20 + i);
+    assert.sameValue(a.x, 10 + i);
+    assert.sameValue(b.x, 20 + i);
+  }
+  set(proxy, 3);
+  assert.sameValue(traps.join(), "2,3");
+})();
+
+// Array length stores are exotic and never cached, but keep their behavior at a polymorphic
+// callsite.
+(function () {
+  function set(o, v) { o.length = v; }
+  var a = { length: 0 };
+  var b = { pad: 0, length: 0 };
+  var arr = [1, 2, 3, 4, 5];
+
+  set(a, 1);
+  set(b, 2);
+  set(arr, 3);
+  assert.sameValue(arr.length, 3);
+  assert.sameValue(arr[3], undefined);
+  set(a, 11);
+  set(arr, 1);
+  assert.sameValue(arr.length, 1);
+  assert.sameValue(a.length, 11);
+  assert.sameValue(b.length, 2);
+})();
+
+// A dictionary (map mode) receiver is uncacheable and mixes safely into a polymorphic callsite.
+(function () {
+  var dict = {};
+  for (var i = 0; i < 80; i++) {
+    dict["k" + i] = i;
+  }
+  dict.x = 0;
+
+  function set(o, v) { o.x = v; }
+  var a = { x: 0 };
+  var b = { pad: 0, x: 0 };
+
+  set(a, 1);
+  set(b, 2);
+  for (var j = 0; j < 3; j++) {
+    set(dict, j);
+    assert.sameValue(dict.x, j);
+    set(a, 10 + j);
+    assert.sameValue(a.x, 10 + j);
+  }
+  assert.sameValue(b.x, 2);
+})();
+
+// A setter that re-enters the same callsite with a different shape leaves both stores correct.
+(function () {
+  var seen = [];
+  var plain = { pad: 0, x: 0 };
+  var reentrant = {
+    set x(v) { seen.push(v); set(plain, v * 2); },
+  };
+
+  function set(o, v) { o.x = v; }
+
+  set(plain, 1);
+  set(reentrant, 5);
+  assert.sameValue(plain.x, 10);
+
+  set(reentrant, 7);
+  assert.sameValue(plain.x, 14);
+  set(plain, 3);
+  assert.sameValue(plain.x, 3);
+  set(reentrant, 9);
+  assert.sameValue(plain.x, 18);
+  assert.sameValue(seen.join(), "5,7,9");
+})();
+
+// A polymorphic cache survives garbage collection with all of its entries intact.
+(function () {
+  var setterCalls = 0;
+  var accessorProto = {};
+  Object.defineProperty(accessorProto, "x", {
+    set: function (v) { setterCalls++; },
+    configurable: true,
+  });
+
+  function set(o, v) { o.x = v; }
+  var a = { x: 0 };
+  var b = { p1: 0, x: 0 };
+  var c = Object.create(accessorProto);
+  function makeFresh() { return { q: 0 }; }
+
+  set(a, 1);
+  set(b, 2);
+  set(c, 3);
+  set(makeFresh(), 4);
+
+  $262.gc();
+
+  set(a, 5);
+  set(b, 6);
+  set(c, 7);
+  var fresh = makeFresh();
+  set(fresh, 8);
+
+  $262.gc();
+
+  assert.sameValue(a.x, 5);
+  assert.sameValue(b.x, 6);
+  assert.sameValue(setterCalls, 2);
+  assert.sameValue(fresh.x, 8);
+})();
+
+// Receivers from another realm have different shapes, so a shared callsite goes polymorphic
+// across realm boundaries.
+(function () {
+  var other = $262.createRealm();
+  other.evalScript("globalThis.make = function () { return { x: 0 }; };");
+
+  function set(o, v) { o.x = v; }
+
+  var mine = { x: 0 };
+  var theirs = other.global.make();
+
+  set(mine, 1);
+  set(theirs, 2);
+  set(mine, 3);
+  set(theirs, 4);
+  assert.sameValue(mine.x, 3);
+  assert.sameValue(theirs.x, 4);
+})();

--- a/tests/integration/language/expression/member/set_named_property_cache/uncacheable.js
+++ b/tests/integration/language/expression/member/set_named_property_cache/uncacheable.js
@@ -3,18 +3,25 @@ description: SetNamedProperty stores stay correct for receivers and callsites th
 flags: [noStrict]
 ---*/
 
-// A polymorphic callsite (two different shapes) stays correct after caching stops.
+// A megamorphic callsite (more shapes than the polymorphic cache holds) stays correct after
+// caching stops.
 (function () {
   function set(o, v) { o.a = v; }
-  var x = { a: 0 };
-  var y = { b: 0, a: 0 };
-  for (var i = 0; i < 6; i++) {
-    var o = i % 2 === 0 ? x : y;
-    set(o, i);
-    assert.sameValue(o.a, i);
+  var os = [
+    { a: 0 },
+    { b: 0, a: 0 },
+    { c: 0, d: 0, a: 0 },
+    { e: 0, f: 0, g: 0, a: 0 },
+    { h: 0, i: 0, j: 0, k: 0, a: 0 },
+  ];
+  for (var round = 0; round < 3; round++) {
+    for (var i = 0; i < os.length; i++) {
+      set(os[i], round * 10 + i);
+      assert.sameValue(os[i].a, round * 10 + i);
+    }
   }
-  assert.sameValue(x.a, 4);
-  assert.sameValue(y.a, 5);
+  assert.sameValue(os[0].a, 20);
+  assert.sameValue(os[4].a, 24);
 })();
 
 // A megamorphic transition callsite (fresh shape every call) stays correct.


### PR DESCRIPTION
## Summary

Implement generic polymorphic caches for `GetNamedProperty` and `SetNamedProperty` caches. We now go from a single (inline) monomorphic cache -> an out of line, 4-entry polymorphic cache -> megamorphic and fail. This is done at the `Cache` level so that the same general implementation can be used.

Notes:
- We make sure to replace monomorphic (and polymorphic) entries with a matching shape, e.g. due to invalidation
- We must preallocate the new polymorphic cache if one may be needed

## Tests

- CI