### PR TITLE
[runtime] GetNamedProperty cache handles array length

### DIFF
--- a/src/js/runtime/bytecode/cache.rs
+++ b/src/js/runtime/bytecode/cache.rs
@@ -2,6 +2,7 @@ use crate::runtime::{
     Context, Handle, HeapItemKind, HeapPtr, PropertyKey, Realm, Value,
     accessor::Accessor,
     alloc_error::AllocResult,
+    array_object::ArrayObject,
     bytecode::function::CacheArray,
     gc::HeapVisitor,
     global_object::GlobalProperty,
@@ -96,13 +97,17 @@ impl Cache {
     }
 
     fn same_receiver_shapes(cache_a: Cache, cache_b: Cache) -> bool {
-        cache_a.receiver_shape().ptr_eq(&cache_b.receiver_shape())
+        match (cache_a.receiver_shape(), cache_b.receiver_shape()) {
+            (Some(shape_a), Some(shape_b)) => shape_a.ptr_eq(&shape_b),
+            (None, None) => true,
+            _ => false,
+        }
     }
 
-    fn receiver_shape(&self) -> HeapPtr<Shape> {
+    fn receiver_shape(&self) -> Option<HeapPtr<Shape>> {
         match self {
             Self::GetNamedProperty(cache) => cache.receiver_shape(),
-            Self::SetNamedProperty(cache) => cache.receiver_shape(),
+            Self::SetNamedProperty(cache) => Some(cache.receiver_shape()),
             _ => unreachable!("cache does not have a receiver shape"),
         }
     }
@@ -127,6 +132,8 @@ pub enum GetNamedPropertyCache {
     /// Property was not found on the receiver or anywhere in its prototype chain. The guard is only
     /// set if the receiver has a prototype.
     NotFound { shape: HeapPtr<Shape>, guard: Option<ValidityGuard> },
+    /// Receiver is an array object and the property is `length`.
+    ArrayLength,
 }
 
 pub enum GetNamedPropertyCacheResult {
@@ -187,6 +194,9 @@ impl GetNamedPropertyCache {
                     GetNamedPropertyCacheResult::InvalidGuard
                 }
             }
+            Self::ArrayLength if receiver.is::<ArrayObject>() => {
+                GetNamedPropertyCacheResult::Data(Value::number(receiver.array_properties_length()))
+            }
             _ => GetNamedPropertyCacheResult::DifferentShape,
         }
     }
@@ -199,6 +209,12 @@ impl GetNamedPropertyCache {
         mut receiver: Handle<ObjectValue>,
         key: Handle<PropertyKey>,
     ) -> AllocResult<Option<Self>> {
+        // Array length is not stored as a regular property. As long as the receiver is an array
+        // object it can be cached as a special case.
+        if receiver.is::<ArrayObject>() && *key == *cx.names.length() {
+            return Ok(Some(Self::ArrayLength));
+        }
+
         if !is_cacheable_named_property(cx, *receiver, *key) {
             return Ok(None);
         }
@@ -256,11 +272,14 @@ impl GetNamedPropertyCache {
         Ok(Some(Self::NotFound { shape: receiver.shape_ptr(), guard }))
     }
 
-    pub fn receiver_shape(&self) -> HeapPtr<Shape> {
+    /// The receiver shape this cache is keyed on, if any. Returns None if the cache is instead
+    /// keyed on the receiver's kind.
+    pub fn receiver_shape(&self) -> Option<HeapPtr<Shape>> {
         match self {
             Self::Own { shape, .. } | Self::Proto { shape, .. } | Self::NotFound { shape, .. } => {
-                *shape
+                Some(*shape)
             }
+            Self::ArrayLength => None,
         }
     }
 
@@ -281,6 +300,7 @@ impl GetNamedPropertyCache {
                     guard.visit_pointers(visitor);
                 }
             }
+            Self::ArrayLength => {}
         }
     }
 }

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -4503,7 +4503,9 @@ impl VM {
                 // Preallocate the polymorphic cache if promotion is possible
                 let new_polymorphic_cache = match self.get_cache(cache_index) {
                     Cache::GetNamedProperty(cache)
-                        if !cache.receiver_shape().ptr_eq(&coerced_object.shape_ptr()) =>
+                        if cache
+                            .receiver_shape()
+                            .is_none_or(|shape| !shape.ptr_eq(&coerced_object.shape_ptr())) =>
                     {
                         Some(CacheArray::new_polymorphic(self.cx())?)
                     }

--- a/tests/integration/language/expression/member/get_named_property_cache/array_length.js
+++ b/tests/integration/language/expression/member/get_named_property_cache/array_length.js
@@ -1,0 +1,156 @@
+/*---
+description: Array length reads are cached, only checking receiver kind.
+---*/
+
+// Each site is read in a loop so the inline cache is filled and then re-matched.
+function readLength(o) {
+  var last;
+  for (var i = 0; i < 100; i++) {
+    last = o.length;
+  }
+  return last;
+}
+
+// Length tracks mutations after the cache is filled
+var mutated = [1, 2, 3];
+assert.sameValue(readLength(mutated), 3);
+mutated.push(4);
+assert.sameValue(readLength(mutated), 4);
+mutated.pop();
+mutated.pop();
+assert.sameValue(readLength(mutated), 2);
+mutated.length = 5;
+assert.sameValue(readLength(mutated), 5);
+mutated.length = 0;
+assert.sameValue(readLength(mutated), 0);
+
+// Sparse arrays and element deletes do not shrink length
+var sparse = [1, 2, 3, 4];
+delete sparse[1];
+assert.sameValue(readLength(sparse), 4);
+sparse[100] = 1;
+assert.sameValue(readLength(sparse), 101);
+
+// A single cache entry must serve every array shape, not just the first one seen
+var shapes = [];
+for (var i = 0; i < 10; i++) {
+  var arr = [];
+  for (var j = 0; j <= i; j++) {
+    arr.push(j);
+  }
+  // Give each array a distinct shape by adding different named properties
+  for (var j = 0; j < i; j++) {
+    arr["p" + j] = j;
+  }
+  shapes.push(arr);
+}
+for (var i = 0; i < 100; i++) {
+  for (var j = 0; j < shapes.length; j++) {
+    assert.sameValue(shapes[j].length, j + 1);
+  }
+}
+
+// Arrays in map (dictionary) mode still report length correctly
+var mapMode = [1, 2, 3];
+mapMode.extra = 1;
+delete mapMode.extra;
+assert.sameValue(readLength(mapMode), 3);
+mapMode.push(4);
+assert.sameValue(readLength(mapMode), 4);
+
+// Non-writable length blocks stores but reads stay correct
+var frozen = [1, 2, 3];
+Object.freeze(frozen);
+assert.sameValue(readLength(frozen), 3);
+assert.sameValue(Object.getOwnPropertyDescriptor(frozen, "length").writable, false);
+
+// length is non-configurable, so it can never become an accessor or be deleted
+var fixed = [1, 2, 3];
+assert.sameValue(readLength(fixed), 3);
+assert.throws(TypeError, function () {
+  Object.defineProperty(fixed, "length", { get: function () { return 99; } });
+});
+assert.sameValue(readLength(fixed), 3);
+assert.throws(TypeError, function () {
+  "use strict";
+  delete fixed.length;
+});
+assert.sameValue(readLength(fixed), 3);
+
+// Array subclasses are array exotic objects too
+class Subclass extends Array {}
+var sub = new Subclass();
+sub.push(1);
+sub.push(2);
+assert.sameValue(readLength(sub), 2);
+
+// Array.prototype is itself an array exotic object with length 0
+assert.sameValue(readLength(Array.prototype), 0);
+
+// Prototype mutation does not affect the own synthesized length
+var reproto = [1, 2, 3, 4];
+assert.sameValue(readLength(reproto), 4);
+Object.setPrototypeOf(reproto, null);
+assert.sameValue(readLength(reproto), 4);
+
+// Lengths above the small-integer range are reported as numbers, not truncated
+var huge = new Array(3000000000);
+assert.sameValue(readLength(huge), 3000000000);
+assert.sameValue(typeof readLength(huge), "number");
+assert.sameValue(readLength(new Array(4294967295)), 4294967295);
+
+// A site that alternates between arrays and non-arrays must stay correct for both
+function polymorphic(o) {
+  return o.length;
+}
+var plain = { length: 7 };
+var str = new String("abcd");
+for (var i = 0; i < 100; i++) {
+  assert.sameValue(polymorphic(mutated), 0);
+  assert.sameValue(polymorphic(plain), 7);
+  assert.sameValue(polymorphic(str), 4);
+  assert.sameValue(polymorphic(shapes[3]), 4);
+}
+
+// An ordinary object inheriting from Array.prototype is not an array
+(function () {
+  function len(o) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = o.length;
+    }
+    return last;
+  }
+
+  assert.sameValue(len([1, 2, 3]), 3);
+
+  var inherited = Object.create(Array.prototype);
+  assert.sameValue(len(inherited), 0);
+  inherited.length = 3;
+  assert.sameValue(len(inherited), 3);
+})();
+
+// A proxy wrapping an array must still route through its trap
+(function () {
+  function len(o) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = o.length;
+    }
+    return last;
+  }
+
+  assert.sameValue(len([1, 2, 3]), 3);
+
+  var trapped = 0;
+  var proxy = new Proxy([1, 2, 3], {
+    get: function (target, key, receiver) {
+      if (key === "length") {
+        trapped++;
+      }
+      return Reflect.get(target, key, receiver);
+    },
+  });
+  assert.sameValue(len(proxy), 3);
+  assert.sameValue(trapped, 100);
+})();


### PR DESCRIPTION
## Summary

Support accessing the `length` property of arrays in the `GetNamedPropertyCache`, given how common accessing array length is. We need a new variant for this cache which doesn't require a shape - it only needs to check whether the receiver is an array object.

+1.7% on octane, and a significant increase to DeltaBlue in particular.

| Benchmark | 67bfd871e (base) | 53c62d483 | Change |
|---|---|---|---|
| Richards | 2,100 med 2,088 ±11.6 n=4 | 2,235 med 2,203 ±44.3 n=4 | +6.4% |
| DeltaBlue | 1,986 med 1,974 ±13.2 n=4 | 2,261 med 2,211 ±27.5 n=4 | +13.8% |
| Crypto | 1,536 med 1,501 ±21.9 n=4 | 1,530 med 1,517 ±13.4 n=4 | -0.4% |
| RayTrace | 2,821 med 2,804 ±18.6 n=4 | 2,874 med 2,868 ±5.8 n=4 | +1.9% |
| EarleyBoyer | 4,846 med 4,832 ±26.3 n=4 | 4,859 med 4,845 ±14.5 n=4 | +0.3% |
| RegExp | 432 med 432 ±1.0 n=4 | 442 med 442 ±1.0 n=4 | +2.3% |
| Splay | 4,518 med 4,358 ±165 n=4 | 4,572 med 4,545 ±21.7 n=4 | +1.2% |
| SplayLatency | 7,138 med 7,025 ±93.6 n=4 | 7,220 med 7,196 ±16.8 n=4 | +1.1% |
| NavierStokes | 1,247 med 1,244 ±3.0 n=4 | 1,250 med 1,246 ±5.1 n=4 | +0.2% |
| PdfJS | 4,557 med 4,544 ±9.3 n=4 | 4,577 med 4,561 ±10.6 n=4 | +0.4% |
| Mandreel | 1,092 med 1,088 ±9.9 n=4 | 1,071 med 1,066 ±12.8 n=4 | -1.9% |
| MandreelLatency | 7,112 med 7,066 ±41.1 n=4 | 7,122 med 7,096 ±25.4 n=4 | +0.1% |
| Gameboy | 4,216 med 4,180 ±42.5 n=4 | 4,186 med 4,176 ±5.4 n=4 | -0.7% |
| CodeLoad | 40,001 med 39,786 ±132 n=4 | 40,018 med 39,952 ±65.1 n=4 | +0.0% |
| Box2D | 7,501 med 7,449 ±27.4 n=4 | 7,695 med 7,656 ±30.7 n=4 | +2.6% |
| zlib | 2,449 med 2,427 ±20.5 n=4 | 2,448 med 2,434 ±18.2 n=4 | -0.0% |
| Typescript | 17,984 med 17,848 ±110 n=4 | 18,130 med 18,066 ±65.0 n=4 | +0.8% |
| **Total (octane)** | **3,590 med 3,585 ±19.5 n=4** | **3,652 med 3,647 ±6.1 n=4** | **+1.7%** |

## Tests

- Added LLM generated test covering many scenarios of a `GetNamedPropertyCache` for array length