### PR TITLE
[runtime] Fast path for GetProperty and SetProperty on dense arrays

### DIFF
--- a/src/js/runtime/array_properties.rs
+++ b/src/js/runtime/array_properties.rs
@@ -62,7 +62,7 @@ impl HeapPtr<ArrayProperties> {
                 return None;
             }
 
-            let value = dense_properties.get(array_index);
+            let value = dense_properties.get_unchecked(array_index);
             if value.is_empty() {
                 return None;
             }
@@ -78,7 +78,7 @@ impl HeapPtr<ArrayProperties> {
 
     pub fn remove_property(&self, array_index: u32) {
         if let Some(mut dense_properties) = self.as_dense_opt() {
-            dense_properties.set(array_index, Value::empty());
+            dense_properties.set_unchecked(array_index, Value::empty());
         } else {
             let mut sparse_properties = self.as_sparse();
             sparse_properties.remove(&array_index);
@@ -321,7 +321,7 @@ impl ArrayProperties {
 
                 Self::set_property(cx, object, array_index, property)?;
             } else {
-                dense_properties.set(array_index, *property.value());
+                dense_properties.set_unchecked(array_index, *property.value());
             }
         } else {
             let mut sparse_properties = array_properties.as_sparse();
@@ -389,12 +389,12 @@ impl DenseArrayProperties {
     }
 
     #[inline]
-    fn get(&self, index: u32) -> Value {
+    pub fn get_unchecked(&self, index: u32) -> Value {
         *(self.array.get_unchecked(index as usize))
     }
 
     #[inline]
-    fn set(&mut self, index: u32, value: Value) {
+    pub fn set_unchecked(&mut self, index: u32, value: Value) {
         *(self.array.get_unchecked_mut(index as usize)) = value;
     }
 
@@ -441,7 +441,7 @@ impl Iterator for DenseArrayPropertiesIter {
         if self.current == self.len {
             None
         } else {
-            let value = self.dense_array_properties.get(self.current);
+            let value = self.dense_array_properties.get_unchecked(self.current);
             self.current += 1;
             Some(value)
         }

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -4271,6 +4271,34 @@ impl VM {
         &mut self,
         instr: &GetPropertyInstruction<W>,
     ) -> EvalResult<()> {
+        let object = self.read_register(instr.object());
+        let key = self.read_register(instr.key());
+
+        // Fast path for loads on dense arrays
+        if object.is_object() && key.is_smi() {
+            let object = object.as_object();
+            if object.is::<ArrayObject>()
+                && let Some(dense_properties) = object.array_properties().as_dense_opt()
+            {
+                let index = key.as_smi() as u32;
+                if (index as i32) >= 0 && index < dense_properties.len() {
+                    let value = dense_properties.get_unchecked(index);
+                    if !value.is_empty() {
+                        self.write_register(instr.dest(), value);
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        self.execute_get_property_slow(instr)
+    }
+
+    #[inline(never)]
+    fn execute_get_property_slow<W: Width>(
+        &mut self,
+        instr: &GetPropertyInstruction<W>,
+    ) -> EvalResult<()> {
         handle_scope!(self.cx(), {
             let object = self.read_register_to_handle(instr.object());
             let key = self.read_register_to_handle(instr.key());
@@ -4298,6 +4326,34 @@ impl VM {
 
     #[inline(always)]
     fn execute_set_property<W: Width>(
+        &mut self,
+        instr: &SetPropertyInstruction<W>,
+    ) -> EvalResult<()> {
+        let object = self.read_register(instr.object());
+        let key = self.read_register(instr.key());
+
+        // Fast path for stores on dense arrays
+        if object.is_object() && key.is_smi() {
+            let object = object.as_object();
+            if object.is::<ArrayObject>()
+                && let Some(mut dense_properties) = object.array_properties().as_dense_opt()
+            {
+                let index = key.as_smi() as u32;
+                if (index as i32) >= 0
+                    && index < dense_properties.len()
+                    && !dense_properties.get_unchecked(index).is_empty()
+                {
+                    dense_properties.set_unchecked(index, self.read_register(instr.value()));
+                    return Ok(());
+                }
+            }
+        }
+
+        self.execute_set_property_slow(instr)
+    }
+
+    #[inline(never)]
+    fn execute_set_property_slow<W: Width>(
         &mut self,
         instr: &SetPropertyInstruction<W>,
     ) -> EvalResult<()> {

--- a/tests/integration/language/expression/member/get_property/dense_array_properties.js
+++ b/tests/integration/language/expression/member/get_property/dense_array_properties.js
@@ -1,0 +1,153 @@
+/*---
+description: GetProperty fast path for dense arrays.
+---*/
+
+// In-range loads of every value type.
+(function () {
+  function get(a, i) { return a[i]; }
+  var obj = {};
+  var a = [1, 2.5, "s", true, null, undefined, obj];
+  for (var round = 0; round < 3; round++) {
+    assert.sameValue(get(a, 0), 1);
+    assert.sameValue(get(a, 1), 2.5);
+    assert.sameValue(get(a, 2), "s");
+    assert.sameValue(get(a, 3), true);
+    assert.sameValue(get(a, 4), null);
+    assert.sameValue(get(a, 5), undefined);
+    assert.sameValue(get(a, 6), obj);
+  }
+})();
+
+// Out of range loads are undefined and do not throw.
+(function () {
+  function get(a, i) { return a[i]; }
+  var a = [1, 2, 3];
+  get(a, 0); get(a, 0);
+  assert.sameValue(get(a, 3), undefined);
+  assert.sameValue(get(a, 1000), undefined);
+})();
+
+// Shrinking the array via length makes old indices read as undefined.
+(function () {
+  function get(a, i) { return a[i]; }
+  var a = [1, 2, 3, 4];
+  assert.sameValue(get(a, 3), 4);
+  a.length = 2;
+  assert.sameValue(get(a, 3), undefined);
+  assert.sameValue(get(a, 1), 2);
+})();
+
+// Growing the array via length exposes holes, not stale values.
+(function () {
+  function get(a, i) { return a[i]; }
+  var a = [1, 2, 3, 4];
+  assert.sameValue(get(a, 3), 4);
+  a.length = 2;
+  a.length = 4;
+  assert.sameValue(get(a, 3), undefined);
+})();
+
+// An accessor element converts the array to sparse storage, loads still work.
+(function () {
+  function get(a, i) { return a[i]; }
+  var a = [1, 2, 3];
+  assert.sameValue(get(a, 1), 2);
+  Object.defineProperty(a, "0", { get: function () { return "got"; } });
+  assert.sameValue(get(a, 0), "got");
+  assert.sameValue(get(a, 1), 2);
+})();
+
+// A warm callsite handles array and non-array receivers interchangeably.
+(function () {
+  function get(o, i) { return o[i]; }
+  var a = [1, 2, 3];
+  var o = { 0: "a", 1: "b" };
+  var s = "xy";
+  assert.sameValue(get(a, 1), 2);
+  assert.sameValue(get(o, 1), "b");
+  assert.sameValue(get(s, 1), "y");
+  assert.sameValue(get(a, 2), 3);
+})();
+
+// Array subclass indexed properties load like plain array indexed properties.
+(function () {
+  function get(a, i) { return a[i]; }
+  class Sub extends Array {}
+  var s = Sub.of(10, 20);
+  assert.sameValue(get(s, 0), 10);
+  assert.sameValue(get(s, 1), 20);
+  assert.sameValue(get(s, 2), undefined);
+})();
+
+// Dense indexed property loads stay correct across a garbage collection.
+(function () {
+  function get(a, i) { return a[i]; }
+  var a = [{ tag: 1 }, { tag: 2 }];
+  assert.sameValue(get(a, 0).tag, 1);
+  $262.gc();
+  assert.sameValue(get(a, 0).tag, 1);
+  assert.sameValue(get(a, 1).tag, 2);
+})();
+
+// A hole load finds a data property on Array.prototype, present indexed properties shadow it.
+(function () {
+  function get(a, i) { return a[i]; }
+  Array.prototype[1] = "proto";
+  try {
+    var a = [0, , 2];
+    get(a, 0); get(a, 0);
+    assert.sameValue(get(a, 1), "proto");
+    assert.sameValue(get(a, 0), 0);
+    assert.sameValue(get(a, 2), 2);
+  } finally {
+    delete Array.prototype[1];
+  }
+})();
+
+// A hole load calls a getter on Array.prototype with the array as receiver.
+(function () {
+  function get(a, i) { return a[i]; }
+  var seenThis;
+  Object.defineProperty(Array.prototype, "1", {
+    get: function () { seenThis = this; return "got"; },
+    configurable: true,
+  });
+  try {
+    var a = [0, , 2];
+    assert.sameValue(get(a, 1), "got");
+    assert.sameValue(seenThis, a);
+    assert.sameValue(get(a, 0), 0);
+  } finally {
+    delete Array.prototype[1];
+  }
+})();
+
+// Deleting an indexed property re-introduces a hole that reads through the prototype again.
+(function () {
+  function get(a, i) { return a[i]; }
+  Array.prototype[0] = "proto";
+  try {
+    var a = [1, 2];
+    assert.sameValue(get(a, 0), 1);
+    assert.sameValue(get(a, 0), 1);
+    delete a[0];
+    assert.sameValue(get(a, 0), "proto");
+  } finally {
+    delete Array.prototype[0];
+  }
+})();
+
+// Integral float and negative zero keys canonicalize to the same indexed property.
+(function () {
+  function get(a, k) { return a[k]; }
+  var a = [1, 2, 3];
+  assert.sameValue(get(a, -0), 1);
+})();
+
+// Fractional and negative keys are not indexed properties.
+(function () {
+  function get(a, k) { return a[k]; }
+  var a = [1, 2, 3];
+  assert.sameValue(get(a, 1.5), undefined);
+  assert.sameValue(get(a, -1), undefined);
+})();

--- a/tests/integration/language/expression/member/set_property/dense_array_properties.js
+++ b/tests/integration/language/expression/member/set_property/dense_array_properties.js
@@ -1,0 +1,141 @@
+/*---
+description: SetProperty fast path for dense arrays.
+---*/
+
+// In-range overwrites of every value type.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var obj = {};
+  var a = [0, 0, 0, 0, 0, 0, 0];
+  var values = [1, 2.5, "s", true, null, undefined, obj];
+  for (var round = 0; round < 3; round++) {
+    for (var i = 0; i < values.length; i++) {
+      set(a, i, values[i]);
+    }
+  }
+  for (var i = 0; i < values.length; i++) {
+    assert.sameValue(a[i], values[i]);
+  }
+})();
+
+// In-range stores do not change the length.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = [1, 2, 3];
+  set(a, 1, "y");
+  set(a, 1, "z");
+  assert.sameValue(a[1], "z");
+  assert.sameValue(a.length, 3);
+})();
+
+// Stores past the end extend the array and update the length.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = [1];
+  set(a, 0, 2); set(a, 0, 3);
+  set(a, 3, "x");
+  assert.sameValue(a.length, 4);
+  assert.sameValue(a[3], "x");
+  assert.sameValue(a[1], undefined);
+})();
+
+// Frozen arrays throw on store in strict mode.
+(function () {
+  "use strict";
+  var a = Object.freeze([1, 2, 3]);
+  function set(x, i, v) { x[i] = v; }
+  assert.throws(TypeError, function () { set(a, 0, 99); });
+  assert.throws(TypeError, function () { set(a, 0, 99); });
+  assert.sameValue(a[0], 1);
+})();
+
+// A warm callsite handles array and non-array receivers interchangeably.
+(function () {
+  function set(o, i, v) { o[i] = v; }
+  var a = [1, 2, 3];
+  var o = {};
+  set(a, 0, "a1");
+  set(a, 0, "a2");
+  set(o, 0, "o1");
+  assert.sameValue(a[0], "a2");
+  assert.sameValue(o[0], "o1");
+})();
+
+// Array subclass indexed properties store like plain array indexed properties.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  class Sub extends Array {}
+  var s = Sub.of(1, 2);
+  set(s, 0, 10);
+  set(s, 0, 11);
+  assert.sameValue(s[0], 11);
+  assert.sameValue(s.length, 2);
+})();
+
+// Stored heap values survive a garbage collection.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = [null, null];
+  set(a, 0, { tag: 1 });
+  set(a, 1, { tag: 2 });
+  $262.gc();
+  assert.sameValue(a[0].tag, 1);
+  assert.sameValue(a[1].tag, 2);
+})();
+
+// A hole store is intercepted by a setter on Array.prototype, no own indexed property is created.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var calls = 0, seenThis, last;
+  Object.defineProperty(Array.prototype, "1", {
+    set: function (v) { calls++; seenThis = this; last = v; },
+    configurable: true,
+  });
+  try {
+    var a = [0, , 2];
+    set(a, 0, 10);
+    set(a, 0, 11);
+    set(a, 1, "trapped");
+    assert.sameValue(calls, 1);
+    assert.sameValue(seenThis, a);
+    assert.sameValue(last, "trapped");
+    assert.sameValue(a.hasOwnProperty("1"), false);
+    // Present indexed properties shadow the prototype setter.
+    set(a, 2, 20);
+    assert.sameValue(calls, 1);
+    assert.sameValue(a[2], 20);
+  } finally {
+    delete Array.prototype[1];
+  }
+})();
+
+// Without prototype interference, a hole store creates an own indexed property that later
+// stores treat as present.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = [0, , 2];
+  assert.sameValue(a[1], undefined);
+  set(a, 1, "own");
+  assert.sameValue(a[1], "own");
+  set(a, 1, "own2");
+  assert.sameValue(a[1], "own2");
+})();
+
+// Integral float and negative zero keys canonicalize to the same indexed property.
+(function () {
+  function set(a, k, v) { a[k] = v; }
+  var a = [1, 2, 3];
+  set(a, -0, "zero");
+  assert.sameValue(a[0], "zero");
+  assert.sameValue(a.length, 3);
+})();
+
+// Fractional and negative keys do not touch indexed properties or the length.
+(function () {
+  function set(a, k, v) { a[k] = v; }
+  var a = [1, 2, 3];
+  set(a, 1.5, "frac");
+  set(a, -1, "neg");
+  assert.sameValue(a[1], 2);
+  assert.sameValue(a.length, 3);
+})();

--- a/tests/integration/language/expression/member/set_property/dense_array_properties_non_strict.js
+++ b/tests/integration/language/expression/member/set_property/dense_array_properties_non_strict.js
@@ -1,0 +1,54 @@
+/*---
+description: SetProperty fast path for dense arrays in non-strict mode.
+flags: [noStrict]
+---*/
+
+// Frozen arrays silently ignore stores in sloppy mode, even at a warm callsite.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = [1, 2, 3];
+  set(a, 0, 10);
+  set(a, 0, 20);
+  Object.freeze(a);
+  set(a, 0, 99);
+  set(a, 1, 99);
+  assert.sameValue(a[0], 20);
+  assert.sameValue(a[1], 2);
+})();
+
+// A single non-writable indexed property rejects stores while its neighbors accept them.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = [1, 2, 3];
+  set(a, 1, 20);
+  Object.defineProperty(a, "1", { writable: false });
+  set(a, 0, 10);
+  set(a, 1, 99);
+  set(a, 2, 30);
+  assert.sameValue(a[0], 10);
+  assert.sameValue(a[1], 20);
+  assert.sameValue(a[2], 30);
+})();
+
+// A hole store with a getter-only accessor on Array.prototype is silently ignored in
+// sloppy mode and throws in strict mode.
+(function () {
+  Object.defineProperty(Array.prototype, "1", {
+    get: function () { return "got"; },
+    configurable: true,
+  });
+  try {
+    var a = [0, , 2];
+    a[1] = "dropped";
+    assert.sameValue(a.hasOwnProperty("1"), false);
+    assert.sameValue(a[1], "got");
+
+    (function () {
+      "use strict";
+      function set(x, i, v) { x[i] = v; }
+      assert.throws(TypeError, function () { set(a, 1, "boom"); });
+    })();
+  } finally {
+    delete Array.prototype[1];
+  }
+})();


### PR DESCRIPTION
## Summary

Introduce a fast path for `GetProperty` and `SetProperty` when the receiver is a dense array object and the key is an in-bounds array index. No caching is necessary, this is purely a check for the array object kind, whether it has dense properties, and whether the key is in bounds. Note that holes must always take the slow path.

A +3.3% increase to Octane. There are some regressions for typed array heavy benchmarks that don't take this fast path, but these will be more than made up for shortly with the similar typed array fast path.

| Benchmark | 67bfd871e (base) | bcce47466 | Change |
|---|---|---|---|
| Richards | 2,104 med 2,080 ±18.9 n=4 | 2,197 med 2,179 ±20.5 n=4 | +4.4% |
| DeltaBlue | 1,970 med 1,968 ±6.1 n=4 | 2,171 med 2,163 ±11.0 n=4 | +10.2% |
| Crypto | 1,498 med 1,492 ±4.5 n=4 | 2,252 med 2,237 ±12.9 n=4 | +50.3% |
| RayTrace | 2,795 med 2,790 ±3.9 n=4 | 2,841 med 2,834 ±8.4 n=4 | +1.6% |
| EarleyBoyer | 4,849 med 4,819 ±23.4 n=4 | 4,984 med 4,964 ±22.1 n=4 | +2.8% |
| RegExp | 432 med 432 ±1.0 n=4 | 432 med 432 ±1.0 n=4 | +0.0% |
| Splay | 4,229 med 4,191 ±28.0 n=4 | 4,506 med 4,482 ±110 n=4 | +6.6% |
| SplayLatency | 7,022 med 6,921 ±57.3 n=4 | 7,164 med 7,095 ±297 n=4 | +2.0% |
| NavierStokes | 1,250 med 1,245 ±6.1 n=4 | 1,188 med 1,183 ±7.9 n=4 | -5.0% |
| PdfJS | 4,544 med 4,520 ±19.1 n=4 | 4,649 med 4,642 ±4.3 n=4 | +2.3% |
| Mandreel | 1,091 med 1,077 ±10.4 n=4 | 1,015 med 1,009 ±18.2 n=4 | -7.0% |
| MandreelLatency | 7,031 med 7,017 ±9.1 n=4 | 6,647 med 6,621 ±23.1 n=4 | -5.5% |
| Gameboy | 4,215 med 4,204 ±19.0 n=4 | 4,250 med 4,212 ±23.2 n=4 | +0.8% |
| CodeLoad | 39,828 med 39,673 ±153 n=4 | 39,936 med 39,848 ±76.8 n=4 | +0.3% |
| Box2D | 7,486 med 7,457 ±64.0 n=4 | 8,021 med 7,963 ±90.3 n=4 | +7.1% |
| zlib | 2,416 med 2,408 ±7.7 n=4 | 2,301 med 2,276 ±19.2 n=4 | -4.8% |
| Typescript | 17,758 med 17,730 ±29.6 n=4 | 17,959 med 17,932 ±68.7 n=4 | +1.1% |
| **Total (octane)** | **3,564 med 3,557 ±10.1 n=4** | **3,681 med 3,672 ±18.0 n=4** | **+3.3%** |

## Tests

- Added LLM generated tests for many scenarios of `GetProperty` and `SetProperty` on arrays with dense properties