### PR TITLE
[runtime] Improve array properties dense vs sparse heuristics and transitions

### DIFF
--- a/src/js/runtime/array_properties.rs
+++ b/src/js/runtime/array_properties.rs
@@ -19,9 +19,19 @@ pub struct ArrayProperties {
     shape: HeapPtr<Shape>,
 }
 
-// Number of indices past the end of an array an access can occur before dense array is converted
-// to a sparse array.
-const SPARSE_ARRAY_THRESHOLD: u32 = 100;
+// Maximum length that can be backed by a dense array. Longer arrays are always sparse.
+const MAX_DENSE_ARRAY_LENGTH: u32 = 1 << 24;
+
+// Arrays grown up to this length always stay dense, regardless of how many holes they contain.
+const MIN_SPARSE_ARRAY_LENGTH: u32 = 1024;
+
+// When growing a dense array beyond its capacity, stay dense only if at least 1/8 of the array
+// would be filled.
+const SPARSE_DENSITY_RATIO: u32 = 8;
+
+// Convert a sparse array back to dense once at least 1/4 of the array is filled. The 1/4 vs 1/8
+// difference prevents oscillation between representations.
+const DENSE_DENSITY_RATIO: u32 = 4;
 
 impl HeapPtr<ArrayProperties> {
     #[inline]
@@ -106,8 +116,10 @@ impl ArrayProperties {
             return Ok(());
         }
 
-        // Capacity must be at least doubled
-        let new_capacity = u32::max(old_capacity.saturating_mul(2), new_length);
+        // Capacity must be at least doubled, but is capped by max dense length
+        debug_assert!(new_length <= MAX_DENSE_ARRAY_LENGTH);
+        let new_capacity =
+            u32::max(old_capacity.saturating_mul(2), new_length).min(MAX_DENSE_ARRAY_LENGTH);
 
         // Save old dense properties before allocation
         let dense_properties = dense_properties.to_handle();
@@ -186,6 +198,7 @@ impl ArrayProperties {
             cx,
             new_capacity,
             dense_properties.len(),
+            /* has_non_dense_property */ false,
         )?;
 
         // Share handle across iterations
@@ -208,6 +221,67 @@ impl ArrayProperties {
         Ok(())
     }
 
+    /// Whether growing a dense array to the new length should convert it to sparse properties.
+    fn should_transition_to_sparse(
+        dense_properties: HeapPtr<DenseArrayProperties>,
+        new_length: u32,
+    ) -> bool {
+        if new_length > MAX_DENSE_ARRAY_LENGTH {
+            return true;
+        }
+
+        // Growing within the current capacity requires no allocation so always stay dense
+        if new_length <= dense_properties.capacity() {
+            return false;
+        }
+
+        if new_length <= MIN_SPARSE_ARRAY_LENGTH {
+            return false;
+        }
+
+        // Otherwise stay dense only if enough of the array would be filled
+        let num_filled = dense_properties
+            .iter_gc_unsafe()
+            .filter(|value| !value.is_empty())
+            .count() as u32;
+
+        num_filled < new_length / SPARSE_DENSITY_RATIO
+    }
+
+    /// Whether a sparse array that is about to have a property added should convert back to a
+    /// dense array with the given length.
+    fn should_transition_to_dense(
+        sparse_properties: HeapPtr<SparseArrayPropertiesMap>,
+        new_length: u32,
+    ) -> bool {
+        if sparse_properties.has_non_dense_property() || new_length > MAX_DENSE_ARRAY_LENGTH {
+            return false;
+        }
+
+        (sparse_properties.len() as u32).saturating_add(1) >= new_length / DENSE_DENSITY_RATIO
+    }
+
+    /// Convert sparse properties back to a dense array of the given length.
+    fn transition_to_dense_properties(
+        cx: Context,
+        mut object: Handle<ObjectValue>,
+        new_length: u32,
+    ) -> AllocResult<()> {
+        let mut dense_properties = DenseArrayProperties::new(cx, new_length)?;
+        dense_properties.set_len(new_length);
+        dense_properties.set_empty_range(0, new_length);
+
+        // No allocations occur, safe to iterate directly
+        let sparse_properties = object.array_properties().as_sparse();
+        for (index, property) in sparse_properties.iter_gc_unsafe() {
+            dense_properties.set_unchecked(index, property.value());
+        }
+
+        object.set_array_properties(dense_properties.cast());
+
+        Ok(())
+    }
+
     // Resize array properties to match a new array length, potentially expanding and adding empty
     // values, or shrinking and removing existing values.
     //
@@ -225,12 +299,12 @@ impl ArrayProperties {
         if let Some(dense_properties) = array_properties.as_dense_opt() {
             let array_length = dense_properties.len();
             if new_length > array_length {
-                if new_length >= array_length + SPARSE_ARRAY_THRESHOLD {
-                    // First try falling back to sparse properties if this is an expanded dense array
+                if new_length > MAX_DENSE_ARRAY_LENGTH {
+                    // Too long to be dense, fall back to sparse properties
                     Self::transition_to_sparse_properties(cx, object)?;
                     Self::set_len(cx, object, new_length)
                 } else {
-                    // Otherwise stay dense but resize array with new empty elements
+                    // Otherwise assume the new length is a presizing hint and stay dense
                     Self::grow_dense_properties(cx, object, new_length)?;
                     Ok(true)
                 }
@@ -281,8 +355,12 @@ impl ArrayProperties {
                 .filter(|(index, _)| *index < new_length)
                 .count();
             let new_capacity = SparseArrayPropertiesMap::min_capacity_needed(num_properties_left);
-            let mut new_sparse_properties =
-                SparseArrayPropertiesMap::new_with_array_length(cx, new_capacity, new_length)?;
+            let mut new_sparse_properties = SparseArrayPropertiesMap::new_with_array_length(
+                cx,
+                new_capacity,
+                new_length,
+                sparse_properties.has_non_dense_property(),
+            )?;
 
             // Create a new map with non-truncated values. Can use stored property directly since
             // loop does not allocate on managed heap as map has capacity for all properties.
@@ -312,8 +390,8 @@ impl ArrayProperties {
                 Self::transition_to_sparse_properties(cx, object)?;
                 Self::set_property(cx, object, array_index, property)?;
             } else if array_index >= dense_properties.len() {
-                // Transition if property is added past the end of the array by a threshold
-                if array_index >= dense_properties.len() + SPARSE_ARRAY_THRESHOLD {
+                // Transition if growing the array would leave it too long or too sparse
+                if Self::should_transition_to_sparse(dense_properties, array_index + 1) {
                     Self::transition_to_sparse_properties(cx, object)?;
                 } else {
                     Self::grow_dense_properties(cx, object, array_index + 1)?;
@@ -326,14 +404,40 @@ impl ArrayProperties {
         } else {
             let mut sparse_properties = array_properties.as_sparse();
 
+            // Hole values are not written into the sparse array, only the length is updated if
+            // needed.
+            if property.value().is_empty() {
+                if array_index >= sparse_properties.array_length() {
+                    sparse_properties.set_array_length(array_index + 1);
+                }
+
+                return Ok(());
+            }
+
+            let new_length = u32::max(sparse_properties.array_length(), array_index + 1);
+
+            // Transition back to dense properties once the array becomes dense enough
+            if property.is_allowed_as_dense_array_property()
+                && Self::should_transition_to_dense(sparse_properties, new_length)
+            {
+                Self::transition_to_dense_properties(cx, object, new_length)?;
+                return Self::set_property(cx, object, array_index, property);
+            }
+
             if array_index >= sparse_properties.array_length() {
                 sparse_properties.set_array_length(array_index + 1);
             }
 
             let mut sparse_map_field = SparseMapField(object);
-            sparse_map_field
-                .maybe_grow_for_insertion(cx)?
-                .insert_without_growing(array_index, property.to_heap());
+            let mut sparse_properties = sparse_map_field.maybe_grow_for_insertion(cx)?;
+
+            // A property that cannot be stored densely permanently prevents converting back to
+            // dense properties.
+            if !property.is_allowed_as_dense_array_property() {
+                sparse_properties.set_has_non_dense_property();
+            }
+
+            sparse_properties.insert_without_growing(array_index, property.to_heap());
         }
 
         Ok(())
@@ -482,6 +586,9 @@ impl_hash_map_instance!(
 /// Extra header data for a sparse properties map, storing the length of the array.
 pub struct SparseArrayPropertiesExtraStorage {
     array_length: u32,
+    /// Whether a property that is not allowed as a dense array property was ever inserted. Once
+    /// set the array can never transition back to dense properties.
+    has_non_dense_property: bool,
 }
 
 impl SparseArrayPropertiesMap {
@@ -492,10 +599,12 @@ impl SparseArrayPropertiesMap {
         cx: Context,
         capacity: usize,
         array_length: u32,
+        has_non_dense_property: bool,
     ) -> AllocResult<HeapPtr<SparseArrayPropertiesMap>> {
         let mut map = Self::new(cx, capacity)?;
 
-        map.set_array_length(array_length);
+        *map.extra_data_mut() =
+            SparseArrayPropertiesExtraStorage { array_length, has_non_dense_property };
 
         Ok(map)
     }
@@ -506,6 +615,14 @@ impl SparseArrayPropertiesMap {
 
     fn set_array_length(&mut self, array_length: u32) {
         self.extra_data_mut().array_length = array_length;
+    }
+
+    fn has_non_dense_property(&self) -> bool {
+        self.extra_data().has_non_dense_property
+    }
+
+    fn set_has_non_dense_property(&mut self) {
+        self.extra_data_mut().has_non_dense_property = true;
     }
 
     pub fn ordered_keys(&self) -> Vec<u32> {
@@ -529,9 +646,16 @@ impl BsHashMapField<SparseArrayPropertiesMap> for SparseMapField {
         cx: Context,
         capacity: usize,
     ) -> AllocResult<HeapPtr<SparseArrayPropertiesMap>> {
-        let array_length = self.0.array_properties_length();
+        let old_map = self.0.array_properties().as_sparse();
+        let array_length = old_map.array_length();
+        let has_non_dense_property = old_map.has_non_dense_property();
 
-        let new_map = SparseArrayPropertiesMap::new_with_array_length(cx, capacity, array_length)?;
+        let new_map = SparseArrayPropertiesMap::new_with_array_length(
+            cx,
+            capacity,
+            array_length,
+            has_non_dense_property,
+        )?;
         self.0.set_array_properties(new_map.cast());
 
         Ok(new_map)

--- a/tests/integration/built-ins/Array/indexed_property_storage.js
+++ b/tests/integration/built-ins/Array/indexed_property_storage.js
@@ -1,0 +1,402 @@
+/*---
+description: Array indexed properties in both dense and sparse storage.
+---*/
+
+// Array constructor presizes without creating own indexed properties.
+(function () {
+  var a = new Array(2000);
+  assert.sameValue(a.length, 2000);
+  assert.sameValue(0 in a, false);
+  assert.sameValue(1999 in a, false);
+  assert.sameValue(a[0], undefined);
+  assert.sameValue(Object.keys(a).length, 0);
+})();
+
+// Presized array can have all indexed properties filled in and read back.
+(function () {
+  var a = new Array(2000);
+  for (var i = 0; i < 2000; i++) {
+    a[i] = i;
+  }
+  var sum = 0;
+  for (var i = 0; i < 2000; i++) {
+    sum += a[i];
+  }
+  assert.sameValue(sum, 2000 * 1999 / 2);
+  assert.sameValue(a.length, 2000);
+  assert.sameValue(Object.keys(a).length, 2000);
+})();
+
+// Growing the length presizes, preserving existing indexed properties.
+(function () {
+  var a = [1, 2, 3];
+  a.length = 3000;
+  assert.sameValue(a.length, 3000);
+  assert.sameValue(a[0], 1);
+  assert.sameValue(a[2], 3);
+  assert.sameValue(a[2999], undefined);
+  assert.sameValue(2999 in a, false);
+  assert.sameValue(Object.keys(a).length, 3);
+})();
+
+// Appending just past a presized array extends it.
+(function () {
+  var a = new Array(1500);
+  a.push("end");
+  assert.sameValue(a.length, 1501);
+  assert.sameValue(a[1500], "end");
+  a[1501] = "next";
+  assert.sameValue(a.length, 1502);
+})();
+
+// Shrinking removes indexed properties; re-growing does not resurrect them.
+(function () {
+  var a = new Array(2000);
+  a[1500] = "x";
+  a.length = 100;
+  assert.sameValue(a.length, 100);
+  assert.sameValue(a[1500], undefined);
+  a.length = 2000;
+  assert.sameValue(a[1500], undefined);
+  assert.sameValue(1500 in a, false);
+})();
+
+// Enumeration only visits indexed properties that exist, in ascending order.
+(function () {
+  var a = new Array(2000);
+  a[7] = "a";
+  a[3] = "b";
+  a[1999] = "c";
+  var keys = [];
+  for (var key in a) {
+    keys.push(key);
+  }
+  assert.sameValue(keys.join(","), "3,7,1999");
+  assert.sameValue(Object.keys(a).join(","), "3,7,1999");
+})();
+
+// Common methods treat holes as undefined but skip them where specified.
+(function () {
+  var a = new Array(1200);
+  assert.sameValue(a.indexOf(undefined), -1);
+  assert.sameValue(a.fill(2).reduce(function (x, y) { return x + y; }, 0), 2400);
+
+  var b = new Array(1100);
+  b[0] = 1;
+  var visited = 0;
+  b.forEach(function () { visited++; });
+  assert.sameValue(visited, 1);
+})();
+
+// A store far past the end of an empty array is sparse but fully functional.
+(function () {
+  var a = [];
+  a[5000] = "far";
+  assert.sameValue(a.length, 5001);
+  assert.sameValue(a[5000], "far");
+  assert.sameValue(a[0], undefined);
+  assert.sameValue(4999 in a, false);
+  assert.sameValue(Object.keys(a).join(","), "5000");
+
+  delete a[5000];
+  assert.sameValue(5000 in a, false);
+  assert.sameValue(a.length, 5001);
+})();
+
+// Filling a sparse array from the front converts it back to dense storage.
+(function () {
+  var a = [];
+  a[5000] = "far";
+  for (var i = 0; i < 5000; i++) {
+    a[i] = i;
+  }
+  assert.sameValue(a.length, 5001);
+  assert.sameValue(a[5000], "far");
+  var sum = 0;
+  for (var i = 0; i < 5000; i++) {
+    sum += a[i];
+  }
+  assert.sameValue(sum, 5000 * 4999 / 2);
+  assert.sameValue(Object.keys(a).length, 5001);
+})();
+
+// Filling back-to-front also densifies, preserving ascending enumeration order.
+(function () {
+  var a = [];
+  for (var i = 3000; i >= 0; i--) {
+    a[i] = i;
+  }
+  assert.sameValue(a.length, 3001);
+  assert.sameValue(a[0], 0);
+  assert.sameValue(a[3000], 3000);
+
+  var keys = Object.keys(a);
+  assert.sameValue(keys.length, 3001);
+  assert.sameValue(keys[0], "0");
+  assert.sameValue(keys[3000], "3000");
+})();
+
+// Holes remaining after densification still read from the prototype chain.
+(function () {
+  var a = [];
+  a[4000] = "far";
+  for (var i = 0; i < 1500; i++) {
+    a[i] = i;
+  }
+  Array.prototype[2000] = "proto";
+  try {
+    assert.sameValue(a[2000], "proto");
+    assert.sameValue(a.hasOwnProperty(2000), false);
+    assert.sameValue(a[1499], 1499);
+  } finally {
+    delete Array.prototype[2000];
+  }
+})();
+
+// Repeated grows and shrinks across representations keep values consistent.
+(function () {
+  var a = [];
+  a[2000] = "s";     // sparse
+  a.length = 10;     // shrink removes it
+  assert.sameValue(a[2000], undefined);
+  a[5] = "d";
+  a[2000] = "s2";
+  assert.sameValue(a[5], "d");
+  assert.sameValue(a[2000], "s2");
+  assert.sameValue(a.length, 2001);
+})();
+
+// Non-array objects use the same indexed property storage transitions.
+(function () {
+  var o = {};
+  o[4000] = "far";
+  for (var i = 0; i < 1200; i++) {
+    o[i] = i;
+  }
+  assert.sameValue(o[4000], "far");
+  assert.sameValue(o[1199], 1199);
+  assert.sameValue(o[3999], undefined);
+
+  var keys = Object.keys(o);
+  assert.sameValue(keys.length, 1201);
+  assert.sameValue(keys[0], "0");
+  assert.sameValue(keys[1200], "4000");
+})();
+
+// Lengths beyond the dense storage maximum are fully functional.
+(function () {
+  var len = Math.pow(2, 24) + 1;
+  var a = [];
+  a.length = len;
+  assert.sameValue(a.length, len);
+
+  a[len - 1] = "end";
+  a[0] = "start";
+  assert.sameValue(a[len - 1], "end");
+  assert.sameValue(a[0], "start");
+  assert.sameValue(a[12345678], undefined);
+  assert.sameValue(Object.keys(a).length, 2);
+
+  a.length = 10;
+  assert.sameValue(a.length, 10);
+  assert.sameValue(a[0], "start");
+  assert.sameValue(len - 1 in a, false);
+})();
+
+// The Array constructor accepts lengths beyond the dense storage maximum.
+(function () {
+  var len = Math.pow(2, 24) + 10;
+  var a = new Array(len);
+  assert.sameValue(a.length, len);
+  assert.sameValue(0 in a, false);
+
+  a[len - 5] = "x";
+  assert.sameValue(a[len - 5], "x");
+  assert.sameValue(Object.keys(a).join(","), String(len - 5));
+})();
+
+// The maximum array index updates the length; larger keys are named properties.
+(function () {
+  var a = [];
+  a[4294967294] = "max";
+  assert.sameValue(a.length, 4294967295);
+  assert.sameValue(a[4294967294], "max");
+
+  a[4294967295] = "named";
+  assert.sameValue(a.length, 4294967295);
+  assert.sameValue(a[4294967295], "named");
+  assert.sameValue(a.hasOwnProperty("4294967295"), true);
+})();
+
+// Shrinking a sparse array removes only indexed properties beyond the new length.
+(function () {
+  var a = [];
+  a[3000] = "low";
+  a[4000] = "high";
+  a.length = 3500;
+  assert.sameValue(a.length, 3500);
+  assert.sameValue(a[3000], "low");
+  assert.sameValue(4000 in a, false);
+})();
+
+// Array literal holes past the dense to sparse transition do not become own properties.
+(function () {
+  var a = eval("[" + ",".repeat(2000) + "1]");
+  assert.sameValue(a.length, 2001);
+  assert.sameValue(a[2000], 1);
+  assert.sameValue(Object.keys(a).length, 1);
+
+  // Holes must read back as undefined instead of leaking the empty value.
+  assert.sameValue(1500 in a, false);
+  assert.sameValue(a[1500], undefined);
+  assert.sameValue(a[1500] + 1, NaN);
+
+  var visited = 0;
+  a.forEach(function () {
+    visited++;
+  });
+  assert.sameValue(visited, 1);
+  assert.sameValue(a.filter(function () { return true; }).length, 1);
+})();
+
+// Array literal that is entirely holes past the transition has no own properties.
+(function () {
+  var a = eval("[" + ",".repeat(2000) + "]");
+  assert.sameValue(a.length, 2000);
+  assert.sameValue(Object.keys(a).length, 0);
+  assert.sameValue(0 in a, false);
+  assert.sameValue(1999 in a, false);
+})();
+
+// Storing a hole into a sparse array extends the length without adding a property.
+(function () {
+  var a = [];
+  a[5000] = 1;
+  assert.sameValue(Object.keys(a).length, 1);
+
+  a.length = 0;
+  a[8000] = 2;
+  assert.sameValue(a.length, 8001);
+  assert.sameValue(Object.keys(a).join(","), "8000");
+})();
+
+// Indices beyond the maximum dense array length are stored sparsely.
+(function () {
+  var a = [1, 2, 3];
+  a[20000000] = "far";
+  assert.sameValue(a.length, 20000001);
+  assert.sameValue(a[20000000], "far");
+  assert.sameValue(Object.keys(a).length, 4);
+  assert.sameValue(1000000 in a, false);
+  assert.sameValue(a[1000000], undefined);
+})();
+
+// An array that becomes sparse and is then refilled densely keeps all of its properties.
+(function () {
+  var a = [];
+  for (var i = 0; i < 100; i++) {
+    a[i] = i;
+  }
+
+  // Far past the end of a mostly empty array, forcing sparse storage.
+  a[50000] = "far";
+  assert.sameValue(a.length, 50001);
+  assert.sameValue(a[0], 0);
+  assert.sameValue(a[99], 99);
+  assert.sameValue(a[50000], "far");
+  assert.sameValue(Object.keys(a).length, 101);
+  assert.sameValue(1000 in a, false);
+
+  // Refilling makes the array dense enough to be stored densely again.
+  for (var i = 100; i < 50000; i++) {
+    a[i] = i;
+  }
+  assert.sameValue(a.length, 50001);
+  assert.sameValue(a[0], 0);
+  assert.sameValue(a[49999], 49999);
+  assert.sameValue(a[50000], "far");
+  assert.sameValue(Object.keys(a).length, 50001);
+})();
+
+// Arrays around the minimum sparse length stay correct no matter how many holes they have.
+(function () {
+  var a = [];
+  a[1023] = "end";
+  assert.sameValue(a.length, 1024);
+  assert.sameValue(a[1023], "end");
+  assert.sameValue(Object.keys(a).join(","), "1023");
+  assert.sameValue(0 in a, false);
+  assert.sameValue(a[0], undefined);
+
+  var b = [];
+  b[1024] = "end";
+  assert.sameValue(b.length, 1025);
+  assert.sameValue(b[1024], "end");
+  assert.sameValue(Object.keys(b).join(","), "1024");
+  assert.sameValue(0 in b, false);
+  assert.sameValue(b[0], undefined);
+})();
+
+// Growing a partially filled array across the density threshold preserves every property.
+(function () {
+  var a = [];
+  for (var i = 0; i < 300; i++) {
+    a[i] = i;
+  }
+
+  // Still filled enough to stay dense.
+  a[2399] = "near";
+  assert.sameValue(a.length, 2400);
+  assert.sameValue(a[299], 299);
+  assert.sameValue(a[2399], "near");
+  assert.sameValue(Object.keys(a).length, 301);
+
+  // Now far too empty to stay dense.
+  a[24000] = "far";
+  assert.sameValue(a.length, 24001);
+  assert.sameValue(a[0], 0);
+  assert.sameValue(a[299], 299);
+  assert.sameValue(a[2399], "near");
+  assert.sameValue(a[24000], "far");
+  assert.sameValue(Object.keys(a).length, 302);
+  assert.sameValue(300 in a, false);
+})();
+
+// Repeatedly crossing the dense and sparse thresholds keeps the array consistent.
+(function () {
+  var a = [];
+  for (var round = 0; round < 3; round++) {
+    a[20000] = "far";
+    assert.sameValue(a.length, 20001);
+    assert.sameValue(Object.keys(a).length, 1);
+
+    for (var i = 0; i < 20000; i++) {
+      a[i] = i;
+    }
+    assert.sameValue(a[0], 0);
+    assert.sameValue(a[19999], 19999);
+    assert.sameValue(a[20000], "far");
+    assert.sameValue(Object.keys(a).length, 20001);
+
+    a.length = 0;
+    assert.sameValue(a.length, 0);
+    assert.sameValue(Object.keys(a).length, 0);
+    assert.sameValue(0 in a, false);
+  }
+})();
+
+// A length beyond the maximum dense length is stored sparsely without presizing.
+(function () {
+  var a = [1, 2, 3];
+  a.length = 20000000;
+  assert.sameValue(a.length, 20000000);
+  assert.sameValue(a[0], 1);
+  assert.sameValue(a[2], 3);
+  assert.sameValue(Object.keys(a).length, 3);
+  assert.sameValue(1000000 in a, false);
+
+  a[19999999] = "end";
+  assert.sameValue(a[19999999], "end");
+  assert.sameValue(a.length, 20000000);
+  assert.sameValue(Object.keys(a).length, 4);
+})();

--- a/tests/integration/built-ins/Array/indexed_property_storage_non_default.js
+++ b/tests/integration/built-ins/Array/indexed_property_storage_non_default.js
@@ -1,0 +1,246 @@
+/*---
+description: Array indexed properties with non-default attributes.
+---*/
+
+// Non-default attributes survive filling a sparse array densely.
+(function () {
+  var a = [];
+  a[2000] = "far";
+  Object.defineProperty(a, 100, {
+    value: "fixed",
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+
+  for (var i = 0; i < 2000; i++) {
+    if (i !== 100) {
+      a[i] = i;
+    }
+  }
+
+  assert.sameValue(a[100], "fixed");
+  assert.sameValue(a[1999], 1999);
+  assert.sameValue(a.length, 2001);
+
+  var desc = Object.getOwnPropertyDescriptor(a, 100);
+  assert.sameValue(desc.writable, false);
+  assert.sameValue(desc.enumerable, false);
+  assert.sameValue(desc.configurable, false);
+
+  // Non-enumerable indexed property is skipped by enumeration but still readable.
+  assert.sameValue(Object.keys(a).indexOf("100"), -1);
+  assert.sameValue(100 in a, true);
+
+  // Writes to the non-writable indexed property fail.
+  assert.throws(TypeError, function () {
+    "use strict";
+    a[100] = "changed";
+  });
+  assert.sameValue(a[100], "fixed");
+})();
+
+// Accessors on array indexes survive dense fills and keep being invoked.
+(function () {
+  var a = [];
+  a[1500] = "far";
+  var gets = 0;
+  Object.defineProperty(a, 50, {
+    get: function () { gets++; return "got"; },
+    configurable: true,
+  });
+
+  for (var i = 0; i < 1500; i++) {
+    if (i !== 50) {
+      a[i] = i;
+    }
+  }
+
+  assert.sameValue(a[50], "got");
+  assert.sameValue(a[50], "got");
+  assert.sameValue(gets, 2);
+  assert.sameValue(a[1499], 1499);
+})();
+
+// Defining a non-default indexed property preserves the other indexed properties.
+(function () {
+  var a = [];
+  for (var i = 0; i < 1200; i++) {
+    a[i] = i;
+  }
+  Object.defineProperty(a, 600, { value: "mid", writable: false });
+
+  assert.sameValue(a[600], "mid");
+  assert.sameValue(a[599], 599);
+  assert.sameValue(a[601], 601);
+  assert.sameValue(a.length, 1200);
+
+  // The array continues to accept normal stores and grows.
+  a[1200] = "end";
+  assert.sameValue(a[1200], "end");
+  assert.sameValue(a.length, 1201);
+})();
+
+// Length shrink stops at a non-configurable indexed property.
+(function () {
+  var a = [];
+  a[2000] = "far";
+  Object.defineProperty(a, 5, { value: "keep", configurable: false });
+
+  try {
+    a.length = 3;
+  } catch (e) {
+    // Throws in strict mode after partially shrinking
+  }
+
+  assert.sameValue(a.length, 6);
+  assert.sameValue(a[5], "keep");
+  assert.sameValue(a[2000], undefined);
+})();
+
+// Frozen arrays reject all indexed property stores and length changes.
+(function () {
+  var a = [1, 2, 3];
+  Object.freeze(a);
+  assert.throws(TypeError, function () {
+    "use strict";
+    a[0] = 10;
+  });
+  assert.throws(TypeError, function () {
+    "use strict";
+    a[3] = 4;
+  });
+  assert.throws(TypeError, function () {
+    "use strict";
+    a.length = 1;
+  });
+  assert.sameValue(a.join(","), "1,2,3");
+})();
+
+// Non-default attributes on a dense array are preserved instead of stored densely.
+(function () {
+  var a = [1, 2, 3];
+  Object.defineProperty(a, 1, {
+    value: "fixed",
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+
+  var desc = Object.getOwnPropertyDescriptor(a, 1);
+  assert.sameValue(desc.value, "fixed");
+  assert.sameValue(desc.writable, false);
+  assert.sameValue(desc.enumerable, false);
+  assert.sameValue(desc.configurable, false);
+
+  assert.sameValue(Object.keys(a).indexOf("1"), -1);
+  assert.sameValue(1 in a, true);
+  assert.throws(TypeError, function () {
+    "use strict";
+    a[1] = "changed";
+  });
+  assert.sameValue(a[1], "fixed");
+
+  // Surrounding indexed properties are untouched.
+  assert.sameValue(a[0], 1);
+  assert.sameValue(a[2], 3);
+  assert.sameValue(a.length, 3);
+})();
+
+// Accessors defined on a dense array keep accessor semantics.
+(function () {
+  var a = [1, 2, 3];
+  var gets = 0;
+  var sets = 0;
+  Object.defineProperty(a, 0, {
+    get: function () {
+      gets++;
+      return "got";
+    },
+    set: function () {
+      sets++;
+    },
+    configurable: true,
+  });
+
+  assert.sameValue(a[0], "got");
+  assert.sameValue(gets, 1);
+
+  a[0] = "ignored";
+  assert.sameValue(sets, 1);
+  assert.sameValue(a[0], "got");
+
+  var desc = Object.getOwnPropertyDescriptor(a, 0);
+  assert.sameValue(typeof desc.get, "function");
+  assert.sameValue(typeof desc.set, "function");
+  assert.sameValue(desc.value, undefined);
+  assert.sameValue(a[1], 2);
+})();
+
+// Non-default attributes survive shrinking a sparse array and then refilling it densely.
+(function () {
+  var a = [];
+  a[5000] = "far";
+  Object.defineProperty(a, 10, {
+    value: "fixed",
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+
+  // Shrinking rebuilds the sparse map, which must not forget the non-default property.
+  a.length = 200;
+  assert.sameValue(a.length, 200);
+  assert.sameValue(a[10], "fixed");
+  assert.sameValue(5000 in a, false);
+
+  // Refill densely. The array must not be stored densely again, which would drop attributes.
+  for (var i = 0; i < 200; i++) {
+    if (i !== 10) {
+      a[i] = i;
+    }
+  }
+
+  var desc = Object.getOwnPropertyDescriptor(a, 10);
+  assert.sameValue(desc.value, "fixed");
+  assert.sameValue(desc.writable, false);
+  assert.sameValue(desc.enumerable, false);
+  assert.sameValue(desc.configurable, false);
+
+  assert.sameValue(Object.keys(a).indexOf("10"), -1);
+  assert.sameValue(a[0], 0);
+  assert.sameValue(a[199], 199);
+  assert.throws(TypeError, function () {
+    "use strict";
+    a[10] = "changed";
+  });
+})();
+
+// An accessor survives shrinking a sparse array and then refilling it densely.
+(function () {
+  var a = [];
+  a[4000] = "far";
+  var gets = 0;
+  Object.defineProperty(a, 20, {
+    get: function () {
+      gets++;
+      return "got";
+    },
+    configurable: true,
+  });
+
+  a.length = 300;
+  assert.sameValue(a.length, 300);
+  assert.sameValue(a[20], "got");
+  assert.sameValue(gets, 1);
+
+  for (var i = 0; i < 300; i++) {
+    if (i !== 20) {
+      a[i] = i;
+    }
+  }
+
+  assert.sameValue(a[20], "got");
+  assert.sameValue(gets, 2);
+  assert.sameValue(a[299], 299);
+})();


### PR DESCRIPTION
## Summary

Improve heuristics for when array properties are stored in the dense vs sparse representation. Now:

- Max dense array size of 2^24, after that always sparse
- Always dense under size 1024
- Transition from dense to sparse if less than 1/8 full, transition from sparse to dense if more than 1/4 full

This allows for the common pattern of presizing a larger array up front then densely filling it in.

Significant improvement to octane score, +10.4% due to a whopping +248.7% on NavierStokes, which was previously always using sparse array storage.

| Benchmark | f1eb32bcf (base) | a4d6caf41 | Change |
|---|---|---|---|
| Richards | 2,231 med 2,193 ±43.9 n=4 | 2,254 med 2,250 ±6.9 n=4 | +1.0% |
| DeltaBlue | 2,343 med 2,312 ±28.0 n=4 | 2,351 med 2,341 ±23.3 n=4 | +0.3% |
| Crypto | 2,358 med 2,155 ±217 n=4 | 2,368 med 2,321 ±176 n=4 | +0.4% |
| RayTrace | 2,872 med 2,852 ±42.5 n=4 | 2,860 med 2,840 ±13.7 n=4 | -0.4% |
| EarleyBoyer | 5,032 med 5,017 ±38.0 n=4 | 4,996 med 4,950 ±24.8 n=4 | -0.7% |
| RegExp | 438 med 437 ±3.7 n=4 | 439 med 438 ±0.5 n=4 | +0.2% |
| Splay | 4,474 med 4,401 ±114 n=4 | 4,453 med 4,429 ±30.1 n=4 | -0.5% |
| SplayLatency | 7,121 med 6,941 ±243 n=4 | 7,087 med 7,056 ±62.7 n=4 | -0.5% |
| NavierStokes | 1,187 med 1,183 ±6.1 n=4 | 4,139 med 4,135 ±8.2 n=4 | +248.7% |
| PdfJS | 4,632 med 4,615 ±39.2 n=4 | 5,609 med 5,597 ±11.9 n=4 | +21.1% |
| Mandreel | 1,009 med 1,000 ±10.1 n=4 | 1,031 med 1,025 ±11.4 n=4 | +2.2% |
| MandreelLatency | 6,755 med 6,728 ±65.5 n=4 | 6,838 med 6,820 ±17.0 n=4 | +1.2% |
| Gameboy | 4,138 med 4,117 ±20.7 n=4 | 4,240 med 4,221 ±19.0 n=4 | +2.5% |
| CodeLoad | 39,856 med 39,653 ±350 n=4 | 39,632 med 39,544 ±51.0 n=4 | -0.6% |
| Box2D | 8,109 med 8,034 ±82.7 n=4 | 8,162 med 8,105 ±33.4 n=4 | +0.7% |
| zlib | 2,248 med 2,231 ±13.1 n=4 | 2,282 med 2,255 ±20.3 n=4 | +1.5% |
| Typescript | 17,989 med 17,952 ±28.0 n=4 | 18,317 med 18,278 ±42.0 n=4 | +1.8% |
| **Total (octane)** | **3,676 med 3,668 ±13.4 n=4** | **4,057 med 4,049 ±22.1 n=4** | **+10.4%** |

## Tests

- Added LLM generated tests for array storage across dense and sparse formats