### PR TITLE
[runtime] Fast path for GetProperty and SetProperty on typed arrays

### DIFF
--- a/src/js/common/math.rs
+++ b/src/js/common/math.rs
@@ -2,6 +2,8 @@ use std::ops::{Add, Rem};
 
 use half::f16;
 
+use crate::common::numeric::{MAX_U32_PLUS_ONE_AS_F64, Numeric};
+
 /// Spec-compliant modulo implementation
 #[inline]
 pub fn modulo<T>(a: T, b: T) -> T
@@ -68,6 +70,39 @@ pub fn f64_to_f16(value: f64) -> f16 {
     // Convert sign bit to f16 location then reapply to value
     let f16_sign = (f64_sign >> 48) as u16;
     f16::from_bits(result | f16_sign)
+}
+
+/// Convert an f64 to a u32 forming the core of the spec's ToIntN/ToUintN methods.
+#[inline]
+pub fn f64_to_wrapping_u32(value: f64) -> u32 {
+    // Number is truncated towards zero
+    let f64_int = value.trunc();
+
+    // A wrapping cast through i64 is exact for all integers in (-2^32, 2^32)
+    if f64_int > -MAX_U32_PLUS_ONE_AS_F64 && f64_int < MAX_U32_PLUS_ONE_AS_F64 {
+        return f64_int as i64 as u32;
+    }
+
+    // All infinities and NaNs map to zero
+    if !f64_int.is_finite() {
+        return 0;
+    }
+
+    // Modulo into range
+    modulo(f64_int, MAX_U32_PLUS_ONE_AS_F64) as u32
+}
+
+/// ToUint8Clamp (https://tc39.es/ecma262/#sec-touint8clamp) specialized for an f64
+#[inline]
+pub fn f64_to_clamped_u8(value: f64) -> u8 {
+    if value >= u8::MAX_AS_F64 {
+        u8::MAX
+    } else if value > 0.0 {
+        value.round_ties_even() as u8
+    } else {
+        // Zero, negative, or NaN, all of which clamp to zero
+        0
+    }
 }
 
 pub const fn is_negative_zero(value: f64) -> bool {

--- a/src/js/common/numeric.rs
+++ b/src/js/common/numeric.rs
@@ -111,8 +111,6 @@ pub const MIN_SAFE_INTEGER_F64: f64 = -9007199254740991.0;
 
 pub const MIN_POSITIVE_SUBNORMAL_F64: f64 = 5e-324;
 
-pub const MAX_U8_PLUS_ONE_AS_F64: f64 = (u8::MAX as u16 + 1) as f64;
-pub const MAX_U16_PLUS_ONE_AS_F64: f64 = (u16::MAX as u32 + 1) as f64;
 pub const MAX_U32_PLUS_ONE_AS_F64: f64 = (u32::MAX as u64 + 1) as f64;
 pub const MAX_I32_PLUS_ONE_AS_F64: f64 = (i32::MAX as i64 + 1) as f64;
 

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -111,7 +111,7 @@ use crate::{
         eval_result::EvalError,
         for_in_iterator::ForInIterator,
         function::build_function_name,
-        gc::{AnyHeapItem, HeapVisitor},
+        gc::{AnyHeapItem, HeapItemKind, HeapVisitor},
         generator_object::{GeneratorCompletionType, GeneratorObject, TGeneratorObject},
         get,
         intrinsics::{
@@ -120,6 +120,7 @@ use crate::{
             native_error::{ReferenceError, TypeError},
             regexp_object::RegExpObject,
             rust_runtime::RuntimeFunctionId,
+            typed_array_fast::{typed_array_fast_get, typed_array_fast_set},
         },
         iterator::{IteratorHint, get_iterator, iterator_complete, iterator_value},
         module::{execute::dynamic_import, source_text_module::SourceTextModule},
@@ -4274,11 +4275,11 @@ impl VM {
         let object = self.read_register(instr.object());
         let key = self.read_register(instr.key());
 
-        // Fast path for loads on dense arrays
-        if object.is_object() && key.is_smi() {
-            let object = object.as_object();
-            if object.is::<ArrayObject>()
-                && let Some(dense_properties) = object.array_properties().as_dense_opt()
+        // Fast path for loads on dense arrays and typed arrays
+        if object.is_pointer() && key.is_smi() {
+            let kind = object.as_pointer().shape().kind();
+            if kind == HeapItemKind::ArrayObject
+                && let Some(dense_properties) = object.as_object().array_properties().as_dense_opt()
             {
                 let index = key.as_smi() as u32;
                 if (index as i32) >= 0 && index < dense_properties.len() {
@@ -4287,6 +4288,13 @@ impl VM {
                         self.write_register(instr.dest(), value);
                         return Ok(());
                     }
+                }
+            } else {
+                // Cast negative smi keys to usize. They are guaranteed to fail bounds checks.
+                let index = key.as_smi() as usize;
+                if let Some(value) = typed_array_fast_get(object.as_pointer(), kind, index) {
+                    self.write_register(instr.dest(), value);
+                    return Ok(());
                 }
             }
         }
@@ -4332,11 +4340,12 @@ impl VM {
         let object = self.read_register(instr.object());
         let key = self.read_register(instr.key());
 
-        // Fast path for stores on dense arrays
-        if object.is_object() && key.is_smi() {
-            let object = object.as_object();
-            if object.is::<ArrayObject>()
-                && let Some(mut dense_properties) = object.array_properties().as_dense_opt()
+        // Fast path for stores on dense arrays and typed arrays
+        if object.is_pointer() && key.is_smi() {
+            let kind = object.as_pointer().shape().kind();
+            if kind == HeapItemKind::ArrayObject
+                && let Some(mut dense_properties) =
+                    object.as_object().array_properties().as_dense_opt()
             {
                 let index = key.as_smi() as u32;
                 if (index as i32) >= 0
@@ -4344,6 +4353,12 @@ impl VM {
                     && !dense_properties.get_unchecked(index).is_empty()
                 {
                     dense_properties.set_unchecked(index, self.read_register(instr.value()));
+                    return Ok(());
+                }
+            } else {
+                // Cast negative smi keys to usize. They are guaranteed to fail bounds checks.
+                let value = self.read_register(instr.value());
+                if typed_array_fast_set(object.as_pointer(), kind, key.as_smi() as usize, value) {
                     return Ok(());
                 }
             }

--- a/src/js/runtime/intrinsics/array_buffer_object.rs
+++ b/src/js/runtime/intrinsics/array_buffer_object.rs
@@ -120,6 +120,12 @@ impl ArrayBufferObject {
         self.data.map(|data| data.to_handle())
     }
 
+    /// The buffer's backing data, or None if the buffer is detached.
+    #[inline]
+    pub fn data_ptr(&self) -> Option<HeapPtr<ByteArray>> {
+        self.data
+    }
+
     pub fn set_data(&mut self, data: HeapPtr<ByteArray>) {
         self.data = Some(data);
     }

--- a/src/js/runtime/intrinsics/mod.rs
+++ b/src/js/runtime/intrinsics/mod.rs
@@ -83,6 +83,7 @@ mod symbol_prototype;
 pub mod temporal;
 pub mod typed_array;
 mod typed_array_constructor;
+pub mod typed_array_fast;
 mod typed_array_object;
 mod typed_array_prototype;
 mod utils;

--- a/src/js/runtime/intrinsics/typed_array_fast.rs
+++ b/src/js/runtime/intrinsics/typed_array_fast.rs
@@ -1,0 +1,254 @@
+use half::f16;
+
+use crate::{
+    common::math::{f64_to_clamped_u8, f64_to_f16, f64_to_wrapping_u32},
+    runtime::{
+        HeapItemKind, HeapPtr, Value,
+        gc::AnyHeapItem,
+        intrinsics::{
+            array_buffer_object::ArrayBufferObject,
+            typed_array::{
+                Float16ArrayObject, Float32ArrayObject, Float64ArrayObject, Int8ArrayObject,
+                Int16ArrayObject, Int32ArrayObject, UInt8ArrayObject, UInt8ClampedArrayObject,
+                UInt16ArrayObject, UInt32ArrayObject,
+            },
+        },
+    },
+};
+
+/// Generic fast path element conversion.
+trait FastElement: Copy {
+    /// Convert the element to a value. Cannot allocate or fail.
+    fn to_value(self) -> Value;
+
+    /// Convert the value to an element, or None if the value is not a number. Cannot allocate.
+    fn from_value(value: Value) -> Option<Self>;
+}
+
+macro_rules! impl_fast_elements {
+    ($(($element_type:ty, $from_value:expr),)*) => {
+        $(impl FastElement for $element_type {
+            #[inline]
+            fn to_value(self) -> Value {
+                Value::number(self)
+            }
+
+            #[inline]
+            fn from_value(value: Value) -> Option<Self> {
+                $from_value(value)
+            }
+        })*
+    };
+}
+
+// Spec's ToIntN/ToUintN is converting to a wrapped u32 then truncating to the element's width.
+impl_fast_elements! {
+    (i8, |value| Some(value_to_wrapping_u32(value)? as i8)),
+    (u8, |value| Some(value_to_wrapping_u32(value)? as u8)),
+    (i16, |value| Some(value_to_wrapping_u32(value)? as i16)),
+    (u16, |value| Some(value_to_wrapping_u32(value)? as u16)),
+    (i32, |value| Some(value_to_wrapping_u32(value)? as i32)),
+    (u32, value_to_wrapping_u32),
+    (f32, |value| Some(value_to_f64(value)? as f32)),
+    (f64, value_to_f64),
+}
+
+impl FastElement for f16 {
+    #[inline]
+    fn to_value(self) -> Value {
+        Value::number(self.to_f64())
+    }
+
+    #[inline]
+    fn from_value(value: Value) -> Option<Self> {
+        Some(f64_to_f16(value_to_f64(value)?))
+    }
+}
+
+/// Uint8Clamped elements are identical to u8 except with custom clamping logic.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+struct ClampedU8(u8);
+
+impl FastElement for ClampedU8 {
+    #[inline]
+    fn to_value(self) -> Value {
+        Value::number(self.0)
+    }
+
+    #[inline]
+    fn from_value(value: Value) -> Option<Self> {
+        if value.is_smi() {
+            Some(ClampedU8(value.as_smi().clamp(0, u8::MAX as i32) as u8))
+        } else if value.is_double() {
+            Some(ClampedU8(f64_to_clamped_u8(value.as_double())))
+        } else {
+            None
+        }
+    }
+}
+
+/// Convert value to an f64 if it is a number, or None if value is not a number.
+#[inline]
+fn value_to_f64(value: Value) -> Option<f64> {
+    if value.is_smi() {
+        Some(value.as_smi() as f64)
+    } else if value.is_double() {
+        Some(value.as_double())
+    } else {
+        None
+    }
+}
+
+/// Convert value to a u32 (following the spec's ToInt32/ToUint32) if it is a number, or None if
+/// value is not a number.
+#[inline]
+fn value_to_wrapping_u32(value: Value) -> Option<u32> {
+    if value.is_smi() {
+        Some(value.as_smi() as u32)
+    } else if value.is_double() {
+        Some(f64_to_wrapping_u32(value.as_double()))
+    } else {
+        None
+    }
+}
+
+/// Return the pointer to the element at `index` in the typed array with the given fields.
+///
+/// Return None if the buffer is detached or the index is out of bounds (possibly due to resizing).
+#[inline]
+fn fast_element_ptr<T>(
+    buffer: HeapPtr<ArrayBufferObject>,
+    byte_offset: usize,
+    array_length: Option<usize>,
+    index: usize,
+) -> Option<*mut T> {
+    let mut data = buffer.data_ptr()?;
+    let data = data.as_mut_slice();
+
+    debug_assert!(data.len() == buffer.byte_length());
+
+    let array_length = match array_length {
+        Some(array_length) => {
+            // The entire fixed length typed array is invalid if the underlying buffer has shrunk
+            // below the necessary length for the typed array.
+            if byte_offset + array_length * size_of::<T>() > data.len() {
+                return None;
+            }
+
+            array_length
+        }
+        // Resizable typed arrays use the underlying buffer size to determine their length
+        None => data.len().checked_sub(byte_offset)? / size_of::<T>(),
+    };
+
+    if index >= array_length {
+        return None;
+    }
+
+    let element_offset = byte_offset + index * size_of::<T>();
+    let element_ptr = unsafe { data.as_mut_ptr().add(element_offset) }.cast::<T>();
+
+    Some(element_ptr)
+}
+
+/// Fast path for getting an element from a specific typed array kind.
+#[inline]
+fn fast_get_element<T: FastElement>(
+    buffer: HeapPtr<ArrayBufferObject>,
+    byte_offset: usize,
+    array_length: Option<usize>,
+    index: usize,
+) -> Value {
+    match fast_element_ptr::<T>(buffer, byte_offset, array_length, index) {
+        Some(element_ptr) => unsafe { element_ptr.read() }.to_value(),
+        None => Value::undefined(),
+    }
+}
+
+/// Fast path for setting an element on a specific typed array kind.
+///
+/// Returns true if the store was handled, or false if the slow path must be taken.
+#[inline]
+fn fast_set_element<T: FastElement>(
+    buffer: HeapPtr<ArrayBufferObject>,
+    byte_offset: usize,
+    array_length: Option<usize>,
+    index: usize,
+    value: Value,
+) -> bool {
+    let Some(element) = T::from_value(value) else {
+        return false;
+    };
+
+    if let Some(element_ptr) = fast_element_ptr::<T>(buffer, byte_offset, array_length, index) {
+        unsafe { element_ptr.write(element) };
+    }
+
+    true
+}
+
+macro_rules! create_typed_array_fast_paths {
+    ($(($kind:ident, $element_type:ty),)*) => {
+        /// Fast path for getting an element from any kind of typed array.
+        ///
+        /// Returns the value if the load was handled, None if the slow path must be taken.
+        #[inline]
+        pub fn typed_array_fast_get(
+            object: HeapPtr<AnyHeapItem>,
+            kind: HeapItemKind,
+            index: usize,
+        ) -> Option<Value> {
+            match kind {
+                $(HeapItemKind::$kind => {
+                    let typed_array = object.cast::<$kind>();
+                    Some(fast_get_element::<$element_type>(
+                        typed_array.viewed_array_buffer_ptr(),
+                        typed_array.byte_offset(),
+                        typed_array.array_length(),
+                        index,
+                    ))
+                })*
+                _ => None,
+            }
+        }
+
+        /// Fast path for setting an element on any kind of typed array.
+        ///
+        /// Returns true if the store was handled, false if the slow path must be taken.
+        #[inline]
+        pub fn typed_array_fast_set(
+            object: HeapPtr<AnyHeapItem>,
+            kind: HeapItemKind,
+            index: usize,
+            value: Value,
+        ) -> bool {
+            match kind {
+                $(HeapItemKind::$kind => {
+                    let typed_array = object.cast::<$kind>();
+                    fast_set_element::<$element_type>(
+                        typed_array.viewed_array_buffer_ptr(),
+                        typed_array.byte_offset(),
+                        typed_array.array_length(),
+                        index,
+                        value,
+                    )
+                })*
+                _ => false,
+            }
+        }
+    };
+}
+
+create_typed_array_fast_paths!(
+    (Int8ArrayObject, i8),
+    (UInt8ArrayObject, u8),
+    (UInt8ClampedArrayObject, ClampedU8),
+    (Int16ArrayObject, i16),
+    (UInt16ArrayObject, u16),
+    (Int32ArrayObject, i32),
+    (UInt32ArrayObject, u32),
+    (Float16ArrayObject, f16),
+    (Float32ArrayObject, f32),
+    (Float64ArrayObject, f64),
+);

--- a/src/js/runtime/intrinsics/typed_array_object.rs
+++ b/src/js/runtime/intrinsics/typed_array_object.rs
@@ -58,6 +58,21 @@ macro_rules! create_typed_array_object {
             }
 
             #[inline]
+            pub fn viewed_array_buffer_ptr(&self) -> HeapPtr<ArrayBufferObject> {
+                self.viewed_array_buffer
+            }
+
+            #[inline]
+            pub fn array_length(&self) -> Option<usize> {
+                self.array_length
+            }
+
+            #[inline]
+            pub fn byte_offset(&self) -> usize {
+                self.byte_offset
+            }
+
+            #[inline]
             fn write_element(
                 mut array_buffer: HeapPtr<ArrayBufferObject>,
                 byte_index: usize,

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -4,11 +4,8 @@ use num_bigint::{BigInt, ToBigInt};
 
 use crate::{
     common::{
-        math::modulo,
-        numeric::{
-            MAX_SAFE_INTEGER_F64, MAX_U8_PLUS_ONE_AS_F64, MAX_U16_PLUS_ONE_AS_F64,
-            MAX_U32_PLUS_ONE_AS_F64, Numeric,
-        },
+        math::{f64_to_clamped_u8, f64_to_wrapping_u32},
+        numeric::MAX_SAFE_INTEGER_F64,
     },
     must_a,
     runtime::{
@@ -256,22 +253,7 @@ pub fn to_int32(cx: Context, value_handle: Handle<Value>) -> EvalResult<i32> {
     }
 
     let number_value = to_number(cx, value_handle)?;
-
-    // Number is truncated towards zero
-    let f64_int = number_value.as_number().trunc();
-
-    // Integer f64 is in range and can be directly converted
-    if (i32::MIN_AS_F64..=i32::MAX_AS_F64).contains(&f64_int) {
-        return Ok(f64_int as i32);
-    }
-
-    // All infinities and NaNs map to zero
-    if !f64_int.is_finite() {
-        return Ok(0);
-    }
-
-    // Modulo into u32 range then reinterpret as i32
-    Ok(modulo(f64_int, MAX_U32_PLUS_ONE_AS_F64) as u32 as i32)
+    Ok(f64_to_wrapping_u32(number_value.as_number()) as i32)
 }
 
 /// ToUint32 (https://tc39.es/ecma262/#sec-touint32)
@@ -283,22 +265,7 @@ pub fn to_uint32(cx: Context, value_handle: Handle<Value>) -> EvalResult<u32> {
     }
 
     let number_value = to_number(cx, value_handle)?;
-
-    // Number is truncated towards zero
-    let f64_int = number_value.as_number().trunc();
-
-    // Integer f64 is in range and can be directly converted
-    if (0.0..=u32::MAX_AS_F64).contains(&f64_int) {
-        return Ok(f64_int as u32);
-    }
-
-    // All infinities and NaNs map to zero
-    if !f64_int.is_finite() {
-        return Ok(0);
-    }
-
-    // Modulo into range
-    Ok(modulo(f64_int, MAX_U32_PLUS_ONE_AS_F64) as u32)
+    Ok(f64_to_wrapping_u32(number_value.as_number()))
 }
 
 /// ToInt16 (https://tc39.es/ecma262/#sec-toint16)
@@ -310,22 +277,7 @@ pub fn to_int16(cx: Context, value_handle: Handle<Value>) -> EvalResult<i16> {
     }
 
     let number_value = to_number(cx, value_handle)?;
-
-    // Number is truncated towards zero
-    let f64_int = number_value.as_number().trunc();
-
-    // Integer f64 is in range and can be directly converted
-    if (i16::MIN_AS_F64..=i16::MAX_AS_F64).contains(&f64_int) {
-        return Ok(f64_int as i16);
-    }
-
-    // All infinities and NaNs map to zero
-    if !f64_int.is_finite() {
-        return Ok(0);
-    }
-
-    // Modulo into u16 range then reinterpret as i16
-    Ok(modulo(f64_int, MAX_U16_PLUS_ONE_AS_F64) as u16 as i16)
+    Ok(f64_to_wrapping_u32(number_value.as_number()) as i16)
 }
 
 /// ToUint16 (https://tc39.es/ecma262/#sec-touint16)
@@ -337,22 +289,7 @@ pub fn to_uint16(cx: Context, value_handle: Handle<Value>) -> EvalResult<u16> {
     }
 
     let number_value = to_number(cx, value_handle)?;
-
-    // Number is truncated towards zero
-    let f64_int = number_value.as_number().trunc();
-
-    // Integer f64 is in range and can be directly converted
-    if (0.0..=u16::MAX_AS_F64).contains(&f64_int) {
-        return Ok(f64_int as u16);
-    }
-
-    // All infinities and NaNs map to zero
-    if !f64_int.is_finite() {
-        return Ok(0);
-    }
-
-    // Modulo into range
-    Ok(modulo(f64_int, MAX_U16_PLUS_ONE_AS_F64) as u16)
+    Ok(f64_to_wrapping_u32(number_value.as_number()) as u16)
 }
 
 /// ToInt8 (https://tc39.es/ecma262/#sec-toint8)
@@ -364,22 +301,7 @@ pub fn to_int8(cx: Context, value_handle: Handle<Value>) -> EvalResult<i8> {
     }
 
     let number_value = to_number(cx, value_handle)?;
-
-    // Number is truncated towards zero
-    let f64_int = number_value.as_number().trunc();
-
-    // Integer f64 is in range and can be directly converted
-    if (i8::MIN_AS_F64..=i8::MAX_AS_F64).contains(&f64_int) {
-        return Ok(f64_int as i8);
-    }
-
-    // All infinities and NaNs map to zero
-    if !f64_int.is_finite() {
-        return Ok(0);
-    }
-
-    // Modulo into u8 range then reinterpret as i8
-    Ok(modulo(f64_int, MAX_U8_PLUS_ONE_AS_F64) as u8 as i8)
+    Ok(f64_to_wrapping_u32(number_value.as_number()) as i8)
 }
 
 /// ToUint8 (https://tc39.es/ecma262/#sec-touint8)
@@ -391,22 +313,7 @@ pub fn to_uint8(cx: Context, value_handle: Handle<Value>) -> EvalResult<u8> {
     }
 
     let number_value = to_number(cx, value_handle)?;
-
-    // Number is truncated towards zero
-    let f64_int = number_value.as_number().trunc();
-
-    // Integer f64 is in range and can be directly converted
-    if (0.0..=u8::MAX_AS_F64).contains(&f64_int) {
-        return Ok(f64_int as u8);
-    }
-
-    // All infinities and NaNs map to zero
-    if !f64_int.is_finite() {
-        return Ok(0);
-    }
-
-    // Modulo into range
-    Ok(modulo(f64_int, MAX_U8_PLUS_ONE_AS_F64) as u8)
+    Ok(f64_to_wrapping_u32(number_value.as_number()) as u8)
 }
 
 /// ToUint8Clamp (https://tc39.es/ecma262/#sec-touint8clamp)
@@ -414,44 +321,11 @@ pub fn to_uint8_clamp(cx: Context, value_handle: Handle<Value>) -> EvalResult<u8
     // Fast path if the value is a smi
     let value = *value_handle;
     if value.is_smi() {
-        let i32_value = value.as_smi();
-
-        // Clamp within range
-        if i32_value <= 0 {
-            return Ok(0);
-        } else if i32_value >= (u8::MAX as i32) {
-            return Ok(u8::MAX);
-        } else {
-            return Ok(i32_value as u8);
-        }
+        return Ok(value.as_smi().clamp(0, u8::MAX as i32) as u8);
     }
 
     let number_value = to_number(cx, value_handle)?;
-    let f64_number = number_value.as_number();
-
-    // Clamp within range
-    if f64_number <= 0.0 {
-        return Ok(0);
-    } else if f64_number >= u8::MAX_AS_F64 {
-        return Ok(u8::MAX);
-    } else if f64_number.is_nan() {
-        return Ok(0);
-    }
-
-    // Round to closest integer
-    let floor = f64_number.floor();
-    if floor + 0.5 < f64_number {
-        return Ok((floor + 1.0) as u8);
-    } else if f64_number < floor + 0.5 {
-        return Ok(floor as u8);
-    }
-
-    // Round ties to even
-    if floor % 2.0 == 1.0 {
-        Ok((floor + 1.0) as u8)
-    } else {
-        Ok(floor as u8)
-    }
+    Ok(f64_to_clamped_u8(number_value.as_number()))
 }
 
 /// ToBigInt (https://tc39.es/ecma262/#sec-tobigint)

--- a/tests/integration/language/expression/member/get_property/typed_array_properties.js
+++ b/tests/integration/language/expression/member/get_property/typed_array_properties.js
@@ -1,0 +1,336 @@
+/*---
+description: GetProperty fast path for typed arrays.
+---*/
+
+// In-range loads for every typed array kind, covering each kind's value range.
+(function () {
+  function get(a, i) { return a[i]; }
+  var i8 = new Int8Array([1, -128, 127]);
+  assert.sameValue(get(i8, 0), 1);
+  assert.sameValue(get(i8, 1), -128);
+  assert.sameValue(get(i8, 2), 127);
+
+  var u8 = new Uint8Array([0, 255]);
+  assert.sameValue(get(u8, 1), 255);
+
+  var u8c = new Uint8ClampedArray([0, 255]);
+  assert.sameValue(get(u8c, 1), 255);
+
+  var i16 = new Int16Array([-32768, 32767]);
+  assert.sameValue(get(i16, 0), -32768);
+  assert.sameValue(get(i16, 1), 32767);
+
+  var u16 = new Uint16Array([65535]);
+  assert.sameValue(get(u16, 0), 65535);
+
+  var i32 = new Int32Array([-2147483648, 2147483647]);
+  assert.sameValue(get(i32, 0), -2147483648);
+  assert.sameValue(get(i32, 1), 2147483647);
+
+  // Uint32 values above the smi range read back as doubles.
+  var u32 = new Uint32Array([2147483648, 4294967295]);
+  assert.sameValue(get(u32, 0), 2147483648);
+  assert.sameValue(get(u32, 1), 4294967295);
+
+  var f32 = new Float32Array([1.5]);
+  assert.sameValue(get(f32, 0), 1.5);
+
+  var f64 = new Float64Array([0.1, NaN]);
+  assert.sameValue(get(f64, 0), 0.1);
+  assert.sameValue(Number.isNaN(get(f64, 1)), true);
+
+  var f16 = new Float16Array([1.5, 0.1, 65504, Infinity, NaN]);
+  assert.sameValue(get(f16, 0), 1.5);
+  assert.sameValue(get(f16, 1), 0.0999755859375);
+  assert.sameValue(get(f16, 2), 65504);
+  assert.sameValue(get(f16, 3), Infinity);
+  assert.sameValue(Number.isNaN(get(f16, 4)), true);
+})();
+
+// Negative zero loads as negative zero, not positive zero.
+(function () {
+  function get(a, i) { return a[i]; }
+  var f64 = new Float64Array([-0]);
+  assert.sameValue(get(f64, 0), -0);
+  var f32 = new Float32Array([-0]);
+  assert.sameValue(get(f32, 0), -0);
+  var f16 = new Float16Array([-0]);
+  assert.sameValue(get(f16, 0), -0);
+})();
+
+// Arbitrary NaN bit patterns written through an aliasing view load as NaN numbers. The
+// payload must be canonicalized and can never be misread as another value type.
+(function () {
+  function get(a, i) { return a[i]; }
+  var buffer = new ArrayBuffer(16);
+  var f64 = new Float64Array(buffer);
+  var u8 = new Uint8Array(buffer);
+  // All-ones bit pattern: a quiet NaN with every payload bit set
+  for (var i = 0; i < 8; i++) u8[i] = 0xff;
+  // Signaling NaN bit pattern: exponent all ones, high mantissa bit clear (little-endian)
+  u8[8] = 0x01; u8[14] = 0xf4; u8[15] = 0x7f;
+  for (var i = 0; i < 2; i++) {
+    var value = get(f64, i);
+    assert.sameValue(typeof value, "number", "index " + i);
+    assert.sameValue(Number.isNaN(value), true, "index " + i);
+  }
+
+  var f32buffer = new ArrayBuffer(4);
+  var f32 = new Float32Array(f32buffer);
+  var f32u8 = new Uint8Array(f32buffer);
+  for (var i = 0; i < 4; i++) f32u8[i] = 0xff;
+  assert.sameValue(Number.isNaN(get(f32, 0)), true);
+
+  // Half precision widens to a double before boxing, so it must canonicalize too
+  var f16buffer = new ArrayBuffer(4);
+  var f16 = new Float16Array(f16buffer);
+  var f16u8 = new Uint8Array(f16buffer);
+  // All-ones bit pattern: a quiet NaN with every payload bit set
+  f16u8[0] = 0xff; f16u8[1] = 0xff;
+  // Signaling NaN bit pattern: exponent all ones, high mantissa bit clear (little-endian)
+  f16u8[2] = 0x01; f16u8[3] = 0x7c;
+  for (var i = 0; i < 2; i++) {
+    var f16Value = get(f16, i);
+    assert.sameValue(typeof f16Value, "number", "f16 index " + i);
+    assert.sameValue(Number.isNaN(f16Value), true, "f16 index " + i);
+  }
+})();
+
+// Invalid indices read as undefined and never consult the prototype chain.
+(function () {
+  function get(a, i) { return a[i]; }
+  Int32Array.prototype[4] = "proto";
+  try {
+    var a = new Int32Array([1, 2]);
+    get(a, 0); get(a, 0);
+    assert.sameValue(get(a, 2), undefined);
+    assert.sameValue(get(a, 4), undefined);
+    assert.sameValue(get(a, -1), undefined);
+    // Not a smi key, so this one is checked by the slow path
+    assert.sameValue(get(a, 0.5), undefined);
+  } finally {
+    delete Int32Array.prototype[4];
+  }
+})();
+
+// Invalid indices still read as undefined when the prototype has an accessor at a
+// negative or huge index, which are the indices the fast path folds into a huge usize.
+(function () {
+  function get(a, i) { return a[i]; }
+  var descriptor = { get: function () { return "proto"; }, configurable: true };
+  Object.defineProperty(Int32Array.prototype, "-1", descriptor);
+  Object.defineProperty(Int32Array.prototype, "2147483647", descriptor);
+  try {
+    var a = new Int32Array([1, 2]);
+    assert.sameValue(get(a, -1), undefined);
+    assert.sameValue(get(a, -2147483648), undefined);
+    assert.sameValue(get(a, 2147483647), undefined);
+  } finally {
+    delete Int32Array.prototype["-1"];
+    delete Int32Array.prototype["2147483647"];
+  }
+})();
+
+// Integral float keys are smis, so `1.0` takes the same fast path as `1`. Negative zero
+// is a double key and is only handled by the slow path, but must agree with the fast path.
+(function () {
+  function get(a, k) { return a[k]; }
+  var a = new Int32Array([10, 20]);
+  // Smi key, fast path
+  assert.sameValue(get(a, 1.0), 20);
+  assert.sameValue(get(a, 1), 20);
+  // Double keys, slow path
+  assert.sameValue(get(a, -0), 10);
+  assert.sameValue(get(a, 1.5), undefined);
+})();
+
+// A large in-bounds smi index is handled by the fast path.
+(function () {
+  function get(a, i) { return a[i]; }
+  var a = new Int8Array(3000);
+  a[2999] = 7;
+  assert.sameValue(get(a, 2999), 7);
+  assert.sameValue(get(a, 3000), undefined);
+})();
+
+// Views at byte offsets into the same buffer are disjoint.
+(function () {
+  function get(a, i) { return a[i]; }
+  var buffer = new ArrayBuffer(16);
+  var lo = new Int32Array(buffer, 0, 2);
+  var hi = new Int32Array(buffer, 8, 2);
+  lo[0] = 1; lo[1] = 2; hi[0] = 3; hi[1] = 4;
+  assert.sameValue(get(lo, 0), 1);
+  assert.sameValue(get(lo, 1), 2);
+  assert.sameValue(get(hi, 0), 3);
+  assert.sameValue(get(hi, 1), 4);
+})();
+
+// Shrinking a resizable buffer puts a fixed-length view out of bounds, every index
+// reads as undefined. Regrowing exposes zeroed memory, not stale values.
+(function () {
+  function get(a, i) { return a[i]; }
+  var buffer = new ArrayBuffer(16, { maxByteLength: 16 });
+  var a = new Int32Array(buffer, 0, 4);
+  a[0] = 11; a[1] = 22; a[2] = 33; a[3] = 44;
+  assert.sameValue(get(a, 3), 44);
+  buffer.resize(8);
+  for (var i = 0; i < 4; i++) {
+    assert.sameValue(get(a, i), undefined);
+  }
+  buffer.resize(16);
+  assert.sameValue(get(a, 0), 11);
+  assert.sameValue(get(a, 1), 22);
+  assert.sameValue(get(a, 2), 0);
+  assert.sameValue(get(a, 3), 0);
+})();
+
+// Length-tracking views follow buffer resizes.
+(function () {
+  function get(a, i) { return a[i]; }
+  var buffer = new ArrayBuffer(8, { maxByteLength: 16 });
+  var a = new Int32Array(buffer);
+  a[1] = 5;
+  assert.sameValue(get(a, 1), 5);
+  assert.sameValue(get(a, 2), undefined);
+  buffer.resize(16);
+  a[3] = 7;
+  assert.sameValue(get(a, 3), 7);
+  buffer.resize(4);
+  assert.sameValue(get(a, 1), undefined);
+})();
+
+// A partial trailing property exposed by a resize is excluded from a length-tracking view.
+(function () {
+  function get(a, i) { return a[i]; }
+  var buffer = new ArrayBuffer(8, { maxByteLength: 16 });
+  var a = new Int32Array(buffer);
+  a[0] = 1; a[1] = 2;
+  buffer.resize(10);
+  assert.sameValue(a.length, 2);
+  assert.sameValue(get(a, 1), 2);
+  assert.sameValue(get(a, 2), undefined);
+})();
+
+// Shrinking below a length-tracking view's byte offset makes every index read as undefined.
+(function () {
+  function get(a, i) { return a[i]; }
+  var buffer = new ArrayBuffer(16, { maxByteLength: 24 });
+  var a = new Float64Array(buffer, 8);
+  a[0] = 1.5;
+  assert.sameValue(get(a, 0), 1.5);
+  buffer.resize(4);
+  assert.sameValue(a.length, 0);
+  assert.sameValue(get(a, 0), undefined);
+  buffer.resize(24);
+  assert.sameValue(a.length, 2);
+  assert.sameValue(get(a, 0), 0);
+  assert.sameValue(get(a, 1), 0);
+})();
+
+// Detaching the buffer makes every index read as undefined.
+(function () {
+  function get(a, i) { return a[i]; }
+  var buffer = new ArrayBuffer(8);
+  var a = new Int32Array(buffer);
+  a[0] = 5;
+  assert.sameValue(get(a, 0), 5);
+  $262.detachArrayBuffer(buffer);
+  assert.sameValue(get(a, 0), undefined);
+})();
+
+// Indexed property loads stay correct across a garbage collection.
+(function () {
+  function get(a, i) { return a[i]; }
+  var a = new Int32Array([1, 2]);
+  assert.sameValue(get(a, 0), 1);
+  $262.gc();
+  assert.sameValue(get(a, 0), 1);
+  assert.sameValue(get(a, 1), 2);
+})();
+
+// BigInt typed array loads return bigints.
+(function () {
+  function get(a, i) { return a[i]; }
+  var a = new BigInt64Array([1n, -2n]);
+  assert.sameValue(get(a, 0), 1n);
+  assert.sameValue(get(a, 1), -2n);
+  assert.sameValue(get(a, 2), undefined);
+
+  var u = new BigUint64Array([0n, 18446744073709551615n]);
+  assert.sameValue(get(u, 0), 0n);
+  assert.sameValue(get(u, 1), 18446744073709551615n);
+  assert.sameValue(get(u, 2), undefined);
+})();
+
+// The fast path is guarded on any pointer value, not just objects, so smi keyed loads on
+// strings, symbols and bigints reach the kind check before falling back to the slow path.
+(function () {
+  function get(a, i) { return a[i]; }
+  var string = "abc";
+  assert.sameValue(get(string, 0), "a");
+  assert.sameValue(get(string, 2), "c");
+  assert.sameValue(get(string, 3), undefined);
+  assert.sameValue(get(string, -1), undefined);
+
+  assert.sameValue(get(new String("xy"), 1), "y");
+  assert.sameValue(get(Symbol("desc"), 0), undefined);
+  assert.sameValue(get(1234n, 0), undefined);
+  assert.sameValue(get(new Map([[0, "zero"]]), 0), undefined);
+  assert.sameValue(get({ 0: "own" }, 0), "own");
+})();
+
+// A proxy wrapping a typed array is a different kind of object, so its traps still run.
+(function () {
+  function get(a, i) { return a[i]; }
+  var target = new Int32Array([10, 20]);
+  var keys = [];
+  var proxy = new Proxy(target, {
+    get: function (t, k, r) {
+      keys.push(String(k));
+      return Reflect.get(t, k, r);
+    },
+  });
+  assert.sameValue(get(proxy, 0), 10);
+  assert.sameValue(get(proxy, 1), 20);
+  assert.sameValue(get(proxy, 5), undefined);
+  assert.sameValue(keys.join(","), "0,1,5");
+})();
+
+// Named properties on a typed array change its shape but not its indexed elements.
+(function () {
+  function get(a, i) { return a[i]; }
+  var a = new Int32Array([1, 2]);
+  for (var i = 0; i < 200; i++) a["p" + i] = i;
+  assert.sameValue(get(a, 0), 1);
+  assert.sameValue(get(a, 1), 2);
+  assert.sameValue(get(a, 2), undefined);
+  assert.sameValue(a.p199, 199);
+})();
+
+// Subclass instances keep their typed array kind, so they use the same fast path and
+// still ignore an indexed accessor inherited from the subclass prototype.
+(function () {
+  function get(a, i) { return a[i]; }
+  class Subclass extends Int32Array {}
+  Object.defineProperty(Subclass.prototype, "0", {
+    get: function () { return "proto"; },
+    configurable: true,
+  });
+  var a = new Subclass([1, 2]);
+  assert.sameValue(get(a, 0), 1);
+  assert.sameValue(get(a, 1), 2);
+  assert.sameValue(get(a, 2), undefined);
+})();
+
+// A single callsite handles different typed array kinds and regular arrays interchangeably.
+(function () {
+  function get(a, i) { return a[i]; }
+  var i8 = new Int8Array([1]);
+  var f64 = new Float64Array([2.5]);
+  var arr = [3];
+  assert.sameValue(get(i8, 0), 1);
+  assert.sameValue(get(f64, 0), 2.5);
+  assert.sameValue(get(arr, 0), 3);
+  assert.sameValue(get(i8, 0), 1);
+})();

--- a/tests/integration/language/expression/member/set_property/typed_array_properties.js
+++ b/tests/integration/language/expression/member/set_property/typed_array_properties.js
@@ -1,0 +1,442 @@
+/*---
+description: SetProperty fast path for typed arrays.
+---*/
+
+// In-range stores roundtrip for every typed array kind.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var kinds = [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,
+               Int32Array, Uint32Array, Float16Array, Float32Array, Float64Array];
+  for (var k = 0; k < kinds.length; k++) {
+    var a = new kinds[k](4);
+    set(a, 2, 42);
+    set(a, 2, 43);
+    assert.sameValue(a[2], 43, kinds[k].name);
+    assert.sameValue(a[0], 0, kinds[k].name);
+  }
+})();
+
+// Out-of-range integer stores wrap modularly, for both smi and double values.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var i8 = new Int8Array(4);
+  set(i8, 0, 300);
+  set(i8, 1, -129);
+  set(i8, 2, 130.7);
+  assert.sameValue(i8[0], 44);
+  assert.sameValue(i8[1], 127);
+  assert.sameValue(i8[2], -126);
+
+  var u8 = new Uint8Array(2);
+  set(u8, 0, 256);
+  set(u8, 1, -1);
+  assert.sameValue(u8[0], 0);
+  assert.sameValue(u8[1], 255);
+
+  var i16 = new Int16Array(1);
+  set(i16, 0, 32768);
+  assert.sameValue(i16[0], -32768);
+
+  var u16 = new Uint16Array(1);
+  set(u16, 0, 65536);
+  assert.sameValue(u16[0], 0);
+
+  var i32 = new Int32Array(2);
+  set(i32, 0, 2147483648.5);
+  set(i32, 1, -2147483649.5);
+  assert.sameValue(i32[0], -2147483648);
+  assert.sameValue(i32[1], 2147483647);
+
+  var u32 = new Uint32Array(3);
+  set(u32, 0, -1);
+  set(u32, 1, 4294967297.5);
+  set(u32, 2, -1.5);
+  assert.sameValue(u32[0], 4294967295);
+  assert.sameValue(u32[1], 1);
+  assert.sameValue(u32[2], 4294967295);
+})();
+
+// Non-finite doubles store as zero in integer arrays.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = new Int32Array(3);
+  set(a, 0, NaN);
+  set(a, 1, Infinity);
+  set(a, 2, -Infinity);
+  assert.sameValue(a[0], 0);
+  assert.sameValue(a[1], 0);
+  assert.sameValue(a[2], 0);
+})();
+
+// Uint8Clamped stores clamp and round instead of wrapping.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = new Uint8ClampedArray(8);
+  set(a, 0, 300);
+  set(a, 1, -5);
+  set(a, 2, 1.5);
+  set(a, 3, 2.5);
+  set(a, 4, 254.5);
+  set(a, 5, NaN);
+  set(a, 6, Infinity);
+  set(a, 7, -Infinity);
+  assert.sameValue(a[0], 255);
+  assert.sameValue(a[1], 0);
+  assert.sameValue(a[2], 2);
+  assert.sameValue(a[3], 2);
+  assert.sameValue(a[4], 254);
+  assert.sameValue(a[5], 0);
+  assert.sameValue(a[6], 255);
+  assert.sameValue(a[7], 0);
+})();
+
+// Float16 stores round to the nearest half-precision value.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = new Float16Array(6);
+  set(a, 0, 0.1);
+  set(a, 1, 65505);
+  set(a, 2, 100000);
+  set(a, 3, NaN);
+  set(a, 4, -0);
+  set(a, 5, 1.5);
+  assert.sameValue(a[0], 0.0999755859375);
+  assert.sameValue(a[0], Math.f16round(0.1));
+  assert.sameValue(a[1], 65504);
+  assert.sameValue(a[2], Infinity);
+  assert.sameValue(Number.isNaN(a[3]), true);
+  assert.sameValue(a[4], -0);
+  assert.sameValue(a[5], 1.5);
+})();
+
+// Negative zero stores preserve the sign in float arrays.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var f64 = new Float64Array(1);
+  set(f64, 0, -0);
+  assert.sameValue(f64[0], -0);
+  var f32 = new Float32Array(1);
+  set(f32, 0, -0);
+  assert.sameValue(f32[0], -0);
+})();
+
+// Double stores into float arrays, including Float32 rounding and NaN.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var f64 = new Float64Array(2);
+  set(f64, 0, 0.1);
+  set(f64, 1, NaN);
+  assert.sameValue(f64[0], 0.1);
+  assert.sameValue(Number.isNaN(f64[1]), true);
+
+  var f32 = new Float32Array(1);
+  set(f32, 0, 0.1);
+  assert.sameValue(f32[0], Math.fround(0.1));
+})();
+
+// Non-number values are converted with ToNumber.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = new Int32Array(4);
+  set(a, 0, { valueOf: function () { return 7; } });
+  set(a, 1, "5");
+  set(a, 2, true);
+  set(a, 3, null);
+  assert.sameValue(a[0], 7);
+  assert.sameValue(a[1], 5);
+  assert.sameValue(a[2], 1);
+  assert.sameValue(a[3], 0);
+})();
+
+// Invalid indices are silent no-ops in both sloppy and strict mode, no own indexed
+// property is created and the prototype chain is never consulted.
+(function () {
+  "use strict";
+  function set(a, i, v) { a[i] = v; }
+  var a = new Int32Array([1, 2]);
+  set(a, 0, 10);
+  set(a, 2, 99);
+  set(a, -1, 99);
+  // Not a smi key, so this one is dropped by the slow path
+  set(a, 0.5, 99);
+  assert.sameValue(a[0], 10);
+  assert.sameValue(a[1], 2);
+  assert.sameValue(a.hasOwnProperty("2"), false);
+  assert.sameValue(a.hasOwnProperty("-1"), false);
+  assert.sameValue(a.length, 2);
+})();
+
+// Dropped stores never reach a setter inherited for the same index, including at the
+// negative and huge indices that the fast path folds into a huge usize.
+(function () {
+  "use strict";
+  function set(a, i, v) { a[i] = v; }
+  var calls = 0;
+  var descriptor = {
+    set: function () { calls++; },
+    get: function () { return "proto"; },
+    configurable: true,
+  };
+  Object.defineProperty(Int32Array.prototype, "4", descriptor);
+  Object.defineProperty(Int32Array.prototype, "-1", descriptor);
+  Object.defineProperty(Int32Array.prototype, "2147483647", descriptor);
+  try {
+    var a = new Int32Array([1, 2]);
+    set(a, 4, 99);
+    set(a, -1, 99);
+    set(a, -2147483648, 99);
+    set(a, 2147483647, 99);
+    assert.sameValue(calls, 0);
+    assert.sameValue(a.hasOwnProperty("4"), false);
+  } finally {
+    delete Int32Array.prototype["4"];
+    delete Int32Array.prototype["-1"];
+    delete Int32Array.prototype["2147483647"];
+  }
+})();
+
+// Integral float keys are smis, so `1.0` takes the same fast path as `1`. Negative zero
+// is a double key and is only handled by the slow path, but must agree with the fast path.
+(function () {
+  function set(a, k, v) { a[k] = v; }
+  var a = new Int32Array(2);
+  // Smi key, fast path
+  set(a, 1.0, 20);
+  // Double key, slow path
+  set(a, -0, 10);
+  assert.sameValue(a[1], 20);
+  assert.sameValue(a[0], 10);
+})();
+
+// Stores through views at byte offsets land in the right part of the buffer.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var buffer = new ArrayBuffer(16);
+  var lo = new Int32Array(buffer, 0, 2);
+  var hi = new Int32Array(buffer, 8, 2);
+  set(lo, 0, 1);
+  set(hi, 0, 3);
+  assert.sameValue(lo[0], 1);
+  assert.sameValue(lo[1], 0);
+  assert.sameValue(hi[0], 3);
+})();
+
+// Shrinking a resizable buffer puts a fixed-length view out of bounds, stores are
+// silently dropped. Regrowing exposes zeroed memory, not the dropped values.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var buffer = new ArrayBuffer(16, { maxByteLength: 16 });
+  var a = new Int32Array(buffer, 0, 4);
+  set(a, 0, 11);
+  set(a, 3, 44);
+  buffer.resize(8);
+  for (var i = 0; i < 4; i++) {
+    set(a, i, 99);
+  }
+  buffer.resize(16);
+  assert.sameValue(a[0], 11);
+  assert.sameValue(a[2], 0);
+  assert.sameValue(a[3], 0);
+})();
+
+// Length-tracking views accept stores to indices exposed by a grow.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var buffer = new ArrayBuffer(8, { maxByteLength: 16 });
+  var a = new Int32Array(buffer);
+  set(a, 1, 5);
+  set(a, 2, 99);
+  assert.sameValue(a[1], 5);
+  buffer.resize(16);
+  set(a, 3, 7);
+  assert.sameValue(a[3], 7);
+  assert.sameValue(a[2], 0);
+})();
+
+// Detaching the buffer makes stores silent no-ops, even in strict mode.
+(function () {
+  "use strict";
+  function set(a, i, v) { a[i] = v; }
+  var buffer = new ArrayBuffer(8);
+  var a = new Int32Array(buffer);
+  set(a, 0, 5);
+  $262.detachArrayBuffer(buffer);
+  set(a, 0, 9);
+  assert.sameValue(a[0], undefined);
+})();
+
+// BigInt typed arrays accept bigint stores and reject number stores.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = new BigInt64Array(2);
+  set(a, 0, 5n);
+  assert.sameValue(a[0], 5n);
+  assert.throws(TypeError, function () { set(a, 1, 5); });
+
+  var u = new BigUint64Array(2);
+  set(u, 0, 18446744073709551615n);
+  set(u, 1, -1n);
+  assert.sameValue(u[0], 18446744073709551615n);
+  assert.sameValue(u[1], 18446744073709551615n);
+  assert.throws(TypeError, function () { set(u, 0, 5); });
+})();
+
+// Shrinking below a length-tracking view's byte offset makes stores silent no-ops.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var buffer = new ArrayBuffer(16, { maxByteLength: 24 });
+  var a = new Float64Array(buffer, 8);
+  set(a, 0, 1.5);
+  assert.sameValue(a[0], 1.5);
+  buffer.resize(4);
+  set(a, 0, 99);
+  assert.sameValue(a.length, 0);
+  buffer.resize(24);
+  assert.sameValue(a[0], 0);
+  assert.sameValue(a[1], 0);
+})();
+
+// A ToNumber conversion that resizes the buffer runs before the bounds check and
+// reallocates the backing data, so the store must be rechecked against the new bounds.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+
+  // Growing exposes the index, so the store lands in the reallocated data
+  var grown = new ArrayBuffer(4, { maxByteLength: 64 });
+  var growing = new Int32Array(grown);
+  set(growing, 0, 111);
+  set(growing, 3, { valueOf: function () { grown.resize(64); return 999; } });
+  assert.sameValue(growing.length, 16);
+  assert.sameValue(growing[0], 111);
+  assert.sameValue(growing[3], 999);
+
+  // The same conversion on a fixed length view, which stays in bounds after the grow
+  var fixedBuffer = new ArrayBuffer(4, { maxByteLength: 64 });
+  var fixed = new Int32Array(fixedBuffer, 0, 1);
+  set(fixed, 0, { valueOf: function () { fixedBuffer.resize(64); return 42; } });
+  assert.sameValue(fixed[0], 42);
+
+  // Shrinking takes the index out of bounds, so the store is dropped
+  var shrunk = new ArrayBuffer(64, { maxByteLength: 64 });
+  var shrinking = new Int32Array(shrunk);
+  set(shrinking, 15, { valueOf: function () { shrunk.resize(4); return 5; } });
+  assert.sameValue(shrinking.length, 1);
+  assert.sameValue(shrinking[15], undefined);
+
+  // Detaching drops the store without throwing
+  var detached = new ArrayBuffer(8);
+  var detaching = new Int32Array(detached);
+  var converted = 0;
+  set(detaching, 0, {
+    valueOf: function () {
+      converted++;
+      $262.detachArrayBuffer(detached);
+      return 5;
+    },
+  });
+  assert.sameValue(converted, 1);
+  assert.sameValue(detaching[0], undefined);
+})();
+
+// A ToNumber conversion runs even when the index is already out of bounds, so its side
+// effects are observable and it can still throw.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = new Int32Array(2);
+  var converted = 0;
+  var counter = { valueOf: function () { converted++; return 1; } };
+  set(a, 99, counter);
+  set(a, -1, counter);
+  assert.sameValue(converted, 2);
+  assert.throws(RangeError, function () {
+    set(a, 99, { valueOf: function () { throw new RangeError("boom"); } });
+  });
+  // ToBigInt still rejects a number store on a BigInt array at an invalid index
+  var big = new BigInt64Array(1);
+  assert.throws(TypeError, function () { set(big, 99, 5); });
+})();
+
+// The fast path is guarded on any pointer value, not just objects, so smi keyed stores
+// on other kinds of heap values fall back to the slow path unchanged.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var object = {};
+  set(object, 0, "zero");
+  assert.sameValue(object[0], "zero");
+
+  var array = [1, 2];
+  set(array, 1, 22);
+  assert.sameValue(array[1], 22);
+
+  // Indices past a string wrapper's length are ordinary extensible properties
+  var boxedString = new String("xy");
+  set(boxedString, 5, "five");
+  assert.sameValue(boxedString[5], "five");
+  assert.sameValue(boxedString[0], "x");
+
+  var boxedNumber = new Number(1);
+  set(boxedNumber, 0, "zero");
+  assert.sameValue(boxedNumber[0], "zero");
+
+  var map = new Map();
+  set(map, 0, "zero");
+  assert.sameValue(map[0], "zero");
+  assert.sameValue(map.size, 0);
+})();
+
+// A proxy wrapping a typed array is a different kind of object, so its traps still run.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var target = new Int32Array(2);
+  var keys = [];
+  var proxy = new Proxy(target, {
+    set: function (t, k, v, r) {
+      keys.push(String(k));
+      return Reflect.set(t, k, v, r);
+    },
+  });
+  set(proxy, 0, 10);
+  set(proxy, 5, 99);
+  assert.sameValue(keys.join(","), "0,5");
+  assert.sameValue(target[0], 10);
+  assert.sameValue(target.hasOwnProperty("5"), false);
+})();
+
+// Subclass instances keep their typed array kind, so they use the same fast path and
+// still ignore an indexed setter inherited from the subclass prototype.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  class Subclass extends Int32Array {}
+  var calls = 0;
+  Object.defineProperty(Subclass.prototype, "0", {
+    set: function () { calls++; },
+    configurable: true,
+  });
+  var a = new Subclass(2);
+  set(a, 0, 7);
+  assert.sameValue(calls, 0);
+  assert.sameValue(a[0], 7);
+})();
+
+// Named properties on a typed array change its shape but not its indexed elements.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = new Int32Array(2);
+  for (var i = 0; i < 200; i++) a["p" + i] = i;
+  set(a, 0, 5);
+  set(a, 1, 6);
+  assert.sameValue(a[0], 5);
+  assert.sameValue(a[1], 6);
+  assert.sameValue(a.p199, 199);
+})();
+
+// Stores stay correct across a garbage collection.
+(function () {
+  function set(a, i, v) { a[i] = v; }
+  var a = new Int32Array(2);
+  set(a, 0, 1);
+  $262.gc();
+  set(a, 1, 2);
+  assert.sameValue(a[0], 1);
+  assert.sameValue(a[1], 2);
+})();


### PR DESCRIPTION
## Summary

Introduce a fast path for `GetProperty` and `SetProperty` when the receiver is a (non-BigInt) typed array object and the key is an in-bounds array index. No caching is necessary, this is purely a check for the typed array object kind, the typed array's fields, and whether the key is in bounds.

Notes:
- Set up some generic `FastElement` machinery to assist in conversion
- Created shared `f64_to_wrapping_u32` and `f64_to_clamped_u8` utilities used by all element conversion functions

Substanial speedup on Octane. All benchmarks using typed arrays are heavily improved by a factor of 2x+. Entire Octane suite run time also decreased from 115s to 77s (almost all zlib improvement).

| Benchmark | 4d88a5156 (base) | c658a9441 | Change |
|---|---|---|---|
| Richards | 2,316 med 2,304 ±49.2 n=4 | 2,242 med 2,229 ±18.8 n=4 | -3.2% |
| DeltaBlue | 2,345 med 2,331 ±9.6 n=4 | 2,466 med 2,411 ±34.7 n=4 | +5.2% |
| Crypto | 2,372 med 1,976 ±212 n=4 | 2,633 med 2,020 ±309 n=4 | +11.0% |
| RayTrace | 2,910 med 2,898 ±14.2 n=4 | 2,934 med 2,921 ±13.2 n=4 | +0.8% |
| EarleyBoyer | 5,103 med 5,093 ±23.0 n=4 | 5,042 med 5,028 ±9.1 n=4 | -1.2% |
| RegExp | 441 med 439 ±1.4 n=4 | 440 med 438 ±1.6 n=4 | -0.2% |
| Splay | 4,315 med 4,278 ±46.7 n=4 | 4,254 med 4,218 ±45.9 n=4 | -1.4% |
| SplayLatency | 6,752 med 6,611 ±113 n=4 | 6,559 med 6,511 ±40.0 n=4 | -2.9% |
| NavierStokes | 4,126 med 4,124 ±7.6 n=4 | 4,170 med 4,147 ±16.0 n=4 | +1.1% |
| PdfJS | 5,563 med 5,551 ±15.8 n=4 | 6,217 med 6,190 ±23.8 n=4 | +11.8% |
| Mandreel | 1,019 med 1,012 ±6.8 n=4 | 2,175 med 2,133 ±26.1 n=4 | +113.4% |
| MandreelLatency | 6,755 med 6,656 ±59.9 n=4 | 16,842 med 16,729 ±70.9 n=4 | +149.3% |
| Gameboy | 4,282 med 4,269 ±33.5 n=4 | 5,085 med 5,062 ±28.5 n=4 | +18.8% |
| CodeLoad | 40,150 med 40,079 ±80.0 n=4 | 40,155 med 39,965 ±115 n=4 | +0.0% |
| Box2D | 8,247 med 8,220 ±16.8 n=4 | 8,133 med 8,121 ±49.3 n=4 | -1.4% |
| zlib | 2,286 med 2,272 ±12.5 n=4 | 4,561 med 4,545 ±11.9 n=4 | +99.5% |
| Typescript | 18,609 med 18,576 ±189 n=4 | 18,690 med 18,545 ±87.0 n=4 | +0.4% |
| **Total (octane)** | **4,040 med 4,010 ±19.8 n=4** | **4,755 med 4,678 ±41.9 n=4** | **+17.7%** |

## Tests

- Added LLM generated tests for many scenarios of `GetProperty` and `SetProperty` on typed arrays