### PR TITLE
[runtime] Allocate array literals with estimated size

### DIFF
--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -4,6 +4,7 @@ use crate::{
         Context, EvalResult, Handle, HeapPtr, Realm, Value,
         abstract_operations::{construct, create_data_property_or_throw, get_function_realm},
         alloc_error::AllocResult,
+        array_properties::{DenseArrayProperties, MAX_DENSE_ARRAY_LENGTH},
         common_shapes::CommonShape,
         error::{range_error, type_error},
         gc::{HeapItem, HeapVisitor},
@@ -42,12 +43,13 @@ pub enum ArrayCreateShape {
 impl ArrayObject {
     pub const VIRTUAL_OBJECT_VTABLE: *const () = extract_virtual_object_vtable::<Self>();
 
-    /// Create a new array object with the given length and shape. Note that if a common shape is
-    /// used the caller is responsible for initializing the object's properties.
+    /// Create a new array object with the given length, capacity and shape. Note that if a common
+    /// shape is used the caller is responsible for initializing the object's properties.
     pub fn new(
         cx: Context,
         mut realm: Handle<Realm>,
         length: u32,
+        capacity: Option<u32>,
         shape: ArrayCreateShape,
     ) -> AllocResult<Handle<ArrayObject>> {
         let mut array = match shape {
@@ -68,6 +70,18 @@ impl ArrayObject {
         set_uninit!(array.is_length_writable, true);
 
         let array = array.to_handle();
+
+        // Presize array properties to have dense storage with the provided capacity
+        if let Some(capacity) = capacity
+            && capacity != 0
+            && capacity <= MAX_DENSE_ARRAY_LENGTH
+        {
+            let array_properties = DenseArrayProperties::new(cx, capacity)?;
+            array
+                .as_object()
+                .set_array_properties(array_properties.cast());
+        }
+
         array.as_object().set_array_properties_length(cx, length)?;
 
         Ok(array)
@@ -167,7 +181,13 @@ pub fn array_create_in_realm(
         return range_error(cx, "array length out of range");
     };
 
-    Ok(ArrayObject::new(cx, realm, length, shape)?)
+    Ok(ArrayObject::new(cx, realm, length, /* capacity */ None, shape)?)
+}
+
+/// Create an empty array with the given capacity.
+pub fn array_create_with_capacity(cx: Context, capacity: u32) -> AllocResult<Handle<ArrayObject>> {
+    let realm = cx.current_realm();
+    ArrayObject::new(cx, realm, /* length */ 0, Some(capacity), ArrayCreateShape::Proto(None))
 }
 
 /// ArraySpeciesCreate (https://tc39.es/ecma262/#sec-arrayspeciescreate)

--- a/src/js/runtime/array_properties.rs
+++ b/src/js/runtime/array_properties.rs
@@ -20,7 +20,7 @@ pub struct ArrayProperties {
 }
 
 // Maximum length that can be backed by a dense array. Longer arrays are always sparse.
-const MAX_DENSE_ARRAY_LENGTH: u32 = 1 << 24;
+pub const MAX_DENSE_ARRAY_LENGTH: u32 = 1 << 24;
 
 // Arrays grown up to this length always stay dense, regardless of how many holes they contain.
 const MIN_SPARSE_ARRAY_LENGTH: u32 = 1024;

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -4096,8 +4096,17 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             self.gen_ensure_dest_is_temporary(dest)
         };
 
+        // Calculate number of non-spread elements to use as a lower bound for the number of
+        // elements in the array.
+        let capacity = elements
+            .iter()
+            .filter(|element| !matches!(element, ArrayElement::Spread(_)))
+            .count()
+            .min(u32::MAX as usize) as u32;
+
         let array = self.allocate_destination(array_dest)?;
-        self.writer.new_array_instruction(array);
+        self.writer
+            .new_array_instruction(array, UInt::new(capacity));
 
         // Fast path for empty arrays
         if elements.is_empty() {
@@ -6788,6 +6797,9 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         iterable: GenRegister,
         flags: StoreFlags,
     ) -> EmitResult<()> {
+        /// The default capacity for the array created by a rest element
+        const REST_ARRAY_INITIAL_CAPACITY: u32 = 4;
+
         // Registers needed until end of finally block
         let iterator = self.register_allocator.allocate()?;
         let is_done = self.register_allocator.allocate()?;
@@ -6815,7 +6827,8 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             // Rest element creates a new array with remaining values until iterator is done
             let (reference, element_pos) = if let ast::ArrayPatternElement::Rest(rest) = element {
                 let array = self.register_allocator.allocate()?;
-                self.writer.new_array_instruction(array);
+                self.writer
+                    .new_array_instruction(array, UInt::new(REST_ARRAY_INITIAL_CAPACITY));
 
                 // Evaluate pattern to reference before gathering remaining items
                 let (exception_handler, reference) = self.gen_in_exception_handler(|this| {

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1191,12 +1191,13 @@ define_instructions!(
         }
     }
 
-    /// Create a new empty array stored in dest.
+    /// Create a new empty array with the given capacity stored in dest.
     NewArray {
         camel_case: NewArrayInstruction,
         snake_case: new_array_instruction,
         operands: {
             [0] dest: Register,
+            [1] capacity: UInt,
         }
     }
 

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -17,7 +17,7 @@ use crate::{
         },
         accessor::Accessor,
         arguments_object::{MappedArgumentsObject, UnmappedArgumentsObject},
-        array_object::{ArrayObject, array_create},
+        array_object::{ArrayObject, array_create, array_create_with_capacity},
         async_generator_object::{AsyncGeneratorObject, async_generator_complete_step},
         boxed_value::BoxedValue,
         bytecode::{
@@ -4102,9 +4102,10 @@ impl VM {
         handle_scope_guard!(self.cx());
 
         let dest = instr.dest();
+        let capacity = instr.capacity().value().to_usize() as u32;
 
         // Allocates
-        let array = must!(array_create(self.cx(), 0, None));
+        let array = array_create_with_capacity(self.cx(), capacity)?;
 
         self.write_register(dest, *array.as_value());
 

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -10,7 +10,9 @@ use crate::{
             has_property, invoke, length_of_array_like, set,
         },
         alloc_error::AllocResult,
-        array_object::{ArrayCreateShape, ArrayObject, array_create, array_species_create},
+        array_object::{
+            ArrayCreateShape, array_create, array_create_in_realm, array_species_create,
+        },
         error::{range_error, type_error},
         get,
         intrinsic_builder::IntrinsicBuilder,
@@ -41,8 +43,14 @@ impl ArrayPrototype {
     /// Properties of the Array Prototype Object (https://tc39.es/ecma262/#sec-properties-of-the-array-prototype-object)
     pub fn new(cx: Context, realm: Handle<Realm>) -> AllocResult<Handle<ObjectValue>> {
         let object_proto = realm.get_intrinsic(Intrinsic::ObjectPrototype);
-        let array = ArrayObject::new(cx, realm, 0, ArrayCreateShape::Proto(Some(object_proto)))?
-            .as_object();
+        let array = must_a!(array_create_in_realm(
+            cx,
+            realm,
+            /* length */ 0,
+            ArrayCreateShape::Proto(Some(object_proto))
+        ))
+        .as_object();
+
         let mut builder = IntrinsicBuilder::ordinary(cx, realm, array);
 
         // Constructor property is added once ArrayConstructor has been created

--- a/tests/snapshot/bytecode/annex_b/assign_to_call_expression.exp
+++ b/tests/snapshot/bytecode/annex_b/assign_to_call_expression.exp
@@ -86,29 +86,29 @@
 
 [BytecodeFunction: forOfInitializer] {
   Parameters: 0, Registers: 5
-     0: NewArray r2
-     2: GetIterator r0, r1, r2
+     0: NewArray r2, 0
+     3: GetIterator r0, r1, r2
   .L0:
-     6: IteratorNext r2, r3, r0, r1
-    11: JumpTrue r3, 32 (.L2)
-    14: LoadGlobal r3, c0, k0
-    18: Call r3, r3, r3, 0
-    23: ThrowNewError 0, c1
-    26: Mov r4, <scope>
-    29: Jump 12 (.L1)
-    31: LoadImmediate r2, 0
-    34: Mov <scope>, r4
-    37: IteratorClose r0
-    39: Rethrow r3
+     7: IteratorNext r2, r3, r0, r1
+    12: JumpTrue r3, 32 (.L2)
+    15: LoadGlobal r3, c0, k0
+    19: Call r3, r3, r3, 0
+    24: ThrowNewError 0, c1
+    27: Mov r4, <scope>
+    30: Jump 12 (.L1)
+    32: LoadImmediate r2, 0
+    35: Mov <scope>, r4
+    38: IteratorClose r0
+    40: Rethrow r3
   .L1:
-    41: Jump -35 (.L0)
+    42: Jump -35 (.L0)
   .L2:
-    43: LoadUndefined r0
-    45: Ret r0
+    44: LoadUndefined r0
+    46: Ret r0
   Constant Table:
     0: [String: f]
     1: [String: cannot assign to call expression]
   Exception Handlers:
-    14-29 -> 31 (r3)
-    37-39 -> 39
+    15-30 -> 32 (r3)
+    38-40 -> 40
 }

--- a/tests/snapshot/bytecode/eval/completion.exp
+++ b/tests/snapshot/bytecode/eval/completion.exp
@@ -258,29 +258,29 @@
   Parameters: 0, Registers: 6
      0: LoadConstant r0, c0
      3: LoadUndefined r0
-     5: NewArray r3
-     7: GetIterator r1, r2, r3
+     5: NewArray r3, 0
+     8: GetIterator r1, r2, r3
   .L0:
-    11: IteratorNext r3, r4, r1, r2
-    16: JumpTrue r4, 26 (.L2)
-    19: StoreDynamic r3, c1
-    22: Mov r5, <scope>
-    25: LoadImmediate r0, 1
-    28: Jump 12 (.L1)
-    30: LoadImmediate r3, 0
-    33: Mov <scope>, r5
-    36: IteratorClose r1
-    38: Rethrow r4
+    12: IteratorNext r3, r4, r1, r2
+    17: JumpTrue r4, 26 (.L2)
+    20: StoreDynamic r3, c1
+    23: Mov r5, <scope>
+    26: LoadImmediate r0, 1
+    29: Jump 12 (.L1)
+    31: LoadImmediate r3, 0
+    34: Mov <scope>, r5
+    37: IteratorClose r1
+    39: Rethrow r4
   .L1:
-    40: Jump -29 (.L0)
+    41: Jump -29 (.L0)
   .L2:
-    42: Ret r0
+    43: Ret r0
   Constant Table:
     0: [String: for-of completion]
     1: [String: x]
   Exception Handlers:
-    19-28 -> 30 (r4)
-    36-38 -> 38
+    20-29 -> 31 (r4)
+    37-39 -> 39
 }
 
 [BytecodeFunction: <eval>] {

--- a/tests/snapshot/bytecode/expression/array.exp
+++ b/tests/snapshot/bytecode/expression/array.exp
@@ -43,141 +43,141 @@
 
 [BytecodeFunction: testEmptyArray] {
   Parameters: 0, Registers: 1
-    0: NewArray r0
-    2: Ret r0
+    0: NewArray r0, 0
+    3: Ret r0
 }
 
 [BytecodeFunction: testArrayWithOneElement] {
   Parameters: 0, Registers: 3
-     0: NewArray r0
-     2: LoadImmediate r1, 0
-     5: LoadImmediate r2, 1
-     8: SetArrayProperty r0, r1, r2
-    12: Ret r0
+     0: NewArray r0, 1
+     3: LoadImmediate r1, 0
+     6: LoadImmediate r2, 1
+     9: SetArrayProperty r0, r1, r2
+    13: Ret r0
 }
 
 [BytecodeFunction: testArrayWithElements] {
   Parameters: 0, Registers: 3
-     0: NewArray r0
-     2: LoadImmediate r1, 0
-     5: LoadImmediate r2, 1
-     8: SetArrayProperty r0, r1, r2
-    12: Inc r1
-    14: LoadImmediate r2, 2
-    17: SetArrayProperty r0, r1, r2
-    21: Inc r1
-    23: LoadImmediate r2, 3
-    26: SetArrayProperty r0, r1, r2
-    30: Ret r0
+     0: NewArray r0, 3
+     3: LoadImmediate r1, 0
+     6: LoadImmediate r2, 1
+     9: SetArrayProperty r0, r1, r2
+    13: Inc r1
+    15: LoadImmediate r2, 2
+    18: SetArrayProperty r0, r1, r2
+    22: Inc r1
+    24: LoadImmediate r2, 3
+    27: SetArrayProperty r0, r1, r2
+    31: Ret r0
 }
 
 [BytecodeFunction: testArrayWithHolesAndElements] {
   Parameters: 0, Registers: 3
-     0: NewArray r0
-     2: LoadImmediate r1, 0
-     5: LoadImmediate r2, 1
+     0: NewArray r0, 7
+     3: LoadImmediate r1, 0
+     6: LoadImmediate r2, 1
+     9: SetArrayProperty r0, r1, r2
+    13: Inc r1
+    15: LoadEmpty r2
+    17: SetArrayProperty r0, r1, r2
+    21: Inc r1
+    23: LoadImmediate r2, 2
+    26: SetArrayProperty r0, r1, r2
+    30: Inc r1
+    32: LoadEmpty r2
+    34: SetArrayProperty r0, r1, r2
+    38: Inc r1
+    40: LoadEmpty r2
+    42: SetArrayProperty r0, r1, r2
+    46: Inc r1
+    48: LoadImmediate r2, 3
+    51: SetArrayProperty r0, r1, r2
+    55: Inc r1
+    57: LoadEmpty r2
+    59: SetArrayProperty r0, r1, r2
+    63: Ret r0
+}
+
+[BytecodeFunction: testArrayWithOnlyHoles] {
+  Parameters: 0, Registers: 3
+     0: NewArray r0, 3
+     3: LoadImmediate r1, 0
+     6: LoadEmpty r2
      8: SetArrayProperty r0, r1, r2
     12: Inc r1
     14: LoadEmpty r2
     16: SetArrayProperty r0, r1, r2
     20: Inc r1
-    22: LoadImmediate r2, 2
-    25: SetArrayProperty r0, r1, r2
-    29: Inc r1
-    31: LoadEmpty r2
-    33: SetArrayProperty r0, r1, r2
-    37: Inc r1
-    39: LoadEmpty r2
-    41: SetArrayProperty r0, r1, r2
-    45: Inc r1
-    47: LoadImmediate r2, 3
-    50: SetArrayProperty r0, r1, r2
-    54: Inc r1
-    56: LoadEmpty r2
-    58: SetArrayProperty r0, r1, r2
-    62: Ret r0
-}
-
-[BytecodeFunction: testArrayWithOnlyHoles] {
-  Parameters: 0, Registers: 3
-     0: NewArray r0
-     2: LoadImmediate r1, 0
-     5: LoadEmpty r2
-     7: SetArrayProperty r0, r1, r2
-    11: Inc r1
-    13: LoadEmpty r2
-    15: SetArrayProperty r0, r1, r2
-    19: Inc r1
-    21: LoadEmpty r2
-    23: SetArrayProperty r0, r1, r2
-    27: Ret r0
+    22: LoadEmpty r2
+    24: SetArrayProperty r0, r1, r2
+    28: Ret r0
 }
 
 [BytecodeFunction: onlySpread] {
   Parameters: 1, Registers: 6
-     0: NewArray r0
-     2: LoadImmediate r1, 0
-     5: GetIterator r2, r3, a0
+     0: NewArray r0, 0
+     3: LoadImmediate r1, 0
+     6: GetIterator r2, r3, a0
   .L0:
-     9: IteratorNext r4, r5, r2, r3
-    14: JumpTrue r5, 11 (.L1)
-    17: SetArrayProperty r0, r1, r4
-    21: Inc r1
-    23: Jump -14 (.L0)
+    10: IteratorNext r4, r5, r2, r3
+    15: JumpTrue r5, 11 (.L1)
+    18: SetArrayProperty r0, r1, r4
+    22: Inc r1
+    24: Jump -14 (.L0)
   .L1:
-    25: Ret r0
+    26: Ret r0
 }
 
 [BytecodeFunction: multipleSpreads] {
   Parameters: 3, Registers: 6
-     0: NewArray r0
-     2: LoadImmediate r1, 0
-     5: GetIterator r2, r3, a0
+     0: NewArray r0, 1
+     3: LoadImmediate r1, 0
+     6: GetIterator r2, r3, a0
   .L0:
-     9: IteratorNext r4, r5, r2, r3
-    14: JumpTrue r5, 11 (.L1)
-    17: SetArrayProperty r0, r1, r4
-    21: Inc r1
-    23: Jump -14 (.L0)
+    10: IteratorNext r4, r5, r2, r3
+    15: JumpTrue r5, 11 (.L1)
+    18: SetArrayProperty r0, r1, r4
+    22: Inc r1
+    24: Jump -14 (.L0)
   .L1:
-    25: GetIterator r2, r3, a1
+    26: GetIterator r2, r3, a1
   .L2:
-    29: IteratorNext r4, r5, r2, r3
-    34: JumpTrue r5, 11 (.L3)
-    37: SetArrayProperty r0, r1, r4
-    41: Inc r1
-    43: Jump -14 (.L2)
+    30: IteratorNext r4, r5, r2, r3
+    35: JumpTrue r5, 11 (.L3)
+    38: SetArrayProperty r0, r1, r4
+    42: Inc r1
+    44: Jump -14 (.L2)
   .L3:
-    45: LoadImmediate r2, 1
-    48: SetArrayProperty r0, r1, r2
-    52: Inc r1
-    54: GetIterator r2, r3, a2
+    46: LoadImmediate r2, 1
+    49: SetArrayProperty r0, r1, r2
+    53: Inc r1
+    55: GetIterator r2, r3, a2
   .L4:
-    58: IteratorNext r4, r5, r2, r3
-    63: JumpTrue r5, 11 (.L5)
-    66: SetArrayProperty r0, r1, r4
-    70: Inc r1
-    72: Jump -14 (.L4)
+    59: IteratorNext r4, r5, r2, r3
+    64: JumpTrue r5, 11 (.L5)
+    67: SetArrayProperty r0, r1, r4
+    71: Inc r1
+    73: Jump -14 (.L4)
   .L5:
-    74: Ret r0
+    75: Ret r0
 }
 
 [BytecodeFunction: temporaryRegisterToAvoidClobbering] {
   Parameters: 0, Registers: 4
      0: LoadImmediate r0, 1
-     3: NewArray r1
-     5: LoadImmediate r2, 0
-     8: LoadImmediate r3, 2
-    11: SetArrayProperty r1, r2, r3
-    15: Mov r0, r1
-    18: LoadUndefined r1
-    20: Ret r1
+     3: NewArray r1, 1
+     6: LoadImmediate r2, 0
+     9: LoadImmediate r3, 2
+    12: SetArrayProperty r1, r2, r3
+    16: Mov r0, r1
+    19: LoadUndefined r1
+    21: Ret r1
 }
 
 [BytecodeFunction: noTemporaryRegisterNeededForEmptyObject] {
   Parameters: 0, Registers: 2
     0: LoadImmediate r0, 1
-    3: NewArray r0
-    5: LoadUndefined r1
-    7: Ret r1
+    3: NewArray r0, 0
+    6: LoadUndefined r1
+    8: Ret r1
 }

--- a/tests/snapshot/bytecode/expression/calls/spread.exp
+++ b/tests/snapshot/bytecode/expression/calls/spread.exp
@@ -28,88 +28,9 @@
 [BytecodeFunction: simpleSpread] {
   Parameters: 1, Registers: 7
      0: LoadGlobal r0, c0, k0
-     4: NewArray r1
-     6: LoadImmediate r2, 0
-     9: GetIterator r3, r4, a0
-  .L0:
-    13: IteratorNext r5, r6, r3, r4
-    18: JumpTrue r6, 11 (.L1)
-    21: SetArrayProperty r1, r2, r5
-    25: Inc r2
-    27: Jump -14 (.L0)
-  .L1:
-    29: LoadUndefined r2
-    31: CallVarargs r0, r0, r2, r1
-    36: Ret r0
-  Constant Table:
-    0: [String: f]
-}
-
-[BytecodeFunction: spreadWithArgs] {
-  Parameters: 1, Registers: 7
-     0: LoadGlobal r0, c0, k0
-     4: NewArray r1
-     6: LoadImmediate r2, 0
-     9: LoadImmediate r3, 1
-    12: SetArrayProperty r1, r2, r3
-    16: Inc r2
-    18: GetIterator r3, r4, a0
-  .L0:
-    22: IteratorNext r5, r6, r3, r4
-    27: JumpTrue r6, 11 (.L1)
-    30: SetArrayProperty r1, r2, r5
-    34: Inc r2
-    36: Jump -14 (.L0)
-  .L1:
-    38: LoadUndefined r2
-    40: CallVarargs r0, r0, r2, r1
-    45: Ret r0
-  Constant Table:
-    0: [String: f]
-}
-
-[BytecodeFunction: complexSpread] {
-  Parameters: 0, Registers: 8
-     0: LoadGlobal r0, c0, k0
-     4: NewArray r1
-     6: LoadImmediate r2, 0
-     9: LoadImmediate r3, 1
-    12: SetArrayProperty r1, r2, r3
-    16: Inc r2
-    18: LoadImmediate r3, 2
-    21: GetIterator r4, r5, r3
-  .L0:
-    25: IteratorNext r6, r7, r4, r5
-    30: JumpTrue r7, 11 (.L1)
-    33: SetArrayProperty r1, r2, r6
-    37: Inc r2
-    39: Jump -14 (.L0)
-  .L1:
-    41: LoadImmediate r3, 3
-    44: SetArrayProperty r1, r2, r3
-    48: Inc r2
-    50: LoadImmediate r3, 4
-    53: GetIterator r4, r5, r3
-  .L2:
-    57: IteratorNext r6, r7, r4, r5
-    62: JumpTrue r7, 11 (.L3)
-    65: SetArrayProperty r1, r2, r6
-    69: Inc r2
-    71: Jump -14 (.L2)
-  .L3:
-    73: LoadUndefined r2
-    75: CallVarargs r0, r0, r2, r1
-    80: Ret r0
-  Constant Table:
-    0: [String: f]
-}
-
-[BytecodeFunction: spreadWithReceiver] {
-  Parameters: 2, Registers: 7
-     0: GetNamedProperty r0, a0, c0, k0
-     5: NewArray r1
+     4: NewArray r1, 0
      7: LoadImmediate r2, 0
-    10: GetIterator r3, r4, a1
+    10: GetIterator r3, r4, a0
   .L0:
     14: IteratorNext r5, r6, r3, r4
     19: JumpTrue r6, 11 (.L1)
@@ -117,8 +38,87 @@
     26: Inc r2
     28: Jump -14 (.L0)
   .L1:
-    30: CallVarargs r0, r0, a0, r1
-    35: Ret r0
+    30: LoadUndefined r2
+    32: CallVarargs r0, r0, r2, r1
+    37: Ret r0
+  Constant Table:
+    0: [String: f]
+}
+
+[BytecodeFunction: spreadWithArgs] {
+  Parameters: 1, Registers: 7
+     0: LoadGlobal r0, c0, k0
+     4: NewArray r1, 1
+     7: LoadImmediate r2, 0
+    10: LoadImmediate r3, 1
+    13: SetArrayProperty r1, r2, r3
+    17: Inc r2
+    19: GetIterator r3, r4, a0
+  .L0:
+    23: IteratorNext r5, r6, r3, r4
+    28: JumpTrue r6, 11 (.L1)
+    31: SetArrayProperty r1, r2, r5
+    35: Inc r2
+    37: Jump -14 (.L0)
+  .L1:
+    39: LoadUndefined r2
+    41: CallVarargs r0, r0, r2, r1
+    46: Ret r0
+  Constant Table:
+    0: [String: f]
+}
+
+[BytecodeFunction: complexSpread] {
+  Parameters: 0, Registers: 8
+     0: LoadGlobal r0, c0, k0
+     4: NewArray r1, 2
+     7: LoadImmediate r2, 0
+    10: LoadImmediate r3, 1
+    13: SetArrayProperty r1, r2, r3
+    17: Inc r2
+    19: LoadImmediate r3, 2
+    22: GetIterator r4, r5, r3
+  .L0:
+    26: IteratorNext r6, r7, r4, r5
+    31: JumpTrue r7, 11 (.L1)
+    34: SetArrayProperty r1, r2, r6
+    38: Inc r2
+    40: Jump -14 (.L0)
+  .L1:
+    42: LoadImmediate r3, 3
+    45: SetArrayProperty r1, r2, r3
+    49: Inc r2
+    51: LoadImmediate r3, 4
+    54: GetIterator r4, r5, r3
+  .L2:
+    58: IteratorNext r6, r7, r4, r5
+    63: JumpTrue r7, 11 (.L3)
+    66: SetArrayProperty r1, r2, r6
+    70: Inc r2
+    72: Jump -14 (.L2)
+  .L3:
+    74: LoadUndefined r2
+    76: CallVarargs r0, r0, r2, r1
+    81: Ret r0
+  Constant Table:
+    0: [String: f]
+}
+
+[BytecodeFunction: spreadWithReceiver] {
+  Parameters: 2, Registers: 7
+     0: GetNamedProperty r0, a0, c0, k0
+     5: NewArray r1, 0
+     8: LoadImmediate r2, 0
+    11: GetIterator r3, r4, a1
+  .L0:
+    15: IteratorNext r5, r6, r3, r4
+    20: JumpTrue r6, 11 (.L1)
+    23: SetArrayProperty r1, r2, r5
+    27: Inc r2
+    29: Jump -14 (.L0)
+  .L1:
+    31: CallVarargs r0, r0, a0, r1
+    36: Ret r0
   Constant Table:
     0: [String: f]
 }
@@ -132,19 +132,19 @@
     14: NewMappedArguments r0
     16: StoreToScope r0, 2, 0
     20: LoadDynamic r0, c1
-    23: NewArray r1
-    25: LoadImmediate r2, 0
-    28: LoadFromScope r3, 0, 0
-    32: GetIterator r4, r5, r3
+    23: NewArray r1, 0
+    26: LoadImmediate r2, 0
+    29: LoadFromScope r3, 0, 0
+    33: GetIterator r4, r5, r3
   .L0:
-    36: IteratorNext r6, r7, r4, r5
-    41: JumpTrue r7, 11 (.L1)
-    44: SetArrayProperty r1, r2, r6
-    48: Inc r2
-    50: Jump -14 (.L0)
+    37: IteratorNext r6, r7, r4, r5
+    42: JumpTrue r7, 11 (.L1)
+    45: SetArrayProperty r1, r2, r6
+    49: Inc r2
+    51: Jump -14 (.L0)
   .L1:
-    52: CallMaybeEvalVarargs r0, r0, r1, 1
-    57: Ret r0
+    53: CallMaybeEvalVarargs r0, r0, r1, 1
+    58: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [String: eval]

--- a/tests/snapshot/bytecode/expression/new.exp
+++ b/tests/snapshot/bytecode/expression/new.exp
@@ -52,18 +52,18 @@
 [BytecodeFunction: spread] {
   Parameters: 1, Registers: 7
      0: LoadGlobal r0, c0, k0
-     4: NewArray r1
-     6: LoadImmediate r2, 0
-     9: GetIterator r3, r4, a0
+     4: NewArray r1, 0
+     7: LoadImmediate r2, 0
+    10: GetIterator r3, r4, a0
   .L0:
-    13: IteratorNext r5, r6, r3, r4
-    18: JumpTrue r6, 11 (.L1)
-    21: SetArrayProperty r1, r2, r5
-    25: Inc r2
-    27: Jump -14 (.L0)
+    14: IteratorNext r5, r6, r3, r4
+    19: JumpTrue r6, 11 (.L1)
+    22: SetArrayProperty r1, r2, r5
+    26: Inc r2
+    28: Jump -14 (.L0)
   .L1:
-    29: ConstructVarargs r0, r0, r0, r1
-    34: Ret r0
+    30: ConstructVarargs r0, r0, r0, r1
+    35: Ret r0
   Constant Table:
     0: [String: foo]
 }
@@ -71,21 +71,21 @@
 [BytecodeFunction: argAndSpread] {
   Parameters: 1, Registers: 7
      0: LoadGlobal r0, c0, k0
-     4: NewArray r1
-     6: LoadImmediate r2, 0
-     9: LoadImmediate r3, 1
-    12: SetArrayProperty r1, r2, r3
-    16: Inc r2
-    18: GetIterator r3, r4, a0
+     4: NewArray r1, 1
+     7: LoadImmediate r2, 0
+    10: LoadImmediate r3, 1
+    13: SetArrayProperty r1, r2, r3
+    17: Inc r2
+    19: GetIterator r3, r4, a0
   .L0:
-    22: IteratorNext r5, r6, r3, r4
-    27: JumpTrue r6, 11 (.L1)
-    30: SetArrayProperty r1, r2, r5
-    34: Inc r2
-    36: Jump -14 (.L0)
+    23: IteratorNext r5, r6, r3, r4
+    28: JumpTrue r6, 11 (.L1)
+    31: SetArrayProperty r1, r2, r5
+    35: Inc r2
+    37: Jump -14 (.L0)
   .L1:
-    38: ConstructVarargs r0, r0, r0, r1
-    43: Ret r0
+    39: ConstructVarargs r0, r0, r0, r1
+    44: Ret r0
   Constant Table:
     0: [String: foo]
 }

--- a/tests/snapshot/bytecode/pattern/iterator_destructuring.exp
+++ b/tests/snapshot/bytecode/pattern/iterator_destructuring.exp
@@ -358,44 +358,44 @@
      0: Mov r1, a0
      3: Mov r6, <scope>
      6: GetIterator r2, r7, r1
-    10: NewArray r9
-    12: LoadImmediate r10, 0
+    10: NewArray r9, 4
+    13: LoadImmediate r10, 0
   .L0:
-    15: IteratorNext r8, r3, r2, r7
-    20: JumpTrue r3, 11 (.L1)
-    23: SetArrayProperty r9, r10, r8
-    27: Inc r10
-    29: Jump -14 (.L0)
+    16: IteratorNext r8, r3, r2, r7
+    21: JumpTrue r3, 11 (.L1)
+    24: SetArrayProperty r9, r10, r8
+    28: Inc r10
+    30: Jump -14 (.L0)
   .L1:
-    31: Mov r0, r9
-    34: JumpTrue r3, 50 (.L6)
-    37: LoadImmediate r4, 1
-    40: Jump 5 (.L2)
-    42: LoadImmediate r4, 0
+    32: Mov r0, r9
+    35: JumpTrue r3, 50 (.L6)
+    38: LoadImmediate r4, 1
+    41: Jump 5 (.L2)
+    43: LoadImmediate r4, 0
   .L2:
-    45: Mov <scope>, r6
-    48: JumpTrue r3, 22 (.L4)
-    51: IteratorClose r2
-    53: Jump 17 (.L4)
-    55: LoadImmediate r7, 0
-    58: StrictNotEqual r7, r7, r4
-    62: JumpTrue r7, 6 (.L3)
-    65: Mov r6, r5
+    46: Mov <scope>, r6
+    49: JumpTrue r3, 22 (.L4)
+    52: IteratorClose r2
+    54: Jump 17 (.L4)
+    56: LoadImmediate r7, 0
+    59: StrictNotEqual r7, r7, r4
+    63: JumpTrue r7, 6 (.L3)
+    66: Mov r6, r5
   .L3:
-    68: Rethrow r6
+    69: Rethrow r6
   .L4:
-    70: LoadImmediate r6, 0
-    73: StrictEqual r6, r4, r6
-    77: JumpFalse r6, 5 (.L5)
-    80: Rethrow r5
+    71: LoadImmediate r6, 0
+    74: StrictEqual r6, r4, r6
+    78: JumpFalse r6, 5 (.L5)
+    81: Rethrow r5
   .L5:
-    82: Jump 2 (.L6)
+    83: Jump 2 (.L6)
   .L6:
-    84: LoadUndefined r1
-    86: Ret r1
+    85: LoadUndefined r1
+    87: Ret r1
   Exception Handlers:
-    31-34 -> 42 (r5)
-    51-53 -> 55 (r6)
+    32-35 -> 43 (r5)
+    52-54 -> 56 (r6)
 }
 
 [BytecodeFunction: valuesAndRest] {
@@ -415,47 +415,47 @@
      34: LoadUndefined r10
   .L2:
      36: Mov r1, r10
-     39: NewArray r11
-     41: LoadImmediate r12, 0
-     44: JumpTrue r5, 19 (.L4)
+     39: NewArray r11, 4
+     42: LoadImmediate r12, 0
+     45: JumpTrue r5, 19 (.L4)
   .L3:
-     47: IteratorNext r10, r5, r4, r9
-     52: JumpTrue r5, 11 (.L4)
-     55: SetArrayProperty r11, r12, r10
-     59: Inc r12
-     61: Jump -14 (.L3)
+     48: IteratorNext r10, r5, r4, r9
+     53: JumpTrue r5, 11 (.L4)
+     56: SetArrayProperty r11, r12, r10
+     60: Inc r12
+     62: Jump -14 (.L3)
   .L4:
-     63: Mov r2, r11
-     66: JumpTrue r5, 50 (.L9)
-     69: LoadImmediate r6, 1
-     72: Jump 5 (.L5)
-     74: LoadImmediate r6, 0
+     64: Mov r2, r11
+     67: JumpTrue r5, 50 (.L9)
+     70: LoadImmediate r6, 1
+     73: Jump 5 (.L5)
+     75: LoadImmediate r6, 0
   .L5:
-     77: Mov <scope>, r8
-     80: JumpTrue r5, 22 (.L7)
-     83: IteratorClose r4
-     85: Jump 17 (.L7)
-     87: LoadImmediate r9, 0
-     90: StrictNotEqual r9, r9, r6
-     94: JumpTrue r9, 6 (.L6)
-     97: Mov r8, r7
+     78: Mov <scope>, r8
+     81: JumpTrue r5, 22 (.L7)
+     84: IteratorClose r4
+     86: Jump 17 (.L7)
+     88: LoadImmediate r9, 0
+     91: StrictNotEqual r9, r9, r6
+     95: JumpTrue r9, 6 (.L6)
+     98: Mov r8, r7
   .L6:
-    100: Rethrow r8
+    101: Rethrow r8
   .L7:
-    102: LoadImmediate r8, 0
-    105: StrictEqual r8, r6, r8
-    109: JumpFalse r8, 5 (.L8)
-    112: Rethrow r7
+    103: LoadImmediate r8, 0
+    106: StrictEqual r8, r6, r8
+    110: JumpFalse r8, 5 (.L8)
+    113: Rethrow r7
   .L8:
-    114: Jump 2 (.L9)
+    115: Jump 2 (.L9)
   .L9:
-    116: LoadUndefined r3
-    118: Ret r3
+    117: LoadUndefined r3
+    119: Ret r3
   Exception Handlers:
-    20-23 -> 74 (r7)
-    36-39 -> 74 (r7)
-    63-66 -> 74 (r7)
-    83-85 -> 87 (r8)
+    20-23 -> 75 (r7)
+    36-39 -> 75 (r7)
+    64-67 -> 75 (r7)
+    84-86 -> 88 (r8)
 }
 
 [BytecodeFunction: restDestructuring] {
@@ -463,46 +463,46 @@
      0: Mov r1, a0
      3: Mov r6, <scope>
      6: GetIterator r2, r7, r1
-    10: NewArray r9
-    12: LoadImmediate r10, 0
+    10: NewArray r9, 4
+    13: LoadImmediate r10, 0
   .L0:
-    15: IteratorNext r8, r3, r2, r7
-    20: JumpTrue r3, 11 (.L1)
-    23: SetArrayProperty r9, r10, r8
-    27: Inc r10
-    29: Jump -14 (.L0)
+    16: IteratorNext r8, r3, r2, r7
+    21: JumpTrue r3, 11 (.L1)
+    24: SetArrayProperty r9, r10, r8
+    28: Inc r10
+    30: Jump -14 (.L0)
   .L1:
-    31: GetNamedProperty r0, r9, c0, k0
-    36: JumpTrue r3, 50 (.L6)
-    39: LoadImmediate r4, 1
-    42: Jump 5 (.L2)
-    44: LoadImmediate r4, 0
+    32: GetNamedProperty r0, r9, c0, k0
+    37: JumpTrue r3, 50 (.L6)
+    40: LoadImmediate r4, 1
+    43: Jump 5 (.L2)
+    45: LoadImmediate r4, 0
   .L2:
-    47: Mov <scope>, r6
-    50: JumpTrue r3, 22 (.L4)
-    53: IteratorClose r2
-    55: Jump 17 (.L4)
-    57: LoadImmediate r7, 0
-    60: StrictNotEqual r7, r7, r4
-    64: JumpTrue r7, 6 (.L3)
-    67: Mov r6, r5
+    48: Mov <scope>, r6
+    51: JumpTrue r3, 22 (.L4)
+    54: IteratorClose r2
+    56: Jump 17 (.L4)
+    58: LoadImmediate r7, 0
+    61: StrictNotEqual r7, r7, r4
+    65: JumpTrue r7, 6 (.L3)
+    68: Mov r6, r5
   .L3:
-    70: Rethrow r6
+    71: Rethrow r6
   .L4:
-    72: LoadImmediate r6, 0
-    75: StrictEqual r6, r4, r6
-    79: JumpFalse r6, 5 (.L5)
-    82: Rethrow r5
+    73: LoadImmediate r6, 0
+    76: StrictEqual r6, r4, r6
+    80: JumpFalse r6, 5 (.L5)
+    83: Rethrow r5
   .L5:
-    84: Jump 2 (.L6)
+    85: Jump 2 (.L6)
   .L6:
-    86: LoadUndefined r1
-    88: Ret r1
+    87: LoadUndefined r1
+    89: Ret r1
   Constant Table:
     0: [String: b]
   Exception Handlers:
-    31-36 -> 44 (r5)
-    53-55 -> 57 (r6)
+    32-37 -> 45 (r5)
+    54-56 -> 58 (r6)
 }
 
 [BytecodeFunction: elementEvaluationOrder] {
@@ -561,53 +561,53 @@
       4: Call r0, r0, r0, 0
       9: Mov r5, <scope>
      12: GetIterator r1, r6, r0
-     16: NewArray r8
-     18: LoadGlobal r9, c1, k1
-     22: Call r9, r9, r9, 0
-     27: LoadGlobal r10, c2, k2
-     31: Call r10, r10, r10, 0
-     36: LoadImmediate r11, 0
+     16: NewArray r8, 4
+     19: LoadGlobal r9, c1, k1
+     23: Call r9, r9, r9, 0
+     28: LoadGlobal r10, c2, k2
+     32: Call r10, r10, r10, 0
+     37: LoadImmediate r11, 0
   .L0:
-     39: IteratorNext r7, r2, r1, r6
-     44: JumpTrue r2, 11 (.L1)
-     47: SetArrayProperty r8, r11, r7
-     51: Inc r11
-     53: Jump -14 (.L0)
+     40: IteratorNext r7, r2, r1, r6
+     45: JumpTrue r2, 11 (.L1)
+     48: SetArrayProperty r8, r11, r7
+     52: Inc r11
+     54: Jump -14 (.L0)
   .L1:
-     55: SetProperty r9, r10, r8
-     59: JumpTrue r2, 50 (.L6)
-     62: LoadImmediate r3, 1
-     65: Jump 5 (.L2)
-     67: LoadImmediate r3, 0
+     56: SetProperty r9, r10, r8
+     60: JumpTrue r2, 50 (.L6)
+     63: LoadImmediate r3, 1
+     66: Jump 5 (.L2)
+     68: LoadImmediate r3, 0
   .L2:
-     70: Mov <scope>, r5
-     73: JumpTrue r2, 22 (.L4)
-     76: IteratorClose r1
-     78: Jump 17 (.L4)
-     80: LoadImmediate r6, 0
-     83: StrictNotEqual r6, r6, r3
-     87: JumpTrue r6, 6 (.L3)
-     90: Mov r5, r4
+     71: Mov <scope>, r5
+     74: JumpTrue r2, 22 (.L4)
+     77: IteratorClose r1
+     79: Jump 17 (.L4)
+     81: LoadImmediate r6, 0
+     84: StrictNotEqual r6, r6, r3
+     88: JumpTrue r6, 6 (.L3)
+     91: Mov r5, r4
   .L3:
-     93: Rethrow r5
+     94: Rethrow r5
   .L4:
-     95: LoadImmediate r5, 0
-     98: StrictEqual r5, r3, r5
-    102: JumpFalse r5, 5 (.L5)
-    105: Rethrow r4
+     96: LoadImmediate r5, 0
+     99: StrictEqual r5, r3, r5
+    103: JumpFalse r5, 5 (.L5)
+    106: Rethrow r4
   .L5:
-    107: Jump 2 (.L6)
+    108: Jump 2 (.L6)
   .L6:
-    109: LoadUndefined r0
-    111: Ret r0
+    110: LoadUndefined r0
+    112: Ret r0
   Constant Table:
     0: [String: c]
     1: [String: a]
     2: [String: b]
   Exception Handlers:
-    18-36 -> 67 (r4)
-    55-59 -> 67 (r4)
-    76-78 -> 80 (r5)
+    19-37 -> 68 (r4)
+    56-60 -> 68 (r4)
+    77-79 -> 81 (r5)
 }
 
 [BytecodeFunction: withYield] {

--- a/tests/snapshot/bytecode/scope/for_of.exp
+++ b/tests/snapshot/bytecode/scope/for_of.exp
@@ -23,32 +23,32 @@
 
 [BytecodeFunction: startScope] {
   Parameters: 0, Registers: 8
-     0: NewArray r4
-     2: GetIterator r2, r3, r4
+     0: NewArray r4, 0
+     3: GetIterator r2, r3, r4
   .L0:
-     6: IteratorNext r4, r5, r2, r3
-    11: JumpTrue r5, 35 (.L2)
-    14: Mov r0, r4
-    17: Mov r6, <scope>
-    20: LoadEmpty r1
-    22: CheckTdz r1, c0
-    25: Add r7, r0, r1
-    29: LoadImmediate r1, 0
-    32: Jump 12 (.L1)
-    34: LoadImmediate r4, 0
-    37: Mov <scope>, r6
-    40: IteratorClose r2
-    42: Rethrow r5
+     7: IteratorNext r4, r5, r2, r3
+    12: JumpTrue r5, 35 (.L2)
+    15: Mov r0, r4
+    18: Mov r6, <scope>
+    21: LoadEmpty r1
+    23: CheckTdz r1, c0
+    26: Add r7, r0, r1
+    30: LoadImmediate r1, 0
+    33: Jump 12 (.L1)
+    35: LoadImmediate r4, 0
+    38: Mov <scope>, r6
+    41: IteratorClose r2
+    43: Rethrow r5
   .L1:
-    44: Jump -38 (.L0)
+    45: Jump -38 (.L0)
   .L2:
-    46: LoadUndefined r2
-    48: Ret r2
+    47: LoadUndefined r2
+    49: Ret r2
   Constant Table:
     0: [String: inner]
   Exception Handlers:
-    14-32 -> 34 (r5)
-    40-42 -> 42
+    15-33 -> 35 (r5)
+    41-43 -> 43
 }
 
 [BytecodeFunction: captures] {
@@ -56,43 +56,43 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: StoreToScope r1, 0, 0
-     8: NewArray r3
-    10: GetIterator r1, r2, r3
-    14: PopScope 
+     8: NewArray r3, 0
+    11: GetIterator r1, r2, r3
+    15: PopScope 
   .L0:
-    15: PushLexicalScope c0
-    17: LoadEmpty r3
-    19: StoreToScope r3, 0, 0
-    23: IteratorNext r3, r4, r1, r2
-    28: JumpTrue r4, 44 (.L2)
-    31: StoreToScope r3, 0, 0
-    35: Mov r5, <scope>
-    38: PushLexicalScope c1
-    40: LoadEmpty r6
-    42: StoreToScope r6, 0, 0
-    46: NewClosure r0, c2
-    49: LoadImmediate r6, 2
-    52: StoreToScope r6, 0, 0
-    56: PopScope 
-    57: Jump 12 (.L1)
-    59: LoadImmediate r3, 0
-    62: Mov <scope>, r5
-    65: IteratorClose r1
-    67: Rethrow r4
+    16: PushLexicalScope c0
+    18: LoadEmpty r3
+    20: StoreToScope r3, 0, 0
+    24: IteratorNext r3, r4, r1, r2
+    29: JumpTrue r4, 44 (.L2)
+    32: StoreToScope r3, 0, 0
+    36: Mov r5, <scope>
+    39: PushLexicalScope c1
+    41: LoadEmpty r6
+    43: StoreToScope r6, 0, 0
+    47: NewClosure r0, c2
+    50: LoadImmediate r6, 2
+    53: StoreToScope r6, 0, 0
+    57: PopScope 
+    58: Jump 12 (.L1)
+    60: LoadImmediate r3, 0
+    63: Mov <scope>, r5
+    66: IteratorClose r1
+    68: Rethrow r4
   .L1:
-    69: PopScope 
-    70: Jump -55 (.L0)
+    70: PopScope 
+    71: Jump -55 (.L0)
   .L2:
-    72: PopScope 
-    73: LoadUndefined r1
-    75: Ret r1
+    73: PopScope 
+    74: LoadUndefined r1
+    76: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]
     2: [BytecodeFunction: inner]
   Exception Handlers:
-    31-57 -> 59 (r4)
-    65-67 -> 67
+    32-58 -> 60 (r4)
+    66-68 -> 68
 }
 
 [BytecodeFunction: inner] {

--- a/tests/snapshot/bytecode/scope/for_of_break.exp
+++ b/tests/snapshot/bytecode/scope/for_of_break.exp
@@ -18,76 +18,76 @@
       0: PushLexicalScope c0
       2: LoadEmpty r1
       4: StoreToScope r1, 0, 0
-      8: NewArray r3
-     10: GetIterator r1, r2, r3
-     14: PopScope 
+      8: NewArray r3, 0
+     11: GetIterator r1, r2, r3
+     15: PopScope 
   .L0:
-     15: PushLexicalScope c0
-     17: LoadEmpty r3
-     19: StoreToScope r3, 0, 0
-     23: IteratorNext r3, r4, r1, r2
-     28: JumpTrue r4, 112 (.L8)
-     31: StoreToScope r3, 0, 0
-     35: Mov r5, <scope>
-     38: PushLexicalScope c1
-     40: LoadEmpty r6
-     42: StoreToScope r6, 0, 0
-     46: LoadImmediate r6, 1
-     49: StoreToScope r6, 0, 0
-     53: LoadImmediate r6, 2
-     56: JumpToBooleanFalse r6, 8 (.L1)
-     59: LoadImmediate r3, 1
-     62: Jump 38 (.L3)
+     16: PushLexicalScope c0
+     18: LoadEmpty r3
+     20: StoreToScope r3, 0, 0
+     24: IteratorNext r3, r4, r1, r2
+     29: JumpTrue r4, 112 (.L8)
+     32: StoreToScope r3, 0, 0
+     36: Mov r5, <scope>
+     39: PushLexicalScope c1
+     41: LoadEmpty r6
+     43: StoreToScope r6, 0, 0
+     47: LoadImmediate r6, 1
+     50: StoreToScope r6, 0, 0
+     54: LoadImmediate r6, 2
+     57: JumpToBooleanFalse r6, 8 (.L1)
+     60: LoadImmediate r3, 1
+     63: Jump 38 (.L3)
   .L1:
-     64: PushLexicalScope c2
-     66: LoadEmpty r6
-     68: StoreToScope r6, 0, 0
-     72: NewClosure r0, c3
-     75: LoadImmediate r6, 3
-     78: StoreToScope r6, 0, 0
-     82: LoadImmediate r6, 4
-     85: JumpToBooleanFalse r6, 8 (.L2)
-     88: LoadImmediate r3, 1
-     91: Jump 9 (.L3)
+     65: PushLexicalScope c2
+     67: LoadEmpty r6
+     69: StoreToScope r6, 0, 0
+     73: NewClosure r0, c3
+     76: LoadImmediate r6, 3
+     79: StoreToScope r6, 0, 0
+     83: LoadImmediate r6, 4
+     86: JumpToBooleanFalse r6, 8 (.L2)
+     89: LoadImmediate r3, 1
+     92: Jump 9 (.L3)
   .L2:
-     93: PopScope 
      94: PopScope 
-     95: Jump 42 (.L7)
-     97: LoadImmediate r3, 0
+     95: PopScope 
+     96: Jump 42 (.L7)
+     98: LoadImmediate r3, 0
   .L3:
-    100: Mov <scope>, r5
-    103: IteratorClose r1
-    105: Jump 17 (.L5)
-    107: LoadImmediate r6, 0
-    110: StrictEqual r6, r3, r6
-    114: JumpFalse r6, 6 (.L4)
-    117: Mov r5, r4
+    101: Mov <scope>, r5
+    104: IteratorClose r1
+    106: Jump 17 (.L5)
+    108: LoadImmediate r6, 0
+    111: StrictEqual r6, r3, r6
+    115: JumpFalse r6, 6 (.L4)
+    118: Mov r5, r4
   .L4:
-    120: Rethrow r5
+    121: Rethrow r5
   .L5:
-    122: LoadImmediate r5, 0
-    125: StrictEqual r5, r3, r5
-    129: JumpFalse r5, 5 (.L6)
-    132: Rethrow r4
+    123: LoadImmediate r5, 0
+    126: StrictEqual r5, r3, r5
+    130: JumpFalse r5, 5 (.L6)
+    133: Rethrow r4
   .L6:
-    134: PopScope 
-    135: Jump 6 (.L9)
+    135: PopScope 
+    136: Jump 6 (.L9)
   .L7:
-    137: PopScope 
-    138: Jump -123 (.L0)
+    138: PopScope 
+    139: Jump -123 (.L0)
   .L8:
-    140: PopScope 
+    141: PopScope 
   .L9:
-    141: LoadUndefined r1
-    143: Ret r1
+    142: LoadUndefined r1
+    144: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]
     2: [ScopeNames]
     3: [BytecodeFunction: inner]
   Exception Handlers:
-    31-95 -> 97 (r4)
-    103-105 -> 107 (r5)
+    32-96 -> 98 (r4)
+    104-106 -> 108 (r5)
 }
 
 [BytecodeFunction: inner] {
@@ -110,68 +110,68 @@
 [BytecodeFunction: breakToFinallyNoScopeRestore] {
   Parameters: 0, Registers: 7
       0: PushFunctionScope c0
-      2: NewArray r3
-      4: GetIterator r1, r2, r3
+      2: NewArray r3, 0
+      5: GetIterator r1, r2, r3
   .L0:
-      8: IteratorNext r3, r4, r1, r2
-     13: JumpTrue r4, 110 (.L8)
-     16: StoreToScope r3, 0, 0
-     20: Mov r5, <scope>
-     23: PushLexicalScope c1
-     25: LoadEmpty r6
-     27: StoreToScope r6, 0, 0
-     31: LoadImmediate r6, 1
-     34: StoreToScope r6, 0, 0
-     38: LoadImmediate r6, 2
-     41: JumpToBooleanFalse r6, 8 (.L1)
-     44: LoadImmediate r3, 1
-     47: Jump 38 (.L3)
+      9: IteratorNext r3, r4, r1, r2
+     14: JumpTrue r4, 110 (.L8)
+     17: StoreToScope r3, 0, 0
+     21: Mov r5, <scope>
+     24: PushLexicalScope c1
+     26: LoadEmpty r6
+     28: StoreToScope r6, 0, 0
+     32: LoadImmediate r6, 1
+     35: StoreToScope r6, 0, 0
+     39: LoadImmediate r6, 2
+     42: JumpToBooleanFalse r6, 8 (.L1)
+     45: LoadImmediate r3, 1
+     48: Jump 38 (.L3)
   .L1:
-     49: PushLexicalScope c2
-     51: LoadEmpty r6
-     53: StoreToScope r6, 0, 0
-     57: NewClosure r0, c3
-     60: LoadImmediate r6, 3
-     63: StoreToScope r6, 0, 0
-     67: LoadImmediate r6, 4
-     70: JumpToBooleanFalse r6, 8 (.L2)
-     73: LoadImmediate r3, 1
-     76: Jump 9 (.L3)
+     50: PushLexicalScope c2
+     52: LoadEmpty r6
+     54: StoreToScope r6, 0, 0
+     58: NewClosure r0, c3
+     61: LoadImmediate r6, 3
+     64: StoreToScope r6, 0, 0
+     68: LoadImmediate r6, 4
+     71: JumpToBooleanFalse r6, 8 (.L2)
+     74: LoadImmediate r3, 1
+     77: Jump 9 (.L3)
   .L2:
-     78: PopScope 
      79: PopScope 
-     80: Jump 41 (.L7)
-     82: LoadImmediate r3, 0
+     80: PopScope 
+     81: Jump 41 (.L7)
+     83: LoadImmediate r3, 0
   .L3:
-     85: Mov <scope>, r5
-     88: IteratorClose r1
-     90: Jump 17 (.L5)
-     92: LoadImmediate r6, 0
-     95: StrictEqual r6, r3, r6
-     99: JumpFalse r6, 6 (.L4)
-    102: Mov r5, r4
+     86: Mov <scope>, r5
+     89: IteratorClose r1
+     91: Jump 17 (.L5)
+     93: LoadImmediate r6, 0
+     96: StrictEqual r6, r3, r6
+    100: JumpFalse r6, 6 (.L4)
+    103: Mov r5, r4
   .L4:
-    105: Rethrow r5
+    106: Rethrow r5
   .L5:
-    107: LoadImmediate r5, 0
-    110: StrictEqual r5, r3, r5
-    114: JumpFalse r5, 5 (.L6)
-    117: Rethrow r4
+    108: LoadImmediate r5, 0
+    111: StrictEqual r5, r3, r5
+    115: JumpFalse r5, 5 (.L6)
+    118: Rethrow r4
   .L6:
-    119: Jump 4 (.L8)
+    120: Jump 4 (.L8)
   .L7:
-    121: Jump -113 (.L0)
+    122: Jump -113 (.L0)
   .L8:
-    123: LoadUndefined r1
-    125: Ret r1
+    124: LoadUndefined r1
+    126: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]
     2: [ScopeNames]
     3: [BytecodeFunction: inner]
   Exception Handlers:
-    16-80 -> 82 (r4)
-    88-90 -> 92 (r5)
+    17-81 -> 83 (r4)
+    89-91 -> 93 (r5)
 }
 
 [BytecodeFunction: inner] {

--- a/tests/snapshot/bytecode/scope/for_of_continue.exp
+++ b/tests/snapshot/bytecode/scope/for_of_continue.exp
@@ -18,63 +18,63 @@
       0: PushLexicalScope c0
       2: LoadEmpty r1
       4: StoreToScope r1, 0, 0
-      8: NewArray r3
-     10: GetIterator r1, r2, r3
-     14: PopScope 
+      8: NewArray r3, 0
+     11: GetIterator r1, r2, r3
+     15: PopScope 
   .L0:
-     15: PushLexicalScope c0
-     17: LoadEmpty r3
-     19: StoreToScope r3, 0, 0
-     23: IteratorNext r3, r4, r1, r2
-     28: JumpTrue r4, 81 (.L4)
-     31: StoreToScope r3, 0, 0
-     35: Mov r5, <scope>
-     38: PushLexicalScope c1
-     40: LoadEmpty r6
-     42: StoreToScope r6, 0, 0
-     46: LoadImmediate r6, 1
-     49: StoreToScope r6, 0, 0
-     53: LoadImmediate r6, 2
-     56: JumpToBooleanFalse r6, 7 (.L1)
-     59: PopScope 
+     16: PushLexicalScope c0
+     18: LoadEmpty r3
+     20: StoreToScope r3, 0, 0
+     24: IteratorNext r3, r4, r1, r2
+     29: JumpTrue r4, 81 (.L4)
+     32: StoreToScope r3, 0, 0
+     36: Mov r5, <scope>
+     39: PushLexicalScope c1
+     41: LoadEmpty r6
+     43: StoreToScope r6, 0, 0
+     47: LoadImmediate r6, 1
+     50: StoreToScope r6, 0, 0
+     54: LoadImmediate r6, 2
+     57: JumpToBooleanFalse r6, 7 (.L1)
      60: PopScope 
-     61: Jump -46 (.L0)
+     61: PopScope 
+     62: Jump -46 (.L0)
   .L1:
-     63: PushLexicalScope c2
-     65: LoadEmpty r6
-     67: StoreToScope r6, 0, 0
-     71: NewClosure r0, c3
-     74: LoadImmediate r6, 3
-     77: StoreToScope r6, 0, 0
-     81: LoadImmediate r6, 4
-     84: JumpToBooleanFalse r6, 8 (.L2)
-     87: PopScope 
+     64: PushLexicalScope c2
+     66: LoadEmpty r6
+     68: StoreToScope r6, 0, 0
+     72: NewClosure r0, c3
+     75: LoadImmediate r6, 3
+     78: StoreToScope r6, 0, 0
+     82: LoadImmediate r6, 4
+     85: JumpToBooleanFalse r6, 8 (.L2)
      88: PopScope 
      89: PopScope 
-     90: Jump -75 (.L0)
+     90: PopScope 
+     91: Jump -75 (.L0)
   .L2:
-     92: PopScope 
      93: PopScope 
-     94: Jump 12 (.L3)
-     96: LoadImmediate r3, 0
-     99: Mov <scope>, r5
-    102: IteratorClose r1
-    104: Rethrow r4
+     94: PopScope 
+     95: Jump 12 (.L3)
+     97: LoadImmediate r3, 0
+    100: Mov <scope>, r5
+    103: IteratorClose r1
+    105: Rethrow r4
   .L3:
-    106: PopScope 
-    107: Jump -92 (.L0)
+    107: PopScope 
+    108: Jump -92 (.L0)
   .L4:
-    109: PopScope 
-    110: LoadUndefined r1
-    112: Ret r1
+    110: PopScope 
+    111: LoadUndefined r1
+    113: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]
     2: [ScopeNames]
     3: [BytecodeFunction: inner]
   Exception Handlers:
-    31-94 -> 96 (r4)
-    102-104 -> 104
+    32-95 -> 97 (r4)
+    103-105 -> 105
 }
 
 [BytecodeFunction: inner] {
@@ -97,55 +97,55 @@
 [BytecodeFunction: continueToFinallyNoScopeRestore] {
   Parameters: 0, Registers: 7
      0: PushFunctionScope c0
-     2: NewArray r3
-     4: GetIterator r1, r2, r3
+     2: NewArray r3, 0
+     5: GetIterator r1, r2, r3
   .L0:
-     8: IteratorNext r3, r4, r1, r2
-    13: JumpTrue r4, 78 (.L4)
-    16: StoreToScope r3, 0, 0
-    20: Mov r5, <scope>
-    23: PushLexicalScope c1
-    25: LoadEmpty r6
-    27: StoreToScope r6, 0, 0
-    31: LoadImmediate r6, 1
-    34: StoreToScope r6, 0, 0
-    38: LoadImmediate r6, 2
-    41: JumpToBooleanFalse r6, 6 (.L1)
-    44: PopScope 
-    45: Jump -37 (.L0)
+     9: IteratorNext r3, r4, r1, r2
+    14: JumpTrue r4, 78 (.L4)
+    17: StoreToScope r3, 0, 0
+    21: Mov r5, <scope>
+    24: PushLexicalScope c1
+    26: LoadEmpty r6
+    28: StoreToScope r6, 0, 0
+    32: LoadImmediate r6, 1
+    35: StoreToScope r6, 0, 0
+    39: LoadImmediate r6, 2
+    42: JumpToBooleanFalse r6, 6 (.L1)
+    45: PopScope 
+    46: Jump -37 (.L0)
   .L1:
-    47: PushLexicalScope c2
-    49: LoadEmpty r6
-    51: StoreToScope r6, 0, 0
-    55: NewClosure r0, c3
-    58: LoadImmediate r6, 3
-    61: StoreToScope r6, 0, 0
-    65: LoadImmediate r6, 4
-    68: JumpToBooleanFalse r6, 7 (.L2)
-    71: PopScope 
+    48: PushLexicalScope c2
+    50: LoadEmpty r6
+    52: StoreToScope r6, 0, 0
+    56: NewClosure r0, c3
+    59: LoadImmediate r6, 3
+    62: StoreToScope r6, 0, 0
+    66: LoadImmediate r6, 4
+    69: JumpToBooleanFalse r6, 7 (.L2)
     72: PopScope 
-    73: Jump -65 (.L0)
+    73: PopScope 
+    74: Jump -65 (.L0)
   .L2:
-    75: PopScope 
     76: PopScope 
-    77: Jump 12 (.L3)
-    79: LoadImmediate r3, 0
-    82: Mov <scope>, r5
-    85: IteratorClose r1
-    87: Rethrow r4
+    77: PopScope 
+    78: Jump 12 (.L3)
+    80: LoadImmediate r3, 0
+    83: Mov <scope>, r5
+    86: IteratorClose r1
+    88: Rethrow r4
   .L3:
-    89: Jump -81 (.L0)
+    90: Jump -81 (.L0)
   .L4:
-    91: LoadUndefined r1
-    93: Ret r1
+    92: LoadUndefined r1
+    94: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]
     2: [ScopeNames]
     3: [BytecodeFunction: inner]
   Exception Handlers:
-    16-77 -> 79 (r4)
-    85-87 -> 87
+    17-78 -> 80 (r4)
+    86-88 -> 88
 }
 
 [BytecodeFunction: inner] {

--- a/tests/snapshot/bytecode/statement/for_of.exp
+++ b/tests/snapshot/bytecode/statement/for_of.exp
@@ -40,271 +40,271 @@
 [BytecodeFunction: basicVar] {
   Parameters: 0, Registers: 7
      0: LoadImmediate r1, 1
-     3: NewArray r3
-     5: GetIterator r1, r2, r3
+     3: NewArray r3, 0
+     6: GetIterator r1, r2, r3
   .L0:
-     9: IteratorNext r3, r4, r1, r2
-    14: JumpTrue r4, 26 (.L2)
-    17: Mov r0, r3
-    20: Mov r5, <scope>
-    23: LoadImmediate r6, 2
-    26: Jump 12 (.L1)
-    28: LoadImmediate r3, 0
-    31: Mov <scope>, r5
-    34: IteratorClose r1
-    36: Rethrow r4
+    10: IteratorNext r3, r4, r1, r2
+    15: JumpTrue r4, 26 (.L2)
+    18: Mov r0, r3
+    21: Mov r5, <scope>
+    24: LoadImmediate r6, 2
+    27: Jump 12 (.L1)
+    29: LoadImmediate r3, 0
+    32: Mov <scope>, r5
+    35: IteratorClose r1
+    37: Rethrow r4
   .L1:
-    38: Jump -29 (.L0)
+    39: Jump -29 (.L0)
   .L2:
-    40: LoadImmediate r1, 3
-    43: LoadUndefined r1
-    45: Ret r1
+    41: LoadImmediate r1, 3
+    44: LoadUndefined r1
+    46: Ret r1
   Exception Handlers:
-    17-26 -> 28 (r4)
-    34-36 -> 36
+    18-27 -> 29 (r4)
+    35-37 -> 37
 }
 
 [BytecodeFunction: basicConstLet] {
   Parameters: 0, Registers: 8
      0: LoadImmediate r2, 1
-     3: NewArray r4
-     5: GetIterator r2, r3, r4
+     3: NewArray r4, 0
+     6: GetIterator r2, r3, r4
   .L0:
-     9: IteratorNext r4, r5, r2, r3
-    14: JumpTrue r5, 26 (.L2)
-    17: Mov r1, r4
-    20: Mov r6, <scope>
-    23: LoadImmediate r7, 2
-    26: Jump 12 (.L1)
-    28: LoadImmediate r4, 0
-    31: Mov <scope>, r6
-    34: IteratorClose r2
-    36: Rethrow r5
+    10: IteratorNext r4, r5, r2, r3
+    15: JumpTrue r5, 26 (.L2)
+    18: Mov r1, r4
+    21: Mov r6, <scope>
+    24: LoadImmediate r7, 2
+    27: Jump 12 (.L1)
+    29: LoadImmediate r4, 0
+    32: Mov <scope>, r6
+    35: IteratorClose r2
+    37: Rethrow r5
   .L1:
-    38: Jump -29 (.L0)
+    39: Jump -29 (.L0)
   .L2:
-    40: LoadImmediate r2, 3
-    43: NewArray r4
-    45: GetIterator r2, r3, r4
+    41: LoadImmediate r2, 3
+    44: NewArray r4, 0
+    47: GetIterator r2, r3, r4
   .L3:
-    49: IteratorNext r4, r5, r2, r3
-    54: JumpTrue r5, 26 (.L5)
-    57: Mov r0, r4
-    60: Mov r6, <scope>
-    63: LoadImmediate r7, 3
-    66: Jump 12 (.L4)
-    68: LoadImmediate r4, 0
-    71: Mov <scope>, r6
-    74: IteratorClose r2
-    76: Rethrow r5
+    51: IteratorNext r4, r5, r2, r3
+    56: JumpTrue r5, 26 (.L5)
+    59: Mov r0, r4
+    62: Mov r6, <scope>
+    65: LoadImmediate r7, 3
+    68: Jump 12 (.L4)
+    70: LoadImmediate r4, 0
+    73: Mov <scope>, r6
+    76: IteratorClose r2
+    78: Rethrow r5
   .L4:
-    78: Jump -29 (.L3)
+    80: Jump -29 (.L3)
   .L5:
-    80: LoadImmediate r2, 4
-    83: LoadUndefined r2
-    85: Ret r2
+    82: LoadImmediate r2, 4
+    85: LoadUndefined r2
+    87: Ret r2
   Exception Handlers:
-    17-26 -> 28 (r5)
-    34-36 -> 36
-    57-66 -> 68 (r5)
-    74-76 -> 76
+    18-27 -> 29 (r5)
+    35-37 -> 37
+    59-68 -> 70 (r5)
+    76-78 -> 78
 }
 
 [BytecodeFunction: testAllAbruptPaths] {
   Parameters: 1, Registers: 7
       0: LoadImmediate r1, 1
-      3: NewArray r3
-      5: GetIterator r1, r2, r3
+      3: NewArray r3, 0
+      6: GetIterator r1, r2, r3
   .L0:
-      9: IteratorNext r3, r4, r1, r2
-     14: JumpTrue r4, 97 (.L10)
-     17: Mov r0, r3
-     20: Mov r5, <scope>
-     23: LoadImmediate r6, 2
-     26: JumpToBooleanFalse r6, 8 (.L1)
-     29: LoadImmediate r3, 1
-     32: Jump 29 (.L4)
+     10: IteratorNext r3, r4, r1, r2
+     15: JumpTrue r4, 97 (.L10)
+     18: Mov r0, r3
+     21: Mov r5, <scope>
+     24: LoadImmediate r6, 2
+     27: JumpToBooleanFalse r6, 8 (.L1)
+     30: LoadImmediate r3, 1
+     33: Jump 29 (.L4)
   .L1:
-     34: LoadImmediate r6, 3
-     37: JumpToBooleanFalse r6, 5 (.L2)
-     40: Jump -31 (.L0)
+     35: LoadImmediate r6, 3
+     38: JumpToBooleanFalse r6, 5 (.L2)
+     41: Jump -31 (.L0)
   .L2:
-     42: LoadImmediate r6, 4
-     45: JumpToBooleanFalse r6, 11 (.L3)
-     48: LoadImmediate r3, 2
-     51: Mov r4, a0
-     54: Jump 7 (.L4)
+     43: LoadImmediate r6, 4
+     46: JumpToBooleanFalse r6, 11 (.L3)
+     49: LoadImmediate r3, 2
+     52: Mov r4, a0
+     55: Jump 7 (.L4)
   .L3:
-     56: Jump 53 (.L9)
-     58: LoadImmediate r3, 0
+     57: Jump 53 (.L9)
+     59: LoadImmediate r3, 0
   .L4:
-     61: Mov <scope>, r5
-     64: IteratorClose r1
-     66: Jump 17 (.L6)
-     68: LoadImmediate r6, 0
-     71: StrictEqual r6, r3, r6
-     75: JumpFalse r6, 6 (.L5)
-     78: Mov r5, r4
+     62: Mov <scope>, r5
+     65: IteratorClose r1
+     67: Jump 17 (.L6)
+     69: LoadImmediate r6, 0
+     72: StrictEqual r6, r3, r6
+     76: JumpFalse r6, 6 (.L5)
+     79: Mov r5, r4
   .L5:
-     81: Rethrow r5
+     82: Rethrow r5
   .L6:
-     83: LoadImmediate r5, 0
-     86: StrictEqual r5, r3, r5
-     90: JumpFalse r5, 5 (.L7)
-     93: Rethrow r4
+     84: LoadImmediate r5, 0
+     87: StrictEqual r5, r3, r5
+     91: JumpFalse r5, 5 (.L7)
+     94: Rethrow r4
   .L7:
-     95: LoadImmediate r5, 2
-     98: StrictEqual r5, r3, r5
-    102: JumpFalse r5, 5 (.L8)
-    105: Ret r4
+     96: LoadImmediate r5, 2
+     99: StrictEqual r5, r3, r5
+    103: JumpFalse r5, 5 (.L8)
+    106: Ret r4
   .L8:
-    107: Jump 4 (.L10)
+    108: Jump 4 (.L10)
   .L9:
-    109: Jump -100 (.L0)
+    110: Jump -100 (.L0)
   .L10:
-    111: LoadImmediate r1, 5
-    114: LoadUndefined r1
-    116: Ret r1
+    112: LoadImmediate r1, 5
+    115: LoadUndefined r1
+    117: Ret r1
   Exception Handlers:
-    17-56 -> 58 (r4)
-    64-66 -> 68 (r5)
+    18-57 -> 59 (r4)
+    65-67 -> 69 (r5)
 }
 
 [BytecodeFunction: lhsIdentifier] {
   Parameters: 1, Registers: 5
      0: LoadImmediate r0, 1
-     3: NewArray r2
-     5: GetIterator r0, r1, r2
+     3: NewArray r2, 0
+     6: GetIterator r0, r1, r2
   .L0:
-     9: IteratorNext r2, r3, r0, r1
-    14: JumpTrue r3, 23 (.L2)
-    17: Mov a0, r2
-    20: Mov r4, <scope>
-    23: Jump 12 (.L1)
-    25: LoadImmediate r2, 0
-    28: Mov <scope>, r4
-    31: IteratorClose r0
-    33: Rethrow r3
+    10: IteratorNext r2, r3, r0, r1
+    15: JumpTrue r3, 23 (.L2)
+    18: Mov a0, r2
+    21: Mov r4, <scope>
+    24: Jump 12 (.L1)
+    26: LoadImmediate r2, 0
+    29: Mov <scope>, r4
+    32: IteratorClose r0
+    34: Rethrow r3
   .L1:
-    35: Jump -26 (.L0)
+    36: Jump -26 (.L0)
   .L2:
-    37: LoadImmediate r0, 2
-    40: LoadUndefined r0
-    42: Ret r0
+    38: LoadImmediate r0, 2
+    41: LoadUndefined r0
+    43: Ret r0
   Exception Handlers:
-    17-23 -> 25 (r3)
-    31-33 -> 33
+    18-24 -> 26 (r3)
+    32-34 -> 34
 }
 
 [BytecodeFunction: lhsMember] {
   Parameters: 1, Registers: 6
      0: LoadImmediate r0, 1
-     3: NewArray r2
-     5: GetIterator r0, r1, r2
+     3: NewArray r2, 0
+     6: GetIterator r0, r1, r2
   .L0:
-     9: IteratorNext r2, r3, r0, r1
-    14: JumpTrue r3, 28 (.L2)
-    17: SetNamedProperty a0, c0, r2, k0
-    22: Mov r4, <scope>
-    25: LoadImmediate r5, 2
-    28: Jump 12 (.L1)
-    30: LoadImmediate r2, 0
-    33: Mov <scope>, r4
-    36: IteratorClose r0
-    38: Rethrow r3
+    10: IteratorNext r2, r3, r0, r1
+    15: JumpTrue r3, 28 (.L2)
+    18: SetNamedProperty a0, c0, r2, k0
+    23: Mov r4, <scope>
+    26: LoadImmediate r5, 2
+    29: Jump 12 (.L1)
+    31: LoadImmediate r2, 0
+    34: Mov <scope>, r4
+    37: IteratorClose r0
+    39: Rethrow r3
   .L1:
-    40: Jump -31 (.L0)
+    41: Jump -31 (.L0)
   .L2:
-    42: LoadImmediate r0, 3
-    45: NewArray r2
-    47: GetIterator r0, r1, r2
+    43: LoadImmediate r0, 3
+    46: NewArray r2, 0
+    49: GetIterator r0, r1, r2
   .L3:
-    51: IteratorNext r2, r3, r0, r1
-    56: JumpTrue r3, 30 (.L5)
-    59: LoadImmediate r3, 1
-    62: SetProperty a0, r3, r2
-    66: Mov r4, <scope>
-    69: LoadImmediate r5, 4
-    72: Jump 12 (.L4)
-    74: LoadImmediate r2, 0
-    77: Mov <scope>, r4
-    80: IteratorClose r0
-    82: Rethrow r3
+    53: IteratorNext r2, r3, r0, r1
+    58: JumpTrue r3, 30 (.L5)
+    61: LoadImmediate r3, 1
+    64: SetProperty a0, r3, r2
+    68: Mov r4, <scope>
+    71: LoadImmediate r5, 4
+    74: Jump 12 (.L4)
+    76: LoadImmediate r2, 0
+    79: Mov <scope>, r4
+    82: IteratorClose r0
+    84: Rethrow r3
   .L4:
-    84: Jump -33 (.L3)
+    86: Jump -33 (.L3)
   .L5:
-    86: LoadImmediate r0, 5
-    89: LoadUndefined r0
-    91: Ret r0
+    88: LoadImmediate r0, 5
+    91: LoadUndefined r0
+    93: Ret r0
   Constant Table:
     0: [String: foo]
   Exception Handlers:
-    17-28 -> 30 (r3)
-    36-38 -> 38
-    59-72 -> 74 (r3)
-    80-82 -> 82
+    18-29 -> 31 (r3)
+    37-39 -> 39
+    61-74 -> 76 (r3)
+    82-84 -> 84
 }
 
 [BytecodeFunction: lhsDestructuring] {
   Parameters: 1, Registers: 9
       0: LoadImmediate r3, 1
-      3: NewArray r5
-      5: GetIterator r3, r4, r5
+      3: NewArray r5, 0
+      6: GetIterator r3, r4, r5
   .L0:
-      9: IteratorNext r5, r6, r3, r4
-     14: JumpTrue r6, 47 (.L3)
-     17: GetNamedProperty r0, r5, c0, k0
-     22: GetNamedProperty r1, r5, c1, k1
-     27: GetNamedProperty r6, r5, c2, k2
-     32: JumpNotUndefined r6, 6 (.L1)
-     35: LoadImmediate r6, 1
+     10: IteratorNext r5, r6, r3, r4
+     15: JumpTrue r6, 47 (.L3)
+     18: GetNamedProperty r0, r5, c0, k0
+     23: GetNamedProperty r1, r5, c1, k1
+     28: GetNamedProperty r6, r5, c2, k2
+     33: JumpNotUndefined r6, 6 (.L1)
+     36: LoadImmediate r6, 1
   .L1:
-     38: Mov r2, r6
-     41: Mov r7, <scope>
-     44: LoadImmediate r8, 2
-     47: Jump 12 (.L2)
-     49: LoadImmediate r5, 0
-     52: Mov <scope>, r7
-     55: IteratorClose r3
-     57: Rethrow r6
+     39: Mov r2, r6
+     42: Mov r7, <scope>
+     45: LoadImmediate r8, 2
+     48: Jump 12 (.L2)
+     50: LoadImmediate r5, 0
+     53: Mov <scope>, r7
+     56: IteratorClose r3
+     58: Rethrow r6
   .L2:
-     59: Jump -50 (.L0)
+     60: Jump -50 (.L0)
   .L3:
-     61: LoadImmediate r3, 3
-     64: NewArray r5
-     66: GetIterator r3, r4, r5
+     62: LoadImmediate r3, 3
+     65: NewArray r5, 0
+     68: GetIterator r3, r4, r5
   .L4:
-     70: IteratorNext r5, r6, r3, r4
-     75: JumpTrue r6, 47 (.L7)
-     78: GetNamedProperty r0, r5, c0, k3
-     83: GetNamedProperty r1, r5, c1, k4
-     88: GetNamedProperty r6, r5, c2, k5
-     93: JumpNotUndefined r6, 6 (.L5)
-     96: LoadImmediate r6, 1
+     72: IteratorNext r5, r6, r3, r4
+     77: JumpTrue r6, 47 (.L7)
+     80: GetNamedProperty r0, r5, c0, k3
+     85: GetNamedProperty r1, r5, c1, k4
+     90: GetNamedProperty r6, r5, c2, k5
+     95: JumpNotUndefined r6, 6 (.L5)
+     98: LoadImmediate r6, 1
   .L5:
-     99: Mov r2, r6
-    102: Mov r7, <scope>
-    105: LoadImmediate r8, 4
-    108: Jump 12 (.L6)
-    110: LoadImmediate r5, 0
-    113: Mov <scope>, r7
-    116: IteratorClose r3
-    118: Rethrow r6
+    101: Mov r2, r6
+    104: Mov r7, <scope>
+    107: LoadImmediate r8, 4
+    110: Jump 12 (.L6)
+    112: LoadImmediate r5, 0
+    115: Mov <scope>, r7
+    118: IteratorClose r3
+    120: Rethrow r6
   .L6:
-    120: Jump -50 (.L4)
+    122: Jump -50 (.L4)
   .L7:
-    122: LoadImmediate r3, 5
-    125: LoadUndefined r3
-    127: Ret r3
+    124: LoadImmediate r3, 5
+    127: LoadUndefined r3
+    129: Ret r3
   Constant Table:
     0: [String: a]
     1: [String: b]
     2: [String: d]
   Exception Handlers:
-    17-47 -> 49 (r6)
-    55-57 -> 57
-    78-108 -> 110 (r6)
-    116-118 -> 118
+    18-48 -> 50 (r6)
+    56-58 -> 58
+    80-110 -> 112 (r6)
+    118-120 -> 120
 }
 
 [BytecodeFunction: lhsTdz] {
@@ -315,50 +315,50 @@
       8: PushLexicalScope c1
      10: LoadEmpty r2
      12: StoreToScope r2, 0, 0
-     16: NewArray r4
-     18: GetIterator r2, r3, r4
-     22: PopScope 
+     16: NewArray r4, 0
+     19: GetIterator r2, r3, r4
+     23: PopScope 
   .L0:
-     23: PushLexicalScope c1
-     25: LoadEmpty r4
-     27: StoreToScope r4, 0, 0
-     31: IteratorNext r4, r5, r2, r3
-     36: JumpTrue r5, 28 (.L2)
-     39: StoreToScope r4, 0, 0
-     43: Mov r6, <scope>
-     46: NewClosure r1, c2
-     49: Jump 12 (.L1)
-     51: LoadImmediate r4, 0
-     54: Mov <scope>, r6
-     57: IteratorClose r2
-     59: Rethrow r5
+     24: PushLexicalScope c1
+     26: LoadEmpty r4
+     28: StoreToScope r4, 0, 0
+     32: IteratorNext r4, r5, r2, r3
+     37: JumpTrue r5, 28 (.L2)
+     40: StoreToScope r4, 0, 0
+     44: Mov r6, <scope>
+     47: NewClosure r1, c2
+     50: Jump 12 (.L1)
+     52: LoadImmediate r4, 0
+     55: Mov <scope>, r6
+     58: IteratorClose r2
+     60: Rethrow r5
   .L1:
-     61: PopScope 
-     62: Jump -39 (.L0)
+     62: PopScope 
+     63: Jump -39 (.L0)
   .L2:
-     64: PopScope 
-     65: LoadImmediate r2, 1
-     68: StoreToScope r2, 0, 0
-     72: NewArray r4
-     74: GetIterator r2, r3, r4
+     65: PopScope 
+     66: LoadImmediate r2, 1
+     69: StoreToScope r2, 0, 0
+     73: NewArray r4, 0
+     76: GetIterator r2, r3, r4
   .L3:
-     78: IteratorNext r4, r5, r2, r3
-     83: JumpTrue r5, 34 (.L5)
-     86: LoadFromScope r5, 0, 0
-     90: CheckTdz r5, c3
-     93: StoreToScope r4, 0, 0
-     97: Mov r6, <scope>
-    100: NewClosure r0, c4
-    103: Jump 12 (.L4)
-    105: LoadImmediate r4, 0
-    108: Mov <scope>, r6
-    111: IteratorClose r2
-    113: Rethrow r5
+     80: IteratorNext r4, r5, r2, r3
+     85: JumpTrue r5, 34 (.L5)
+     88: LoadFromScope r5, 0, 0
+     92: CheckTdz r5, c3
+     95: StoreToScope r4, 0, 0
+     99: Mov r6, <scope>
+    102: NewClosure r0, c4
+    105: Jump 12 (.L4)
+    107: LoadImmediate r4, 0
+    110: Mov <scope>, r6
+    113: IteratorClose r2
+    115: Rethrow r5
   .L4:
-    115: Jump -37 (.L3)
+    117: Jump -37 (.L3)
   .L5:
-    117: LoadUndefined r2
-    119: Ret r2
+    119: LoadUndefined r2
+    121: Ret r2
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]
@@ -366,10 +366,10 @@
     3: [String: y]
     4: [BytecodeFunction: inner]
   Exception Handlers:
-    39-49 -> 51 (r5)
-    57-59 -> 59
-    86-103 -> 105 (r5)
-    111-113 -> 113
+    40-50 -> 52 (r5)
+    58-60 -> 60
+    88-105 -> 107 (r5)
+    113-115 -> 115
 }
 
 [BytecodeFunction: inner] {
@@ -394,42 +394,42 @@
   Parameters: 0, Registers: 9
      0: NewPromise r1
      2: LoadImmediate r2, 1
-     5: NewArray r4
-     7: GetAsyncIterator r2, r3, r4
+     5: NewArray r4, 0
+     8: GetAsyncIterator r2, r3, r4
   .L0:
-    11: CallWithReceiver r6, r3, r2, r2, 0
-    17: Await r6, r7, r1, r6
-    22: JumpTrue r7, 5 (.L1)
-    25: Throw r6
+    12: CallWithReceiver r6, r3, r2, r2, 0
+    18: Await r6, r7, r1, r6
+    23: JumpTrue r7, 5 (.L1)
+    26: Throw r6
   .L1:
-    27: IteratorUnpackResult r4, r5, r6
-    31: JumpTrue r5, 43 (.L5)
-    34: Mov r0, r4
-    37: Mov r6, <scope>
-    40: LoadImmediate r7, 2
-    43: Jump 29 (.L4)
-    45: LoadImmediate r4, 0
-    48: Mov <scope>, r6
-    51: AsyncIteratorCloseStart r7, r6, r2
-    55: JumpFalse r6, 15 (.L3)
-    58: Await r7, r8, r1, r7
-    63: JumpTrue r8, 5 (.L2)
-    66: Throw r7
+    28: IteratorUnpackResult r4, r5, r6
+    32: JumpTrue r5, 43 (.L5)
+    35: Mov r0, r4
+    38: Mov r6, <scope>
+    41: LoadImmediate r7, 2
+    44: Jump 29 (.L4)
+    46: LoadImmediate r4, 0
+    49: Mov <scope>, r6
+    52: AsyncIteratorCloseStart r7, r6, r2
+    56: JumpFalse r6, 15 (.L3)
+    59: Await r7, r8, r1, r7
+    64: JumpTrue r8, 5 (.L2)
+    67: Throw r7
   .L2:
-    68: AsyncIteratorCloseFinish r7
+    69: AsyncIteratorCloseFinish r7
   .L3:
-    70: Rethrow r5
+    71: Rethrow r5
   .L4:
-    72: Jump -61 (.L0)
+    73: Jump -61 (.L0)
   .L5:
-    74: LoadImmediate r2, 3
-    77: LoadUndefined r2
-    79: ResolvePromise r1, r2
-    82: Ret r1
-    84: RejectPromise r1, r2
-    87: Ret r1
+    75: LoadImmediate r2, 3
+    78: LoadUndefined r2
+    80: ResolvePromise r1, r2
+    83: Ret r1
+    85: RejectPromise r1, r2
+    88: Ret r1
   Exception Handlers:
-    34-43 -> 45 (r5)
-    51-70 -> 70
-    2-84 -> 84 (r2)
+    35-44 -> 46 (r5)
+    52-71 -> 71
+    2-85 -> 85 (r2)
 }


### PR DESCRIPTION
## Summary

Array literals now have their size estimated during bytecode generation and written as an operand of the `NewArray` instruction. The array allocates dense property storage for this estimated capacity since it is the precise capacity needed in the common case.

Seeing ~3.4% increase on Octane.

| Benchmark | 32c0359d1 (base) | d4459535d | Change |
|---|---|---|---|
| Richards | 2,224 med 2,217 ±24.2 n=3 | 2,196 med 2,195 ±1.4 n=2 | -1.3% |
| DeltaBlue | 2,448 med 2,420 ±35.2 n=3 | 2,384 med 2,375 ±13.4 n=2 | -2.6% |
| Crypto | 2,007 med 1,998 ±41.5 n=3 | 2,045 med 1,977 ±96.2 n=2 | +1.9% |
| RayTrace | 2,891 med 2,877 ±25.8 n=3 | 2,846 med 2,842 ±5.7 n=2 | -1.6% |
| EarleyBoyer | 5,034 med 5,013 ±29.4 n=3 | 5,015 med 5,008 ±9.9 n=2 | -0.4% |
| RegExp | 439 med 437 ±2.0 n=3 | 445 med 445 ±0.7 n=2 | +1.4% |
| Splay | 4,498 med 4,240 ±158 n=3 | 4,942 med 4,909 ±46.7 n=2 | +9.9% |
| SplayLatency | 7,035 med 6,537 ±305 n=3 | 9,989 med 9,950 ±55.9 n=2 | +42.0% |
| NavierStokes | 4,162 med 4,155 ±9.6 n=3 | 4,151 med 4,129 ±31.8 n=2 | -0.3% |
| PdfJS | 6,212 med 6,190 ±19.1 n=3 | 6,250 med 6,247 ±4.2 n=2 | +0.6% |
| Mandreel | 2,109 med 2,107 ±2.0 n=3 | 2,161 med 2,147 ±19.8 n=2 | +2.5% |
| MandreelLatency | 16,729 med 16,673 ±85.0 n=3 | 17,014 med 16,957 ±81.3 n=2 | +1.7% |
| Gameboy | 5,155 med 5,155 ±55.4 n=3 | 5,149 med 5,141 ±12.0 n=2 | -0.1% |
| CodeLoad | 40,018 med 39,991 ±199 n=3 | 39,690 med 39,635 ±78.5 n=2 | -0.8% |
| Box2D | 8,216 med 8,125 ±60.7 n=3 | 8,231 med 8,201 ±43.1 n=2 | +0.2% |
| zlib | 4,531 med 4,513 ±17.5 n=3 | 4,614 med 4,494 ±170 n=2 | +1.8% |
| Typescript | 18,652 med 18,552 ±93.1 n=3 | 18,617 med 18,558 ±84.1 n=2 | -0.2% |
| **Total (octane)** | **4,681 med 4,673 ±11.1 n=3** | **4,842 med 4,825 ±24.0 n=2** | **+3.4%** |

## Tests

- Updated bytecode snapshots that create arrays, existing tests sufficiently cover element estimation