### PR TITLE
[bytecode] Instructions for common binary operations with smi immediates

### DIFF
--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -3507,6 +3507,13 @@ impl<'a> BytecodeFunctionGenerator<'a> {
             return self.gen_private_in_expression(expr, dest);
         }
 
+        // First try to generate a specialized instruction with a smi immediate operand
+        if let Some(result) = self.gen_binary_expression_with_immediate_rhs(expr, dest)? {
+            return Ok(result);
+        } else if let Some(result) = self.gen_binary_expression_with_immediate_lhs(expr, dest)? {
+            return Ok(result);
+        }
+
         let pos = expr.operator_pos;
 
         let left = self.gen_expression(&expr.left)?;
@@ -3565,6 +3572,142 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         }
 
         Ok(dest)
+    }
+
+    /// Generate a specialized instruction for a binary expression if the right operand is a valid
+    /// immediate. Returns the destination register if a specialized instruction was generated.
+    fn gen_binary_expression_with_immediate_rhs(
+        &mut self,
+        expr: &'a ast::BinaryExpression<'a>,
+        dest: ExprDest,
+    ) -> EmitResult<Option<GenRegister>> {
+        // Right operand must be a smi literal
+        let right = match Self::as_smi_immediate(&expr.right) {
+            Some(immediate) => immediate,
+            None => return Ok(None),
+        };
+
+        let has_immediate_instruction = matches!(
+            expr.operator,
+            ast::BinaryOperator::Add
+                | ast::BinaryOperator::Subtract
+                | ast::BinaryOperator::Multiply
+                | ast::BinaryOperator::Divide
+                | ast::BinaryOperator::Remainder
+                | ast::BinaryOperator::And
+                | ast::BinaryOperator::Or
+                | ast::BinaryOperator::Xor
+                | ast::BinaryOperator::ShiftLeft
+                | ast::BinaryOperator::ShiftRightArithmetic
+                | ast::BinaryOperator::ShiftRightLogical
+        );
+        if !has_immediate_instruction {
+            return Ok(None);
+        }
+
+        let left = self.gen_expression(&expr.left)?;
+        self.register_allocator.release(left);
+
+        let dest = self.allocate_destination(dest)?;
+        let pos = expr.operator_pos;
+
+        match expr.operator {
+            ast::BinaryOperator::Add => self.writer.add_imm_instruction(dest, left, right, pos),
+            ast::BinaryOperator::Subtract => {
+                self.writer.sub_imm_instruction(dest, left, right, pos)
+            }
+            ast::BinaryOperator::Multiply => {
+                self.writer.mul_imm_instruction(dest, left, right, pos)
+            }
+            ast::BinaryOperator::Divide => self.writer.div_imm_instruction(dest, left, right, pos),
+            ast::BinaryOperator::Remainder => {
+                self.writer.rem_imm_instruction(dest, left, right, pos)
+            }
+            ast::BinaryOperator::And => self.writer.bit_and_imm_instruction(dest, left, right, pos),
+            ast::BinaryOperator::Or => self.writer.bit_or_imm_instruction(dest, left, right, pos),
+            ast::BinaryOperator::Xor => self.writer.bit_xor_imm_instruction(dest, left, right, pos),
+            ast::BinaryOperator::ShiftLeft => self
+                .writer
+                .shift_left_imm_instruction(dest, left, right, pos),
+            ast::BinaryOperator::ShiftRightArithmetic => self
+                .writer
+                .shift_right_arithmetic_imm_instruction(dest, left, right, pos),
+            ast::BinaryOperator::ShiftRightLogical => self
+                .writer
+                .shift_right_logical_imm_instruction(dest, left, right, pos),
+            _ => unreachable!("unsupported operator"),
+        }
+
+        Ok(Some(dest))
+    }
+
+    /// Generate a specialized instruction for a binary expression if the left operand is a valid
+    /// immediate. Returns the destination register if a specialized instruction was generated.
+    fn gen_binary_expression_with_immediate_lhs(
+        &mut self,
+        expr: &'a ast::BinaryExpression<'a>,
+        dest: ExprDest,
+    ) -> EmitResult<Option<GenRegister>> {
+        // Left operand must be a smi literal
+        let left = match Self::as_smi_immediate(&expr.left) {
+            Some(immediate) => immediate,
+            None => return Ok(None),
+        };
+
+        // Only the commutative operators are supported since operands must be flipped
+        let has_commutative_immediate_instruction = matches!(
+            expr.operator,
+            ast::BinaryOperator::Multiply
+                | ast::BinaryOperator::And
+                | ast::BinaryOperator::Or
+                | ast::BinaryOperator::Xor
+        );
+        if !has_commutative_immediate_instruction {
+            return Ok(None);
+        }
+
+        let right = self.gen_expression(&expr.right)?;
+        self.register_allocator.release(right);
+
+        let dest = self.allocate_destination(dest)?;
+        let pos = expr.operator_pos;
+
+        match expr.operator {
+            ast::BinaryOperator::Multiply => {
+                self.writer.mul_imm_instruction(dest, right, left, pos)
+            }
+            ast::BinaryOperator::And => self.writer.bit_and_imm_instruction(dest, right, left, pos),
+            ast::BinaryOperator::Or => self.writer.bit_or_imm_instruction(dest, right, left, pos),
+            ast::BinaryOperator::Xor => self.writer.bit_xor_imm_instruction(dest, right, left, pos),
+            _ => unreachable!("unsupported operator"),
+        }
+
+        Ok(Some(dest))
+    }
+
+    /// Return the value of an expression as a smi immediate, if the expression is a literal that
+    /// can be represented as a smi. Includes unary minus.
+    fn as_smi_immediate(expr: &ast::Expression) -> Option<GenSInt> {
+        let value = match expr {
+            ast::Expression::Number(number_expr) => number_expr.value,
+            ast::Expression::Unary(unary_expr)
+                if unary_expr.operator == ast::UnaryOperator::Minus =>
+            {
+                if let ast::Expression::Number(number_expr) = &unary_expr.argument {
+                    -number_expr.value
+                } else {
+                    return None;
+                }
+            }
+            _ => return None,
+        };
+
+        let number = Value::number(value);
+        if number.is_smi() {
+            Some(SInt::new(number.as_smi()))
+        } else {
+            None
+        }
     }
 
     fn gen_private_in_expression(

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -722,6 +722,141 @@ define_instructions!(
         }
     }
 
+    /// Add a value and a smi immediate together, storing the result in dest.
+    AddImm {
+        camel_case: AddImmInstruction,
+        snake_case: add_imm_instruction,
+        can_throw: true,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: SInt,
+        }
+    }
+
+    /// Subtract a smi immediate from a value, storing the result in dest.
+    SubImm {
+        camel_case: SubImmInstruction,
+        snake_case: sub_imm_instruction,
+        can_throw: true,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: SInt,
+        }
+    }
+
+    /// Multiply a value with a smi immediate, storing the result in dest.
+    MulImm {
+        camel_case: MulImmInstruction,
+        snake_case: mul_imm_instruction,
+        can_throw: true,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: SInt,
+        }
+    }
+
+    /// Divide a value by a smi immediate, storing the result in dest.
+    DivImm {
+        camel_case: DivImmInstruction,
+        snake_case: div_imm_instruction,
+        can_throw: true,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: SInt,
+        }
+    }
+
+    /// Find the remainder from dividing the left value with a smi immediate, storing the result in
+    /// dest.
+    RemImm {
+        camel_case: RemImmInstruction,
+        snake_case: rem_imm_instruction,
+        can_throw: true,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: SInt,
+        }
+    }
+
+    /// Bitwise and the left operand with a smi immediate, storing the result in dest.
+    BitAndImm {
+        camel_case: BitAndImmInstruction,
+        snake_case: bit_and_imm_instruction,
+        can_throw: true,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: SInt,
+        }
+    }
+
+    /// Bitwise or the left operand with a smi immediate, storing the result in dest.
+    BitOrImm {
+        camel_case: BitOrImmInstruction,
+        snake_case: bit_or_imm_instruction,
+        can_throw: true,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: SInt,
+        }
+    }
+
+    /// Bitwise xor the left operand with a smi immediate, storing the result in dest.
+    BitXorImm {
+        camel_case: BitXorImmInstruction,
+        snake_case: bit_xor_imm_instruction,
+        can_throw: true,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: SInt,
+        }
+    }
+
+    /// Shift the left operand left by a smi immediate, storing the result in dest.
+    ShiftLeftImm {
+        camel_case: ShiftLeftImmInstruction,
+        snake_case: shift_left_imm_instruction,
+        can_throw: true,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: SInt,
+        }
+    }
+
+    /// Shift the left operand right by a smi immediate, storing the result in dest. Extends the
+    /// highest bit of the left operand, preserving the sign of the left operand.
+    ShiftRightArithmeticImm {
+        camel_case: ShiftRightArithmeticImmInstruction,
+        snake_case: shift_right_arithmetic_imm_instruction,
+        can_throw: true,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: SInt,
+        }
+    }
+
+    /// Shift the left operand right by a smi immediate, storing the result in dest. New bits are
+    /// filled with zeroes.
+    ShiftRightLogicalImm {
+        camel_case: ShiftRightLogicalImmInstruction,
+        snake_case: shift_right_logical_imm_instruction,
+        can_throw: true,
+        operands: {
+            [0] dest: Register,
+            [1] left: Register,
+            [2] right: SInt,
+        }
+    }
+
     /// Test if the two operands are loosely equal to each other (`==`), storing the result in dest.
     LooseEqual {
         camel_case: LooseEqualInstruction,

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -29,28 +29,30 @@ use crate::{
             function::{BytecodeFunction, CacheArray, ClosureObject},
             generator::BytecodeScript,
             instruction::{
-                AddInstruction, AsyncIteratorCloseFinishInstruction,
-                AsyncIteratorCloseStartInstruction, AwaitInstruction, BitAndInstruction,
-                BitNotInstruction, BitOrInstruction, BitXorInstruction, CallInstruction,
-                CallMaybeEvalInstruction, CallMaybeEvalVarargsInstruction, CallVarargsInstruction,
+                AddImmInstruction, AddInstruction, AsyncIteratorCloseFinishInstruction,
+                AsyncIteratorCloseStartInstruction, AwaitInstruction, BitAndImmInstruction,
+                BitAndInstruction, BitNotInstruction, BitOrImmInstruction, BitOrInstruction,
+                BitXorImmInstruction, BitXorInstruction, CallInstruction, CallMaybeEvalInstruction,
+                CallMaybeEvalVarargsInstruction, CallVarargsInstruction,
                 CallWithReceiverInstruction, CheckIteratorResultObjectInstruction,
                 CheckSuperAlreadyCalledInstruction, CheckTdzInstruction,
                 CheckThisInitializedInstruction, ConstructInstruction, ConstructVarargsInstruction,
                 CopyDataPropertiesInstruction, DecInstruction, DefaultSuperCallInstruction,
                 DefineNamedPropertyInstruction, DefinePrivatePropertyFlags,
                 DefinePrivatePropertyInstruction, DefinePropertyFlags, DefinePropertyInstruction,
-                DeleteBindingInstruction, DeletePropertyInstruction, DivInstruction,
-                DupScopeInstruction, DynamicImportInstruction, ErrorConstInstruction, EvalFlags,
-                ExpInstruction, ForInNextInstruction, GeneratorStartInstruction,
-                GetAsyncIteratorInstruction, GetIteratorInstruction, GetMethodInstruction,
-                GetNamedPropertyInstruction, GetNamedSuperPropertyInstruction,
-                GetPrivatePropertyInstruction, GetPropertyInstruction,
-                GetSuperConstructorInstruction, GetSuperPropertyInstruction,
-                GreaterThanInstruction, GreaterThanOrEqualInstruction, ImportMetaInstruction,
-                InInstruction, IncInstruction, InstanceOfInstruction, Instruction,
-                IteratorCloseInstruction, IteratorNextInstruction, IteratorUnpackResultInstruction,
-                JumpConstantInstruction, JumpFalseConstantInstruction, JumpFalseInstruction,
-                JumpInstruction, JumpNotNullishConstantInstruction, JumpNotNullishInstruction,
+                DeleteBindingInstruction, DeletePropertyInstruction, DivImmInstruction,
+                DivInstruction, DupScopeInstruction, DynamicImportInstruction,
+                ErrorConstInstruction, EvalFlags, ExpInstruction, ForInNextInstruction,
+                GeneratorStartInstruction, GetAsyncIteratorInstruction, GetIteratorInstruction,
+                GetMethodInstruction, GetNamedPropertyInstruction,
+                GetNamedSuperPropertyInstruction, GetPrivatePropertyInstruction,
+                GetPropertyInstruction, GetSuperConstructorInstruction,
+                GetSuperPropertyInstruction, GreaterThanInstruction, GreaterThanOrEqualInstruction,
+                ImportMetaInstruction, InInstruction, IncInstruction, InstanceOfInstruction,
+                Instruction, IteratorCloseInstruction, IteratorNextInstruction,
+                IteratorUnpackResultInstruction, JumpConstantInstruction,
+                JumpFalseConstantInstruction, JumpFalseInstruction, JumpInstruction,
+                JumpNotNullishConstantInstruction, JumpNotNullishInstruction,
                 JumpNotUndefinedConstantInstruction, JumpNotUndefinedInstruction,
                 JumpNullishConstantInstruction, JumpNullishInstruction,
                 JumpToBooleanFalseConstantInstruction, JumpToBooleanFalseInstruction,
@@ -61,23 +63,25 @@ use crate::{
                 LoadFromModuleInstruction, LoadFromScopeInstruction, LoadGlobalInstruction,
                 LoadGlobalOrUnresolvedInstruction, LoadImmediateInstruction, LoadNullInstruction,
                 LoadTrueInstruction, LoadUndefinedInstruction, LogNotInstruction,
-                LooseEqualInstruction, LooseNotEqualInstruction, MovInstruction, MulInstruction,
-                NegInstruction, NewAccessorInstruction, NewArrayInstruction,
+                LooseEqualInstruction, LooseNotEqualInstruction, MovInstruction, MulImmInstruction,
+                MulInstruction, NegInstruction, NewAccessorInstruction, NewArrayInstruction,
                 NewAsyncClosureInstruction, NewAsyncGeneratorInstruction, NewClassInstruction,
                 NewClosureInstruction, NewForInIteratorInstruction, NewGeneratorInstruction,
                 NewMappedArgumentsInstruction, NewObjectInstruction, NewPrivateSymbolInstruction,
                 NewPromiseInstruction, NewRegExpInstruction, NewUnmappedArgumentsInstruction,
                 OpCode, PopScopeInstruction, PushFunctionScopeInstruction,
                 PushLexicalScopeInstruction, PushWithScopeInstruction, RejectPromiseInstruction,
-                RemInstruction, ResolvePromiseInstruction, RestParameterInstruction,
-                RetInstruction, RethrowInstruction, SetArrayPropertyInstruction,
-                SetNamedPropertyInstruction, SetPrivatePropertyInstruction, SetPropertyInstruction,
-                SetPrototypeOfInstruction, SetSuperPropertyInstruction, ShiftLeftInstruction,
-                ShiftRightArithmeticInstruction, ShiftRightLogicalInstruction,
+                RemImmInstruction, RemInstruction, ResolvePromiseInstruction,
+                RestParameterInstruction, RetInstruction, RethrowInstruction,
+                SetArrayPropertyInstruction, SetNamedPropertyInstruction,
+                SetPrivatePropertyInstruction, SetPropertyInstruction, SetPrototypeOfInstruction,
+                SetSuperPropertyInstruction, ShiftLeftImmInstruction, ShiftLeftInstruction,
+                ShiftRightArithmeticImmInstruction, ShiftRightArithmeticInstruction,
+                ShiftRightLogicalImmInstruction, ShiftRightLogicalInstruction,
                 StoreDynamicInstruction, StoreGlobalInstruction, StoreToModuleInstruction,
                 StoreToScopeInstruction, StrictEqualInstruction, StrictNotEqualInstruction,
-                SubInstruction, ThrowInstruction, ThrowNewErrorInstruction, ThrowNewErrorKind,
-                ToNumberInstruction, ToNumericInstruction, ToObjectInstruction,
+                SubImmInstruction, SubInstruction, ThrowInstruction, ThrowNewErrorInstruction,
+                ThrowNewErrorKind, ToNumberInstruction, ToNumericInstruction, ToObjectInstruction,
                 ToPropertyKeyInstruction, ToStringInstruction, TypeOfInstruction, YieldInstruction,
                 extra_wide_prefix_index_to_opcode_index, wide_prefix_index_to_opcode_index,
             },
@@ -255,6 +259,29 @@ macro_rules! binary_op_runtime_bool_instruction {
     };
 }
 
+/// A binary operation instruction handler with a smi immediate right operand which calls a single
+/// Rust function with the signature (Context, Handle<Value>, Handle<Value>) ->
+/// EvalResult<Handle<Value>>.
+macro_rules! binary_op_imm_runtime_instruction {
+    ($name:ident, $instr:ident, $op:ident) => {
+        #[inline(never)]
+        fn $name<W: Width>(&mut self, instr: &$instr<W>) -> EvalResult<()> {
+            handle_scope!(self.cx(), {
+                let left = self.read_register_to_handle(instr.left());
+                let right = Value::smi(instr.right().value().to_i32()).to_handle(self.cx());
+                let dest = instr.dest();
+
+                // May allocate
+                let result = $op(self.cx(), left, right)?;
+
+                self.write_register(dest, *result);
+
+                Ok(())
+            })
+        }
+    };
+}
+
 /// Generate a fast path handler for a binary operation instruction handler from a Rust operation
 /// with the signature (i32, i32) -> i32.
 macro_rules! binary_op_fast_smi_instruction {
@@ -275,6 +302,26 @@ macro_rules! binary_op_fast_smi_instruction {
     };
 }
 
+/// Generate a fast path handler for a binary operation instruction with a smi immediate right
+/// operand from a Rust operation with the signature (i32, i32) -> i32.
+macro_rules! binary_op_imm_fast_smi_instruction {
+    ($name:ident, $instr:ident, $op:tt) => {
+        #[inline(always)]
+        fn $name<W: Width>(&mut self, instr: &$instr<W>) -> bool {
+            let left = self.read_register(instr.left());
+            let right = instr.right().value().to_i32();
+
+            if left.is_smi() {
+                let result = left.as_smi() $op right;
+                self.write_register(instr.dest(), Value::smi(result));
+                return true;
+            }
+
+            false
+        }
+    };
+}
+
 /// Generate a fast path handler for a binary operation instruction handler that generically handles
 /// any number operands. Argument is a Rust operation with the signature (f64, f64) -> f64.
 macro_rules! binary_op_fast_number_instruction {
@@ -286,6 +333,27 @@ macro_rules! binary_op_fast_number_instruction {
 
             if left.is_number() && right.is_number() {
                 let result = left.as_number() $op right.as_number();
+                self.write_register(instr.dest(), Value::number(result));
+                return true;
+            }
+
+            false
+        }
+    };
+}
+
+/// Generate a fast path handler for a binary operation instruction with a smi immediate right
+/// operand that generically handles any number left operand. Argument is a Rust operation with the
+/// signature (f64, f64) -> f64.
+macro_rules! binary_op_imm_fast_number_instruction {
+    ($name:ident, $instr:ident, $op:tt) => {
+        #[inline(always)]
+        fn $name<W: Width>(&mut self, instr: &$instr<W>) -> bool {
+            let left = self.read_register(instr.left());
+            let right = instr.right().value().to_i32();
+
+            if left.is_number() {
+                let result = left.as_number() $op right as f64;
                 self.write_register(instr.dest(), Value::number(result));
                 return true;
             }
@@ -326,6 +394,36 @@ macro_rules! binary_op_fast_smi_double_instruction {
                 } else {
                     return false;
                 }
+            } else {
+                return false;
+            };
+
+            self.write_register(instr.dest(), result);
+
+            true
+        }
+    };
+}
+
+/// Generate a fast path handler for a binary operation instruction with a smi immediate right
+/// operand that handles both smi and double left operands. Arguments are a Rust operation with the
+/// signature (f64, f64) -> f64 and a Rust checked operation (i32, i32) -> Option<i32>.
+macro_rules! binary_op_imm_fast_smi_double_instruction {
+    ($name:ident, $instr:ident, $op:tt, $checked_op:ident) => {
+        #[inline(always)]
+        fn $name<W: Width>(&mut self, instr: &$instr<W>) -> bool {
+            let left = self.read_register(instr.left());
+            let right = instr.right().value().to_i32();
+
+            // Fast path for smi and double left operands
+            let result = if left.is_smi() {
+                if let Some(result) = left.as_smi().$checked_op(right) {
+                    Value::smi(result)
+                } else {
+                    Value::number(left.as_smi() as f64 $op right as f64)
+                }
+            } else if left.is_double() {
+                Value::number(left.as_double() $op right as f64)
             } else {
                 return false;
             };
@@ -1195,6 +1293,93 @@ impl VM {
                             ShiftRightLogicalInstruction,
                             execute_shift_right_logical_fast,
                             execute_shift_right_logical_slow,
+                            $width,
+                            $opcode_pc
+                        ),
+                        OpCode::AddImm => {
+                            dispatch_fast_or_throw!(
+                                AddImmInstruction,
+                                execute_add_imm_fast,
+                                execute_add_imm_slow,
+                                $width,
+                                $opcode_pc
+                            )
+                        }
+                        OpCode::SubImm => {
+                            dispatch_fast_or_throw!(
+                                SubImmInstruction,
+                                execute_sub_imm_fast,
+                                execute_sub_imm_slow,
+                                $width,
+                                $opcode_pc
+                            )
+                        }
+                        OpCode::MulImm => {
+                            dispatch_fast_or_throw!(
+                                MulImmInstruction,
+                                execute_mul_imm_fast,
+                                execute_mul_imm_slow,
+                                $width,
+                                $opcode_pc
+                            )
+                        }
+                        OpCode::DivImm => {
+                            dispatch_fast_or_throw!(
+                                DivImmInstruction,
+                                execute_div_imm_fast,
+                                execute_div_imm_slow,
+                                $width,
+                                $opcode_pc
+                            )
+                        }
+                        OpCode::RemImm => {
+                            dispatch_fast_or_throw!(
+                                RemImmInstruction,
+                                execute_rem_imm_fast,
+                                execute_rem_imm_slow,
+                                $width,
+                                $opcode_pc
+                            )
+                        }
+                        OpCode::BitAndImm => dispatch_fast_or_throw!(
+                            BitAndImmInstruction,
+                            execute_bit_and_imm_fast,
+                            execute_bit_and_imm_slow,
+                            $width,
+                            $opcode_pc
+                        ),
+                        OpCode::BitOrImm => dispatch_fast_or_throw!(
+                            BitOrImmInstruction,
+                            execute_bit_or_imm_fast,
+                            execute_bit_or_imm_slow,
+                            $width,
+                            $opcode_pc
+                        ),
+                        OpCode::BitXorImm => dispatch_fast_or_throw!(
+                            BitXorImmInstruction,
+                            execute_bit_xor_imm_fast,
+                            execute_bit_xor_imm_slow,
+                            $width,
+                            $opcode_pc
+                        ),
+                        OpCode::ShiftLeftImm => dispatch_fast_or_throw!(
+                            ShiftLeftImmInstruction,
+                            execute_shift_left_imm_fast,
+                            execute_shift_left_imm_slow,
+                            $width,
+                            $opcode_pc
+                        ),
+                        OpCode::ShiftRightArithmeticImm => dispatch_fast_or_throw!(
+                            ShiftRightArithmeticImmInstruction,
+                            execute_shift_right_arithmetic_imm_fast,
+                            execute_shift_right_arithmetic_imm_slow,
+                            $width,
+                            $opcode_pc
+                        ),
+                        OpCode::ShiftRightLogicalImm => dispatch_fast_or_throw!(
+                            ShiftRightLogicalImmInstruction,
+                            execute_shift_right_logical_imm_fast,
+                            execute_shift_right_logical_imm_slow,
                             $width,
                             $opcode_pc
                         ),
@@ -3904,6 +4089,112 @@ impl VM {
     binary_op_runtime_instruction!(
         execute_shift_right_logical_slow,
         ShiftRightLogicalInstruction,
+        eval_shift_right_logical
+    );
+
+    binary_op_imm_fast_smi_double_instruction!(execute_add_imm_fast, AddImmInstruction, +, checked_add);
+    binary_op_imm_runtime_instruction!(execute_add_imm_slow, AddImmInstruction, eval_add);
+
+    binary_op_imm_fast_smi_double_instruction!(execute_sub_imm_fast, SubImmInstruction, -, checked_sub);
+    binary_op_imm_runtime_instruction!(execute_sub_imm_slow, SubImmInstruction, eval_subtract);
+
+    binary_op_imm_fast_number_instruction!(execute_mul_imm_fast, MulImmInstruction, *);
+    binary_op_imm_runtime_instruction!(execute_mul_imm_slow, MulImmInstruction, eval_multiply);
+
+    binary_op_imm_fast_number_instruction!(execute_div_imm_fast, DivImmInstruction, /);
+    binary_op_imm_runtime_instruction!(execute_div_imm_slow, DivImmInstruction, eval_divide);
+
+    binary_op_imm_fast_number_instruction!(execute_rem_imm_fast, RemImmInstruction, %);
+    binary_op_imm_runtime_instruction!(execute_rem_imm_slow, RemImmInstruction, eval_remainder);
+
+    binary_op_imm_fast_smi_instruction!(execute_bit_and_imm_fast, BitAndImmInstruction, &);
+    binary_op_imm_runtime_instruction!(
+        execute_bit_and_imm_slow,
+        BitAndImmInstruction,
+        eval_bitwise_and
+    );
+
+    binary_op_imm_fast_smi_instruction!(execute_bit_or_imm_fast, BitOrImmInstruction, |);
+    binary_op_imm_runtime_instruction!(
+        execute_bit_or_imm_slow,
+        BitOrImmInstruction,
+        eval_bitwise_or
+    );
+
+    binary_op_imm_fast_smi_instruction!(execute_bit_xor_imm_fast, BitXorImmInstruction, ^);
+    binary_op_imm_runtime_instruction!(
+        execute_bit_xor_imm_slow,
+        BitXorImmInstruction,
+        eval_bitwise_xor
+    );
+
+    #[inline(always)]
+    fn execute_shift_left_imm_fast<W: Width>(
+        &mut self,
+        instr: &ShiftLeftImmInstruction<W>,
+    ) -> bool {
+        let left = self.read_register(instr.left());
+        let right = instr.right().value().to_i32();
+
+        if left.is_smi() {
+            let result = left.as_smi().wrapping_shl(right as u32);
+            self.write_register(instr.dest(), Value::smi(result));
+            return true;
+        }
+
+        false
+    }
+
+    binary_op_imm_runtime_instruction!(
+        execute_shift_left_imm_slow,
+        ShiftLeftImmInstruction,
+        eval_shift_left
+    );
+
+    #[inline(always)]
+    fn execute_shift_right_arithmetic_imm_fast<W: Width>(
+        &mut self,
+        instr: &ShiftRightArithmeticImmInstruction<W>,
+    ) -> bool {
+        let left = self.read_register(instr.left());
+        let right = instr.right().value().to_i32();
+
+        if left.is_smi() {
+            let result = left.as_smi().wrapping_shr(right as u32);
+            self.write_register(instr.dest(), Value::smi(result));
+            return true;
+        }
+
+        false
+    }
+
+    binary_op_imm_runtime_instruction!(
+        execute_shift_right_arithmetic_imm_slow,
+        ShiftRightArithmeticImmInstruction,
+        eval_shift_right_arithmetic
+    );
+
+    #[inline(always)]
+    fn execute_shift_right_logical_imm_fast<W: Width>(
+        &mut self,
+        instr: &ShiftRightLogicalImmInstruction<W>,
+    ) -> bool {
+        let left = self.read_register(instr.left());
+        let right = instr.right().value().to_i32();
+
+        if left.is_smi() {
+            // Note that result might not be a smi
+            let result = (left.as_smi() as u32).wrapping_shr(right as u32);
+            self.write_register(instr.dest(), Value::number(result));
+            return true;
+        }
+
+        false
+    }
+
+    binary_op_imm_runtime_instruction!(
+        execute_shift_right_logical_imm_slow,
+        ShiftRightLogicalImmInstruction,
         eval_shift_right_logical
     );
 

--- a/tests/integration/language/expression/binary/smi_immediate.js
+++ b/tests/integration/language/expression/binary/smi_immediate.js
@@ -1,0 +1,146 @@
+/*---
+description: Binary expressions where the right operand is a smi immediate.
+---*/
+
+function add(x) {
+  return x + 3;
+}
+
+function addNegative(x) {
+  return x + -3;
+}
+
+function sub(x) {
+  return x - 3;
+}
+
+function mul(x) {
+  return x * 3;
+}
+
+function mulLhs(x) {
+  return 3 * x;
+}
+
+function div(x) {
+  return x / 2;
+}
+
+function rem(x) {
+  return x % 3;
+}
+
+function bitAnd(x) {
+  return x & 6;
+}
+
+function bitAndLhs(x) {
+  return 6 & x;
+}
+
+function bitOr(x) {
+  return x | 6;
+}
+
+function bitOrLhs(x) {
+  return 6 | x;
+}
+
+function bitXor(x) {
+  return x ^ 6;
+}
+
+function bitXorLhs(x) {
+  return 6 ^ x;
+}
+
+function shiftLeft(x) {
+  return x << 2;
+}
+
+function shiftLeftOverflow(x) {
+  return x << 34;
+}
+
+function shiftRightArithmetic(x) {
+  return x >> 2;
+}
+
+function shiftRightArithmeticOverflow(x) {
+  return x >> 34;
+}
+
+function shiftRightLogical(x) {
+  return x >>> 2;
+}
+
+function shiftRightLogicalOverflow(x) {
+  return x >>> 34;
+}
+
+// Smi operands
+assert.sameValue(add(1), 4);
+assert.sameValue(addNegative(1), -2);
+assert.sameValue(sub(1), -2);
+assert.sameValue(mul(-2), -6);
+assert.sameValue(mulLhs(-2), -6);
+assert.sameValue(div(7), 3.5);
+assert.sameValue(rem(7), 1);
+assert.sameValue(bitAnd(5), 4);
+assert.sameValue(bitAndLhs(5), 4);
+assert.sameValue(bitOr(5), 7);
+assert.sameValue(bitOrLhs(5), 7);
+assert.sameValue(bitXor(5), 3);
+assert.sameValue(bitXorLhs(5), 3);
+assert.sameValue(shiftLeft(5), 20);
+assert.sameValue(shiftRightArithmetic(-8), -2);
+assert.sameValue(shiftRightLogical(-8), 1073741822);
+
+// Smi operands that overflow to doubles
+assert.sameValue(add(2147483647), 2147483650);
+assert.sameValue(sub(-2147483648), -2147483651);
+assert.sameValue(shiftLeft(2147483647), -4);
+
+// Overflowing shift operands are masked to 5 bits
+assert.sameValue(shiftLeftOverflow(5), 20);
+assert.sameValue(shiftRightArithmeticOverflow(-8), -2);
+assert.sameValue(shiftRightLogicalOverflow(-8), 1073741822);
+
+// Double operands
+assert.sameValue(add(1.5), 4.5);
+assert.sameValue(sub(1.5), -1.5);
+assert.sameValue(mul(1.5), 4.5);
+assert.sameValue(mulLhs(1.5), 4.5);
+assert.sameValue(div(1.5), 0.75);
+assert.sameValue(rem(7.5), 1.5);
+assert.sameValue(bitAnd(5.7), 4);
+assert.sameValue(bitAndLhs(5.7), 4);
+assert.sameValue(bitOr(5.7), 7);
+assert.sameValue(bitOrLhs(5.7), 7);
+assert.sameValue(bitXor(5.7), 3);
+assert.sameValue(bitXorLhs(5.7), 3);
+assert.sameValue(shiftLeft(5.7), 20);
+assert.sameValue(shiftRightArithmetic(-8.7), -2);
+assert.sameValue(shiftRightLogical(-8.7), 1073741822);
+
+// Multiplying by zero preserves the sign of the left operand
+assert.sameValue(1 / mul(-0), -Infinity);
+assert.sameValue(1 / mulLhs(-0), -Infinity);
+
+// Operands that are not numbers
+assert.sameValue(add('foo'), 'foo3');
+assert.sameValue(sub('7'), 4);
+assert.sameValue(mul('7'), 21);
+assert.sameValue(mulLhs('7'), 21);
+assert.sameValue(div('7'), 3.5);
+assert.sameValue(rem('7'), 1);
+assert.sameValue(bitAnd('5'), 4);
+assert.sameValue(bitAndLhs('5'), 4);
+assert.sameValue(bitOr('5'), 7);
+assert.sameValue(bitOrLhs('5'), 7);
+assert.sameValue(bitXor('5'), 3);
+assert.sameValue(bitXorLhs('5'), 3);
+assert.sameValue(shiftLeft('5'), 20);
+assert.sameValue(shiftRightArithmetic('-8'), -2);
+assert.sameValue(shiftRightLogical('-8'), 1073741822);
+assert.sameValue(add({ valueOf: () => 39 }), 42);

--- a/tests/snapshot/bytecode/arguments_object/binding.exp
+++ b/tests/snapshot/bytecode/arguments_object/binding.exp
@@ -15,11 +15,10 @@
 
 [BytecodeFunction: bindingReferenced] {
   Parameters: 0, Registers: 2
-     0: NewUnmappedArguments r0
-     2: LoadImmediate r1, 1
-     5: Add r1, r0, r1
-     9: LoadUndefined r1
-    11: Ret r1
+    0: NewUnmappedArguments r0
+    2: AddImm r1, r0, 1
+    6: LoadUndefined r1
+    8: Ret r1
 }
 
 [BytecodeFunction: capturedByArrow] {

--- a/tests/snapshot/bytecode/bytecode/assign_hazard.exp
+++ b/tests/snapshot/bytecode/bytecode/assign_hazard.exp
@@ -156,15 +156,14 @@
 
 [BytecodeFunction: toplevelAssignExpressions] {
   Parameters: 2, Registers: 1
-     0: LoadImmediate r0, 1
-     3: Add a0, a0, r0
-     7: Mov r0, a0
-    10: LoadImmediate a0, 2
-    13: Add a1, r0, a0
-    17: LoadImmediate a0, 3
-    20: Mov a1, a0
-    23: LoadUndefined r0
-    25: Ret r0
+     0: AddImm a0, a0, 1
+     4: Mov r0, a0
+     7: LoadImmediate a0, 2
+    10: Add a1, r0, a0
+    14: LoadImmediate a0, 3
+    17: Mov a1, a0
+    20: LoadUndefined r0
+    22: Ret r0
 }
 
 [BytecodeFunction: nestedFunctionOrClass] {

--- a/tests/snapshot/bytecode/class/fields.exp
+++ b/tests/snapshot/bytecode/class/fields.exp
@@ -123,24 +123,22 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: LoadImmediate r2, 1
-     7: LoadImmediate r3, 2
-    10: Add r2, r2, r3
-    14: ToPropertyKey r2, r2
-    17: StoreToScope r2, 0, 0
-    21: LoadImmediate r2, 3
-    24: LoadImmediate r3, 4
-    27: Add r2, r2, r3
-    31: ToPropertyKey r2, r2
-    34: StoreToScope r2, 1, 0
-    38: NewClass r0, c2, c1, r1, r0
-    44: NewClosure r2, c3
-    47: LoadConstant r3, c4
-    50: DefinePrivateProperty r0, r3, r2, 0
-    55: NewClosure r2, c5
-    58: CallWithReceiver r2, r2, r0, r2, 0
-    64: PopScope 
-    65: LoadUndefined r1
-    67: Ret r1
+     7: AddImm r2, r2, 2
+    11: ToPropertyKey r2, r2
+    14: StoreToScope r2, 0, 0
+    18: LoadImmediate r2, 3
+    21: AddImm r2, r2, 4
+    25: ToPropertyKey r2, r2
+    28: StoreToScope r2, 1, 0
+    32: NewClass r0, c2, c1, r1, r0
+    38: NewClosure r2, c3
+    41: LoadConstant r3, c4
+    44: DefinePrivateProperty r0, r3, r2, 0
+    49: NewClosure r2, c5
+    52: CallWithReceiver r2, r2, r0, r2, 0
+    58: PopScope 
+    59: LoadUndefined r1
+    61: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [BytecodeFunction: C]
@@ -243,24 +241,22 @@
     11: NewPrivateSymbol r2, c2
     14: StoreToScope r2, 5, 0
     18: LoadImmediate r2, 1
-    21: LoadImmediate r3, 2
-    24: Add r2, r2, r3
-    28: ToPropertyKey r2, r2
-    31: StoreToScope r2, 0, 0
-    35: LoadImmediate r2, 3
-    38: LoadImmediate r3, 4
-    41: Add r2, r2, r3
-    45: ToPropertyKey r2, r2
-    48: StoreToScope r2, 1, 0
-    52: NewClass r0, c4, c3, r1, r0
-    58: NewClosure r2, c5
-    61: LoadConstant r3, c6
-    64: DefinePrivateProperty r0, r3, r2, 0
-    69: NewClosure r2, c7
-    72: CallWithReceiver r2, r2, r0, r2, 0
-    78: PopScope 
-    79: LoadUndefined r1
-    81: Ret r1
+    21: AddImm r2, r2, 2
+    25: ToPropertyKey r2, r2
+    28: StoreToScope r2, 0, 0
+    32: LoadImmediate r2, 3
+    35: AddImm r2, r2, 4
+    39: ToPropertyKey r2, r2
+    42: StoreToScope r2, 1, 0
+    46: NewClass r0, c4, c3, r1, r0
+    52: NewClosure r2, c5
+    55: LoadConstant r3, c6
+    58: DefinePrivateProperty r0, r3, r2, 0
+    63: NewClosure r2, c7
+    66: CallWithReceiver r2, r2, r0, r2, 0
+    72: PopScope 
+    73: LoadUndefined r1
+    75: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: private1]
@@ -319,17 +315,16 @@
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: LoadImmediate r2, 1
-     7: LoadImmediate r3, 2
-    10: Add r2, r2, r3
-    14: ToPropertyKey r2, r2
-    17: StoreToScope r2, 0, 0
-    21: NewClass r0, c2, c1, r1, r0
-    27: NewClosure r2, c3
-    30: LoadConstant r3, c4
-    33: DefinePrivateProperty r0, r3, r2, 0
-    38: PopScope 
-    39: LoadUndefined r1
-    41: Ret r1
+     7: AddImm r2, r2, 2
+    11: ToPropertyKey r2, r2
+    14: StoreToScope r2, 0, 0
+    18: NewClass r0, c2, c1, r1, r0
+    24: NewClosure r2, c3
+    27: LoadConstant r3, c4
+    30: DefinePrivateProperty r0, r3, r2, 0
+    35: PopScope 
+    36: LoadUndefined r1
+    38: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [BytecodeFunction: C]
@@ -466,24 +461,22 @@
     14: StoreToScope r2, 4, 0
     18: NewClosure r2, c3
     21: LoadImmediate r3, 1
-    24: LoadImmediate r4, 2
-    27: Add r3, r3, r4
-    31: ToPropertyKey r3, r3
-    34: StoreToScope r3, 0, 0
-    38: LoadImmediate r3, 3
-    41: LoadImmediate r4, 4
-    44: Add r3, r3, r4
-    48: ToPropertyKey r3, r3
-    51: NewClosure r4, c4
-    54: NewClosure r5, c5
-    57: StoreToScope r5, 1, 0
-    61: NewClass r0, c7, c6, r1, r2
-    67: NewClosure r5, c8
-    70: LoadConstant r6, c9
-    73: DefinePrivateProperty r0, r6, r5, 0
-    78: PopScope 
-    79: LoadUndefined r1
-    81: Ret r1
+    24: AddImm r3, r3, 2
+    28: ToPropertyKey r3, r3
+    31: StoreToScope r3, 0, 0
+    35: LoadImmediate r3, 3
+    38: AddImm r3, r3, 4
+    42: ToPropertyKey r3, r3
+    45: NewClosure r4, c4
+    48: NewClosure r5, c5
+    51: StoreToScope r5, 1, 0
+    55: NewClass r0, c7, c6, r1, r2
+    61: NewClosure r5, c8
+    64: LoadConstant r6, c9
+    67: DefinePrivateProperty r0, r6, r5, 0
+    72: PopScope 
+    73: LoadUndefined r1
+    75: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: private1]
@@ -553,21 +546,20 @@
     10: NewPrivateSymbol r2, c1
     13: StoreToScope r2, 3, 0
     17: LoadImmediate r2, 1
-    20: LoadImmediate r3, 2
-    23: Add r2, r2, r3
-    27: ToPropertyKey r2, r2
-    30: StoreToScope r2, 0, 0
-    34: NewClosure r2, c2
-    37: StoreToScope r2, 1, 0
-    41: NewClosure r2, c3
-    44: NewClass r0, c5, c4, r1, r2
-    50: StoreToScope r0, 2, 0
-    54: NewClosure r3, c6
-    57: LoadConstant r4, c7
-    60: DefinePrivateProperty r0, r4, r3, 0
-    65: PopScope 
-    66: LoadUndefined r1
-    68: Ret r1
+    20: AddImm r2, r2, 2
+    24: ToPropertyKey r2, r2
+    27: StoreToScope r2, 0, 0
+    31: NewClosure r2, c2
+    34: StoreToScope r2, 1, 0
+    38: NewClosure r2, c3
+    41: NewClass r0, c5, c4, r1, r2
+    47: StoreToScope r0, 2, 0
+    51: NewClosure r3, c6
+    54: LoadConstant r4, c7
+    57: DefinePrivateProperty r0, r4, r3, 0
+    62: PopScope 
+    63: LoadUndefined r1
+    65: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: private1]
@@ -617,22 +609,21 @@
 }
 
 [BytecodeFunction: withStaticInitializers] {
-  Parameters: 0, Registers: 4
+  Parameters: 0, Registers: 3
      0: PushLexicalScope c0
      2: LoadEmpty r1
      4: NewPrivateSymbol r2, c1
      7: StoreToScope r2, 2, 0
     11: LoadImmediate r2, 1
-    14: LoadImmediate r3, 2
-    17: Add r2, r2, r3
-    21: ToPropertyKey r2, r2
-    24: StoreToScope r2, 0, 0
-    28: NewClass r0, c3, c2, r1, r0
-    34: NewClosure r2, c4
-    37: CallWithReceiver r2, r2, r0, r2, 0
-    43: PopScope 
-    44: LoadUndefined r1
-    46: Ret r1
+    14: AddImm r2, r2, 2
+    18: ToPropertyKey r2, r2
+    21: StoreToScope r2, 0, 0
+    25: NewClass r0, c3, c2, r1, r0
+    31: NewClosure r2, c4
+    34: CallWithReceiver r2, r2, r0, r2, 0
+    40: PopScope 
+    41: LoadUndefined r1
+    43: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: private]
@@ -670,24 +661,22 @@
     11: NewPrivateSymbol r2, c2
     14: StoreToScope r2, 5, 0
     18: LoadImmediate r2, 1
-    21: LoadImmediate r3, 2
-    24: Add r2, r2, r3
-    28: ToPropertyKey r2, r2
-    31: StoreToScope r2, 0, 0
-    35: LoadImmediate r2, 3
-    38: LoadImmediate r3, 4
-    41: Add r2, r2, r3
-    45: ToPropertyKey r2, r2
-    48: StoreToScope r2, 1, 0
-    52: NewClass r0, c4, c3, r1, r0
-    58: NewClosure r2, c5
-    61: LoadConstant r3, c6
-    64: DefinePrivateProperty r0, r3, r2, 0
-    69: NewClosure r2, c7
-    72: CallWithReceiver r2, r2, r0, r2, 0
-    78: PopScope 
-    79: LoadUndefined r1
-    81: Ret r1
+    21: AddImm r2, r2, 2
+    25: ToPropertyKey r2, r2
+    28: StoreToScope r2, 0, 0
+    32: LoadImmediate r2, 3
+    35: AddImm r2, r2, 4
+    39: ToPropertyKey r2, r2
+    42: StoreToScope r2, 1, 0
+    46: NewClass r0, c4, c3, r1, r0
+    52: NewClosure r2, c5
+    55: LoadConstant r3, c6
+    58: DefinePrivateProperty r0, r3, r2, 0
+    63: NewClosure r2, c7
+    66: CallWithReceiver r2, r2, r0, r2, 0
+    72: PopScope 
+    73: LoadUndefined r1
+    75: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [String: private1]

--- a/tests/snapshot/bytecode/class/methods.exp
+++ b/tests/snapshot/bytecode/class/methods.exp
@@ -10,34 +10,30 @@
      20: ToPropertyKey r6, r6
      23: NewClosure r7, c4
      26: LoadImmediate r8, 1
-     29: LoadImmediate r9, 2
-     32: Add r8, r8, r9
-     36: ToPropertyKey r8, r8
-     39: NewClosure r9, c5
-     42: NewClosure r10, c6
-     45: NewClosure r11, c7
-     48: LoadImmediate r12, 3
-     51: LoadImmediate r13, 4
-     54: Add r12, r12, r13
-     58: ToPropertyKey r12, r12
-     61: NewClosure r13, c8
-     64: LoadImmediate r14, 5
-     67: LoadImmediate r15, 6
-     70: Add r14, r14, r15
-     74: ToPropertyKey r14, r14
-     77: NewClosure r15, c9
-     80: NewClosure r16, c10
-     83: NewClosure r17, c11
-     86: NewClosure r18, c12
-     89: LoadImmediate r19, 1
-     92: LoadImmediate r20, 2
-     95: Add r19, r19, r20
-     99: ToPropertyKey r19, r19
-    102: NewClosure r20, c13
-    105: NewClass r0, c15, c14, r1, r2
-    111: StoreToScope r0, 1, 0
-    115: LoadUndefined r0
-    117: Ret r0
+     29: AddImm r8, r8, 2
+     33: ToPropertyKey r8, r8
+     36: NewClosure r9, c5
+     39: NewClosure r10, c6
+     42: NewClosure r11, c7
+     45: LoadImmediate r12, 3
+     48: AddImm r12, r12, 4
+     52: ToPropertyKey r12, r12
+     55: NewClosure r13, c8
+     58: LoadImmediate r14, 5
+     61: AddImm r14, r14, 6
+     65: ToPropertyKey r14, r14
+     68: NewClosure r15, c9
+     71: NewClosure r16, c10
+     74: NewClosure r17, c11
+     77: NewClosure r18, c12
+     80: LoadImmediate r19, 1
+     83: AddImm r19, r19, 2
+     87: ToPropertyKey r19, r19
+     90: NewClosure r20, c13
+     93: NewClass r0, c15, c14, r1, r2
+     99: StoreToScope r0, 1, 0
+    103: LoadUndefined r0
+    105: Ret r0
   Constant Table:
     0: [BytecodeFunction: named1]
     1: [BytecodeFunction: named2]

--- a/tests/snapshot/bytecode/class/static_initializer.exp
+++ b/tests/snapshot/bytecode/class/static_initializer.exp
@@ -73,15 +73,13 @@
 }
 
 [BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
+  Parameters: 0, Registers: 1
      0: LoadImmediate r0, 1
-     3: LoadImmediate r1, 2
-     6: Add r0, r0, r1
-    10: LoadImmediate r0, 3
-    13: LoadImmediate r1, 4
-    16: Add r0, r0, r1
-    20: LoadUndefined r0
-    22: Ret r0
+     3: AddImm r0, r0, 2
+     7: LoadImmediate r0, 3
+    10: AddImm r0, r0, 4
+    14: LoadUndefined r0
+    16: Ret r0
 }
 
 [BytecodeFunction: StaticInitializerAfterCreateClass] {
@@ -91,12 +89,11 @@
 }
 
 [BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
-     0: LoadImmediate r0, 1
-     3: LoadImmediate r1, 2
-     6: Add r0, r0, r1
-    10: LoadUndefined r0
-    12: Ret r0
+  Parameters: 0, Registers: 1
+    0: LoadImmediate r0, 1
+    3: AddImm r0, r0, 2
+    7: LoadUndefined r0
+    9: Ret r0
 }
 
 [BytecodeFunction: method1] {
@@ -112,18 +109,15 @@
 }
 
 [BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 2
+  Parameters: 0, Registers: 1
      0: LoadImmediate r0, 1
-     3: LoadImmediate r1, 2
-     6: Add r0, r0, r1
-    10: LoadImmediate r0, 3
-    13: LoadImmediate r1, 4
-    16: Add r0, r0, r1
-    20: LoadImmediate r0, 5
-    23: LoadImmediate r1, 6
-    26: Add r0, r0, r1
-    30: LoadUndefined r0
-    32: Ret r0
+     3: AddImm r0, r0, 2
+     7: LoadImmediate r0, 3
+    10: AddImm r0, r0, 4
+    14: LoadImmediate r0, 5
+    17: AddImm r0, r0, 6
+    21: LoadUndefined r0
+    23: Ret r0
 }
 
 [BytecodeFunction: EvalInStaticInitializer] {
@@ -175,17 +169,14 @@
 }
 
 [BytecodeFunction: staticInitializer] {
-  Parameters: 0, Registers: 3
-     0: LoadImmediate r1, 1
-     3: Add r1, <this>, r1
-     7: LoadImmediate r1, 2
-    10: Add r1, r0, r1
-    14: LoadFromScope r1, 1, 0
-    18: GetNamedSuperProperty r1, r1, <this>, c0
-    23: LoadImmediate r2, 3
-    26: Add r1, r1, r2
-    30: LoadUndefined r1
-    32: Ret r1
+  Parameters: 0, Registers: 2
+     0: AddImm r1, <this>, 1
+     4: AddImm r1, r0, 2
+     8: LoadFromScope r1, 1, 0
+    12: GetNamedSuperProperty r1, r1, <this>, c0
+    17: AddImm r1, r1, 3
+    21: LoadUndefined r1
+    23: Ret r1
   Constant Table:
     0: [String: foo]
 }

--- a/tests/snapshot/bytecode/class/super_class.exp
+++ b/tests/snapshot/bytecode/class/super_class.exp
@@ -10,13 +10,12 @@
 }
 
 [BytecodeFunction: superClass] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 2
      0: LoadImmediate r1, 1
-     3: LoadImmediate r2, 2
-     6: Add r1, r1, r2
-    10: NewClass r0, c1, c0, r1, r0
-    16: LoadUndefined r1
-    18: Ret r1
+     3: AddImm r1, r1, 2
+     7: NewClass r0, c1, c0, r1, r0
+    13: LoadUndefined r1
+    15: Ret r1
   Constant Table:
     0: [BytecodeFunction: C]
     1: [ClassNames]

--- a/tests/snapshot/bytecode/eval/completion.exp
+++ b/tests/snapshot/bytecode/eval/completion.exp
@@ -116,13 +116,12 @@
   Parameters: 0, Registers: 3
      0: LoadConstant r0, c0
      3: LoadImmediate r1, 1
-     6: LoadImmediate r2, 2
-     9: Add r0, r1, r2
-    13: LoadDynamic r1, c1
-    16: LoadDynamic r2, c2
-    19: Add r0, r1, r2
-    23: LoadConstant r0, c3
-    26: Ret r0
+     6: AddImm r0, r1, 2
+    10: LoadDynamic r1, c1
+    13: LoadDynamic r2, c2
+    16: Add r0, r1, r2
+    20: LoadConstant r0, c3
+    23: Ret r0
   Constant Table:
     0: [String: expression statement completions]
     1: [String: a]

--- a/tests/snapshot/bytecode/eval/forces_dynamic.exp
+++ b/tests/snapshot/bytecode/eval/forces_dynamic.exp
@@ -76,14 +76,12 @@
     111: LoadFromScope r0, 3, 0
     115: CheckTdz r0, c2
     118: LoadDynamic r0, c5
-    121: LoadImmediate r1, 5
-    124: Add r0, r0, r1
-    128: LoadDynamic r0, c4
-    131: LoadDynamic r0, c5
-    134: LoadImmediate r1, 6
-    137: Add r0, r0, r1
-    141: LoadUndefined r0
-    143: Ret r0
+    121: AddImm r0, r0, 5
+    125: LoadDynamic r0, c4
+    128: LoadDynamic r0, c5
+    131: AddImm r0, r0, 6
+    135: LoadUndefined r0
+    137: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]

--- a/tests/snapshot/bytecode/eval/function_constructor.exp
+++ b/tests/snapshot/bytecode/eval/function_constructor.exp
@@ -32,12 +32,11 @@
 }
 
 [BytecodeFunction: anonymous] {
-  Parameters: 0, Registers: 2
+  Parameters: 0, Registers: 1
      0: LoadGlobal r0, c0, k0
-     4: LoadImmediate r1, 1
-     7: Add r0, r0, r1
-    11: LoadUndefined r0
-    13: Ret r0
+     4: AddImm r0, r0, 1
+     8: LoadUndefined r0
+    10: Ret r0
   Constant Table:
     0: [String: y]
 }

--- a/tests/snapshot/bytecode/example_program/fib.exp
+++ b/tests/snapshot/bytecode/example_program/fib.exp
@@ -21,15 +21,13 @@
     13: Ret r0
   .L0:
     15: LoadGlobal r0, c0, k0
-    19: LoadImmediate r1, 1
-    22: Sub r1, a0, r1
-    26: Call r0, r0, r1, 1
-    31: LoadGlobal r1, c0, k1
-    35: LoadImmediate r2, 2
-    38: Sub r2, a0, r2
-    42: Call r1, r1, r2, 1
-    47: Add r0, r0, r1
-    51: Ret r0
+    19: SubImm r1, a0, 1
+    23: Call r0, r0, r1, 1
+    28: LoadGlobal r1, c0, k1
+    32: SubImm r2, a0, 2
+    36: Call r1, r1, r2, 1
+    41: Add r0, r0, r1
+    45: Ret r0
   Constant Table:
     0: [String: fib]
 }

--- a/tests/snapshot/bytecode/expression/arrow_function.exp
+++ b/tests/snapshot/bytecode/expression/arrow_function.exp
@@ -14,16 +14,14 @@
 }
 
 [BytecodeFunction: basic] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 2
      0: NewClosure r1, c0
-     3: LoadImmediate r2, 2
-     6: Add r1, r1, r2
-    10: NewClosure r1, c1
-    13: LoadImmediate r2, 4
-    16: Add r1, r1, r2
-    20: NewClosure r0, c2
-    23: LoadUndefined r1
-    25: Ret r1
+     3: AddImm r1, r1, 2
+     7: NewClosure r1, c1
+    10: AddImm r1, r1, 4
+    14: NewClosure r0, c2
+    17: LoadUndefined r1
+    19: Ret r1
   Constant Table:
     0: [BytecodeFunction: <anonymous>]
     1: [BytecodeFunction: <anonymous>]
@@ -38,10 +36,9 @@
 
 [BytecodeFunction: <anonymous>] {
   Parameters: 0, Registers: 2
-     0: LoadImmediate r0, 9
-     3: LoadImmediate r1, 3
-     6: Add r1, r0, r1
-    10: Ret r1
+    0: LoadImmediate r0, 9
+    3: AddImm r1, r0, 3
+    7: Ret r1
 }
 
 [BytecodeFunction: x] {

--- a/tests/snapshot/bytecode/expression/binary_imm.exp
+++ b/tests/snapshot/bytecode/expression/binary_imm.exp
@@ -1,0 +1,103 @@
+[BytecodeFunction: <global>] {
+  Parameters: 0, Registers: 1
+     0: NewClosure r0, c0
+     3: StoreGlobal r0, c1, k0
+     7: NewClosure r0, c2
+    10: StoreGlobal r0, c3, k1
+    14: NewClosure r0, c4
+    17: StoreGlobal r0, c5, k2
+    21: NewClosure r0, c6
+    24: StoreGlobal r0, c7, k3
+    28: NewClosure r0, c8
+    31: StoreGlobal r0, c9, k4
+    35: LoadUndefined r0
+    37: Ret r0
+  Constant Table:
+    0: [BytecodeFunction: simpleRhsImmediate]
+    1: [String: simpleRhsImmediate]
+    2: [BytecodeFunction: simpleLhsImmediate]
+    3: [String: simpleLhsImmediate]
+    4: [BytecodeFunction: negativeImmediate]
+    5: [String: negativeImmediate]
+    6: [BytecodeFunction: wideImmediate]
+    7: [String: wideImmediate]
+    8: [BytecodeFunction: notAnImmediate]
+    9: [String: notAnImmediate]
+}
+
+[BytecodeFunction: simpleRhsImmediate] {
+  Parameters: 1, Registers: 1
+     0: AddImm r0, a0, 1
+     4: SubImm r0, a0, 2
+     8: MulImm r0, a0, 3
+    12: DivImm r0, a0, 4
+    16: RemImm r0, a0, 5
+    20: BitAndImm r0, a0, 6
+    24: BitOrImm r0, a0, 7
+    28: BitXorImm r0, a0, 8
+    32: ShiftLeftImm r0, a0, 9
+    36: ShiftRightArithmeticImm r0, a0, 10
+    40: ShiftRightLogicalImm r0, a0, 11
+    44: LoadUndefined r0
+    46: Ret r0
+}
+
+[BytecodeFunction: simpleLhsImmediate] {
+  Parameters: 1, Registers: 1
+     0: MulImm r0, a0, 1
+     4: BitAndImm r0, a0, 2
+     8: BitOrImm r0, a0, 3
+    12: BitXorImm r0, a0, 4
+    16: LoadImmediate r0, 5
+    19: Add r0, r0, a0
+    23: LoadImmediate r0, 6
+    26: Sub r0, r0, a0
+    30: LoadImmediate r0, 7
+    33: Div r0, r0, a0
+    37: LoadImmediate r0, 8
+    40: Rem r0, r0, a0
+    44: LoadImmediate r0, 9
+    47: ShiftLeft r0, r0, a0
+    51: LoadImmediate r0, 10
+    54: ShiftRightArithmetic r0, r0, a0
+    58: LoadImmediate r0, 11
+    61: ShiftRightLogical r0, r0, a0
+    65: LoadUndefined r0
+    67: Ret r0
+}
+
+[BytecodeFunction: negativeImmediate] {
+  Parameters: 1, Registers: 1
+     0: AddImm r0, a0, -1
+     4: SubImm r0, a0, -2
+     8: LoadUndefined r0
+    10: Ret r0
+}
+
+[BytecodeFunction: wideImmediate] {
+  Parameters: 1, Registers: 1
+     0: AddImm (Wide) r0, a0, 1000
+     8: AddImm (ExtraWide) r0, a0, 100000
+    24: LoadUndefined r0
+    26: Ret r0
+}
+
+[BytecodeFunction: notAnImmediate] {
+  Parameters: 1, Registers: 1
+     0: LoadImmediate r0, 1
+     3: Add r0, r0, a0
+     7: LoadImmediate r0, 2
+    10: Exp r0, a0, r0
+    14: LoadConstant r0, c0
+    17: Add r0, a0, r0
+    21: LoadConstant r0, c1
+    24: Add r0, a0, r0
+    28: LoadConstant r0, c2
+    31: Sub r0, a0, r0
+    35: LoadUndefined r0
+    37: Ret r0
+  Constant Table:
+    0: [double: 1.5]
+    1: [double: 2147483648]
+    2: [double: -0]
+}

--- a/tests/snapshot/bytecode/expression/binary_imm.js
+++ b/tests/snapshot/bytecode/expression/binary_imm.js
@@ -1,0 +1,48 @@
+function simpleRhsImmediate(x) {
+  x + 1;
+  x - 2;
+  x * 3;
+  x / 4;
+  x % 5;
+  x & 6;
+  x | 7;
+  x ^ 8;
+  x << 9;
+  x >> 10;
+  x >>> 11;
+}
+
+function simpleLhsImmediate(x) {
+  // Supported operations for immediate LHS
+  1 * x;
+  2 & x;
+  3 | x;
+  4 ^ x;
+
+  // Unsupported operations for immediate LHS
+  5 + x;
+  6 - x;
+  7 / x;
+  8 % x;
+  9 << x;
+  10 >> x;
+  11 >>> x;
+}
+
+function negativeImmediate(x) {
+  x + -1;
+  x - -2;
+}
+
+function wideImmediate(x) {
+  x + 1000;
+  x + 100000;
+}
+
+function notAnImmediate(x) {
+  1 + x;
+  x ** 2;
+  x + 1.5;
+  x + 2147483648;
+  x - -0;
+}

--- a/tests/snapshot/bytecode/expression/calls/member.exp
+++ b/tests/snapshot/bytecode/expression/calls/member.exp
@@ -31,13 +31,12 @@
     22: LoadImmediate r4, 3
     25: CallWithReceiver r1, r1, a0, r2, 3
     31: LoadImmediate r1, 1
-    34: LoadImmediate r2, 2
-    37: Add r0, r1, r2
-    41: GetNamedProperty r1, r0, c0, k2
-    46: LoadImmediate r2, 4
-    49: CallWithReceiver r1, r1, r0, r2, 1
-    55: LoadUndefined r1
-    57: Ret r1
+    34: AddImm r0, r1, 2
+    38: GetNamedProperty r1, r0, c0, k2
+    43: LoadImmediate r2, 4
+    46: CallWithReceiver r1, r1, r0, r2, 1
+    52: LoadUndefined r1
+    54: Ret r1
   Constant Table:
     0: [String: foo]
 }
@@ -48,23 +47,21 @@
      3: GetProperty r1, a0, r1
      7: CallWithReceiver r1, r1, a0, r1, 0
     13: LoadImmediate r1, 0
-    16: LoadImmediate r2, 9
-    19: Add r1, r1, r2
-    23: LoadConstant r2, c0
-    26: GetProperty r2, r1, r2
-    30: LoadImmediate r3, 1
-    33: LoadImmediate r4, 2
-    36: LoadImmediate r5, 3
-    39: CallWithReceiver r1, r2, r1, r3, 3
-    45: LoadImmediate r1, 1
-    48: LoadImmediate r2, 2
-    51: Add r0, r1, r2
-    55: LoadConstant r1, c0
-    58: GetProperty r1, r0, r1
-    62: LoadImmediate r2, 4
-    65: CallWithReceiver r1, r1, r0, r2, 1
-    71: LoadUndefined r1
-    73: Ret r1
+    16: AddImm r1, r1, 9
+    20: LoadConstant r2, c0
+    23: GetProperty r2, r1, r2
+    27: LoadImmediate r3, 1
+    30: LoadImmediate r4, 2
+    33: LoadImmediate r5, 3
+    36: CallWithReceiver r1, r2, r1, r3, 3
+    42: LoadImmediate r1, 1
+    45: AddImm r0, r1, 2
+    49: LoadConstant r1, c0
+    52: GetProperty r1, r0, r1
+    56: LoadImmediate r2, 4
+    59: CallWithReceiver r1, r1, r0, r2, 1
+    65: LoadUndefined r1
+    67: Ret r1
   Constant Table:
     0: [String: foo]
 }

--- a/tests/snapshot/bytecode/expression/conditional.exp
+++ b/tests/snapshot/bytecode/expression/conditional.exp
@@ -14,7 +14,7 @@
 }
 
 [BytecodeFunction: testBasic] {
-  Parameters: 0, Registers: 4
+  Parameters: 0, Registers: 3
      0: LoadImmediate r0, 1
      3: JumpToBooleanFalse r0, 8 (.L0)
      6: LoadImmediate r0, 2
@@ -23,35 +23,29 @@
     11: LoadImmediate r0, 3
   .L1:
     14: LoadImmediate r0, 1
-    17: LoadImmediate r1, 2
-    20: Add r0, r0, r1
-    24: JumpToBooleanFalse r0, 15 (.L2)
-    27: LoadImmediate r1, 3
-    30: LoadImmediate r2, 4
-    33: Add r0, r1, r2
-    37: Jump 12 (.L3)
+    17: AddImm r0, r0, 2
+    21: JumpToBooleanFalse r0, 12 (.L2)
+    24: LoadImmediate r1, 3
+    27: AddImm r0, r1, 4
+    31: Jump 9 (.L3)
   .L2:
-    39: LoadImmediate r1, 5
-    42: LoadImmediate r2, 6
-    45: Add r0, r1, r2
+    33: LoadImmediate r1, 5
+    36: AddImm r0, r1, 6
   .L3:
-    49: LoadGlobal r0, c0, k0
-    53: LoadImmediate r1, 1
-    56: JumpToBooleanFalse r1, 15 (.L4)
-    59: LoadImmediate r2, 2
-    62: LoadImmediate r3, 3
-    65: Add r1, r2, r3
-    69: Jump 19 (.L5)
+    40: LoadGlobal r0, c0, k0
+    44: LoadImmediate r1, 1
+    47: JumpToBooleanFalse r1, 12 (.L4)
+    50: LoadImmediate r2, 2
+    53: AddImm r1, r2, 3
+    57: Jump 13 (.L5)
   .L4:
-    71: LoadImmediate r2, 4
-    74: LoadImmediate r3, 5
-    77: Add r2, r2, r3
-    81: LoadImmediate r3, 6
-    84: Add r1, r2, r3
+    59: LoadImmediate r2, 4
+    62: AddImm r2, r2, 5
+    66: AddImm r1, r2, 6
   .L5:
-    88: Call r0, r0, r1, 1
-    93: LoadUndefined r0
-    95: Ret r0
+    70: Call r0, r0, r1, 1
+    75: LoadUndefined r0
+    77: Ret r0
   Constant Table:
     0: [String: use]
 }

--- a/tests/snapshot/bytecode/expression/delete.exp
+++ b/tests/snapshot/bytecode/expression/delete.exp
@@ -116,15 +116,14 @@
 }
 
 [BytecodeFunction: deleteOtherExpression] {
-  Parameters: 0, Registers: 2
+  Parameters: 0, Registers: 1
      0: LoadImmediate r0, 1
      3: LoadTrue r0
      5: LoadImmediate r0, 1
-     8: LoadImmediate r1, 2
-    11: Add r0, r0, r1
-    15: LoadTrue r0
-    17: LoadUndefined r0
-    19: Ret r0
+     8: AddImm r0, r0, 2
+    12: LoadTrue r0
+    14: LoadUndefined r0
+    16: Ret r0
 }
 
 [BytecodeFunction: deleteIdVars] {
@@ -231,12 +230,11 @@
 }
 
 [BytecodeFunction: deleteComputedSuperProperty] {
-  Parameters: 0, Registers: 2
+  Parameters: 0, Registers: 1
      0: LoadImmediate r0, 1
-     3: LoadImmediate r1, 2
-     6: Add r0, r0, r1
-    10: ThrowNewError 0, c0
-    13: Ret r0
+     3: AddImm r0, r0, 2
+     7: ThrowNewError 0, c0
+    10: Ret r0
   Constant Table:
     0: [String: cannot delete super property]
 }

--- a/tests/snapshot/bytecode/expression/function.exp
+++ b/tests/snapshot/bytecode/expression/function.exp
@@ -34,16 +34,14 @@
 }
 
 [BytecodeFunction: basic] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 2
      0: NewClosure r1, c0
-     3: LoadImmediate r2, 2
-     6: Add r1, r1, r2
-    10: NewClosure r1, c1
-    13: LoadImmediate r2, 4
-    16: Add r1, r1, r2
-    20: NewClosure r0, c2
-    23: LoadUndefined r1
-    25: Ret r1
+     3: AddImm r1, r1, 2
+     7: NewClosure r1, c1
+    10: AddImm r1, r1, 4
+    14: NewClosure r0, c2
+    17: LoadUndefined r1
+    19: Ret r1
   Constant Table:
     0: [BytecodeFunction: foo]
     1: [BytecodeFunction: <anonymous>]

--- a/tests/snapshot/bytecode/expression/logical.exp
+++ b/tests/snapshot/bytecode/expression/logical.exp
@@ -48,64 +48,56 @@
 }
 
 [BytecodeFunction: logicalAndBoolean] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 2
      0: LoadTrue r0
-     2: JumpFalse r0, 13 (.L0)
+     2: JumpFalse r0, 10 (.L0)
      5: LoadImmediate r1, 1
-     8: LoadImmediate r2, 2
-    11: Add r0, r1, r2
+     8: AddImm r0, r1, 2
   .L0:
-    15: Ret r0
+    12: Ret r0
 }
 
 [BytecodeFunction: logicalAndNotBoolean] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 2
      0: LoadImmediate r1, 1
-     3: LoadImmediate r2, 2
-     6: Add r0, r1, r2
-    10: JumpToBooleanFalse r0, 13 (.L0)
-    13: LoadImmediate r1, 3
-    16: LoadImmediate r2, 4
-    19: Add r0, r1, r2
+     3: AddImm r0, r1, 2
+     7: JumpToBooleanFalse r0, 10 (.L0)
+    10: LoadImmediate r1, 3
+    13: AddImm r0, r1, 4
   .L0:
-    23: Ret r0
+    17: Ret r0
 }
 
 [BytecodeFunction: logicalOrBoolean] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 2
      0: LoadTrue r0
-     2: JumpTrue r0, 13 (.L0)
+     2: JumpTrue r0, 10 (.L0)
      5: LoadImmediate r1, 1
-     8: LoadImmediate r2, 2
-    11: Add r0, r1, r2
+     8: AddImm r0, r1, 2
   .L0:
-    15: Ret r0
+    12: Ret r0
 }
 
 [BytecodeFunction: logicalOrNotBoolean] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 2
      0: LoadImmediate r1, 1
-     3: LoadImmediate r2, 2
-     6: Add r0, r1, r2
-    10: JumpToBooleanTrue r0, 13 (.L0)
-    13: LoadImmediate r1, 3
-    16: LoadImmediate r2, 4
-    19: Add r0, r1, r2
+     3: AddImm r0, r1, 2
+     7: JumpToBooleanTrue r0, 10 (.L0)
+    10: LoadImmediate r1, 3
+    13: AddImm r0, r1, 4
   .L0:
-    23: Ret r0
+    17: Ret r0
 }
 
 [BytecodeFunction: nullishCoalesce] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 2
      0: LoadImmediate r1, 1
-     3: LoadImmediate r2, 2
-     6: Add r0, r1, r2
-    10: JumpNotNullish r0, 13 (.L0)
-    13: LoadImmediate r1, 3
-    16: LoadImmediate r2, 4
-    19: Add r0, r1, r2
+     3: AddImm r0, r1, 2
+     7: JumpNotNullish r0, 10 (.L0)
+    10: LoadImmediate r1, 3
+    13: AddImm r0, r1, 4
   .L0:
-    23: Ret r0
+    17: Ret r0
 }
 
 [BytecodeFunction: logicalAndWithTemporary] {
@@ -125,16 +117,15 @@
     30: JumpToBooleanFalse r1, 6 (.L2)
     33: LoadImmediate r1, 6
   .L2:
-    36: LoadImmediate r2, 10
-    39: Mul r1, r1, r2
-    43: LoadGlobal r1, c0, k0
-    47: LoadImmediate r2, 7
-    50: JumpToBooleanFalse r2, 6 (.L3)
-    53: LoadImmediate r2, 8
+    36: MulImm r1, r1, 10
+    40: LoadGlobal r1, c0, k0
+    44: LoadImmediate r2, 7
+    47: JumpToBooleanFalse r2, 6 (.L3)
+    50: LoadImmediate r2, 8
   .L3:
-    56: Call r1, r1, r2, 1
-    61: LoadUndefined r1
-    63: Ret r1
+    53: Call r1, r1, r2, 1
+    58: LoadUndefined r1
+    60: Ret r1
   Constant Table:
     0: [String: use]
 }
@@ -156,16 +147,15 @@
     30: JumpToBooleanTrue r1, 6 (.L2)
     33: LoadImmediate r1, 6
   .L2:
-    36: LoadImmediate r2, 10
-    39: Mul r1, r1, r2
-    43: LoadGlobal r1, c0, k0
-    47: LoadImmediate r2, 7
-    50: JumpToBooleanTrue r2, 6 (.L3)
-    53: LoadImmediate r2, 8
+    36: MulImm r1, r1, 10
+    40: LoadGlobal r1, c0, k0
+    44: LoadImmediate r2, 7
+    47: JumpToBooleanTrue r2, 6 (.L3)
+    50: LoadImmediate r2, 8
   .L3:
-    56: Call r1, r1, r2, 1
-    61: LoadUndefined r1
-    63: Ret r1
+    53: Call r1, r1, r2, 1
+    58: LoadUndefined r1
+    60: Ret r1
   Constant Table:
     0: [String: use]
 }
@@ -187,16 +177,15 @@
     30: JumpNotNullish r1, 6 (.L2)
     33: LoadImmediate r1, 6
   .L2:
-    36: LoadImmediate r2, 10
-    39: Mul r1, r1, r2
-    43: LoadGlobal r1, c0, k0
-    47: LoadImmediate r2, 7
-    50: JumpNotNullish r2, 6 (.L3)
-    53: LoadImmediate r2, 8
+    36: MulImm r1, r1, 10
+    40: LoadGlobal r1, c0, k0
+    44: LoadImmediate r2, 7
+    47: JumpNotNullish r2, 6 (.L3)
+    50: LoadImmediate r2, 8
   .L3:
-    56: Call r1, r1, r2, 1
-    61: LoadUndefined r1
-    63: Ret r1
+    53: Call r1, r1, r2, 1
+    58: LoadUndefined r1
+    60: Ret r1
   Constant Table:
     0: [String: use]
 }

--- a/tests/snapshot/bytecode/expression/member.exp
+++ b/tests/snapshot/bytecode/expression/member.exp
@@ -29,18 +29,16 @@
 }
 
 [BytecodeFunction: testComputedMember] {
-  Parameters: 1, Registers: 3
+  Parameters: 1, Registers: 2
      0: LoadConstant r0, c0
      3: GetProperty r0, a0, r0
      7: LoadImmediate r0, 1
-    10: LoadImmediate r1, 2
-    13: Add r0, r0, r1
-    17: LoadImmediate r1, 3
-    20: LoadImmediate r2, 4
-    23: Add r1, r1, r2
-    27: GetProperty r0, r0, r1
-    31: LoadUndefined r0
-    33: Ret r0
+    10: AddImm r0, r0, 2
+    14: LoadImmediate r1, 3
+    17: AddImm r1, r1, 4
+    21: GetProperty r0, r0, r1
+    25: LoadUndefined r0
+    27: Ret r0
   Constant Table:
     0: [String: foo]
 }

--- a/tests/snapshot/bytecode/expression/new_target.exp
+++ b/tests/snapshot/bytecode/expression/new_target.exp
@@ -19,20 +19,18 @@
 
 [BytecodeFunction: simpleNewTarget] {
   Parameters: 0, Registers: 2
-    0: LoadImmediate r1, 1
-    3: Add r1, r0, r1
-    7: Ret r1
+    0: AddImm r1, r0, 1
+    4: Ret r1
 }
 
 [BytecodeFunction: captured] {
-  Parameters: 0, Registers: 2
+  Parameters: 0, Registers: 1
      0: PushFunctionScope c0
      2: StoreToScope r0, 0, 0
      6: NewClosure r0, c1
      9: LoadFromScope r0, 0, 0
-    13: LoadImmediate r1, 1
-    16: Add r0, r0, r1
-    20: Ret r0
+    13: AddImm r0, r0, 1
+    17: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [BytecodeFunction: <anonymous>]
@@ -47,18 +45,16 @@
 
 [BytecodeFunction: usesInner] {
   Parameters: 0, Registers: 3
-     0: NewClosure r0, c0
-     3: LoadImmediate r2, 3
-     6: Add r2, r1, r2
-    10: Ret r2
+    0: NewClosure r0, c0
+    3: AddImm r2, r1, 3
+    7: Ret r2
   Constant Table:
     0: [BytecodeFunction: inner]
 }
 
 [BytecodeFunction: inner] {
   Parameters: 0, Registers: 3
-     0: LoadImmediate r0, 1
-     3: LoadImmediate r2, 2
-     6: Add r2, r1, r2
-    10: Ret r2
+    0: LoadImmediate r0, 1
+    3: AddImm r2, r1, 2
+    7: Ret r2
 }

--- a/tests/snapshot/bytecode/expression/object/basic.exp
+++ b/tests/snapshot/bytecode/expression/object/basic.exp
@@ -70,15 +70,14 @@
 }
 
 [BytecodeFunction: initializedProperties] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 2
      0: NewObject r0, 2
      3: LoadImmediate r1, 1
      6: DefineNamedProperty r0, c0, r1
     10: LoadImmediate r1, 2
-    13: LoadImmediate r2, 3
-    16: Add r1, r1, r2
-    20: DefineNamedProperty r0, c1, r1
-    24: Ret r0
+    13: AddImm r1, r1, 3
+    17: DefineNamedProperty r0, c1, r1
+    21: Ret r0
   Constant Table:
     0: [String: a]
     1: [String: global]
@@ -107,34 +106,31 @@
     17: LoadImmediate r2, 3
     20: DefineProperty r0, r1, r2, 0
     25: LoadImmediate r1, 4
-    28: LoadImmediate r2, 5
-    31: Add r1, r1, r2
-    35: LoadImmediate r2, 6
-    38: DefineProperty r0, r1, r2, 0
-    43: Ret r0
+    28: AddImm r1, r1, 5
+    32: LoadImmediate r2, 6
+    35: DefineProperty r0, r1, r2, 0
+    40: Ret r0
   Constant Table:
     0: [String: a]
 }
 
 [BytecodeFunction: spread] {
-  Parameters: 1, Registers: 3
+  Parameters: 1, Registers: 2
      0: NewObject r0, 4
      3: CopyDataProperties r0, a0, a0, 0
      8: LoadImmediate r1, 1
-    11: LoadImmediate r2, 2
-    14: Add r1, r1, r2
-    18: CopyDataProperties r0, r1, r1, 0
-    23: Ret r0
+    11: AddImm r1, r1, 2
+    15: CopyDataProperties r0, r1, r1, 0
+    20: Ret r0
 }
 
 [BytecodeFunction: proto] {
-  Parameters: 1, Registers: 3
+  Parameters: 1, Registers: 2
      0: NewObject r0, 4
      3: LoadImmediate r1, 1
-     6: LoadImmediate r2, 2
-     9: Add r1, r1, r2
-    13: SetPrototypeOf r0, r1
-    16: Ret r0
+     6: AddImm r1, r1, 2
+    10: SetPrototypeOf r0, r1
+    13: Ret r0
 }
 
 [BytecodeFunction: propertyNamesNotResolved] {

--- a/tests/snapshot/bytecode/expression/object/named_evalution.exp
+++ b/tests/snapshot/bytecode/expression/object/named_evalution.exp
@@ -80,14 +80,13 @@
   Parameters: 0, Registers: 3
      0: NewObject r0, 2
      3: LoadImmediate r1, 1
-     6: LoadImmediate r2, 2
-     9: Add r1, r1, r2
-    13: NewClosure r2, c0
-    16: DefineProperty r0, r1, r2, 1
-    21: LoadImmediate r1, 3
-    24: NewClosure r2, c1
-    27: DefineProperty r0, r1, r2, 1
-    32: Ret r0
+     6: AddImm r1, r1, 2
+    10: NewClosure r2, c0
+    13: DefineProperty r0, r1, r2, 1
+    18: LoadImmediate r1, 3
+    21: NewClosure r2, c1
+    24: DefineProperty r0, r1, r2, 1
+    29: Ret r0
   Constant Table:
     0: [BytecodeFunction: <anonymous>]
     1: [BytecodeFunction: <anonymous>]

--- a/tests/snapshot/bytecode/expression/super_member.exp
+++ b/tests/snapshot/bytecode/expression/super_member.exp
@@ -32,13 +32,12 @@
 }
 
 [BytecodeFunction: computed] {
-  Parameters: 0, Registers: 3
+  Parameters: 0, Registers: 2
      0: LoadFromScope r0, 0, 0
      4: LoadImmediate r1, 1
-     7: LoadImmediate r2, 2
-    10: Add r1, r1, r2
-    14: GetSuperProperty r0, r0, <this>, r1
-    19: Ret r0
+     7: AddImm r1, r1, 2
+    11: GetSuperProperty r0, r0, <this>, r1
+    16: Ret r0
 }
 
 [BytecodeFunction: captured] {

--- a/tests/snapshot/bytecode/expression/tagged_template.exp
+++ b/tests/snapshot/bytecode/expression/tagged_template.exp
@@ -38,19 +38,16 @@
 }
 
 [BytecodeFunction: evaluationOrder] {
-  Parameters: 0, Registers: 5
+  Parameters: 0, Registers: 4
      0: LoadImmediate r0, 1
-     3: LoadImmediate r1, 2
-     6: Add r0, r0, r1
-    10: LoadConstant r1, c0
-    13: LoadImmediate r2, 3
-    16: LoadImmediate r3, 4
-    19: Add r2, r2, r3
-    23: LoadImmediate r3, 5
-    26: LoadImmediate r4, 6
-    29: Add r3, r3, r4
-    33: Call r0, r0, r1, 3
-    38: Ret r0
+     3: AddImm r0, r0, 2
+     7: LoadConstant r1, c0
+    10: LoadImmediate r2, 3
+    13: AddImm r2, r2, 4
+    17: LoadImmediate r3, 5
+    20: AddImm r3, r3, 6
+    24: Call r0, r0, r1, 3
+    29: Ret r0
   Constant Table:
     0: [ArrayObject]
 }
@@ -97,14 +94,13 @@
     11: LoadImmediate r4, 2
     14: CallWithReceiver r1, r1, a0, r2, 3
     20: LoadImmediate r1, 1
-    23: LoadImmediate r2, 2
-    26: Add r0, r1, r2
-    30: GetNamedProperty r1, r0, c0, k1
-    35: LoadConstant r2, c2
-    38: LoadImmediate r3, 3
-    41: CallWithReceiver r1, r1, r0, r2, 2
-    47: LoadUndefined r1
-    49: Ret r1
+    23: AddImm r0, r1, 2
+    27: GetNamedProperty r1, r0, c0, k1
+    32: LoadConstant r2, c2
+    35: LoadImmediate r3, 3
+    38: CallWithReceiver r1, r1, r0, r2, 2
+    44: LoadUndefined r1
+    46: Ret r1
   Constant Table:
     0: [String: foo]
     1: [ArrayObject]
@@ -120,15 +116,14 @@
     13: LoadImmediate r4, 2
     16: CallWithReceiver r1, r1, a0, r2, 3
     22: LoadImmediate r1, 1
-    25: LoadImmediate r2, 2
-    28: Add r0, r1, r2
-    32: LoadConstant r1, c0
-    35: GetProperty r1, r0, r1
-    39: LoadConstant r2, c2
-    42: LoadImmediate r3, 3
-    45: CallWithReceiver r1, r1, r0, r2, 2
-    51: LoadUndefined r1
-    53: Ret r1
+    25: AddImm r0, r1, 2
+    29: LoadConstant r1, c0
+    32: GetProperty r1, r0, r1
+    36: LoadConstant r2, c2
+    39: LoadImmediate r3, 3
+    42: CallWithReceiver r1, r1, r0, r2, 2
+    48: LoadUndefined r1
+    50: Ret r1
   Constant Table:
     0: [String: foo]
     1: [ArrayObject]

--- a/tests/snapshot/bytecode/expression/this.exp
+++ b/tests/snapshot/bytecode/expression/this.exp
@@ -22,13 +22,12 @@
 [BytecodeFunction: foo] {
   Parameters: 0, Registers: 3
      0: Mov r0, <this>
-     3: LoadImmediate r1, 1
-     6: Add r1, <this>, r1
-    10: LoadGlobal r1, c0, k0
-    14: Mov r2, <this>
-    17: Call r1, r1, r2, 1
-    22: LoadUndefined r1
-    24: Ret r1
+     3: AddImm r1, <this>, 1
+     7: LoadGlobal r1, c0, k0
+    11: Mov r2, <this>
+    14: Call r1, r1, r2, 1
+    19: LoadUndefined r1
+    21: Ret r1
   Constant Table:
     0: [String: use]
 }

--- a/tests/snapshot/bytecode/function/async.exp
+++ b/tests/snapshot/bytecode/function/async.exp
@@ -60,38 +60,36 @@
      0: NewPromise r0
      2: LoadImmediate r1, 1
      5: LoadImmediate r1, 2
-     8: LoadImmediate r2, 3
-    11: Add r1, r1, r2
-    15: Await r1, r2, r0, r1
-    20: JumpTrue r2, 5 (.L0)
-    23: Throw r1
+     8: AddImm r1, r1, 3
+    12: Await r1, r2, r0, r1
+    17: JumpTrue r2, 5 (.L0)
+    20: Throw r1
   .L0:
-    25: LoadImmediate r1, 4
-    28: LoadUndefined r1
-    30: ResolvePromise r0, r1
-    33: Ret r0
-    35: RejectPromise r0, r1
-    38: Ret r0
+    22: LoadImmediate r1, 4
+    25: LoadUndefined r1
+    27: ResolvePromise r0, r1
+    30: Ret r0
+    32: RejectPromise r0, r1
+    35: Ret r0
   Exception Handlers:
-    2-35 -> 35 (r1)
+    2-32 -> 32 (r1)
 }
 
 [BytecodeFunction: paramExpressions] {
-  Parameters: 1, Registers: 3
+  Parameters: 1, Registers: 2
      0: NewPromise r0
-     2: JumpNotUndefined a0, 13 (.L0)
+     2: JumpNotUndefined a0, 10 (.L0)
      5: LoadImmediate r1, 1
-     8: LoadImmediate r2, 2
-    11: Add a0, r1, r2
+     8: AddImm a0, r1, 2
   .L0:
-    15: LoadImmediate r1, 3
-    18: LoadUndefined r1
-    20: ResolvePromise r0, r1
-    23: Ret r0
-    25: RejectPromise r0, r1
-    28: Ret r0
+    12: LoadImmediate r1, 3
+    15: LoadUndefined r1
+    17: ResolvePromise r0, r1
+    20: Ret r0
+    22: RejectPromise r0, r1
+    25: Ret r0
   Exception Handlers:
-    2-25 -> 25 (r1)
+    2-22 -> 22 (r1)
 }
 
 [BytecodeFunction: returnInFinally] {

--- a/tests/snapshot/bytecode/module/dynamic_import.exp
+++ b/tests/snapshot/bytecode/module/dynamic_import.exp
@@ -1,15 +1,13 @@
 [BytecodeFunction: <module>] {
   Parameters: 0, Registers: 3
      0: LoadImmediate r1, 1
-     3: LoadImmediate r2, 2
-     6: Add r1, r1, r2
-    10: LoadUndefined r2
-    12: DynamicImport r0, r1, r2
-    16: LoadImmediate r1, 3
-    19: Add r0, r0, r1
-    23: LoadImmediate r1, 4
-    26: NewObject r2, 4
-    29: DynamicImport r0, r1, r2
-    33: LoadUndefined r0
-    35: Ret r0
+     3: AddImm r1, r1, 2
+     7: LoadUndefined r2
+     9: DynamicImport r0, r1, r2
+    13: AddImm r0, r0, 3
+    17: LoadImmediate r1, 4
+    20: NewObject r2, 4
+    23: DynamicImport r0, r1, r2
+    27: LoadUndefined r0
+    29: Ret r0
 }

--- a/tests/snapshot/bytecode/module/export_default_expression.exp
+++ b/tests/snapshot/bytecode/module/export_default_expression.exp
@@ -1,9 +1,8 @@
 [BytecodeFunction: <module>] {
-  Parameters: 0, Registers: 2
+  Parameters: 0, Registers: 1
      0: LoadImmediate r0, 1
-     3: LoadImmediate r1, 2
-     6: Add r0, r0, r1
-    10: StoreToModule r0, 1, 0
-    14: LoadUndefined r0
-    16: Ret r0
+     3: AddImm r0, r0, 2
+     7: StoreToModule r0, 1, 0
+    11: LoadUndefined r0
+    13: Ret r0
 }

--- a/tests/snapshot/bytecode/module/import_meta.exp
+++ b/tests/snapshot/bytecode/module/import_meta.exp
@@ -1,8 +1,7 @@
 [BytecodeFunction: <module>] {
-  Parameters: 0, Registers: 2
-     0: ImportMeta r0
-     2: LoadImmediate r1, 1
-     5: Add r0, r0, r1
-     9: LoadUndefined r0
-    11: Ret r0
+  Parameters: 0, Registers: 1
+    0: ImportMeta r0
+    2: AddImm r0, r0, 1
+    6: LoadUndefined r0
+    8: Ret r0
 }

--- a/tests/snapshot/bytecode/module/top_level_await.exp
+++ b/tests/snapshot/bytecode/module/top_level_await.exp
@@ -2,22 +2,20 @@
   Parameters: 0, Registers: 3
      0: Mov r0, a0
      3: LoadImmediate r1, 1
-     6: LoadImmediate r2, 2
-     9: Add r1, r1, r2
-    13: LoadImmediate r1, 3
-    16: Await r1, r2, r0, r1
-    21: JumpTrue r2, 5 (.L0)
-    24: Throw r1
+     6: AddImm r1, r1, 2
+    10: LoadImmediate r1, 3
+    13: Await r1, r2, r0, r1
+    18: JumpTrue r2, 5 (.L0)
+    21: Throw r1
   .L0:
-    26: LoadImmediate r1, 4
-    29: LoadImmediate r2, 5
-    32: Add r1, r1, r2
-    36: LoadUndefined r1
-    38: ResolvePromise r0, r1
-    41: Ret r0
-    43: RejectPromise r0, r1
-    46: LoadUndefined r0
-    48: Ret r0
+    23: LoadImmediate r1, 4
+    26: AddImm r1, r1, 5
+    30: LoadUndefined r1
+    32: ResolvePromise r0, r1
+    35: Ret r0
+    37: RejectPromise r0, r1
+    40: LoadUndefined r0
+    42: Ret r0
   Exception Handlers:
-    3-43 -> 43 (r1)
+    3-37 -> 37 (r1)
 }

--- a/tests/snapshot/bytecode/scope/captured.exp
+++ b/tests/snapshot/bytecode/scope/captured.exp
@@ -68,11 +68,10 @@
 }
 
 [BytecodeFunction: inner] {
-  Parameters: 0, Registers: 2
-     0: LoadFromScope r0, 0, 0
-     4: LoadImmediate r1, 2
-     7: Add r0, r0, r1
-    11: Ret r0
+  Parameters: 0, Registers: 1
+    0: LoadFromScope r0, 0, 0
+    4: AddImm r0, r0, 2
+    8: Ret r0
 }
 
 [BytecodeFunction: multipleCaptures] {

--- a/tests/snapshot/bytecode/scope/function_body.exp
+++ b/tests/snapshot/bytecode/scope/function_body.exp
@@ -38,10 +38,9 @@
      9: Mov a1, a0
   .L1:
     12: LoadImmediate r0, 2
-    15: LoadImmediate r1, 3
-    18: Add r1, r0, r1
-    22: LoadUndefined r1
-    24: Ret r1
+    15: AddImm r1, r0, 3
+    19: LoadUndefined r1
+    21: Ret r1
 }
 
 [BytecodeFunction: sameNameCaptureParamOnly] {
@@ -55,10 +54,9 @@
     15: NewClosure a1, c1
   .L1:
     18: LoadImmediate r0, 2
-    21: LoadImmediate r1, 3
-    24: Add r1, r0, r1
-    28: LoadUndefined r1
-    30: Ret r1
+    21: AddImm r1, r0, 3
+    25: LoadUndefined r1
+    27: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [BytecodeFunction: y]

--- a/tests/snapshot/bytecode/scope/with.exp
+++ b/tests/snapshot/bytecode/scope/with.exp
@@ -62,7 +62,7 @@
 }
 
 [BytecodeFunction: dynamicAccessInChildren] {
-  Parameters: 1, Registers: 3
+  Parameters: 1, Registers: 2
      0: PushFunctionScope c0
      2: StoreToScope <this>, 1, 0
      6: StoreToScope r1, 4, 0
@@ -74,24 +74,19 @@
     27: LoadFromScope r1, 0, 0
     31: PushWithScope r1, c1
     34: LoadDynamic r1, c2
-    37: LoadImmediate r2, 2
-    40: Add r1, r1, r2
-    44: LoadImmediate r1, 0
-    47: StoreDynamic r1, c2
-    50: LoadImmediate r0, 3
-    53: LoadImmediate r1, 4
-    56: Add r1, r0, r1
-    60: LoadDynamic r1, c3
-    63: LoadImmediate r2, 5
-    66: Add r1, r1, r2
-    70: LoadImmediate r1, 6
-    73: Add r1, r0, r1
-    77: LoadDynamic r1, c3
-    80: LoadImmediate r2, 7
-    83: Add r1, r1, r2
-    87: PopScope 
-    88: LoadUndefined r1
-    90: Ret r1
+    37: AddImm r1, r1, 2
+    41: LoadImmediate r1, 0
+    44: StoreDynamic r1, c2
+    47: LoadImmediate r0, 3
+    50: AddImm r1, r0, 4
+    54: LoadDynamic r1, c3
+    57: AddImm r1, r1, 5
+    61: AddImm r1, r0, 6
+    65: LoadDynamic r1, c3
+    68: AddImm r1, r1, 7
+    72: PopScope 
+    73: LoadUndefined r1
+    75: Ret r1
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]

--- a/tests/snapshot/bytecode/statement/const_let_declaration.exp
+++ b/tests/snapshot/bytecode/statement/const_let_declaration.exp
@@ -134,11 +134,10 @@
 
 [BytecodeFunction: letNoInitializer] {
   Parameters: 0, Registers: 2
-     0: LoadUndefined r0
-     2: LoadImmediate r1, 2
-     5: Add r1, r0, r1
-     9: LoadUndefined r1
-    11: Ret r1
+    0: LoadUndefined r0
+    2: AddImm r1, r0, 2
+    6: LoadUndefined r1
+    8: Ret r1
 }
 
 [BytecodeFunction: assigningConst] {

--- a/tests/snapshot/bytecode/statement/var_declaration.exp
+++ b/tests/snapshot/bytecode/statement/var_declaration.exp
@@ -46,17 +46,15 @@
 }
 
 [BytecodeFunction: testLoadFrom] {
-  Parameters: 1, Registers: 6
+  Parameters: 1, Registers: 5
      0: LoadImmediate r0, 1
      3: LoadImmediate r4, 1
-     6: LoadImmediate r5, 2
-     9: Add r4, r4, r5
-    13: LoadImmediate r5, 3
-    16: Add r1, r4, r5
-    20: Mov r2, a0
-    23: LoadGlobal r3, c0, k0
-    27: LoadUndefined r4
-    29: Ret r4
+     6: AddImm r4, r4, 2
+    10: AddImm r1, r4, 3
+    14: Mov r2, a0
+    17: LoadGlobal r3, c0, k0
+    21: LoadUndefined r4
+    23: Ret r4
   Constant Table:
     0: [String: y]
 }

--- a/tests/snapshot/bytecode/statement/with.exp
+++ b/tests/snapshot/bytecode/statement/with.exp
@@ -47,7 +47,7 @@
 }
 
 [BytecodeFunction: withVars] {
-  Parameters: 1, Registers: 2
+  Parameters: 1, Registers: 1
      0: PushFunctionScope c0
      2: StoreToScope <this>, 1, 0
      6: StoreToScope r0, 4, 0
@@ -59,18 +59,16 @@
     27: LoadImmediate r0, 1
     30: StoreDynamic r0, c2
     33: LoadDynamic r0, c2
-    36: LoadImmediate r1, 2
-    39: Add r0, r0, r1
-    43: LoadImmediate r0, 3
-    46: StoreDynamic r0, c2
-    49: PopScope 
-    50: LoadDynamic r0, c2
-    53: LoadImmediate r1, 4
-    56: Add r0, r0, r1
-    60: LoadImmediate r0, 5
-    63: StoreDynamic r0, c2
-    66: LoadUndefined r0
-    68: Ret r0
+    36: AddImm r0, r0, 2
+    40: LoadImmediate r0, 3
+    43: StoreDynamic r0, c2
+    46: PopScope 
+    47: LoadDynamic r0, c2
+    50: AddImm r0, r0, 4
+    54: LoadImmediate r0, 5
+    57: StoreDynamic r0, c2
+    60: LoadUndefined r0
+    62: Ret r0
   Constant Table:
     0: [ScopeNames]
     1: [ScopeNames]


### PR DESCRIPTION
## Summary

Introduce specialized instructions for common binary operations with a smi immediate. This includes all binary numeric operations, bitwise operations, and shift operations (except for `Exp`).

Structure directly matches the existing binary operation instructions. Instructions have an immediate RHS but we support immediate LHS for commutative binary operations (only multiplication and bitwise operations).

| Benchmark | 6cbf6c5d2 (base) | 71986b37e | Change |
|---|---|---|---|
| Richards | 2,715 med 2,694 ±16.3 n=4 | 2,718 med 2,706 ±18.4 n=4 | +0.1% |
| DeltaBlue | 2,625 med 2,619 ±5.9 n=4 | 2,671 med 2,654 ±11.2 n=4 | +1.8% |
| Crypto | 3,089 med 3,078 ±64.1 n=4 | 3,257 med 3,253 ±17.1 n=4 | +5.4% |
| RayTrace | 2,919 med 2,912 ±11.6 n=4 | 2,880 med 2,877 ±6.6 n=4 | -1.3% |
| EarleyBoyer | 5,480 med 5,447 ±22.5 n=4 | 5,473 med 5,460 ±14.5 n=4 | -0.1% |
| RegExp | 442 med 442 ±0.6 n=4 | 444 med 440 ±2.4 n=4 | +0.5% |
| Splay | 5,096 med 5,080 ±135 n=4 | 5,126 med 5,095 ±27.7 n=4 | +0.6% |
| SplayLatency | 9,851 med 9,437 ±245 n=4 | 9,709 med 9,472 ±184 n=4 | -1.4% |
| NavierStokes | 4,240 med 4,223 ±15.1 n=4 | 4,278 med 4,259 ±21.1 n=4 | +0.9% |
| PdfJS | 6,385 med 6,365 ±15.8 n=4 | 6,514 med 6,432 ±50.3 n=4 | +2.0% |
| Mandreel | 2,567 med 2,555 ±8.1 n=4 | 2,987 med 2,984 ±3.8 n=4 | +16.4% |
| MandreelLatency | 19,027 med 18,955 ±58.8 n=4 | 21,124 med 21,080 ±51.4 n=4 | +11.0% |
| Gameboy | 5,249 med 5,235 ±78.6 n=4 | 5,275 med 5,238 ±51.8 n=4 | +0.5% |
| CodeLoad | 39,505 med 39,251 ±186 n=4 | 39,710 med 39,458 ±158 n=4 | +0.5% |
| Box2D | 9,616 med 9,592 ±564 n=4 | 9,578 med 9,569 ±103 n=4 | -0.4% |
| zlib | 4,646 med 4,632 ±17.4 n=4 | 5,695 med 5,681 ±13.4 n=4 | +22.6% |
| Typescript | 19,440 med 19,428 ±137 n=4 | 19,535 med 19,477 ±125 n=4 | +0.5% |
| **Total (octane)** | **5,258 med 5,233 ±41.5 n=4** | **5,426 med 5,415 ±18.9 n=4** | **+3.2%** |

## Tests

- Add bytecode snapshot and integration tests for binary operations with smi immediates
- Update all bytecode snapshot tests, as many now emit binary immediate instructions