### PR TITLE
[runtime] Force inlining of entire typed array get/set fast path

### DIFF
--- a/src/js/runtime/intrinsics/typed_array_fast.rs
+++ b/src/js/runtime/intrinsics/typed_array_fast.rs
@@ -28,12 +28,12 @@ trait FastElement: Copy {
 macro_rules! impl_fast_elements {
     ($(($element_type:ty, $from_value:expr),)*) => {
         $(impl FastElement for $element_type {
-            #[inline]
+            #[inline(always)]
             fn to_value(self) -> Value {
                 Value::number(self)
             }
 
-            #[inline]
+            #[inline(always)]
             fn from_value(value: Value) -> Option<Self> {
                 $from_value(value)
             }
@@ -54,12 +54,12 @@ impl_fast_elements! {
 }
 
 impl FastElement for f16 {
-    #[inline]
+    #[inline(always)]
     fn to_value(self) -> Value {
         Value::number(self.to_f64())
     }
 
-    #[inline]
+    #[inline(always)]
     fn from_value(value: Value) -> Option<Self> {
         Some(f64_to_f16(value_to_f64(value)?))
     }
@@ -71,12 +71,12 @@ impl FastElement for f16 {
 struct ClampedU8(u8);
 
 impl FastElement for ClampedU8 {
-    #[inline]
+    #[inline(always)]
     fn to_value(self) -> Value {
         Value::number(self.0)
     }
 
-    #[inline]
+    #[inline(always)]
     fn from_value(value: Value) -> Option<Self> {
         if value.is_smi() {
             Some(ClampedU8(value.as_smi().clamp(0, u8::MAX as i32) as u8))
@@ -89,7 +89,7 @@ impl FastElement for ClampedU8 {
 }
 
 /// Convert value to an f64 if it is a number, or None if value is not a number.
-#[inline]
+#[inline(always)]
 fn value_to_f64(value: Value) -> Option<f64> {
     if value.is_smi() {
         Some(value.as_smi() as f64)
@@ -102,7 +102,7 @@ fn value_to_f64(value: Value) -> Option<f64> {
 
 /// Convert value to a u32 (following the spec's ToInt32/ToUint32) if it is a number, or None if
 /// value is not a number.
-#[inline]
+#[inline(always)]
 fn value_to_wrapping_u32(value: Value) -> Option<u32> {
     if value.is_smi() {
         Some(value.as_smi() as u32)
@@ -116,7 +116,7 @@ fn value_to_wrapping_u32(value: Value) -> Option<u32> {
 /// Return the pointer to the element at `index` in the typed array with the given fields.
 ///
 /// Return None if the buffer is detached or the index is out of bounds (possibly due to resizing).
-#[inline]
+#[inline(always)]
 fn fast_element_ptr<T>(
     buffer: HeapPtr<ArrayBufferObject>,
     byte_offset: usize,
@@ -153,7 +153,7 @@ fn fast_element_ptr<T>(
 }
 
 /// Fast path for getting an element from a specific typed array kind.
-#[inline]
+#[inline(always)]
 fn fast_get_element<T: FastElement>(
     buffer: HeapPtr<ArrayBufferObject>,
     byte_offset: usize,
@@ -169,7 +169,7 @@ fn fast_get_element<T: FastElement>(
 /// Fast path for setting an element on a specific typed array kind.
 ///
 /// Returns true if the store was handled, or false if the slow path must be taken.
-#[inline]
+#[inline(always)]
 fn fast_set_element<T: FastElement>(
     buffer: HeapPtr<ArrayBufferObject>,
     byte_offset: usize,
@@ -193,7 +193,7 @@ macro_rules! create_typed_array_fast_paths {
         /// Fast path for getting an element from any kind of typed array.
         ///
         /// Returns the value if the load was handled, None if the slow path must be taken.
-        #[inline]
+        #[inline(always)]
         pub fn typed_array_fast_get(
             object: HeapPtr<AnyHeapItem>,
             kind: HeapItemKind,
@@ -216,7 +216,7 @@ macro_rules! create_typed_array_fast_paths {
         /// Fast path for setting an element on any kind of typed array.
         ///
         /// Returns true if the store was handled, false if the slow path must be taken.
-        #[inline]
+        #[inline(always)]
         pub fn typed_array_fast_set(
             object: HeapPtr<AnyHeapItem>,
             kind: HeapItemKind,


### PR DESCRIPTION
## Summary

We were failing to inline the full typed array get/set fast path into the VM due to using `#[inline]` instead of `#[inline(always)]`. Forcing inlining for all typed ararys significantly increases the interpreter dispatch loop size but still comes with a roughly 0.6% increase to Octane score.

| Benchmark | 7494b3208 (base) | 3f5a38df7 | Change |
|---|---|---|---|
| Richards | 2,701 med 2,687 ±22.2 n=4 | 2,737 med 2,722 ±9.6 n=4 | +1.3% |
| DeltaBlue | 2,672 med 2,665 ±28.2 n=4 | 2,671 med 2,670 ±1.7 n=4 | -0.0% |
| Crypto | 3,301 med 3,265 ±38.9 n=4 | 3,266 med 3,261 ±3.8 n=4 | -1.1% |
| RayTrace | 2,954 med 2,934 ±45.3 n=4 | 2,957 med 2,931 ±16.0 n=4 | +0.1% |
| EarleyBoyer | 5,615 med 5,574 ±70.1 n=4 | 5,514 med 5,486 ±29.2 n=4 | -1.8% |
| RegExp | 445 med 444 ±1.3 n=4 | 451 med 448 ±2.5 n=4 | +1.3% |
| Splay | 5,023 med 5,015 ±11.9 n=4 | 5,142 med 5,085 ±56.8 n=4 | +2.4% |
| SplayLatency | 10,032 med 9,875 ±367 n=4 | 9,981 med 9,916 ±186 n=4 | -0.5% |
| NavierStokes | 4,278 med 4,255 ±24.1 n=4 | 4,106 med 4,068 ±21.8 n=4 | -4.0% |
| PdfJS | 6,484 med 6,473 ±18.1 n=4 | 6,544 med 6,532 ±13.9 n=4 | +0.9% |
| Mandreel | 3,007 med 3,002 ±17.8 n=4 | 3,164 med 3,142 ±12.2 n=4 | +5.2% |
| MandreelLatency | 21,214 med 21,125 ±103 n=4 | 22,763 med 22,712 ±59.5 n=4 | +7.3% |
| Gameboy | 5,319 med 5,237 ±55.2 n=4 | 5,300 med 5,270 ±29.3 n=4 | -0.4% |
| CodeLoad | 39,786 med 39,695 ±119 n=4 | 39,768 med 39,401 ±250 n=4 | -0.0% |
| Box2D | 9,701 med 9,683 ±143 n=4 | 9,654 med 9,611 ±22.8 n=4 | -0.5% |
| zlib | 5,726 med 5,722 ±17.0 n=4 | 5,922 med 5,916 ±13.0 n=4 | +3.4% |
| Typescript | 19,695 med 19,565 ±128 n=4 | 19,628 med 19,570 ±72.1 n=4 | -0.3% |
| **Total (octane)** | **5,466 med 5,455 ±42.9 n=4** | **5,501 med 5,496 ±11.6 n=4** | **+0.6%** |

## Tests

- CI