### PR TITLE
[runtime] RegExp.prototype[@@replace] substitution template cache is aware of named capture group availability

### DIFF
--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -27,7 +27,7 @@ use crate::{
             regexp_object::RegExpObject,
             regexp_string_iterator_object::RegExpStringIteratorObject,
             rust_runtime::RuntimeFunction,
-            string_prototype::{ReplaceValue, SubstitutionTemplateParser},
+            string_prototype::{ReplaceValue, SubstitutionTemplate, SubstitutionTemplateParser},
         },
         object_value::ObjectValue,
         ordinary_object::ordinary_object_create_without_proto,
@@ -372,8 +372,8 @@ impl RegExpPrototype {
         let mut string_parts = vec![];
         let mut next_source_position = 0;
 
-        // Cached substitution template
-        let mut substitution_template = None;
+        // Cached substitution templates
+        let mut cached_substitution_templates = ParsedSubstitutionTemplateCache::new();
 
         for exec_result in exec_results {
             let result_length = length_of_array_like(cx, exec_result)?;
@@ -437,16 +437,23 @@ impl RegExpPrototype {
                         Some(to_object(cx, named_captures)?)
                     };
 
-                    // Cache substitution template since it does not change between matches
-                    if substitution_template.is_none() {
-                        let new_template =
-                            SubstitutionTemplateParser::new(named_captures.is_some())
-                                .parse(cx, replace_string)?;
-                        substitution_template = Some(new_template);
+                    // Lazily generate cached substitution template
+                    let allow_named_captures = named_captures.is_some();
+                    if cached_substitution_templates
+                        .get(allow_named_captures)
+                        .is_none()
+                    {
+                        let new_template = SubstitutionTemplateParser::new(allow_named_captures)
+                            .parse(cx, replace_string)?;
+                        cached_substitution_templates.set(allow_named_captures, new_template);
                     }
 
+                    let cached_substitution_template = cached_substitution_templates
+                        .get(allow_named_captures)
+                        .unwrap();
+
                     // Apply substitution template
-                    substitution_template.as_ref().unwrap().get_substitution(
+                    cached_substitution_template.get_substitution(
                         cx,
                         target_string,
                         matched_string,
@@ -1072,4 +1079,33 @@ fn snap_index_to_code_point(string_value: Handle<StringValue>, index: u32) -> Al
     }
 
     Ok(prev_index)
+}
+
+/// Substitution templates may be parsed differently depending on if named capture groups are
+/// allowed, so we cache both versions.
+struct ParsedSubstitutionTemplateCache {
+    with_named_groups: Option<SubstitutionTemplate>,
+    without_named_groups: Option<SubstitutionTemplate>,
+}
+
+impl ParsedSubstitutionTemplateCache {
+    fn new() -> Self {
+        Self { with_named_groups: None, without_named_groups: None }
+    }
+
+    fn get(&self, allow_named_groups: bool) -> Option<&SubstitutionTemplate> {
+        if allow_named_groups {
+            self.with_named_groups.as_ref()
+        } else {
+            self.without_named_groups.as_ref()
+        }
+    }
+
+    fn set(&mut self, allow_named_groups: bool, template: SubstitutionTemplate) {
+        if allow_named_groups {
+            self.with_named_groups = Some(template);
+        } else {
+            self.without_named_groups = Some(template);
+        }
+    }
 }

--- a/tests/integration/built-ins/RegExp/replace_substitution_template_cache.js
+++ b/tests/integration/built-ins/RegExp/replace_substitution_template_cache.js
@@ -1,0 +1,48 @@
+/*---
+description: Cached substitution templates are aware of named capture availability per match.
+---*/
+
+function regexpWithMatches(matches) {
+  var regexp = new RegExp("b", "g");
+  var index = 0;
+
+  regexp.exec = function () {
+    return index < matches.length ? matches[index++] : null;
+  };
+
+  return regexp;
+}
+
+function matchAt(index, groups) {
+  return { 0: "b", index: index, groups: groups };
+}
+
+// Named captures only allowed on the second match
+assert.sameValue(
+  "abcb".replace(regexpWithMatches([matchAt(1), matchAt(3, { name: "Q" })]), "<$<name>>"),
+  "a<$<name>>c<Q>"
+);
+
+// Named captures are only allowed on the first match
+assert.sameValue(
+  "abcb".replace(regexpWithMatches([matchAt(1, { name: "Q" }), matchAt(3)]), "<$<name>>"),
+  "a<Q>c<$<name>>"
+);
+
+// Alternating availability of named captures multiple times across matches
+assert.sameValue(
+  "abcbeb".replace(
+    regexpWithMatches([matchAt(1, { name: "1" }), matchAt(3), matchAt(5, { name: "3" })]),
+    "<$<name>>"
+  ),
+  "a<1>c<$<name>>e<3>",
+);
+
+// Every match has named captures
+assert.sameValue(
+  "abcb".replace(
+    regexpWithMatches([matchAt(1, { name: "X" }), matchAt(3, { name: "Y" })]),
+    "<$<name>>"
+  ),
+  "a<X>c<Y>",
+);


### PR DESCRIPTION
## Summary

Bug fix for when `RegExp.prototype[@@replace]` has different named capture group availability per match. This can occur due to a custom `exec`. Substitution templates may parse differently depending on named capture group availability but our cached template was not aware of this. Instead let's cache two versions depending on named capture group availability.

## Tests

- Added integration test covering this case