### PR TITLE
[regexp] RegExp methods call RegExpBuiltinExec directly and use raw match objects where possible

### DIFF
--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -16,6 +16,7 @@ use crate::{
         array_object::{
             ArrayCreateShape, array_create, array_create_in_realm, create_array_from_list,
         },
+        bytecode::function::ClosureObject,
         common_shapes::CommonShape,
         error::type_error,
         eval_result::EvalResult,
@@ -32,7 +33,7 @@ use crate::{
         object_value::ObjectValue,
         ordinary_object::ordinary_object_create_without_proto,
         realm::Realm,
-        regexp::matcher::run_matcher,
+        regexp::matcher::{Match, run_matcher},
         string_value::StringValue,
         to_string,
         type_utilities::{
@@ -112,7 +113,7 @@ impl RegExpPrototype {
         let string_arg = arguments.get(cx, 0);
         let string_value = to_string(cx, string_arg)?;
 
-        regexp_builtin_exec(cx, regexp_object, string_value)
+        regexp_builtin_exec(cx, regexp_object, string_value)?.to_value(cx, string_value)
     }}
 
     runtime_fn! {
@@ -211,7 +212,8 @@ impl RegExpPrototype {
             || flags_string_contains(flags_string, 'v' as u32)?;
 
         if !is_global {
-            return regexp_exec(cx, regexp_object, string_value, "RegExp.prototype[@@match]");
+            return regexp_exec(cx, regexp_object, string_value, "RegExp.prototype[@@match]")?
+                .to_value(cx, string_value);
         }
 
         let zero_value = cx.zero();
@@ -221,22 +223,31 @@ impl RegExpPrototype {
         let mut n = 0;
 
         loop {
-            let result = regexp_exec(cx, regexp_object, string_value, "RegExp.prototype[@@match]")?;
-            if result.is_null() {
-                if n == 0 {
-                    return Ok(cx.null());
-                } else {
-                    return Ok(result_array.as_value());
+            let exec_result =
+                regexp_exec(cx, regexp_object, string_value, "RegExp.prototype[@@match]")?;
+
+            let match_string = match exec_result {
+                // Found the last match - return collected matches if any exit
+                ExecResult::NoMatch => {
+                    if n == 0 {
+                        return Ok(cx.null());
+                    } else {
+                        return Ok(result_array.as_value());
+                    }
                 }
-            }
-
-            // RegExpExec only returns an object or null
-            debug_assert!(result.is_object());
-            let result_object = result.as_object();
-
-            let zero_key = PropertyKey::array_index_handle(cx, 0)?;
-            let match_string = get(cx, result_object, zero_key)?;
-            let match_string = to_string(cx, match_string)?;
+                // Collect the matched string
+                ExecResult::Match(_, match_) => {
+                    let match_bounds = match_.full_capture();
+                    string_value
+                        .substring(cx, match_bounds.start, match_bounds.end)?
+                        .as_string()
+                }
+                ExecResult::Object(exec_result) => {
+                    let zero_key = PropertyKey::array_index_handle(cx, 0)?;
+                    let match_string = get(cx, exec_result, zero_key)?;
+                    to_string(cx, match_string)?
+                }
+            };
 
             let n_key = PropertyKey::array_index_handle(cx, n)?;
             must!(create_data_property_or_throw(
@@ -339,7 +350,8 @@ impl RegExpPrototype {
         loop {
             // Search target string, finding all matches if global
             let exec_result =
-                regexp_exec(cx, regexp_object, target_string, "RegExp.prototype[@@replace]")?;
+                regexp_exec(cx, regexp_object, target_string, "RegExp.prototype[@@replace]")?
+                    .to_value(cx, target_string)?;
             if exec_result.is_null() {
                 break;
             }
@@ -504,7 +516,8 @@ impl RegExpPrototype {
         }
 
         // Perform RegExp search
-        let result = regexp_exec(cx, regexp_object, string_value, "RegExp.prototype[@@search]")?;
+        let exec_result =
+            regexp_exec(cx, regexp_object, string_value, "RegExp.prototype[@@search]")?;
 
         // Restore original last index
         let current_last_index = get(cx, regexp_object, cx.names.last_index())?;
@@ -512,10 +525,11 @@ impl RegExpPrototype {
             set(cx, regexp_object, cx.names.last_index(), previous_last_index, true)?;
         }
 
-        if result.is_null() {
-            Ok(cx.negative_one())
-        } else {
-            get(cx, result.as_object(), cx.names.index())
+        // Return index of the match, or -1 if no match was found
+        match exec_result {
+            ExecResult::NoMatch => Ok(cx.negative_one()),
+            ExecResult::Match(_, match_) => Ok(cx.number(match_.full_capture().start)),
+            ExecResult::Object(exec_result) => get(cx, exec_result, cx.names.index()),
         }
     }}
 
@@ -587,7 +601,7 @@ impl RegExpPrototype {
         // Handle the empty string case
         if string_value.is_empty() {
             let exec_result = regexp_exec(cx, splitter, string_value, "RegExp.prototype[@@split]")?;
-            if !exec_result.is_null() {
+            if exec_result.is_match() {
                 return Ok(result_array.as_value());
             }
 
@@ -610,7 +624,8 @@ impl RegExpPrototype {
             set(cx, splitter, cx.names.last_index(), q_value, true)?;
 
             // Execute RegExp at current index, advancing to next index if there is no match
-            let exec_result = regexp_exec(cx, splitter, string_value, "RegExp.prototype[@@split]")?;
+            let exec_result = regexp_exec(cx, splitter, string_value, "RegExp.prototype[@@split]")?
+                .to_value(cx, string_value)?;
 
             if exec_result.is_null() {
                 q = advance_string_index(string_value, q, is_unicode)?;
@@ -687,7 +702,7 @@ impl RegExpPrototype {
 
         let exec_result = regexp_exec(cx, regexp_object, string_value, "RegExp.prototype.test")?;
 
-        Ok(cx.bool(!exec_result.is_null()))
+        Ok(cx.bool(exec_result.is_match()))
     }}
 
     runtime_fn! {
@@ -802,24 +817,70 @@ pub fn flags_string_contains(
     Ok(flags_string.iter_code_points()?.any(|c| c == flag))
 }
 
+/// Result of RegExpExec. Returns the raw match for use (without converting to an object) where
+/// possible. Still must support an arbitrary user-defined `exec` that returns a full object.
+pub enum ExecResult {
+    /// There was no match.
+    NoMatch,
+    /// A raw match found for the given RegExp.
+    Match(Handle<RegExpObject>, Match),
+    /// The object returned by a user-provided `exec` method.
+    Object(Handle<ObjectValue>),
+}
+
+impl ExecResult {
+    fn is_match(&self) -> bool {
+        !matches!(self, ExecResult::NoMatch)
+    }
+
+    /// Return the result of RegExpExec converted to a value: a match object or null.
+    pub fn to_value(
+        self,
+        cx: Context,
+        string_value: Handle<StringValue>,
+    ) -> EvalResult<Handle<Value>> {
+        match self {
+            ExecResult::NoMatch => Ok(cx.null()),
+            ExecResult::Match(regexp_object, match_) => {
+                Ok(build_match_object(cx, regexp_object, string_value, &match_)?.as_value())
+            }
+            ExecResult::Object(exec_result) => Ok(exec_result.as_value()),
+        }
+    }
+}
+
 /// RegExpExec (https://tc39.es/ecma262/#sec-regexpexec)
+///
+/// Returns the raw match instead of a full match object when possible.
 pub fn regexp_exec(
     cx: Context,
     regexp_object: Handle<ObjectValue>,
     string_value: Handle<StringValue>,
     method_name: &str,
-) -> EvalResult<Handle<Value>> {
+) -> EvalResult<ExecResult> {
     let exec = get(cx, regexp_object, cx.names.exec())?;
 
+    // If the `exec` property is the builtin `RegExp.prototype.exec` then we can skip the call and
+    // perform RegExpBuiltinExec directly.
+    if is_builtin_regexp_exec(cx, exec)
+        && let Some(regexp_object) = regexp_object.as_opt::<RegExpObject>()
+    {
+        return regexp_builtin_exec(cx, regexp_object, string_value);
+    }
+
+    // Otherwise is a user-defined `exec` method, so we must call it and handle the result.
     if is_callable(exec) {
         let exec_result = call(cx, exec, regexp_object.into(), &[string_value.into()])?;
-        if !exec_result.is_null() && !exec_result.is_object() {
+        if exec_result.is_null() {
+            return Ok(ExecResult::NoMatch);
+        } else if !exec_result.is_object() {
             return type_error(cx, &format!("{method_name} `exec` must return null or an object"));
         }
 
-        return Ok(exec_result);
+        return Ok(ExecResult::Object(exec_result.as_object()));
     }
 
+    // No `exec` method so perform RegExpBuiltinExec directly.
     let Some(regexp_object) = regexp_object.as_opt::<RegExpObject>() else {
         return type_error(cx, &format!("{method_name} must be called on a RegExp"));
     };
@@ -827,12 +888,28 @@ pub fn regexp_exec(
     regexp_builtin_exec(cx, regexp_object, string_value)
 }
 
+/// Whether the value is the builtin `RegExp.prototype.exec` function of the current realm.
+///
+/// Realm must match since RegExpBuiltinExec creates the match result array in the realm of the
+/// `exec` function that is called.
+fn is_builtin_regexp_exec(cx: Context, value: Handle<Value>) -> bool {
+    let Some(closure) = value.as_opt::<ClosureObject>() else {
+        return false;
+    };
+
+    closure.function_ptr().runtime_function_id()
+        == Some(RuntimeFunction::RegExpPrototype_exec.to_id())
+        && closure.realm_ptr().ptr_eq(&cx.current_realm_ptr())
+}
+
 /// RegExpBuiltinExec (https://tc39.es/ecma262/#sec-regexpbuiltinexec)
+///
+/// Returns the raw match directly instead of converting it to a match object.
 fn regexp_builtin_exec(
     cx: Context,
     regexp_object: Handle<RegExpObject>,
     string_value: Handle<StringValue>,
-) -> EvalResult<Handle<Value>> {
+) -> EvalResult<ExecResult> {
     let compiled_regexp = regexp_object.compiled_regexp();
     let string_length = string_value.len();
 
@@ -842,7 +919,6 @@ fn regexp_builtin_exec(
     let flags = regexp_object.flags();
     let is_global = flags.is_global();
     let is_sticky = flags.is_sticky();
-    let has_indices = flags.has_indices();
 
     if !is_global && !is_sticky {
         last_index = 0;
@@ -856,7 +932,7 @@ fn regexp_builtin_exec(
             set(cx, regexp_object.into(), cx.names.last_index(), zero_value, true)?;
         }
 
-        return Ok(cx.null());
+        return Ok(ExecResult::NoMatch);
     }
     let last_index = last_index as u32;
 
@@ -871,25 +947,35 @@ fn regexp_builtin_exec(
     let match_ = run_matcher(cx, compiled_regexp, string_value, matcher_start_index)?;
 
     // Handle match failure, resetting last index under sticky flag
-    if match_.is_none() {
+    let Some(match_) = match_ else {
         if is_global || is_sticky {
             let zero_value = cx.zero();
             set(cx, regexp_object.into(), cx.names.last_index(), zero_value, true)?;
         }
 
-        return Ok(cx.null());
-    }
-
-    let capture_groups = &match_.unwrap().capture_groups;
-
-    // 0'th capture which matches entire pattern is guaranteed to exist
-    let full_capture = capture_groups[0].as_ref().unwrap();
+        return Ok(ExecResult::NoMatch);
+    };
 
     // Update last index to point past end of capture
     if is_global || is_sticky {
-        let last_index_value = cx.number(full_capture.end);
+        let last_index_value = cx.number(match_.full_capture().end);
         set(cx, regexp_object.into(), cx.names.last_index(), last_index_value, true)?;
     }
+
+    Ok(ExecResult::Match(regexp_object, match_))
+}
+
+/// Build the match object for a raw match found by RegExpExec.
+fn build_match_object(
+    cx: Context,
+    regexp_object: Handle<RegExpObject>,
+    string_value: Handle<StringValue>,
+    match_: &Match,
+) -> EvalResult<Handle<ObjectValue>> {
+    let compiled_regexp = regexp_object.compiled_regexp();
+    let capture_groups = &match_.capture_groups;
+    let full_capture = match_.full_capture();
+    let has_indices = regexp_object.flags().has_indices();
 
     // Build result array of matches
     let realm = cx.current_realm();
@@ -1018,7 +1104,7 @@ fn regexp_builtin_exec(
         ));
     }
 
-    Ok(result_array.as_value())
+    Ok(result_array)
 }
 
 /// AdvanceStringIndex (https://tc39.es/ecma262/#sec-advancestringindex)

--- a/src/js/runtime/intrinsics/regexp_string_iterator_object.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator_object.rs
@@ -101,7 +101,8 @@ impl RegExpStringIteratorPrototype {
 
         // Run the regular expression
         let match_result =
-            regexp_exec(cx, regexp_object, target_string, "%RegExpStringIteratorPrototype%.next")?;
+            regexp_exec(cx, regexp_object, target_string, "%RegExpStringIteratorPrototype%.next")?
+                .to_value(cx, target_string)?;
 
         // No match so return a completed iterator
         if match_result.is_null() {

--- a/src/js/runtime/regexp/matcher.rs
+++ b/src/js/runtime/regexp/matcher.rs
@@ -109,6 +109,13 @@ pub struct Match {
     pub capture_groups: Vec<Option<Capture>>,
 }
 
+impl Match {
+    /// The bounds of the entire match (i.e. the 0'th capture group)
+    pub fn full_capture(&self) -> &Capture {
+        self.capture_groups[0].as_ref().unwrap()
+    }
+}
+
 /// Bounds of a matched capture group. The start index is inclusive, the end index is exclusive.
 #[derive(Debug)]
 pub struct Capture {

--- a/tests/integration/built-ins/RegExp/builtin_exec_fast_path.js
+++ b/tests/integration/built-ins/RegExp/builtin_exec_fast_path.js
@@ -1,0 +1,356 @@
+/*---
+description: >
+  RegExpExec calls the builtin `exec` inline to obtain the raw match where possible Verify that we
+  get the same results using the raw match directly vs using the full match object when a
+  user-defined `exec` methods is used.
+includes: [compareArray.js]
+---*/
+
+var builtinExec = RegExp.prototype.exec;
+
+// A RegExp equivalent to the argument, but whose `exec` is a user-provided function. This forces
+// RegExpExec down the generic path where the match result array must be built and read back.
+function withWrappedExec(source, flags) {
+  var regexp = new RegExp(source, flags);
+  regexp.exec = function (string) {
+    return builtinExec.call(this, string);
+  };
+
+  return regexp;
+}
+
+// Every operation built on RegExpExec, applied to a freshly created RegExp so that no last index
+// state is carried between them. String.prototype.matchAll requires a global RegExp.
+function runAll(makeRegExp, string) {
+  return {
+    test: makeRegExp().test(string),
+    search: string.search(makeRegExp()),
+    match: string.match(makeRegExp()),
+    matchAll: makeRegExp().global ? [...string.matchAll(makeRegExp())] : [],
+    replaceString: string.replace(makeRegExp(), "<$&|$1|$2>"),
+    replaceFunction: string.replace(makeRegExp(), function () {
+      return "<" + Array.prototype.slice.call(arguments, 0, -2).join(",") + ">";
+    }),
+    split: string.split(makeRegExp()),
+    splitLimited: string.split(makeRegExp(), 3),
+    exec: makeRegExp().exec(string),
+  };
+}
+
+function assertSameResults(source, flags, string) {
+  var message = "/" + source + "/" + flags + " on " + JSON.stringify(string);
+
+  var inline = runAll(function () { return new RegExp(source, flags); }, string);
+  var wrapped = runAll(function () { return withWrappedExec(source, flags); }, string);
+
+  assert.sameValue(inline.test, wrapped.test, message + " test");
+  assert.sameValue(inline.search, wrapped.search, message + " search");
+  assert.sameValue(inline.replaceString, wrapped.replaceString, message + " replace with string");
+  assert.sameValue(
+    inline.replaceFunction,
+    wrapped.replaceFunction,
+    message + " replace with function"
+  );
+  assert.compareArray(inline.split, wrapped.split, message + " split");
+  assert.compareArray(inline.splitLimited, wrapped.splitLimited, message + " split with limit");
+
+  assert.sameValue(
+    JSON.stringify(inline.match),
+    JSON.stringify(wrapped.match),
+    message + " match"
+  );
+  assert.sameValue(
+    JSON.stringify(inline.matchAll),
+    JSON.stringify(wrapped.matchAll),
+    message + " matchAll"
+  );
+  assert.sameValue(
+    JSON.stringify(inline.exec),
+    JSON.stringify(wrapped.exec),
+    message + " exec"
+  );
+}
+
+// Patterns covering no captures, indexed captures, optional captures that do not participate in the
+// match, named captures, and empty matches.
+var patterns = [
+  ["b", ""],
+  ["b", "g"],
+  ["(b)(c)", "g"],
+  ["(z)?(b)", "g"],
+  ["(?<first>b)(?<second>c)", "g"],
+  ["(?<first>b)|(?<first>c)", "g"],
+  ["", "g"],
+  ["(?:)", "g"],
+  ["b", "gy"],
+  ["b", "y"],
+  ["(b)(c)", "gd"],
+  ["B(C)", "gi"],
+  [".", "gs"],
+  ["^.", "gm"],
+  [".", "gu"],
+  ["\\d", "g"],
+];
+
+var strings = ["", "abc", "abcbc", "abc\ndbc", "a\u{1F600}bc", "aaa"];
+
+for (var i = 0; i < patterns.length; i++) {
+  for (var j = 0; j < strings.length; j++) {
+    assertSameResults(patterns[i][0], patterns[i][1], strings[j]);
+  }
+}
+
+// The inline path is also taken when `exec` is an own property that happens to be the builtin, and
+// when it is inherited by a subclass instance.
+var ownBuiltinExec = new RegExp("(b)", "g");
+ownBuiltinExec.exec = builtinExec;
+assert.sameValue("abcb".replace(ownBuiltinExec, "<$1>"), "a<b>c<b>");
+
+class SubRegExp extends RegExp {}
+var subclassed = new SubRegExp("(b)", "g");
+assert.sameValue(subclassed.exec, builtinExec);
+assert.sameValue("abcb".replace(subclassed, "<$1>"), "a<b>c<b>");
+assert.sameValue(subclassed.test("abc"), true);
+assert.compareArray("abcb".split(new SubRegExp("(b)")), ["a", "b", "c", "b", ""]);
+
+// A bound builtin `exec` is a different function, so the generic path is used instead.
+var boundExec = new RegExp("(b)", "g");
+boundExec.exec = builtinExec.bind(boundExec);
+assert.sameValue("abcb".replace(boundExec, "<$1>"), "a<b>c<b>");
+
+// A Proxy is not a RegExp, so the generic path is used even though `exec` is the builtin. The
+// builtin `exec` is then called with the Proxy as its receiver and rejects it.
+var proxied = new Proxy(new RegExp("(b)", "g"), {});
+assert.sameValue(proxied.exec, builtinExec);
+assert.throws(TypeError, function () {
+  RegExp.prototype.test.call(proxied, "abc");
+});
+
+// An ordinary object carrying the builtin `exec` is not a RegExp either, and is rejected the same
+// way rather than being matched against.
+assert.throws(TypeError, function () {
+  RegExp.prototype.test.call({ exec: builtinExec }, "abc");
+});
+
+// A Proxy wrapping the builtin `exec` is a different function, so the generic path is used and the
+// call is forwarded through the Proxy.
+var proxiedExec = new RegExp("(b)", "g");
+proxiedExec.exec = new Proxy(builtinExec, {});
+assert.sameValue("abcb".replace(proxiedExec, "<$1>"), "a<b>c<b>");
+
+// `exec` is looked up once per match attempt, even when it resolves to the builtin.
+function countExecLookups(regexp, run) {
+  var lookups = 0;
+  Object.defineProperty(regexp, "exec", {
+    configurable: true,
+    get: function () {
+      lookups++;
+      return builtinExec;
+    },
+  });
+
+  run(regexp);
+
+  return lookups;
+}
+
+// Three matches in "abcb" plus the final failed attempt.
+assert.sameValue(
+  countExecLookups(new RegExp("b", "g"), function (regexp) {
+    assert.compareArray("abcb".match(regexp), ["b", "b"]);
+  }),
+  3,
+  "@@match looks up `exec` once per attempt"
+);
+
+assert.sameValue(
+  countExecLookups(new RegExp("b", "g"), function (regexp) {
+    assert.sameValue("abcb".replace(regexp, "X"), "aXcX");
+  }),
+  3,
+  "@@replace looks up `exec` once per attempt"
+);
+
+assert.sameValue(
+  countExecLookups(new RegExp("b"), function (regexp) {
+    assert.sameValue(regexp.test("abc"), true);
+  }),
+  1,
+  "test looks up `exec` once"
+);
+
+assert.sameValue(
+  countExecLookups(new RegExp("b"), function (regexp) {
+    assert.sameValue("abc".search(regexp), 1);
+  }),
+  1,
+  "@@search looks up `exec` once"
+);
+
+// Last index is still maintained when the builtin `exec` runs inline. It advances past each match,
+// resumes from wherever it was left, and resets once the match fails.
+var tracked = new RegExp("b", "g");
+assert.sameValue(tracked.test("abcb"), true);
+assert.sameValue(tracked.lastIndex, 2, "last index advances past the match");
+assert.sameValue(tracked.test("abcb"), true);
+assert.sameValue(tracked.lastIndex, 4, "matching resumes from the stored last index");
+assert.sameValue(tracked.test("abcb"), false);
+assert.sameValue(tracked.lastIndex, 0, "last index resets when the match fails");
+
+// A last index past the end of the string fails without running the matcher.
+tracked.lastIndex = 5;
+assert.sameValue(tracked.test("abcb"), false);
+assert.sameValue(tracked.lastIndex, 0, "an out of range last index resets");
+
+// A sticky RegExp only matches at last index.
+var sticky = new RegExp("b", "y");
+sticky.lastIndex = 1;
+assert.sameValue(sticky.test("abcb"), true);
+assert.sameValue(sticky.lastIndex, 2);
+assert.sameValue(sticky.test("abcb"), false, "no match at the new last index");
+assert.sameValue(sticky.lastIndex, 0);
+
+// A non-global, non-sticky RegExp never writes last index and always matches from the start.
+var nonGlobal = new RegExp("b");
+nonGlobal.lastIndex = 3;
+assert.sameValue(nonGlobal.test("abcb"), true);
+assert.sameValue(nonGlobal.lastIndex, 3, "last index is untouched without the g or y flag");
+
+// @@search restores the original last index rather than leaving the match's.
+var searched = new RegExp("b", "g");
+searched.lastIndex = 3;
+assert.sameValue("abcb".search(searched), 1);
+assert.sameValue(searched.lastIndex, 3, "@@search restores last index");
+
+// Swapping `exec` part way through a loop must switch to the swapped-in function. The first attempt
+// uses the builtin and each later attempt returns the next of the given results.
+function swapExecAfterFirst(laterResults) {
+  var regexp = new RegExp("b", "g");
+  var attempts = 0;
+  Object.defineProperty(regexp, "exec", {
+    configurable: true,
+    get: function () {
+      attempts++;
+      if (attempts === 1) {
+        return builtinExec;
+      }
+
+      var result = laterResults[attempts - 2];
+      return function () {
+        if (result === null || result === undefined) {
+          return null;
+        }
+
+        this.lastIndex = result.index + result[0].length;
+        return result;
+      };
+    },
+  });
+
+  return regexp;
+}
+
+assert.compareArray(
+  "abcb".match(swapExecAfterFirst([null])),
+  ["b"],
+  "@@match stops once the swapped-in `exec` reports no match"
+);
+
+assert.sameValue(
+  "abcb".replace(swapExecAfterFirst([{ 0: "c", index: 2, length: 1 }, null]), "<$&>"),
+  "a<b><c>b",
+  "@@replace uses the match reported by the swapped-in `exec`"
+);
+
+// A swapped-in `exec` returning something other than an object or null is a TypeError.
+var badExec = new RegExp("b", "g");
+badExec.exec = function () {
+  return 5;
+};
+assert.throws(TypeError, function () {
+  badExec.test("abcb");
+});
+
+// An `exec` property that is not callable is ignored, and the builtin RegExpBuiltinExec is used
+// instead. This is only reachable on a real RegExp; anything else is a TypeError.
+var nonCallableValues = [5, "exec", null, undefined, true, Symbol("exec"), {}, []];
+for (var i = 0; i < nonCallableValues.length; i++) {
+  var nonCallable = new RegExp("(b)", "g");
+  nonCallable.exec = nonCallableValues[i];
+
+  assert.sameValue(nonCallable.test("abcb"), true, "test with a non-callable `exec`");
+  nonCallable.lastIndex = 0;
+  assert.sameValue("abc".search(nonCallable), 1, "@@search with a non-callable `exec`");
+  nonCallable.lastIndex = 0;
+  assert.compareArray("abcb".match(nonCallable), ["b", "b"], "@@match with a non-callable `exec`");
+  nonCallable.lastIndex = 0;
+  assert.sameValue(
+    "abcb".replace(nonCallable, "<$1>"),
+    "a<b>c<b>",
+    "@@replace with a non-callable `exec`"
+  );
+  nonCallable.lastIndex = 0;
+  assert.compareArray(
+    "abcb".split(nonCallable),
+    ["a", "b", "c", "b", ""],
+    "@@split with a non-callable `exec`"
+  );
+}
+
+assert.throws(TypeError, function () {
+  RegExp.prototype.test.call({ exec: 5 }, "abc");
+});
+
+// A user-provided `exec` may report a match with arbitrary property values. @@search returns the
+// `index` property without converting it, while @@match converts the `0` property to a string.
+var customIndex = new RegExp("b");
+customIndex.exec = function () {
+  return { index: "not a number" };
+};
+assert.sameValue("abc".search(customIndex), "not a number", "@@search returns `index` unconverted");
+
+var customMatched = new RegExp("b");
+customMatched.exec = function () {
+  return { 0: 42 };
+};
+assert.sameValue("abc".match(customMatched)[0], 42, "a non-global @@match returns the object");
+
+var customMatchedGlobal = new RegExp("b", "g");
+var globalAttempts = 0;
+customMatchedGlobal.exec = function () {
+  globalAttempts++;
+  return globalAttempts === 1 ? { 0: 42 } : null;
+};
+assert.compareArray(
+  "abc".match(customMatchedGlobal),
+  ["42"],
+  "a global @@match converts the matched value to a string"
+);
+
+// Errors thrown out of a user-provided `exec` propagate.
+var thrownError = new Error("from exec");
+assert.throws(Error, function () {
+  var regexp = new RegExp("b", "g");
+  regexp.exec = function () {
+    throw thrownError;
+  };
+  "abcb".replace(regexp, "X");
+});
+
+// Reassigning RegExp.prototype.exec makes every method go through the replacement.
+var savedExec = RegExp.prototype.exec;
+try {
+  RegExp.prototype.exec = function () {
+    return null;
+  };
+
+  assert.sameValue(new RegExp("b", "g").test("abcb"), false);
+  assert.sameValue("abcb".search(new RegExp("b")), -1);
+  assert.sameValue("abcb".match(new RegExp("b", "g")), null);
+  assert.sameValue("abcb".replace(new RegExp("b", "g"), "X"), "abcb");
+  assert.compareArray("abcb".split(new RegExp("b")), ["abcb"]);
+} finally {
+  RegExp.prototype.exec = savedExec;
+}
+
+assert.sameValue(new RegExp("b", "g").test("abcb"), true, "the builtin is restored");


### PR DESCRIPTION
## Summary

Many `RegExp` methods internally call the `exec` property then use the resulting match object. Let's improve this by detecting if the builtin `exec` method would be called, and if so directly calling `RegExpBuiltinExec` to run the match engine and return a raw match result.

Then use this raw match object directly instead of converting it into a match object where possible. This includes in `RegExp.prototype.test`, `RegExp.prototype[@@search]`, and `RegExp.prototype[@@match]`.

Notes:
- `ExecResult` enum now is returned from `regexp_exec` and is either a raw match or full match object. Must be explicitly converted to a match object at each use site.
- `exec` method must be in the expected realm since it creates a result array in that realm
- We still lookup `exec` (without any caching), but this could be sped up in the future

Small perf win but mostly setup for using the raw matches in `replace/split/etc` in the future. This commit sees a ~1.4% increase to Octane RegExp benchmark score.

## Tests

 - CI
 - Added LLM-generated integration tests exercising both the raw path and match object path for all RegExp methods