### PR TITLE
[regexp] Fast path for RegExp.prototype[@@replace] using raw match directly

### DIFF
--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -345,33 +345,51 @@ impl RegExpPrototype {
         // Key is shared between iterations
         let mut key = PropertyKey::uninit().to_handle(cx);
 
+        enum MatchKind {
+            Raw(Match),
+            Object(Handle<ObjectValue>),
+        }
+
         let mut exec_results = vec![];
 
         loop {
             // Search target string, finding all matches if global
             let exec_result =
-                regexp_exec(cx, regexp_object, target_string, "RegExp.prototype[@@replace]")?
-                    .to_value(cx, target_string)?;
-            if exec_result.is_null() {
-                break;
-            }
+                regexp_exec(cx, regexp_object, target_string, "RegExp.prototype[@@replace]")?;
 
-            let exec_result = exec_result.as_object();
+            let exec_result = match exec_result {
+                ExecResult::NoMatch => break,
+                // Any matching named capture groups requires taking the slow path.
+                ExecResult::Match(matched_regexp, match_)
+                    if matched_regexp.compiled_regexp().has_named_capture_groups
+                        && replace_value.may_reference_named_captures()? =>
+                {
+                    let result = build_match_object(cx, matched_regexp, target_string, &match_)?;
+                    MatchKind::Object(result)
+                }
+                ExecResult::Match(_, match_) => MatchKind::Raw(match_),
+                ExecResult::Object(exec_result) => MatchKind::Object(exec_result),
+            };
 
             if !is_global {
                 exec_results.push(exec_result);
                 break;
             }
 
-            // Extract matched string
-            key.replace(PropertyKey::array_index(cx, 0)?);
-            let matched_value = get(cx, exec_result, key)?;
-            let matched_string = to_string(cx, matched_value)?;
+            // Extract matched string to determine whether the match was empty
+            let is_empty_match = match &exec_result {
+                MatchKind::Raw(match_) => match_.full_capture().is_empty(),
+                MatchKind::Object(exec_result) => {
+                    key.replace(PropertyKey::array_index(cx, 0)?);
+                    let matched_value = get(cx, *exec_result, key)?;
+                    to_string(cx, matched_value)?.is_empty()
+                }
+            };
 
             exec_results.push(exec_result);
 
             // If matched string is empty then increment last index
-            if matched_string.is_empty() {
+            if is_empty_match {
                 let this_index = get(cx, regexp_object, cx.names.last_index())?;
                 let this_index = to_length(cx, this_index)?;
 
@@ -388,93 +406,24 @@ impl RegExpPrototype {
         let mut cached_substitution_templates = ParsedSubstitutionTemplateCache::new();
 
         for exec_result in exec_results {
-            let result_length = length_of_array_like(cx, exec_result)?;
-            let num_captures = result_length.saturating_sub(1);
-
-            // Extract the matched string
-            key.replace(PropertyKey::array_index(cx, 0)?);
-            let matched_value = get(cx, exec_result, key)?;
-            let matched_string = to_string(cx, matched_value)?;
-
-            // Extract the position of the matched string
-            let matched_position = get(cx, exec_result, cx.names.index())?;
-            let matched_position = to_integer_or_infinity(cx, matched_position)?;
-            let matched_position =
-                f64::clamp(matched_position, 0.0, target_string.len() as f64) as u32;
-
-            // Collect all captures by their capture index
-            let mut indexed_captures = vec![];
-            for i in 1..=num_captures {
-                key.replace(PropertyKey::from_u64(cx, i)?);
-                let capture_value = get(cx, exec_result, key)?;
-                if capture_value.is_undefined() {
-                    indexed_captures.push(None);
-                } else {
-                    let capture_string = to_string(cx, capture_value)?;
-                    indexed_captures.push(Some(capture_string));
-                }
-            }
-
-            let named_captures = get(cx, exec_result, cx.names.groups())?;
-
-            let replacement_string = match replace_value {
-                ReplaceValue::Function(replacer_function) => {
-                    // Construct arguments for replacer function
-                    let mut replacer_args = vec![];
-                    replacer_args.push(matched_string.into());
-                    replacer_args.extend(indexed_captures.into_iter().map(|capture| {
-                        if let Some(capture) = capture {
-                            capture.into()
-                        } else {
-                            cx.undefined()
-                        }
-                    }));
-                    replacer_args.push(cx.number(matched_position));
-                    replacer_args.push(target_string.into());
-
-                    if !named_captures.is_undefined() {
-                        replacer_args.push(named_captures);
-                    }
-
-                    // Call replacer function and return string
-                    let replacement_value =
-                        call_object(cx, replacer_function, cx.undefined(), &replacer_args)?;
-
-                    to_string(cx, replacement_value)?
-                }
-                ReplaceValue::String(replace_string) => {
-                    let named_captures = if named_captures.is_undefined() {
-                        None
-                    } else {
-                        Some(to_object(cx, named_captures)?)
-                    };
-
-                    // Lazily generate cached substitution template
-                    let allow_named_captures = named_captures.is_some();
-                    if cached_substitution_templates
-                        .get(allow_named_captures)
-                        .is_none()
-                    {
-                        let new_template = SubstitutionTemplateParser::new(allow_named_captures)
-                            .parse(cx, replace_string)?;
-                        cached_substitution_templates.set(allow_named_captures, new_template);
-                    }
-
-                    let cached_substitution_template = cached_substitution_templates
-                        .get(allow_named_captures)
-                        .unwrap();
-
-                    // Apply substitution template
-                    cached_substitution_template.get_substitution(
+            let Replacement { replacement_string, matched_position, matched_length } =
+                match exec_result {
+                    MatchKind::Raw(match_) => replacement_for_raw_match(
                         cx,
+                        &match_,
                         target_string,
-                        matched_string,
-                        matched_position,
-                        &indexed_captures,
-                        named_captures,
-                    )?
-                }
-            };
+                        replace_value,
+                        &mut cached_substitution_templates,
+                    )?,
+                    MatchKind::Object(exec_result) => replacement_for_match_object(
+                        cx,
+                        exec_result,
+                        target_string,
+                        replace_value,
+                        key,
+                        &mut cached_substitution_templates,
+                    )?,
+                };
 
             // Add unchanged part between matches, then replacement for match
             if matched_position >= next_source_position {
@@ -485,7 +434,7 @@ impl RegExpPrototype {
                 string_parts.push(unchanged_part);
                 string_parts.push(replacement_string);
 
-                next_source_position = matched_position + matched_string.len();
+                next_source_position = matched_position + matched_length;
             }
         }
 
@@ -815,6 +764,194 @@ pub fn flags_string_contains(
     flag: CodePoint,
 ) -> AllocResult<bool> {
     Ok(flags_string.iter_code_points()?.any(|c| c == flag))
+}
+
+/// The replacement for a single match in `RegExp.prototype[@@replace]`, along with the position
+/// and length of the substring of the target string that it replaces.
+struct Replacement {
+    replacement_string: Handle<StringValue>,
+    matched_position: u32,
+    matched_length: u32,
+}
+
+/// Compute a single `RegExp.prototype[@@replace]` replacement for a raw match.
+///
+/// Cannot have named capture groups.
+fn replacement_for_raw_match(
+    cx: Context,
+    match_: &Match,
+    target_string: Handle<StringValue>,
+    replace_value: ReplaceValue,
+    cached_substitution_templates: &mut ParsedSubstitutionTemplateCache,
+) -> EvalResult<Replacement> {
+    let full_capture = match_.full_capture();
+
+    // Extract the matched string
+    let matched_string = target_string
+        .substring(cx, full_capture.start, full_capture.end)?
+        .as_string();
+
+    // Extract the position of the matched string
+    let matched_position = full_capture.start;
+    let matched_length = full_capture.end - full_capture.start;
+
+    // All captures (excluding the implicit full match capture)
+    let captures = &match_.capture_groups[1..];
+
+    let replacement_string = match replace_value {
+        ReplaceValue::Function(replacer_function) => {
+            // Construct arguments for replacer function. Matched substrings can be reconstructed
+            // from capture bounds.
+            let mut replacer_args = vec![matched_string.into()];
+            for capture in captures {
+                let capture_value = match capture {
+                    None => cx.undefined(),
+                    Some(capture) => target_string
+                        .substring(cx, capture.start, capture.end)?
+                        .as_string()
+                        .into(),
+                };
+                replacer_args.push(capture_value);
+            }
+
+            replacer_args.push(cx.number(matched_position));
+            replacer_args.push(target_string.into());
+
+            // No named capture groups can appear, so always exclude the `groups` argument
+
+            // Call replacer function and return string
+            let replacement_value =
+                call_object(cx, replacer_function, cx.undefined(), &replacer_args)?;
+
+            to_string(cx, replacement_value)?
+        }
+        ReplaceValue::String(replace_string) => {
+            // Named captures are not allowed since there are no named groups
+            let substitution_template =
+                cached_substitution_templates.get(cx, replace_string, false)?;
+
+            // Create matched capture strings for all captures
+            let mut indexed_captures = Vec::with_capacity(captures.len());
+            for (i, capture) in captures.iter().enumerate() {
+                let capture_string = match capture {
+                    Some(capture)
+                        if substitution_template.references_capture(i + 1, captures.len()) =>
+                    {
+                        Some(
+                            target_string
+                                .substring(cx, capture.start, capture.end)?
+                                .as_string(),
+                        )
+                    }
+                    _ => None,
+                };
+                indexed_captures.push(capture_string);
+            }
+
+            // Apply substitution template
+            substitution_template.get_substitution(
+                cx,
+                target_string,
+                matched_string,
+                matched_position,
+                &indexed_captures,
+                None,
+            )?
+        }
+    };
+
+    Ok(Replacement { replacement_string, matched_position, matched_length })
+}
+
+/// Compute a single `RegExp.prototype[@@replace]` replacement for a match result object.
+fn replacement_for_match_object(
+    cx: Context,
+    exec_result: Handle<ObjectValue>,
+    target_string: Handle<StringValue>,
+    replace_value: ReplaceValue,
+    mut key: Handle<PropertyKey>,
+    cached_substitution_templates: &mut ParsedSubstitutionTemplateCache,
+) -> EvalResult<Replacement> {
+    let result_length = length_of_array_like(cx, exec_result)?;
+    let num_captures = result_length.saturating_sub(1);
+
+    // Extract the matched string
+    key.replace(PropertyKey::array_index(cx, 0)?);
+    let matched_value = get(cx, exec_result, key)?;
+    let matched_string = to_string(cx, matched_value)?;
+
+    // Extract the position of the matched string
+    let matched_position = get(cx, exec_result, cx.names.index())?;
+    let matched_position = to_integer_or_infinity(cx, matched_position)?;
+    let matched_position = f64::clamp(matched_position, 0.0, target_string.len() as f64) as u32;
+
+    // Collect all captures by their capture index
+    let mut indexed_captures = vec![];
+    for i in 1..=num_captures {
+        key.replace(PropertyKey::from_u64(cx, i)?);
+        let capture_value = get(cx, exec_result, key)?;
+        if capture_value.is_undefined() {
+            indexed_captures.push(None);
+        } else {
+            let capture_string = to_string(cx, capture_value)?;
+            indexed_captures.push(Some(capture_string));
+        }
+    }
+
+    let named_captures = get(cx, exec_result, cx.names.groups())?;
+
+    let replacement_string = match replace_value {
+        ReplaceValue::Function(replacer_function) => {
+            // Construct arguments for replacer function
+            let mut replacer_args = vec![matched_string.into()];
+            replacer_args.extend(indexed_captures.into_iter().map(|capture| {
+                if let Some(capture) = capture {
+                    capture.into()
+                } else {
+                    cx.undefined()
+                }
+            }));
+            replacer_args.push(cx.number(matched_position));
+            replacer_args.push(target_string.into());
+
+            if !named_captures.is_undefined() {
+                replacer_args.push(named_captures);
+            }
+
+            // Call replacer function and return string
+            let replacement_value =
+                call_object(cx, replacer_function, cx.undefined(), &replacer_args)?;
+
+            to_string(cx, replacement_value)?
+        }
+        ReplaceValue::String(replace_string) => {
+            let named_captures = if named_captures.is_undefined() {
+                None
+            } else {
+                Some(to_object(cx, named_captures)?)
+            };
+
+            let allow_named_captures = named_captures.is_some();
+            let substitution_template =
+                cached_substitution_templates.get(cx, replace_string, allow_named_captures)?;
+
+            // Apply substitution template
+            substitution_template.get_substitution(
+                cx,
+                target_string,
+                matched_string,
+                matched_position,
+                &indexed_captures,
+                named_captures,
+            )?
+        }
+    };
+
+    Ok(Replacement {
+        replacement_string,
+        matched_position,
+        matched_length: matched_string.len() as u32,
+    })
 }
 
 /// Result of RegExpExec. Returns the raw match for use (without converting to an object) where
@@ -1179,19 +1316,31 @@ impl ParsedSubstitutionTemplateCache {
         Self { with_named_groups: None, without_named_groups: None }
     }
 
-    fn get(&self, allow_named_groups: bool) -> Option<&SubstitutionTemplate> {
-        if allow_named_groups {
-            self.with_named_groups.as_ref()
-        } else {
-            self.without_named_groups.as_ref()
+    fn cache(
+        cache: &mut Option<SubstitutionTemplate>,
+        cx: Context,
+        template_string: Handle<StringValue>,
+        allow_named_groups: bool,
+    ) -> AllocResult<&SubstitutionTemplate> {
+        if cache.is_none() {
+            *cache = Some(
+                SubstitutionTemplateParser::new(allow_named_groups).parse(cx, template_string)?,
+            );
         }
+
+        Ok(cache.as_ref().unwrap())
     }
 
-    fn set(&mut self, allow_named_groups: bool, template: SubstitutionTemplate) {
+    fn get(
+        &mut self,
+        cx: Context,
+        template_string: Handle<StringValue>,
+        allow_named_groups: bool,
+    ) -> AllocResult<&SubstitutionTemplate> {
         if allow_named_groups {
-            self.with_named_groups = Some(template);
+            Self::cache(&mut self.with_named_groups, cx, template_string, true)
         } else {
-            self.without_named_groups = Some(template);
+            Self::cache(&mut self.without_named_groups, cx, template_string, false)
         }
     }
 }

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -1396,14 +1396,52 @@ fn normalize_string<I: Iterator<Item = char>>(
 }
 
 /// Replace argument may be either a function or string
+#[derive(Clone, Copy)]
 pub enum ReplaceValue {
     Function(Handle<ObjectValue>),
     String(Handle<StringValue>),
 }
 
+impl ReplaceValue {
+    /// Conservative heuristic for whether a replacement value may reference named captures.
+    pub fn may_reference_named_captures(&self) -> AllocResult<bool> {
+        match self {
+            // Replacement functions will be passed the named captures object
+            ReplaceValue::Function(_) => Ok(true),
+            // Quickly scan the replacement string for a "$<" sequence
+            ReplaceValue::String(replace_string) => {
+                let mut prev_code_unit = 0;
+
+                for code_unit in replace_string.iter_code_units()? {
+                    if prev_code_unit == '$' as u16 && code_unit == '<' as u16 {
+                        return Ok(true);
+                    }
+
+                    prev_code_unit = code_unit;
+                }
+
+                Ok(false)
+            }
+        }
+    }
+}
+
 pub struct SubstitutionTemplate {
     template: Handle<FlatString>,
     parts: Vec<SubstitutionPart>,
+}
+
+impl SubstitutionTemplate {
+    /// Whether the substitution template contains any references to the capture group with the
+    /// given index, given the number of capture groups available.
+    pub fn references_capture(&self, index: usize, num_captures: usize) -> bool {
+        self.parts.iter().any(|part| match part {
+            SubstitutionPart::IndexedCapture(part_index, ..) => {
+                SubstitutionPart::resolve_capture_index(*part_index, num_captures) == Some(index)
+            }
+            _ => false,
+        })
+    }
 }
 
 enum SubstitutionPart {
@@ -1420,6 +1458,28 @@ enum SubstitutionPart {
     IndexedCapture(u8, u32, u32),
     /// The named capture group with the given name
     NamedCapture(Handle<StringValue>),
+}
+
+impl SubstitutionPart {
+    /// The capture group that a `$N` or `$NN` reference resolves to, given the number of capture
+    /// groups available.
+    ///
+    /// Returns:
+    /// - Some(original index) if the full reference is valid and resolves to a capture group
+    /// - Some(first digit) if the full reference is invalid but the first digit resolves to a
+    ///   capture group and the second digit is treated as a literal
+    /// - None if the full reference is invalid and treated as a literal
+    fn resolve_capture_index(index: u8, num_captures: usize) -> Option<usize> {
+        let index = index as usize;
+
+        if index <= num_captures {
+            Some(index)
+        } else if index >= 10 && index / 10 <= num_captures {
+            Some(index / 10)
+        } else {
+            None
+        }
+    }
 }
 
 pub struct SubstitutionTemplateParser {
@@ -1590,42 +1650,27 @@ impl SubstitutionTemplate {
                     string_parts.push(substring);
                 }
                 SubstitutionPart::IndexedCapture(index, start, end) => {
-                    let index = *index as usize;
-
-                    // Only use capture group if index is in range
-                    if index <= indexed_captures.len() {
-                        if let Some(captured_string) = indexed_captures.get(index - 1).unwrap() {
-                            string_parts.push(*captured_string);
-                        }
-
-                        continue;
-                    }
-
-                    // If index is multiple digits but out of range, instead treat as a single digit
-                    // followed by a literal.
-                    if index >= 10 {
-                        // Check if the first digit is in range
-                        let first_digit_index = index / 10;
-                        if first_digit_index <= indexed_captures.len() {
-                            if let Some(captured_string) =
-                                indexed_captures.get(first_digit_index - 1).unwrap()
-                            {
-                                string_parts.push(*captured_string);
+                    match SubstitutionPart::resolve_capture_index(*index, indexed_captures.len()) {
+                        Some(resolved_index) => {
+                            if let Some(captured_string) = indexed_captures[resolved_index - 1] {
+                                string_parts.push(captured_string);
                             }
 
-                            // Append second digit as a literal
-                            let second_digit_char = (index % 10) as u32 + '0' as u32;
-                            let second_digit_string =
-                                FlatString::from_code_point(cx, second_digit_char)?;
-                            string_parts.push(second_digit_string.as_string().to_handle());
-
-                            continue;
+                            // If resolved index differs then the first digit is treated as a
+                            // capture group and the second digit is treated as a literal.
+                            if resolved_index != *index as usize {
+                                let second_digit_char = (*index % 10) as u32 + '0' as u32;
+                                let second_digit_string =
+                                    FlatString::from_code_point(cx, second_digit_char)?;
+                                string_parts.push(second_digit_string.as_string().to_handle());
+                            }
+                        }
+                        // Entire reference is invalid and treated as a literal
+                        None => {
+                            let substring = self.template.substring(cx, *start, *end)?.as_string();
+                            string_parts.push(substring);
                         }
                     }
-
-                    // Otherwise treat as a literal
-                    let substring = self.template.substring(cx, *start, *end)?.as_string();
-                    string_parts.push(substring);
                 }
                 SubstitutionPart::NamedCapture(name) => {
                     if let Some(named_captures) = named_captures {

--- a/src/js/runtime/regexp/matcher.rs
+++ b/src/js/runtime/regexp/matcher.rs
@@ -123,6 +123,13 @@ pub struct Capture {
     pub end: u32,
 }
 
+impl Capture {
+    /// Whether the capture group matched the empty string.
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+}
+
 const FORWARD: bool = true;
 const BACKWARD: bool = false;
 

--- a/tests/integration/built-ins/RegExp/builtin_exec_fast_path.js
+++ b/tests/integration/built-ins/RegExp/builtin_exec_fast_path.js
@@ -1,6 +1,6 @@
 /*---
 description: >
-  RegExpExec calls the builtin `exec` inline to obtain the raw match where possible Verify that we
+  RegExpExec calls the builtin `exec` inline to obtain the raw match where possible. Verify that we
   get the same results using the raw match directly vs using the full match object when a
   user-defined `exec` methods is used.
 includes: [compareArray.js]
@@ -260,6 +260,22 @@ assert.sameValue(
   "abcb".replace(swapExecAfterFirst([{ 0: "c", index: 2, length: 1 }, null]), "<$&>"),
   "a<b><c>b",
   "@@replace uses the match reported by the swapped-in `exec`"
+);
+
+// The substitution template is cached across matches keyed on whether named captures are allowed.
+// Here the first match is a raw match consumed directly and the second is a match result object
+// from the swapped-in `exec`, so the two ways of computing a replacement must share that one cache
+// correctly rather than each reusing the other's template.
+assert.sameValue(
+  "abcb".replace(
+    swapExecAfterFirst([
+      { 0: "c", index: 2, length: 1, groups: { name: "Q" } },
+      null,
+    ]),
+    "<$<name>>"
+  ),
+  "a<$<name>><Q>b",
+  "a raw match and a match result object share the substitution template cache"
 );
 
 // A swapped-in `exec` returning something other than an object or null is a TypeError.

--- a/tests/integration/built-ins/RegExp/replace_raw_match_substitution.js
+++ b/tests/integration/built-ins/RegExp/replace_raw_match_substitution.js
@@ -1,0 +1,161 @@
+/*---
+description: >
+  RegExp.prototype[@@replace] consumes the raw match of the builtin `exec` directly where possible.
+---*/
+
+// A RegExp with the same behaviour whose `exec` is a user-provided function, forcing @@replace down
+// the path that reads a match result array instead of consuming the raw match.
+var builtinExec = RegExp.prototype.exec;
+
+function withWrappedExec(source, flags) {
+  var regexp = new RegExp(source, flags);
+  regexp.exec = function (string) {
+    return builtinExec.call(this, string);
+  };
+
+  return regexp;
+}
+
+function assertSameReplacement(source, flags, string, replacement) {
+  var message =
+    "/" + source + "/" + flags +
+    " on " + JSON.stringify(string) +
+    " with " + JSON.stringify(replacement);
+
+  assert.sameValue(
+    string.replace(new RegExp(source, flags), replacement),
+    string.replace(withWrappedExec(source, flags), replacement),
+    message
+  );
+}
+
+// Every substitution form, against patterns with and without named capture groups.
+var replacements = [
+  "-",
+  "$$",
+  "$&",
+  "$`",
+  "$'",
+  "$`|$&|$'",
+  "$1",
+  "$2",
+  "$3",
+  "[$1][$2]",
+  "$0",
+  "$00",
+  "$01",
+  "$<name>",
+  "$<missing>",
+  "$<",
+  "$",
+  "x$",
+  "$z",
+  "a$1b$$c$&d",
+];
+
+var replacePatterns = [
+  ["b", ""],
+  ["b", "g"],
+  ["(b)", "g"],
+  ["(b)(c)", "g"],
+  ["(z)?(b)", "g"],
+  ["(?<name>b)", "g"],
+  ["(?<name>b)(c)", "g"],
+  ["(?<name>b)|(?<name>c)", "g"],
+  ["", "g"],
+  ["b|c", "g"],
+];
+
+for (var i = 0; i < replacePatterns.length; i++) {
+  for (var j = 0; j < replacements.length; j++) {
+    assertSameReplacement(replacePatterns[i][0], replacePatterns[i][1], "abcbd", replacements[j]);
+    assertSameReplacement(replacePatterns[i][0], replacePatterns[i][1], "", replacements[j]);
+    assertSameReplacement(replacePatterns[i][0], replacePatterns[i][1], "bbb", replacements[j]);
+  }
+}
+
+// Only the captures a template references are materialized, so a template that references none must
+// still produce the right result for a pattern with many captures.
+var manyCaptures = "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)";
+assert.sameValue("abcdefghijkl".replace(new RegExp(manyCaptures), "-"), "-");
+assert.sameValue("abcdefghijkl".replace(new RegExp(manyCaptures), "$1"), "a");
+assert.sameValue("abcdefghijkl".replace(new RegExp(manyCaptures), "$12"), "l");
+assert.sameValue("abcdefghijkl".replace(new RegExp(manyCaptures), "$1$12$5"), "ale");
+
+// A two digit index that is out of range falls back to its first digit followed by a literal, so
+// both the two digit capture and the single digit capture must be available to the template.
+var tenCaptures = "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)";
+assert.sameValue("abcdefghij".replace(new RegExp(tenCaptures), "$10"), "j");
+assert.sameValue("abcdefghij".replace(new RegExp(tenCaptures), "$11"), "a1");
+assert.sameValue("abcdefghij".replace(new RegExp(tenCaptures), "$19"), "a9");
+assert.sameValue("abcdefghij".replace(new RegExp(tenCaptures), "$99"), "i9");
+
+// Both digits out of range leaves the whole reference as a literal.
+assert.sameValue("ab".replace(new RegExp("(a)b"), "$99"), "$99");
+assert.sameValue("ab".replace(new RegExp("(a)b"), "$29"), "$29");
+
+var nineCaptures = "(a)(b)(c)(d)(e)(f)(g)(h)(i)";
+assert.sameValue("abcdefghi".replace(new RegExp(nineCaptures), "$10"), "a0");
+assert.sameValue("abcdefghi".replace(new RegExp(nineCaptures), "$9"), "i");
+
+// A capture that did not participate in the match substitutes as the empty string.
+assert.sameValue("abc".replace(new RegExp("(z)?(b)"), "[$1][$2]"), "a[][b]c");
+assert.sameValue("abc".replace(new RegExp("(z)?(b)"), "$1"), "ac");
+
+// A replacer function receives every capture, whether or not a template would reference it.
+function replacerArguments(source, flags, string) {
+  var seen = [];
+  string.replace(new RegExp(source, flags), function () {
+    seen.push(Array.prototype.slice.call(arguments));
+    return "";
+  });
+
+  return seen;
+}
+
+assert.sameValue(
+  JSON.stringify(replacerArguments("(z)?(b)(c)", "", "abcd")),
+  JSON.stringify([[ "bc", undefined, "b", "c", 1, "abcd" ]]),
+  "captures, position and string are passed to the replacer"
+);
+
+assert.sameValue(
+  JSON.stringify(replacerArguments("(?<name>b)", "", "abc")),
+  JSON.stringify([[ "b", "b", 1, "abc", { name: "b" } ]]),
+  "a groups object is appended for a RegExp with named capture groups"
+);
+
+assert.sameValue(
+  JSON.stringify(replacerArguments("b", "g", "abcb")),
+  JSON.stringify([[ "b", 1, "abcb" ], [ "b", 3, "abcb" ]]),
+  "no groups object is appended without named capture groups"
+);
+
+// Empty matches advance last index so a global replace terminates, and the replacement is inserted
+// at every position.
+assert.sameValue("abc".replace(new RegExp("", "g"), "-"), "-a-b-c-");
+assert.sameValue("abc".replace(new RegExp("(?:)", "g"), "-"), "-a-b-c-");
+assert.sameValue("".replace(new RegExp("", "g"), "-"), "-");
+assert.sameValue("a\u{1F600}b".replace(new RegExp("", "gu"), "-"), "-a-\u{1F600}-b-");
+
+// A sticky global replace only matches at consecutive positions from the start.
+assert.sameValue("aab".replace(new RegExp("a", "gy"), "-"), "--b");
+assert.sameValue("baa".replace(new RegExp("a", "gy"), "-"), "baa");
+
+// The unchanged portions between and around matches are preserved.
+assert.sameValue("xxbyybzz".replace(new RegExp("b", "g"), "<$&>"), "xx<b>yy<b>zz");
+assert.sameValue("bxb".replace(new RegExp("b", "g"), ""), "x");
+assert.sameValue("abc".replace(new RegExp("c$"), "<$&>"), "ab<c>");
+assert.sameValue("abc".replace(new RegExp("^a"), "<$&>"), "<a>bc");
+
+// A replacer function that returns a non-string has its result converted.
+assert.sameValue(
+  "abc".replace(new RegExp("b"), function () {
+    return 42;
+  }),
+  "a42c"
+);
+
+// String.prototype.replaceAll goes through @@replace with a global RegExp.
+assert.sameValue("abcb".replaceAll(new RegExp("(b)", "g"), "<$1>"), "a<b>c<b>");
+assert.sameValue("abcb".replaceAll(new RegExp("(?<name>b)", "g"), "<$<name>>"), "a<b>c<b>");


### PR DESCRIPTION
## Summary

Add a fast path to `RegExp.prototype[@@replace]` so that the raw match result is used directly when possible instead of creating and then immediately querying a full match object.

We can take the fast path if 1) a raw match is returned from `RegExpExec` and 2) no matching named capture groups are used (checked conservatively). Most of this PR is splitting out the existing implementation into two separate `replacement_for_match_object` and `replacement_for_raw_match`, the former matches the old implementation and the latter has the same semantics but directly uses the raw match object, creating the minimal set of JS values needed along the way.

Seeing a +5.4% increase to Octane RegExp benchmark from this change.

## Tests

- Added LLM generated tests for `RegExp.prototype[@@replace]` using both raw matches and match objects