### PR TITLE
[regexp] Fast path for RegExp.prototype[@@split] using raw match directly

### DIFF
--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -572,39 +572,78 @@ impl RegExpPrototype {
             let q_value = cx.number(q);
             set(cx, splitter, cx.names.last_index(), q_value, true)?;
 
+            enum MatchKind {
+                Raw(Match),
+                Object(Handle<ObjectValue>),
+            }
+
             // Execute RegExp at current index, advancing to next index if there is no match
-            let exec_result = regexp_exec(cx, splitter, string_value, "RegExp.prototype[@@split]")?
-                .to_value(cx, string_value)?;
+            let exec_result = regexp_exec(cx, splitter, string_value, "RegExp.prototype[@@split]")?;
 
-            if exec_result.is_null() {
-                q = advance_string_index(string_value, q, is_unicode)?;
-            } else {
-                // Otherwise there was a match so determine end of match
-                let exec_result = exec_result.as_object();
-
-                let e = get(cx, splitter, cx.names.last_index())?;
-                let e = to_length(cx, e)?;
-                let e = u64::min(e, size as u64) as u32;
-
-                // If there was a match but it is empty then advance to next index
-                if e == p {
+            let captures = match exec_result {
+                ExecResult::NoMatch => {
                     q = advance_string_index(string_value, q, is_unicode)?;
-                } else {
-                    // Add portion of the string since the last match to the result array
-                    let match_slice = string_value.substring(cx, p, q)?.as_string();
+                    continue;
+                }
+                ExecResult::Match(_, match_) => MatchKind::Raw(match_),
+                ExecResult::Object(exec_result) => MatchKind::Object(exec_result),
+            };
 
+            // Otherwise there was a match so determine end of match
+            let e = get(cx, splitter, cx.names.last_index())?;
+            let e = to_length(cx, e)?;
+            let e = u64::min(e, size as u64) as u32;
+
+            // If there was a match but it is empty then advance to next index
+            if e == p {
+                q = advance_string_index(string_value, q, is_unicode)?;
+                continue;
+            }
+
+            // Add portion of the string since the last match to the result array
+            let match_slice = string_value.substring(cx, p, q)?.as_string();
+
+            key.replace(PropertyKey::array_index(cx, array_length)?);
+            create_data_property_or_throw(cx, result_array, key, match_slice.into())?;
+
+            // Check if we have hit split limit
+            array_length += 1;
+            if array_length == limit {
+                return Ok(result_array.as_value());
+            }
+
+            p = e;
+
+            macro_rules! set_capture {
+                ($capture_string:expr) => {
                     key.replace(PropertyKey::array_index(cx, array_length)?);
-                    create_data_property_or_throw(cx, result_array, key, match_slice.into())?;
+                    create_data_property_or_throw(cx, result_array, key, $capture_string)?;
 
                     // Check if we have hit split limit
                     array_length += 1;
                     if array_length == limit {
                         return Ok(result_array.as_value());
                     }
+                }
+            }
 
-                    p = e;
+            // Add capture groups to the result array
+            match captures {
+                MatchKind::Raw(match_) => {
+                    for capture in &match_.capture_groups[1..] {
+                        // Extract captured substring from the original string
+                        let next_capture = match capture {
+                            None => cx.undefined(),
+                            Some(capture) => string_value
+                                .substring(cx, capture.start, capture.end)?
+                                .as_string()
+                                .into(),
+                        };
 
-                    // Add capture groups to the result array
+                        set_capture!(next_capture);
+                    }
+                }
+                MatchKind::Object(exec_result) => {
                     let number_of_captures = length_of_array_like(cx, exec_result)?;
                     let number_of_captures = number_of_captures.saturating_sub(1);
 
@@ -612,19 +651,12 @@ impl RegExpPrototype {
                         key.replace(PropertyKey::from_u64(cx, i)?);
                         let next_capture = get(cx, exec_result, key)?;
 
-                        key.replace(PropertyKey::array_index(cx, array_length)?);
-                        create_data_property_or_throw(cx, result_array, key, next_capture)?;
-
-                        // Check if we have hit split limit
-                        array_length += 1;
-                        if array_length == limit {
-                            return Ok(result_array.as_value());
-                        }
+                        set_capture!(next_capture);
                     }
-
-                    q = p;
                 }
             }
+
+            q = p;
         }
 
         // Add remaining portion of the original string to the result array

--- a/tests/integration/built-ins/RegExp/split_raw_match_captures.js
+++ b/tests/integration/built-ins/RegExp/split_raw_match_captures.js
@@ -1,0 +1,120 @@
+/*---
+description: >
+  RegExp.prototype[@@split] consumes the raw match of the builtin `exec` directly where possible.
+includes: [compareArray.js]
+---*/
+
+var builtinExec = RegExp.prototype.exec;
+
+// The splitter is constructed from the RegExp through @@species, so a subclass whose `exec` is a
+// user-provided function forces @@split down the path that reads a match result array.
+function makeWrappedExecClass() {
+  return class extends RegExp {
+    exec(string) {
+      return builtinExec.call(this, string);
+    }
+  };
+}
+
+function assertSameSplit(source, flags, string, limit) {
+  var WrappedExecRegExp = makeWrappedExecClass();
+  var message =
+    "/" + source + "/" + flags +
+    " on " + JSON.stringify(string) +
+    " with limit " + String(limit);
+
+  assert.compareArray(
+    string.split(new RegExp(source, flags), limit),
+    string.split(new WrappedExecRegExp(source, flags), limit),
+    message
+  );
+}
+
+var splitPatterns = [
+  ["b", ""],
+  ["b", "g"],
+  ["b", "y"],
+  ["(b)", ""],
+  ["(b)(c)", ""],
+  ["(z)?(b)", ""],
+  ["(?<name>b)", ""],
+  ["(?<name>b)|(?<name>c)", ""],
+  ["", ""],
+  ["(?:)", ""],
+  ["\\d", ""],
+  ["(\\d)(\\d)?", ""],
+  [".", "s"],
+  ["B", "i"],
+];
+
+var strings = ["", "a", "abc", "abcbd", "a1b22c", "bb", "a\u{1F600}b", "\n"];
+var limits = [undefined, 0, 1, 2, 3, 100];
+
+for (var i = 0; i < splitPatterns.length; i++) {
+  for (var j = 0; j < strings.length; j++) {
+    for (var k = 0; k < limits.length; k++) {
+      assertSameSplit(splitPatterns[i][0], splitPatterns[i][1], strings[j], limits[k]);
+    }
+  }
+}
+
+// Capture groups are inserted into the result between the surrounding pieces.
+assert.compareArray("a1b2c".split(new RegExp("(\\d)")), ["a", "1", "b", "2", "c"]);
+assert.compareArray(
+  "a1b".split(new RegExp("(\\d)(x)?")),
+  ["a", "1", undefined, "b"]
+);
+
+// The limit is checked after each captured group is added, so it can cut a match's captures short.
+assert.compareArray("a1b2c".split(new RegExp("(\\d)"), 1), ["a"]);
+assert.compareArray("a1b2c".split(new RegExp("(\\d)"), 2), ["a", "1"]);
+assert.compareArray("a1b2c".split(new RegExp("(\\d)"), 3), ["a", "1", "b"]);
+assert.compareArray("a1b2c".split(new RegExp("(\\d)"), 4), ["a", "1", "b", "2"]);
+assert.compareArray("a1b2c".split(new RegExp("(\\d)"), 0), []);
+assert.compareArray(
+  "a1b".split(new RegExp("(\\d)(x)?"), 3),
+  ["a", "1", undefined]
+);
+
+// A pattern that matches the empty string splits between every code point, and is unicode aware
+// when a unicode flag is set.
+assert.compareArray("abc".split(new RegExp("")), ["a", "b", "c"]);
+assert.compareArray("a\u{1F600}b".split(new RegExp("", "u")), ["a", "\u{1F600}", "b"]);
+assert.compareArray("a\u{1F600}b".split(new RegExp("")), [
+  "a",
+  "\uD83D",
+  "\uDE00",
+  "b",
+]);
+
+// Splitting the empty string returns the empty string unless the pattern matches it.
+assert.compareArray("".split(new RegExp("a")), [""]);
+assert.compareArray("".split(new RegExp("")), []);
+assert.compareArray("".split(new RegExp("(a)?")), []);
+
+// A RegExp with no match leaves the string whole.
+assert.compareArray("abc".split(new RegExp("z")), ["abc"]);
+assert.compareArray("abc".split(new RegExp("(z)")), ["abc"]);
+
+// The sticky flag is added to the splitter, so a non-sticky RegExp still splits at every match and
+// an already sticky one behaves identically.
+assert.compareArray("a1b2c".split(new RegExp("\\d", "y")), ["a", "b", "c"]);
+assert.compareArray("a1b2c".split(new RegExp("\\d", "g")), ["a", "b", "c"]);
+
+// Splitting must not disturb the original RegExp's last index.
+var splitSource = new RegExp("\\d", "g");
+splitSource.lastIndex = 4;
+assert.compareArray("a1b2c".split(splitSource), ["a", "b", "c"]);
+assert.sameValue(splitSource.lastIndex, 4, "@@split works on a separate splitter");
+
+// @@species controls the splitter that is constructed, and a species returning a RegExp whose
+// `exec` is user-provided still produces the same result.
+var speciesCalls = 0;
+class SpeciesRegExp extends RegExp {
+  static get [Symbol.species]() {
+    speciesCalls++;
+    return RegExp;
+  }
+}
+assert.compareArray("a1b2c".split(new SpeciesRegExp("(\\d)")), ["a", "1", "b", "2", "c"]);
+assert.sameValue(speciesCalls, 1, "@@species is consulted once to build the splitter");


### PR DESCRIPTION
## Summary

Add a fast path to `RegExp.prototype[@@split]` so that the raw match result is used directly when possible instead of creating and then immediately querying a full match object.

Seeing a ~0.4% increase to Octane RegExp score from this change.

## Tests

- Added LLM generated tests for `RegExp.prototype[@@split]` using both raw matches and match objects