### PR TITLE
[regexp] RegExpInitialize reuses compiled bytecode when possible

### DIFF
--- a/src/js/parser/regexp.rs
+++ b/src/js/parser/regexp.rs
@@ -16,7 +16,7 @@ pub struct RegExp<'a> {
 }
 
 bitflags! {
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct RegExpFlags: u8 {
         /// Whether to generate indices for substring matches: `d`
         const HAS_INDICES = 1 << 0;

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -34,7 +34,7 @@ use crate::{
         },
         object_value::ObjectValue,
         realm::Realm,
-        regexp::compiler::compile_regexp,
+        regexp::{compiled_regexp::CompiledRegExp, compiler::compile_regexp},
         string_value::StringValue,
         to_string,
         type_utilities::{is_regexp, same_value},
@@ -95,14 +95,14 @@ impl RegExpConstructor {
         };
 
         let regexp_source = if let Some(pattern_regexp_object) = as_regexp_object(pattern_arg) {
-            // Construction from a regexp object
+            // Construction from a regexp object. Snapshot the compiled regexp now since allocating
+            // the new regexp may run user code that recompiles the pattern regexp.
+            let compiled_regexp = pattern_regexp_object.compiled_regexp();
+
             if flags_arg.is_undefined() {
-                RegExpSource::RegExpObject(pattern_regexp_object)
+                RegExpSource::CompiledRegExp(compiled_regexp)
             } else {
-                // If flags are provided we must reparse pattern instead of using compiled regexp
-                // directly, since different flags may result in a different regexp.
-                let pattern_value = pattern_regexp_object.escaped_pattern_source().into();
-                RegExpSource::PatternAndFlags(pattern_value, FlagsSource::Value(flags_arg))
+                RegExpSource::CompiledRegExpAndFlags(compiled_regexp, FlagsSource::Value(flags_arg))
             }
         } else if pattern_is_regexp {
             // Construction from a pattern object that has a [Symbol.match] property
@@ -197,8 +197,10 @@ pub fn as_regexp_object(value: Handle<Value>) -> Option<Handle<RegExpObject>> {
 
 // Source used to construct a RegExp
 pub enum RegExpSource {
-    // Construct from a pre-existing RegExpObject
-    RegExpObject(Handle<RegExpObject>),
+    // Construct from a pre-existing RegExp's compiled pattern and flags
+    CompiledRegExp(Handle<CompiledRegExp>),
+    // Construct from a pre-existing RegExp's compiled pattern with a different set of flags
+    CompiledRegExpAndFlags(Handle<CompiledRegExp>, FlagsSource),
     // Construct from a pair of pattern value and flags
     PatternAndFlags(Handle<Value>, FlagsSource),
 }
@@ -226,30 +228,54 @@ pub fn regexp_init(
     mut regexp_object: Handle<RegExpObject>,
     regexp_source: RegExpSource,
 ) -> EvalResult<Handle<Value>> {
+    let flags_from_source = |cx, flags_source| match flags_source {
+        FlagsSource::RegExpFlags(flags) => Ok(flags),
+        FlagsSource::Value(flags_value) => {
+            let flags_value = value_or_empty_string(cx, flags_value);
+            let flags_string = to_string(cx, flags_value)?;
+
+            parse_flags(cx, flags_string)
+        }
+    };
+
+    let compile_regexp = |cx, pattern_string, flags| {
+        let alloc = Bump::new();
+        let regexp = parse_pattern(cx, pattern_string, flags, &alloc)?;
+        let source = escape_pattern_string(cx, pattern_string)?;
+
+        EvalResult::Ok(compile_regexp(cx, &regexp, source)?)
+    };
+
     match regexp_source {
-        RegExpSource::RegExpObject(old_regexp_object) => {
-            regexp_object.set_compiled_regexp(old_regexp_object.compiled_regexp_ptr());
+        RegExpSource::CompiledRegExp(old_compiled_regexp) => {
+            regexp_object.set_compiled_regexp(*old_compiled_regexp);
+        }
+        RegExpSource::CompiledRegExpAndFlags(old_compiled_regexp, flags_source) => {
+            // Read fields from the old regexp before converting the flags, which may run user code
+            let old_flags = old_compiled_regexp.flags;
+            let pattern_string = old_compiled_regexp.escaped_pattern_source();
+
+            let flags = flags_from_source(cx, flags_source)?;
+
+            // Attempt to reuse the compiled RegExp if possible, otherwise attempt to reuse the
+            // bytecode in a new copy, otherwise recompile from scratch.
+            let compiled_regexp = if flags == old_flags {
+                old_compiled_regexp
+            } else if CompiledRegExp::can_clone_bytecode_with_flags(flags, old_flags) {
+                CompiledRegExp::clone_with_flags(cx, old_compiled_regexp, flags)?
+            } else {
+                compile_regexp(cx, pattern_string, flags)?
+            };
+
+            regexp_object.set_compiled_regexp(*compiled_regexp);
         }
         RegExpSource::PatternAndFlags(pattern_value, flags_source) => {
             // Make sure to call ToString on pattern before flags, following order in spec
             let pattern = value_or_empty_string(cx, pattern_value);
             let pattern_string = to_string(cx, pattern)?;
 
-            let flags = match flags_source {
-                FlagsSource::RegExpFlags(flags) => flags,
-                FlagsSource::Value(flags_value) => {
-                    let flags_value = value_or_empty_string(cx, flags_value);
-                    let flags_string = to_string(cx, flags_value)?;
-
-                    parse_flags(cx, flags_string)?
-                }
-            };
-
-            let alloc = Bump::new();
-            let regexp = parse_pattern(cx, pattern_string, flags, &alloc)?;
-            let source = escape_pattern_string(cx, pattern_string)?;
-
-            let compiled_regexp = compile_regexp(cx, &regexp, source)?;
+            let flags = flags_from_source(cx, flags_source)?;
+            let compiled_regexp = compile_regexp(cx, pattern_string, flags)?;
 
             regexp_object.set_compiled_regexp(*compiled_regexp);
         }

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -735,7 +735,7 @@ impl RegExpPrototype {
                 );
             }
 
-            RegExpSource::RegExpObject(pattern_regexp_object)
+            RegExpSource::CompiledRegExp(pattern_regexp_object.compiled_regexp())
         } else {
             RegExpSource::PatternAndFlags(pattern_arg, FlagsSource::Value(flags_arg))
         };

--- a/src/js/runtime/regexp/compiled_regexp.rs
+++ b/src/js/runtime/regexp/compiled_regexp.rs
@@ -160,6 +160,50 @@ impl CompiledRegExp {
             )
         }
     }
+
+    /// Whether a pattern compiles to identical bytecode under both sets of flags.
+    #[inline]
+    pub fn can_clone_bytecode_with_flags(flags: RegExpFlags, other_flags: RegExpFlags) -> bool {
+        let flags_affecting_compilation = RegExpFlags::IGNORE_CASE
+            | RegExpFlags::MULTILINE
+            | RegExpFlags::DOT_ALL
+            | RegExpFlags::UNICODE_AWARE
+            | RegExpFlags::UNICODE_SETS;
+
+        flags.intersection(flags_affecting_compilation)
+            == other_flags.intersection(flags_affecting_compilation)
+    }
+
+    /// Return a clone of the compiled RegExp but with a new set of flags.
+    ///
+    /// Only valid for flags that do not affect compilation, since same bytecode is used.
+    pub fn clone_with_flags(
+        cx: Context,
+        compiled_regexp: Handle<CompiledRegExp>,
+        flags: RegExpFlags,
+    ) -> AllocResult<Handle<CompiledRegExp>> {
+        debug_assert!(Self::can_clone_bytecode_with_flags(flags, compiled_regexp.flags));
+
+        let size = Self::calculate_size_in_bytes(
+            compiled_regexp.instructions.len(),
+            compiled_regexp.num_capture_groups,
+        );
+
+        // Create direct bitwise copy of the compiled RegExp, then overwrite the flags field
+        let mut object = cx.alloc_uninit_with_size::<CompiledRegExp>(size)?;
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                compiled_regexp.as_ptr() as *const u8,
+                object.as_ptr() as *mut u8,
+                size,
+            )
+        };
+
+        object.flags = flags;
+
+        Ok(object.to_handle())
+    }
 }
 
 impl HeapPtr<CompiledRegExp> {

--- a/tests/integration/annexB/built-ins/RegExp/flags_only_copy_source_snapshot.js
+++ b/tests/integration/annexB/built-ins/RegExp/flags_only_copy_source_snapshot.js
@@ -1,0 +1,86 @@
+/*---
+description: >
+  Constructing a RegExp from an existing RegExp plus a flags argument uses values from the source
+  RegExp before converting the flags to a string, which may run user code.
+---*/
+
+function assertSnapshot(sourceFlags, recompileSource, recompileFlags, newFlags) {
+  var original = new RegExp("original", sourceFlags);
+  var flagsArgument = {
+    toString: function () {
+      original.compile(recompileSource, recompileFlags);
+      return newFlags;
+    },
+  };
+
+  var copy = new RegExp(original, flagsArgument);
+  var message =
+    "/original/" + sourceFlags +
+    " recompiled to /" + recompileSource + "/" + recompileFlags +
+    " while converting flags to " + JSON.stringify(newFlags);
+
+  assert.sameValue(copy.source, "original", message + " keeps the snapshotted source");
+  assert.sameValue(copy.flags, new RegExp("original", newFlags).flags, message + " flags");
+  assert.sameValue(copy.test("original"), true, message + " matches the snapshotted source");
+  assert.sameValue(copy.test(recompileSource), false, message + " does not match the new source");
+
+  // The source regexp itself is left recompiled.
+  assert.sameValue(original.source, recompileSource, message + " recompiles the source regexp");
+}
+
+// The recompiled flags equal the requested flags, so the recompiled regexp would otherwise be
+// reused directly.
+assertSnapshot("g", "recompiled", "g", "g");
+assertSnapshot("", "recompiled", "", "");
+assertSnapshot("i", "recompiled", "i", "i");
+
+// The recompiled flags differ from the requested flags only in flags that do not affect
+// compilation, so the recompiled bytecode would otherwise be copied.
+assertSnapshot("", "recompiled", "y", "y");
+assertSnapshot("g", "recompiled", "dgy", "dgy");
+assertSnapshot("i", "recompiled", "gi", "i");
+
+// The recompiled flags differ in a flag that affects compilation, so the pattern is reparsed
+// either way.
+assertSnapshot("", "recompiled", "u", "i");
+assertSnapshot("g", "recompiled", "i", "gs");
+
+// Recompiling the source regexp to a pattern that would be invalid under the requested flags must
+// not make the construction fail, since the snapshotted pattern is what gets compiled.
+var bracketOriginal = new RegExp("original", "");
+var bracketFlags = {
+  toString: function () {
+    bracketOriginal.compile("[[]", "");
+    return "v";
+  },
+};
+var bracketCopy = new RegExp(bracketOriginal, bracketFlags);
+assert.sameValue(bracketCopy.source, "original");
+assert.sameValue(bracketCopy.flags, "v");
+assert.sameValue(bracketCopy.test("original"), true);
+
+// Conversely, a source that is invalid under the requested flags still throws even though the
+// source regexp was recompiled to something valid.
+var invalidOriginal = new RegExp("[[]", "");
+var invalidFlags = {
+  toString: function () {
+    invalidOriginal.compile("original", "");
+    return "v";
+  },
+};
+assert.throws(SyntaxError, function () {
+  new RegExp(invalidOriginal, invalidFlags);
+});
+
+// RegExp.prototype.compile itself reuses the compiled regexp when given another RegExp, and rejects
+// a flags argument in that case.
+var compiled = new RegExp("abc", "g");
+compiled.compile(new RegExp("(x)y", "i"));
+assert.sameValue(compiled.source, "(x)y");
+assert.sameValue(compiled.flags, "i");
+assert.sameValue(compiled.lastIndex, 0);
+assert.sameValue(compiled.test("XY"), true);
+
+assert.throws(TypeError, function () {
+  new RegExp("a", "").compile(new RegExp("b", ""), "g");
+});

--- a/tests/integration/annexB/built-ins/RegExp/source_snapshot_before_alloc.js
+++ b/tests/integration/annexB/built-ins/RegExp/source_snapshot_before_alloc.js
@@ -1,0 +1,129 @@
+/*---
+description: >
+  Constructing a RegExp from an existing RegExp reads its source and flags before allocating the
+  new RegExp, which may run user code when the new target is a proxy.
+---*/
+
+// A new target whose "prototype" lookup recompiles the source regexp. RegExpAlloc reads
+// newTarget.prototype, so the trap runs after the source and flags have been snapshotted but
+// before they are used.
+function recompilingNewTarget(regexp, source, flags) {
+  return new Proxy(RegExp, {
+    get: function (target, key, receiver) {
+      if (key === "prototype") {
+        regexp.compile(source, flags);
+      }
+      return Reflect.get(target, key, receiver);
+    },
+  });
+}
+
+// With a flags argument the copy takes the snapshotted source and the given flags.
+function assertSnapshotWithFlags(sourceFlags, recompileSource, recompileFlags, newFlags) {
+  var original = new RegExp("original", sourceFlags);
+  var newTarget = recompilingNewTarget(original, recompileSource, recompileFlags);
+  var copy = Reflect.construct(RegExp, [original, newFlags], newTarget);
+  var message =
+    "/original/" + sourceFlags +
+    " recompiled to /" + recompileSource + "/" + recompileFlags +
+    " while allocating a copy with flags " + JSON.stringify(newFlags);
+
+  assert.sameValue(copy.source, "original", message + " keeps the snapshotted source");
+  assert.sameValue(copy.flags, new RegExp("original", newFlags).flags, message + " flags");
+  assert.sameValue(copy.test("original"), true, message + " matches the snapshotted source");
+  assert.sameValue(copy.test(recompileSource), false, message + " does not match the new source");
+
+  // The source regexp itself is left recompiled.
+  assert.sameValue(original.source, recompileSource, message + " recompiles the source regexp");
+}
+
+// The recompiled flags equal the requested flags, so the recompiled regexp would otherwise be
+// reused directly.
+assertSnapshotWithFlags("g", "recompiled", "g", "g");
+assertSnapshotWithFlags("", "recompiled", "", "");
+assertSnapshotWithFlags("i", "recompiled", "i", "i");
+
+// The recompiled flags differ from the requested flags only in flags that do not affect
+// compilation, so the recompiled bytecode would otherwise be copied.
+assertSnapshotWithFlags("", "recompiled", "y", "y");
+assertSnapshotWithFlags("g", "recompiled", "dgy", "dgy");
+
+// The recompiled flags differ in a flag that affects compilation, so the pattern is reparsed
+// either way.
+assertSnapshotWithFlags("", "recompiled", "u", "i");
+assertSnapshotWithFlags("g", "recompiled", "i", "gs");
+
+// Without a flags argument both the source and the flags come from the snapshot.
+function assertSnapshotWithoutFlags(sourceFlags, recompileSource, recompileFlags) {
+  var original = new RegExp("original", sourceFlags);
+  var newTarget = recompilingNewTarget(original, recompileSource, recompileFlags);
+  var copy = Reflect.construct(RegExp, [original], newTarget);
+  var message =
+    "/original/" + sourceFlags +
+    " recompiled to /" + recompileSource + "/" + recompileFlags +
+    " while allocating a copy with no flags argument";
+
+  assert.sameValue(copy.source, "original", message + " keeps the snapshotted source");
+  assert.sameValue(copy.flags, new RegExp("original", sourceFlags).flags, message + " flags");
+  assert.sameValue(copy.test("original"), true, message + " matches the snapshotted source");
+  assert.sameValue(copy.test(recompileSource), false, message + " does not match the new source");
+
+  assert.sameValue(original.source, recompileSource, message + " recompiles the source regexp");
+}
+
+assertSnapshotWithoutFlags("g", "recompiled", "g");
+assertSnapshotWithoutFlags("", "recompiled", "i");
+assertSnapshotWithoutFlags("i", "recompiled", "");
+assertSnapshotWithoutFlags("dgy", "recompiled", "u");
+
+// Recompiling the source regexp to a pattern that would be invalid under the requested flags must
+// not make the construction fail, since the snapshotted pattern is what gets compiled.
+var bracketOriginal = new RegExp("original", "");
+var bracketCopy = Reflect.construct(
+  RegExp,
+  [bracketOriginal, "v"],
+  recompilingNewTarget(bracketOriginal, "[[]", "")
+);
+assert.sameValue(bracketCopy.source, "original");
+assert.sameValue(bracketCopy.flags, "v");
+assert.sameValue(bracketCopy.test("original"), true);
+
+// Conversely, a source that is invalid under the requested flags still throws even though the
+// source regexp was recompiled to something valid.
+var invalidOriginal = new RegExp("[[]", "");
+assert.throws(SyntaxError, function () {
+  Reflect.construct(
+    RegExp,
+    [invalidOriginal, "v"],
+    recompilingNewTarget(invalidOriginal, "original", "")
+  );
+});
+
+// The snapshot is taken before the prototype lookup, so the copy still gets the prototype the trap
+// returns. RegExp itself cannot be used as the proxy target here since its `prototype` property is
+// non-writable and non-configurable, so a trap may not report a different value for it.
+var protoOriginal = new RegExp("original", "g");
+var customProto = {};
+function ProtoNewTargetTarget() {}
+var protoNewTarget = new Proxy(ProtoNewTargetTarget, {
+  get: function (target, key, receiver) {
+    if (key === "prototype") {
+      protoOriginal.compile("recompiled", "g");
+      return customProto;
+    }
+    return Reflect.get(target, key, receiver);
+  },
+});
+var protoCopy = Reflect.construct(RegExp, [protoOriginal, "g"], protoNewTarget);
+assert.sameValue(Object.getPrototypeOf(protoCopy), customProto);
+assert.sameValue(
+  Object.getOwnPropertyDescriptor(protoCopy, "lastIndex").value,
+  0,
+  "the copy is still initialized"
+);
+// The `source` getter and `exec` read internal slots, unlike the `flags` getter which collects
+// ordinary property lookups that the custom prototype does not provide.
+var sourceGetter = Object.getOwnPropertyDescriptor(RegExp.prototype, "source").get;
+assert.sameValue(sourceGetter.call(protoCopy), "original");
+assert.sameValue(RegExp.prototype.exec.call(protoCopy, "xoriginaly")[0], "original");
+assert.sameValue(RegExp.prototype.exec.call(protoCopy, "xrecompiledy"), null);

--- a/tests/integration/built-ins/RegExp/flags_only_copy.js
+++ b/tests/integration/built-ins/RegExp/flags_only_copy.js
@@ -1,0 +1,139 @@
+/*---
+description: >
+  Constructing a RegExp from an existing RegExp plus a flags argument may reuse compiled bytecode.
+includes: [compareArray.js]
+---*/
+
+// Flags that do not affect compilation, so the copy shares the source regexp's bytecode.
+var runtimeOnlyFlags = ["", "d", "g", "y", "dg", "dy", "gy", "dgy"];
+
+// Flags that do affect compilation, so the pattern must be reparsed and recompiled.
+var compilationFlags = ["i", "m", "s", "u", "v", "im", "gis", "dgimsy"];
+
+// The source is always taken from the source regexp, and the flags always from the argument,
+// however the compiled regexp is obtained.
+function assertCopy(source, sourceFlags, newFlags) {
+  var original = new RegExp(source, sourceFlags);
+  var copy = new RegExp(original, newFlags);
+  var message = "/" + source + "/" + sourceFlags + " with " + JSON.stringify(newFlags);
+
+  assert.sameValue(copy.source, original.source, message + " source");
+  assert.sameValue(copy.flags, new RegExp(source, newFlags).flags, message + " flags");
+  assert.sameValue(copy.lastIndex, 0, message + " last index");
+  assert.notSameValue(copy, original, message + " is a new object");
+
+  // Matching must agree with a regexp compiled from the same source and flags directly.
+  var direct = new RegExp(original.source, newFlags);
+  var strings = ["", "abc", "ABC", "abcabc", "a\nB", "aa/bb", "a\u{1F600}b"];
+  for (var i = 0; i < strings.length; i++) {
+    assert.sameValue(
+      JSON.stringify(new RegExp(original, newFlags).exec(strings[i])),
+      JSON.stringify(new RegExp(direct.source, newFlags).exec(strings[i])),
+      message + " exec on " + JSON.stringify(strings[i])
+    );
+  }
+}
+
+var sources = ["abc", "(a)(b)", "(?<name>a)b", "a|b", "[a-c]+", "a\\/b", "\\d{2,3}", "^a.b$"];
+var allFlags = runtimeOnlyFlags.concat(compilationFlags);
+
+for (var i = 0; i < sources.length; i++) {
+  for (var j = 0; j < allFlags.length; j++) {
+    for (var k = 0; k < allFlags.length; k++) {
+      assertCopy(sources[i], allFlags[j], allFlags[k]);
+    }
+  }
+}
+
+// Copying with identical flags reuses the compiled regexp, which must not disturb the source.
+var shared = new RegExp("(a)b", "g");
+shared.lastIndex = 3;
+var sharedCopy = new RegExp(shared, "g");
+assert.sameValue(sharedCopy.lastIndex, 0, "the copy starts with a fresh last index");
+assert.sameValue(shared.lastIndex, 3, "the source keeps its last index");
+assert.compareArray(sharedCopy.exec("xabx"), ["ab", "a"]);
+assert.sameValue(shared.lastIndex, 3, "matching the copy does not touch the source");
+
+// The copy's own flags drive matching even though the bytecode is shared.
+var caseSource = new RegExp("abc", "i");
+assert.sameValue(new RegExp(caseSource, "i").test("ABC"), true);
+assert.sameValue(new RegExp(caseSource, "").test("ABC"), false, "dropping `i` recompiles");
+assert.sameValue(new RegExp(new RegExp("abc", ""), "i").test("ABC"), true, "adding `i` recompiles");
+
+// Adding `y` to a copy makes it sticky even though the bytecode is unchanged.
+var stickyCopy = new RegExp(new RegExp("b", "g"), "y");
+stickyCopy.lastIndex = 1;
+assert.sameValue(stickyCopy.test("abc"), true);
+stickyCopy.lastIndex = 0;
+assert.sameValue(stickyCopy.test("abc"), false, "the copy honours its own sticky flag");
+
+// Dropping `y` from a copy makes it non-sticky.
+var unstickyCopy = new RegExp(new RegExp("b", "y"), "");
+assert.sameValue(unstickyCopy.test("abc"), true);
+
+// Adding `d` to a copy produces match indices even though the bytecode is unchanged.
+var indicesCopy = new RegExp(new RegExp("(?<name>b)(c)", ""), "d");
+var indicesMatch = indicesCopy.exec("abcd");
+assert.compareArray(indicesMatch.indices[0], [1, 3]);
+assert.compareArray(indicesMatch.indices[1], [1, 2]);
+assert.compareArray(indicesMatch.indices[2], [2, 3]);
+assert.compareArray(indicesMatch.indices.groups.name, [1, 2]);
+
+// Dropping `d` from a copy removes the indices.
+var noIndicesCopy = new RegExp(new RegExp("(b)", "d"), "");
+assert.sameValue(noIndicesCopy.exec("abc").indices, undefined);
+
+// Named capture groups survive a copy that shares the bytecode.
+var namedCopy = new RegExp(new RegExp("(?<first>a)(?<second>b)", ""), "g");
+var namedMatch = namedCopy.exec("xaby");
+assert.sameValue(namedMatch.groups.first, "a");
+assert.sameValue(namedMatch.groups.second, "b");
+assert.sameValue("xaby".replace(namedCopy, "<$<second>$<first>>"), "x<ba>y");
+
+// Duplicate named capture groups survive a copy as well.
+var duplicateCopy = new RegExp(new RegExp("(?<x>a)|(?<x>b)", ""), "g");
+assert.sameValue(duplicateCopy.exec("b").groups.x, "b");
+
+// The escaped source of the copy round trips, and does not get escaped a second time.
+var slashSource = new RegExp("a/b", "");
+assert.sameValue(slashSource.source, "a\\/b");
+assert.sameValue(new RegExp(slashSource, "g").source, "a\\/b");
+assert.sameValue(new RegExp(slashSource, "i").source, "a\\/b");
+assert.sameValue(new RegExp(new RegExp(slashSource, "g"), "i").source, "a\\/b");
+assert.sameValue(new RegExp(slashSource, "g").test("xa/by"), true);
+
+var emptySource = new RegExp("", "");
+assert.sameValue(emptySource.source, "(?:)");
+assert.sameValue(new RegExp(emptySource, "g").source, "(?:)");
+assert.sameValue(new RegExp(emptySource, "u").source, "(?:)");
+
+// An unescaped `[` in a character class is only valid outside unicode sets mode, so reusing the
+// bytecode stays valid while adding `v` forces a reparse which rejects it
+var unescapedBracket = new RegExp("[[]", "");
+assert.sameValue(new RegExp(unescapedBracket, "g").source, "[[]");
+assert.sameValue(new RegExp(unescapedBracket, "g").test("a[b"), true);
+assert.sameValue(new RegExp(unescapedBracket, "dgy").test("["), true);
+assert.sameValue(new RegExp(unescapedBracket, "u").test("a[b"), true, "`u` still accepts it");
+assert.throws(SyntaxError, function () {
+  new RegExp(unescapedBracket, "v");
+});
+assert.throws(SyntaxError, function () {
+  new RegExp(new RegExp(unescapedBracket, "dgy"), "v");
+});
+
+// Copying with no flags argument at all shares the source regexp's flags too.
+var noFlagsArgument = new RegExp(new RegExp("(a)b", "gi"));
+assert.sameValue(noFlagsArgument.source, "(a)b");
+assert.sameValue(noFlagsArgument.flags, "gi");
+assert.compareArray(noFlagsArgument.exec("xABy"), ["AB", "A"]);
+
+// An invalid flags string is still rejected, whichever branch would otherwise be taken.
+assert.throws(SyntaxError, function () {
+  new RegExp(new RegExp("a", "g"), "q");
+});
+assert.throws(SyntaxError, function () {
+  new RegExp(new RegExp("a", "g"), "gg");
+});
+assert.throws(SyntaxError, function () {
+  new RegExp(new RegExp("a", "g"), "uv");
+});


### PR DESCRIPTION
## Summary

If `RegExpInitialize` is called on an already-compiled RegExp with a potentially new set of flags, attempt to reuse the existing compiled bytecode as much as possible.

- If flags are identical share the `CompiledRegExpObject` directly.
- If flags do not affect compilation then create a shallow clone of the `CompiledRegExpObject` and reset the flags field, avoiding recompilation
- Otherwise recompile from scratch

Seeing a small +0.6% to Octane RegExp benchmark.

## Tests

- Added LLM-generated tests exercising the new paths