### PR TITLE
[common] Fix misc typos, bfmt formats tools directory

### DIFF
--- a/src/js/parser/analyze.rs
+++ b/src/js/parser/analyze.rs
@@ -498,7 +498,7 @@ impl<'a> AstVisitor<'a> for Analyzer<'a> {
         self.visit_outer_expression(&mut stmt.object);
 
         // Must conservatively use VM scope locations for all visible bindings so that they can be
-        // dynamcally looked up from within the with statement.
+        // dynamically looked up from within the with statement.
         let current_scope_id = self.current_scope_id();
         self.scope_tree
             .support_dynamic_access_in_visible_bindings(current_scope_id);

--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -2408,7 +2408,7 @@ impl<'a> Parser<'a> {
                     return self.error(self.loc, ParseError::TaggedTemplateInChain);
                 }
 
-                // Malformed escape sequence errors are swalled in tagged template, and cooked
+                // Malformed escape sequence errors are swallowed in tagged template, and cooked
                 // string is marked as None.
                 let cooked = cooked.ok();
 

--- a/src/js/runtime/bytecode/cache.rs
+++ b/src/js/runtime/bytecode/cache.rs
@@ -45,7 +45,7 @@ impl Cache {
         new_entry: Option<Cache>,
         new_polymorphic_cache: Option<Handle<CacheArray>>,
     ) {
-        // An uncachable result:
+        // An uncacheable result:
         // - If monomorphic, stop caching at this site entirely
         // - If polymorphic, keep the existing cache
         let Some(new_entry) = new_entry else {

--- a/src/js/runtime/bytecode/generator.rs
+++ b/src/js/runtime/bytecode/generator.rs
@@ -1029,7 +1029,7 @@ pub struct BytecodeFunctionGenerator<'a> {
     num_blocks: usize,
 
     /// Map from block id to the offset of that block in the bytecode. Contains an entry for every
-    /// block that has been started in the bycode. Used to calculate backwards jump offsets.
+    /// block that has been started in the bytecode. Used to calculate backwards jump offsets.
     ///
     /// Note that not every block that has been allocated has actually been started, e.g. the
     /// continue block allocated for labeled non-loop statements.
@@ -6281,12 +6281,12 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         Ok(())
     }
 
-    /// Load the fields intializer closure from a constructor.
+    /// Load the fields initializer closure from a constructor.
     fn gen_load_fields_initializer_for_constructor(
         &mut self,
         constructor_reg: GenRegister,
     ) -> EmitResult<GenRegister> {
-        // Fields intializer is stored as an internal private property on the constructor. Use
+        // Fields initializer is stored as an internal private property on the constructor. Use
         // GetNamedProperty to load it so that undefined is returned if property does not exist
         // (such as a `super()` call within an arrow function or eval that doesn't know if the
         // constructor has a fields initializer).
@@ -6303,7 +6303,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         Ok(fields_initializer)
     }
 
-    /// Call a fields intializer on the `this` value for a class constructor.
+    /// Call a fields initializer on the `this` value for a class constructor.
     fn gen_call_fields_initializer(
         &mut self,
         fields_initializer: GenRegister,
@@ -6965,7 +6965,7 @@ impl<'a> BytecodeFunctionGenerator<'a> {
         self.writer
             .get_iterator_instruction(iterator, next_method, iterable, pattern_pos);
 
-        // Call `next` on iterator for each element of the array pttern
+        // Call `next` on iterator for each element of the array pattern
         for (i, element) in array_pattern.elements.iter().enumerate() {
             // Rest element creates a new array with remaining values until iterator is done
             let (reference, element_pos) = if let ast::ArrayPatternElement::Rest(rest) = element {

--- a/src/js/runtime/bytecode/instruction.rs
+++ b/src/js/runtime/bytecode/instruction.rs
@@ -1143,7 +1143,7 @@ define_instructions!(
     }
 
     /// Conditionally jump to the given instruction if ToBoolean(condition) is true, using an
-    /// inline ofset.
+    /// inline offset.
     JumpToBooleanTrue {
         camel_case: JumpToBooleanTrueInstruction,
         snake_case: jump_to_boolean_true_instruction,
@@ -1188,7 +1188,7 @@ define_instructions!(
     }
 
     /// Conditionally jump to the given instruction if ToBoolean(condition) is false, using an
-    /// inline ofset.
+    /// inline offset.
     JumpToBooleanFalse {
         camel_case: JumpToBooleanFalseInstruction,
         snake_case: jump_to_boolean_false_instruction,

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -67,7 +67,7 @@ use crate::{
 /// fields instead of passing around a `&mut Context`. This allows us to safely interweave Context
 /// mutations from different Context pointers.
 ///
-/// Note that Contexts are not automatically dropped. Contexts must be manually droppd with
+/// Note that Contexts are not automatically dropped. Contexts must be manually dropped with
 /// Context::drop or Context::execute_then_drop.
 #[derive(Copy, Clone)]
 pub struct Context {

--- a/src/js/runtime/intrinsics/iterator_helper_object.rs
+++ b/src/js/runtime/intrinsics/iterator_helper_object.rs
@@ -402,7 +402,7 @@ impl Handle<IteratorHelperObject> {
             return Ok(None);
         }
 
-        // Otherwise decrement a non-inifinite remaining value
+        // Otherwise decrement a non-infinite remaining value
         if *remaining != f64::INFINITY {
             *remaining -= 1.0;
         }

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -204,7 +204,7 @@ pub enum RegExpSource {
 }
 
 pub enum FlagsSource {
-    // Construct from pre-existing RegExpFloags
+    // Construct from pre-existing RegExpFlags
     RegExpFlags(RegExpFlags),
     // Construct from flags value
     Value(Handle<Value>),

--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -128,7 +128,7 @@ fn set_capability(
 
 runtime_fn! {
 fn load_requested_modules_static_resolve(cx, _, _) {
-    // Fetch the module and capbility passed from `execute_module`
+    // Fetch the module and capability passed from `execute_module`
     let current_function = cx.current_function();
     let module = get_module(cx, current_function);
     let capability = get_capability(cx, current_function);
@@ -155,7 +155,7 @@ fn load_requested_modules_static_resolve(cx, _, _) {
 
 runtime_fn! {
 fn load_requested_modules_reject(cx, _, arguments) {
-    // Fetch the capbility passed from `execute_module`
+    // Fetch the capability passed from `execute_module`
     let current_function = cx.current_function();
     let capability = get_capability(cx, current_function);
 
@@ -711,7 +711,7 @@ fn load_requested_modules_dynamic_resolve(cx, _, _) {
 
 runtime_fn! {
 fn module_evaluate_dynamic_resolve(cx, _, _) {
-    // Fetch the module and capbility passed from the caller
+    // Fetch the module and capability passed from the caller
     let current_function = cx.current_function();
     let mut module = get_dyn_module(cx, current_function);
     let capability = get_capability(cx, current_function);

--- a/src/js/runtime/shape.rs
+++ b/src/js/runtime/shape.rs
@@ -836,7 +836,7 @@ impl Handle<Shape> {
                     old_prototype_shape.remove_prototype_object_child_shape(**self);
                 }
 
-                // Mark self as unregistered. It will be lazily re-registed when a validity guard
+                // Mark self as unregistered. It will be lazily re-registered when a validity guard
                 // that requires it is requested.
                 self.flags.set_is_registered_prototype_child(false);
             }

--- a/tests/harness/src/runner.rs
+++ b/tests/harness/src/runner.rs
@@ -652,7 +652,7 @@ impl TestResult {
 }
 
 pub struct TestResults {
-    /// List of suceeeded tests in each test suite
+    /// List of succeeded tests in each test suite
     succeeded: HashMap<Suite, Vec<TestResult>>,
     /// List of failed tests in each test suite
     failed: HashMap<Suite, Vec<TestResult>>,

--- a/tools/brimstone_fmt/src/main.rs
+++ b/tools/brimstone_fmt/src/main.rs
@@ -3,7 +3,12 @@
 //! rustfmt leaves untouched. `--install` installs the pinned toolchain first;
 //! `--check` reports instead of writing.
 
-use std::{collections::HashSet, io::Write, path::{Path, PathBuf}, process::{Command, Stdio}};
+use std::{
+    collections::HashSet,
+    io::Write,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
 
 use proc_macro2::{Delimiter, Group, TokenStream, TokenTree};
 
@@ -30,6 +35,7 @@ fn main() {
     if paths.is_empty() {
         paths.push(PathBuf::from("src"));
         paths.push(PathBuf::from("tests"));
+        paths.push(PathBuf::from("tools"));
     }
 
     if install && let Err(e) = install_toolchain() {
@@ -54,8 +60,12 @@ fn main() {
     // files. Files that don't lex were already reported by pass 1.
     let mut entries: Vec<(PathBuf, String, Vec<Block>)> = Vec::new();
     for file in files {
-        let Ok(src) = std::fs::read_to_string(&file) else { continue };
-        let Ok(ts) = src.parse::<TokenStream>() else { continue };
+        let Ok(src) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        let Ok(ts) = src.parse::<TokenStream>() else {
+            continue;
+        };
         let mut blocks = Vec::new();
         find_blocks(ts, &src, &mut blocks);
         if !blocks.is_empty() {
@@ -229,17 +239,32 @@ fn contains_dollar(ts: TokenStream) -> bool {
 /// Leading whitespace of the line containing byte offset `pos`.
 fn line_indent(src: &str, pos: usize) -> String {
     let start = src[..pos].rfind('\n').map_or(0, |n| n + 1);
-    src[start..pos].chars().take_while(|&c| c == ' ' || c == '\t').collect()
+    src[start..pos]
+        .chars()
+        .take_while(|&c| c == ' ' || c == '\t')
+        .collect()
 }
 
 /// Install the pinned toolchain and its rustfmt component (matching CI).
 fn install_toolchain() -> Result<(), String> {
     let ok = Command::new("rustup")
-        .args(["toolchain", "install", RUSTFMT_TOOLCHAIN, "--profile", "minimal", "--component", "rustfmt"])
+        .args([
+            "toolchain",
+            "install",
+            RUSTFMT_TOOLCHAIN,
+            "--profile",
+            "minimal",
+            "--component",
+            "rustfmt",
+        ])
         .status()
         .map_err(|e| format!("running rustup: {e}"))?
         .success();
-    if ok { Ok(()) } else { Err(format!("rustup could not install {RUSTFMT_TOOLCHAIN}")) }
+    if ok {
+        Ok(())
+    } else {
+        Err(format!("rustup could not install {RUSTFMT_TOOLCHAIN}"))
+    }
 }
 
 /// The pinned rustfmt command with the project + CI config applied.
@@ -278,14 +303,18 @@ fn run_fmt(files: &[PathBuf], config: Option<&Path>, check: bool) -> bool {
 fn run_rustfmt(input: &str, config: Option<&Path>) -> Result<String, String> {
     let mut cmd = rustfmt(config);
     cmd.args(["--emit", "stdout"]);
-    cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped());
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
     let mut child = cmd.spawn().map_err(|e| format!("spawn rustfmt: {e}"))?;
 
     // A write failure just means rustfmt already exited (parse error, missing
     // toolchain); ignore it so its real stderr below isn't masked by "broken pipe".
     let _ = child.stdin.take().unwrap().write_all(input.as_bytes());
 
-    let out = child.wait_with_output().map_err(|e| format!("running rustfmt: {e}"))?;
+    let out = child
+        .wait_with_output()
+        .map_err(|e| format!("running rustfmt: {e}"))?;
     if out.status.success() {
         Ok(String::from_utf8_lossy(&out.stdout).into_owned())
     } else {
@@ -319,7 +348,9 @@ fn collect_rs_files(path: &Path, ignored: &HashSet<PathBuf>, out: &mut Vec<PathB
             return;
         }
 
-        let Ok(entries) = std::fs::read_dir(path) else { return };
+        let Ok(entries) = std::fs::read_dir(path) else {
+            return;
+        };
         for entry in entries.flatten() {
             collect_rs_files(&entry.path(), ignored, out);
         }
@@ -332,7 +363,14 @@ fn collect_rs_files(path: &Path, ignored: &HashSet<PathBuf>, out: &mut Vec<PathB
 fn ignored_dirs() -> HashSet<PathBuf> {
     let mut set = HashSet::new();
     let Ok(out) = Command::new("git")
-        .args(["ls-files", "--others", "--ignored", "--exclude-standard", "--directory", "-z"])
+        .args([
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "--directory",
+            "-z",
+        ])
         .output()
     else {
         return set;


### PR DESCRIPTION
## Summary

- Fix misc typos
- Have `bfmt` format the contents of the `tools` directory, aka itself. Include first formatting pass.

## Tests

- CI