### PR TITLE
[common] Fix usage of misc classes of unsafe

### DIFF
--- a/src/js/common/memory.rs
+++ b/src/js/common/memory.rs
@@ -1,20 +1,3 @@
-/// Calculate field offset as const.
-#[macro_export]
-macro_rules! field_offset {
-    ($base_type:ty, $field_name:ident) => {{
-        const FIELD_OFFSET: usize = unsafe {
-            let base_uninit = std::mem::MaybeUninit::uninit();
-            let base_ptr: *const $base_type = base_uninit.as_ptr();
-
-            let field_ptr = std::ptr::addr_of!((*base_ptr).$field_name);
-
-            (field_ptr as *const u8).offset_from(base_ptr as *const u8) as usize
-        };
-
-        FIELD_OFFSET
-    }};
-}
-
 /// Set an uninitialized field to a value, making sure not to drop the old value stored at that field.
 #[macro_export]
 macro_rules! set_uninit {

--- a/src/js/common/unicode.rs
+++ b/src/js/common/unicode.rs
@@ -328,9 +328,8 @@ pub fn as_id_start_unicode(code_point: CodePoint) -> Option<char> {
 #[inline]
 pub fn as_id_part_ascii(code_point: CodePoint) -> Option<char> {
     if is_id_part_ascii(code_point) {
-        // Safe as all ID part code points are valid unicode code points
-        let char = unsafe { char::from_u32_unchecked(code_point) };
-        Some(char)
+        // Exact since all ASCII ID part code points fit in a byte
+        Some(code_point as u8 as char)
     } else {
         None
     }

--- a/src/js/parser/ast.rs
+++ b/src/js/parser/ast.rs
@@ -54,7 +54,7 @@ pub struct AstBox<'a, T> {
 impl<'a, T> AstBox<'a, T> {
     #[inline]
     pub fn new_in(value: T, alloc: AstAlloc<'a>) -> AstBox<'a, T> {
-        let ptr = unsafe { NonNull::new_unchecked(alloc.alloc(value) as *mut _) };
+        let ptr = NonNull::from(alloc.alloc(value));
 
         AstBox { ptr, data: PhantomData }
     }
@@ -112,8 +112,7 @@ impl<'a, T> AstSlice<'a, T> {
     }
 
     pub fn new_empty() -> AstSlice<'a, T> {
-        let ptr = unsafe { NonNull::dangling().as_mut() };
-        Self::new_from_raw_parts(ptr, 0)
+        Self::new_from_raw_parts(NonNull::dangling().as_ptr(), 0)
     }
 
     pub fn into_vec<A: Allocator>(self, alloc: A) -> alloc::Vec<T, A> {
@@ -207,8 +206,7 @@ impl<T> AstPtr<T> {
     }
 
     pub fn from_ref(value: &T) -> AstPtr<T> {
-        let ptr = unsafe { NonNull::new_unchecked(value as *const _ as *mut T) };
-        AstPtr { ptr }
+        AstPtr { ptr: NonNull::from(value) }
     }
 }
 

--- a/src/js/runtime/array_properties.rs
+++ b/src/js/runtime/array_properties.rs
@@ -1,5 +1,5 @@
 use crate::{
-    field_offset, impl_hash_map_instance,
+    impl_hash_map_instance,
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
@@ -453,7 +453,7 @@ pub struct DenseArrayProperties {
     array: InlineArray<Value>,
 }
 
-const DENSE_ARRAY_DATA_OFFSET: usize = field_offset!(DenseArrayProperties, array);
+const DENSE_ARRAY_DATA_OFFSET: usize = std::mem::offset_of!(DenseArrayProperties, array);
 
 impl DenseArrayProperties {
     pub fn new(cx: Context, capacity: u32) -> AllocResult<HeapPtr<DenseArrayProperties>> {

--- a/src/js/runtime/bigint_value.rs
+++ b/src/js/runtime/bigint_value.rs
@@ -1,7 +1,6 @@
 use num_bigint::{BigInt, Sign};
 
 use crate::{
-    field_offset,
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
@@ -25,7 +24,7 @@ pub struct BigIntValue {
 }
 
 impl BigIntValue {
-    const DIGITS_OFFSET: usize = field_offset!(BigIntValue, digits);
+    const DIGITS_OFFSET: usize = std::mem::offset_of!(BigIntValue, digits);
 
     pub fn new(cx: Context, value: BigInt) -> AllocResult<Handle<BigIntValue>> {
         Ok(Self::new_ptr(cx, value)?.to_handle())

--- a/src/js/runtime/bytecode/constant_table.rs
+++ b/src/js/runtime/bytecode/constant_table.rs
@@ -1,5 +1,4 @@
 use crate::{
-    field_offset,
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
@@ -45,7 +44,7 @@ impl ConstantTable {
         Ok(object.to_handle())
     }
 
-    const CONSTANTS_BYTE_OFFSET: usize = field_offset!(ConstantTable, constants);
+    const CONSTANTS_BYTE_OFFSET: usize = std::mem::offset_of!(ConstantTable, constants);
 
     fn calculate_size_in_bytes(num_constants: usize) -> usize {
         Self::metadata_offset(num_constants) + Self::calculate_metadata_size(num_constants)

--- a/src/js/runtime/bytecode/exception_handlers.rs
+++ b/src/js/runtime/bytecode/exception_handlers.rs
@@ -1,5 +1,4 @@
 use crate::{
-    field_offset,
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
@@ -123,7 +122,7 @@ impl ExceptionHandlers {
         Ok(object.to_handle())
     }
 
-    const HANDLERS_BYTE_OFFSET: usize = field_offset!(ExceptionHandlers, handlers);
+    const HANDLERS_BYTE_OFFSET: usize = std::mem::offset_of!(ExceptionHandlers, handlers);
 
     fn calculate_size_in_bytes(handlers_len: usize) -> usize {
         Self::HANDLERS_BYTE_OFFSET + InlineArray::<u8>::calculate_size_in_bytes(handlers_len)

--- a/src/js/runtime/bytecode/function.rs
+++ b/src/js/runtime/bytecode/function.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use crate::{
     common::graphviz::DotGraphBuilder,
-    extend_object, field_offset, impl_array_instance, must_a,
+    extend_object, impl_array_instance, must_a,
     parser::loc::Pos,
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr, PropertyDescriptor, Realm, Value,
@@ -469,7 +469,7 @@ impl BytecodeFunction {
         Ok(object.to_handle())
     }
 
-    const BYTECODE_BYTE_OFFSET: usize = field_offset!(BytecodeFunction, bytecode);
+    const BYTECODE_BYTE_OFFSET: usize = std::mem::offset_of!(BytecodeFunction, bytecode);
 
     fn calculate_size_in_bytes(bytecode_len: usize) -> usize {
         Self::BYTECODE_BYTE_OFFSET + InlineArray::<u8>::calculate_size_in_bytes(bytecode_len)

--- a/src/js/runtime/class_names.rs
+++ b/src/js/runtime/class_names.rs
@@ -1,5 +1,5 @@
 use crate::{
-    field_offset, must,
+    must,
     runtime::{
         Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyDescriptor, PropertyFlags,
         PropertyKey, Value,
@@ -105,7 +105,7 @@ impl ClassNames {
         Ok(class_names.to_handle())
     }
 
-    const METHODS_OFFSET: usize = field_offset!(ClassNames, methods);
+    const METHODS_OFFSET: usize = std::mem::offset_of!(ClassNames, methods);
 
     fn calculate_size_in_bytes(num_methods: usize) -> usize {
         Self::METHODS_OFFSET + InlineArray::<Method>::calculate_size_in_bytes(num_methods)

--- a/src/js/runtime/collections/array.rs
+++ b/src/js/runtime/collections/array.rs
@@ -1,5 +1,4 @@
 use crate::{
-    field_offset,
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
@@ -17,7 +16,7 @@ pub struct BsArray<T> {
     array: InlineArray<T>,
 }
 
-const ARRAY_BYTE_OFFSITE: usize = field_offset!(BsArray<u8>, array);
+const ARRAY_BYTE_OFFSITE: usize = std::mem::offset_of!(BsArray<u8>, array);
 
 impl<T: Clone> BsArray<T> {
     pub fn new(

--- a/src/js/runtime/collections/index_map.rs
+++ b/src/js/runtime/collections/index_map.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use crate::{
-    field_offset,
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
@@ -62,7 +61,7 @@ struct OccupiedEntry<K, V> {
 }
 
 const INDICES_BYTE_OFFSET: usize =
-    field_offset!(BsIndexMap<String, String, HashDosResistantHasher>, indices);
+    std::mem::offset_of!(BsIndexMap<String, String, HashDosResistantHasher>, indices);
 
 impl<K: Eq + Hash + Clone, V: Clone, H: BsBuildHasher> BsIndexMap<K, V, H> {
     pub const MIN_CAPACITY: usize = 4;

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -179,7 +179,7 @@ impl Context {
             temporal_provider: CompiledTzdbProvider::default(),
         });
 
-        let mut cx = unsafe { Context::from_ptr(NonNull::new_unchecked(Box::leak(cx_cell))) };
+        let mut cx = Context::from_ptr(NonNull::from(Box::leak(cx_cell)));
 
         cx.heap.info().set_context(cx);
         cx.vm = Some(Box::new(VM::new(cx)));

--- a/src/js/runtime/for_in_iterator.rs
+++ b/src/js/runtime/for_in_iterator.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 
 use crate::{
-    field_offset,
     runtime::{
         Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyKey, Value,
         alloc_error::AllocResult,
@@ -101,7 +100,7 @@ impl ForInIterator {
         Ok(Self::new(cx, object, &keys)?)
     }
 
-    const KEYS_OFFSET: usize = field_offset!(ForInIterator, keys);
+    const KEYS_OFFSET: usize = std::mem::offset_of!(ForInIterator, keys);
 
     fn calculate_size_in_bytes(len: usize) -> usize {
         Self::KEYS_OFFSET + InlineArray::<HeapPtr<StringValue>>::calculate_size_in_bytes(len)

--- a/src/js/runtime/gc/handle.rs
+++ b/src/js/runtime/gc/handle.rs
@@ -442,7 +442,7 @@ impl HandleContext {
 impl Handle<Value> {
     #[inline]
     pub fn from_fixed_non_heap_ptr(value_ref: &Value) -> Handle<Value> {
-        let ptr = unsafe { NonNull::new_unchecked(value_ref as *const Value as *mut Value) };
+        let ptr = NonNull::from(value_ref);
         Handle { ptr: ptr.cast(), phantom_data: PhantomData }
     }
 

--- a/src/js/runtime/global_names.rs
+++ b/src/js/runtime/global_names.rs
@@ -1,5 +1,4 @@
 use crate::{
-    field_offset,
     runtime::{
         Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyDescriptor, PropertyFlags,
         PropertyKey, Realm, Value,
@@ -57,7 +56,7 @@ impl GlobalNames {
     }
 
     fn calculate_size_in_bytes(num_names: usize) -> usize {
-        let names_offset = field_offset!(GlobalNames, names);
+        let names_offset = std::mem::offset_of!(GlobalNames, names);
         names_offset + InlineArray::<GlobalDeclaration>::calculate_size_in_bytes(num_names)
     }
 

--- a/src/js/runtime/intrinsics/data_view_prototype.rs
+++ b/src/js/runtime/intrinsics/data_view_prototype.rs
@@ -567,10 +567,8 @@ fn is_view_out_of_bounds(data_view_record: &DataViewWithBufferWitnessRecord) -> 
 
 #[inline]
 fn f16_swap_bytes(element: f16) -> f16 {
-    unsafe {
-        let bits = std::mem::transmute::<f16, u16>(element);
-        std::mem::transmute::<u16, f16>(bits.swap_bytes())
-    }
+    let bits = f16::to_bits(element);
+    f16::from_bits(bits.swap_bytes())
 }
 
 #[inline]

--- a/src/js/runtime/intrinsics/finalization_registry_object.rs
+++ b/src/js/runtime/intrinsics/finalization_registry_object.rs
@@ -1,7 +1,7 @@
 use std::slice;
 
 use crate::{
-    extend_object, field_offset,
+    extend_object,
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr, Value,
         alloc_error::AllocResult,
@@ -87,7 +87,7 @@ pub struct FinalizationRegistryCells {
     cells: InlineArray<Option<FinalizationRegistryCell>>,
 }
 
-const CELLS_BYTE_OFFSET: usize = field_offset!(FinalizationRegistryCells, cells);
+const CELLS_BYTE_OFFSET: usize = std::mem::offset_of!(FinalizationRegistryCells, cells);
 
 impl FinalizationRegistryCells {
     const MIN_CAPACITY: usize = 4;

--- a/src/js/runtime/intrinsics/globals.rs
+++ b/src/js/runtime/intrinsics/globals.rs
@@ -314,17 +314,16 @@ fn parse_int_impl(mut lexer: StringLexer, radix: i32) -> Option<f64> {
     let lowercase_digit_upper_bound;
     let uppercase_digit_upper_bound;
 
-    unsafe {
-        if radix <= 10 {
-            numeric_digit_upper_bound = char::from_u32_unchecked(('0' as u32) + radix);
-            lowercase_digit_upper_bound = char::from_u32_unchecked('a' as u32);
-            uppercase_digit_upper_bound = char::from_u32_unchecked('A' as u32);
-        } else {
-            let num_letter_digits = radix - 10;
-            numeric_digit_upper_bound = char::from_u32_unchecked('9' as u32 + 1);
-            lowercase_digit_upper_bound = char::from_u32_unchecked('a' as u32 + num_letter_digits);
-            uppercase_digit_upper_bound = char::from_u32_unchecked('A' as u32 + num_letter_digits);
-        }
+    // All bounds are ASCII since the radix is at most 36
+    if radix <= 10 {
+        numeric_digit_upper_bound = (b'0' + radix as u8) as char;
+        lowercase_digit_upper_bound = 'a';
+        uppercase_digit_upper_bound = 'A';
+    } else {
+        let num_letter_digits = (radix - 10) as u8;
+        numeric_digit_upper_bound = (b'9' + 1) as char;
+        lowercase_digit_upper_bound = (b'a' + num_letter_digits) as char;
+        uppercase_digit_upper_bound = (b'A' + num_letter_digits) as char;
     }
 
     // Parse digits on at a time, building up value

--- a/src/js/runtime/module/import_attributes.rs
+++ b/src/js/runtime/module/import_attributes.rs
@@ -1,5 +1,4 @@
 use crate::{
-    field_offset,
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
@@ -22,7 +21,7 @@ pub struct ImportAttributes {
 }
 
 impl ImportAttributes {
-    const ATTRIBUTE_PAIRS_OFFSET: usize = field_offset!(ImportAttributes, attribute_pairs);
+    const ATTRIBUTE_PAIRS_OFFSET: usize = std::mem::offset_of!(ImportAttributes, attribute_pairs);
 
     pub fn new(
         cx: Context,

--- a/src/js/runtime/module/source_text_module.rs
+++ b/src/js/runtime/module/source_text_module.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, hash::Hash, num::NonZeroUsize};
 use indexmap_allocator_api::IndexSet;
 
 use crate::{
-    field_offset, handle_scope, impl_array_instance, impl_hash_map_instance, impl_vec_instance,
+    handle_scope, impl_array_instance, impl_hash_map_instance, impl_vec_instance,
     runtime::{
         Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyKey, Value,
         alloc_error::AllocResult,
@@ -178,7 +178,7 @@ impl SourceTextModule {
         Ok(object.to_handle())
     }
 
-    const ENTRIES_OFFSET: usize = field_offset!(SourceTextModule, entries);
+    const ENTRIES_OFFSET: usize = std::mem::offset_of!(SourceTextModule, entries);
 
     #[inline]
     fn calculate_size_in_bytes(num_entries: usize) -> usize {

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use crate::{
-    field_offset, handle_scope, impl_hash_map_instance, must_a,
+    handle_scope, impl_hash_map_instance, must_a,
     parser::scope_tree::REALM_SCOPE_SLOT_NAME,
     runtime::{
         Context, EvalResult, HeapItemKind, PropertyKey, Value,
@@ -56,7 +56,7 @@ pub struct Realm {
     pub intrinsics: Intrinsics,
 }
 
-const INTRINSICS_BYTE_OFFSET: usize = field_offset!(Realm, intrinsics);
+const INTRINSICS_BYTE_OFFSET: usize = std::mem::offset_of!(Realm, intrinsics);
 
 impl Realm {
     /// InitializeHostDefinedRealm (https://tc39.es/ecma262/#sec-initializehostdefinedrealm)
@@ -424,7 +424,7 @@ impl GlobalScopes {
         Ok(global_scopes)
     }
 
-    const SCOPES_OFFSET: usize = field_offset!(GlobalScopes, scopes);
+    const SCOPES_OFFSET: usize = std::mem::offset_of!(GlobalScopes, scopes);
 
     fn calculate_size_in_bytes(len: usize) -> usize {
         Self::SCOPES_OFFSET + InlineArray::<HeapPtr<Scope>>::calculate_size_in_bytes(len)

--- a/src/js/runtime/regexp/compiled_regexp.rs
+++ b/src/js/runtime/regexp/compiled_regexp.rs
@@ -2,7 +2,6 @@ use std::mem::size_of;
 
 use crate::{
     common::{graphviz::DotGraphBuilder, math::round_to_power_of_two},
-    field_offset,
     parser::regexp::{RegExp, RegExpFlags},
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr,
@@ -46,7 +45,7 @@ pub struct CompiledRegExp {
     _capture_groups: [Option<HeapPtr<FlatString>>; 1],
 }
 
-const INSTRUCTIONS_BYTE_OFFSET: usize = field_offset!(CompiledRegExp, instructions);
+const INSTRUCTIONS_BYTE_OFFSET: usize = std::mem::offset_of!(CompiledRegExp, instructions);
 
 impl CompiledRegExp {
     pub fn new(

--- a/src/js/runtime/scope.rs
+++ b/src/js/runtime/scope.rs
@@ -1,5 +1,4 @@
 use crate::{
-    field_offset,
     runtime::{
         Context, EvalResult, Handle, HeapItemKind, HeapPtr, PropertyKey, Realm, Value,
         abstract_operations::has_property,
@@ -113,7 +112,7 @@ impl Scope {
         Self::new(cx, ScopeKind::With, Some(parent), scope_names, Some(object))
     }
 
-    const SLOTS_OFFSET: usize = field_offset!(Scope, slots);
+    const SLOTS_OFFSET: usize = std::mem::offset_of!(Scope, slots);
 
     fn calculate_size_in_bytes(num_slots: usize) -> usize {
         Self::SLOTS_OFFSET + InlineArray::<Value>::calculate_size_in_bytes(num_slots)

--- a/src/js/runtime/scope_names.rs
+++ b/src/js/runtime/scope_names.rs
@@ -1,7 +1,6 @@
 use bitflags::bitflags;
 
 use crate::{
-    field_offset,
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr,
         alloc_error::AllocResult,
@@ -91,7 +90,7 @@ impl ScopeNames {
         Ok(scope_names.to_handle())
     }
 
-    const NAMES_OFFSET: usize = field_offset!(ScopeNames, names);
+    const NAMES_OFFSET: usize = std::mem::offset_of!(ScopeNames, names);
 
     fn calculate_size_in_bytes(num_slots: usize) -> usize {
         Self::name_flags_offset(num_slots) + Self::calculate_name_flags_size(num_slots)

--- a/src/js/runtime/shape_registry.rs
+++ b/src/js/runtime/shape_registry.rs
@@ -51,10 +51,7 @@ impl ShapeRegistry {
     }
 
     pub fn uninit() -> Self {
-        let mut canonical_shapes = vec![];
-
-        canonical_shapes.reserve_exact(HeapItemKind::COUNT);
-        unsafe { canonical_shapes.set_len(HeapItemKind::COUNT) };
+        let canonical_shapes = vec![HeapPtr::uninit(); HeapItemKind::COUNT];
 
         ShapeRegistry {
             canonical_shapes,

--- a/src/js/runtime/source_file.rs
+++ b/src/js/runtime/source_file.rs
@@ -1,5 +1,5 @@
 use crate::{
-    field_offset, must_a,
+    must_a,
     parser::{loc::calculate_line_offsets, source::Source},
     runtime::{
         Context, Handle, HeapItemKind, HeapPtr,
@@ -50,7 +50,7 @@ impl SourceFile {
         Ok(scope.to_handle())
     }
 
-    const CONTENTS_OFFSET: usize = field_offset!(SourceFile, contents);
+    const CONTENTS_OFFSET: usize = std::mem::offset_of!(SourceFile, contents);
 
     #[inline]
     fn calculate_size_in_bytes(contents_len: usize) -> usize {

--- a/src/js/runtime/string_value.rs
+++ b/src/js/runtime/string_value.rs
@@ -25,7 +25,7 @@ use crate::{
         },
         wtf_8::{Wtf8CodePointsIterator, Wtf8String},
     },
-    field_offset, must_a,
+    must_a,
     runtime::{
         Context, EvalResult, HeapItemKind, Value,
         alloc_error::AllocResult,
@@ -754,7 +754,7 @@ struct FlatStringNoInteriorMutability {
 }
 
 impl FlatString {
-    const DATA_OFFSET: usize = field_offset!(FlatStringNoInteriorMutability, data);
+    const DATA_OFFSET: usize = std::mem::offset_of!(FlatStringNoInteriorMutability, data);
 
     fn new_one_byte(cx: Context, one_byte_slice: &[u8]) -> EvalResult<HeapPtr<FlatString>> {
         let len = check_string_length(cx, one_byte_slice.len() as u64)?;


### PR DESCRIPTION
## Summary

Fix usage of misc classes of unsafe that can be easily replaced with safe equivalents.

- Replace custom `field_offset!` with equivalent `std::mem::offset_of`
- Use `NonNull::from` on a ref instead of `NonNull::new_unchecked` with a cast
- Stop using `char::from_u32_unchecked` on statically known ASCII code points
- `ShapeRegistry::uninit` initializes elements to `HeapPtr::uninit()` instead of leaving uninitialized
- Misc fixes to `f16_swap_bytes` and `AstSlice::new_empty`

## Tests

- CI