### PR TITLE
[regexp] Write match results directly into dense array storage

### DIFF
--- a/src/js/parser/regexp_parser.rs
+++ b/src/js/parser/regexp_parser.rs
@@ -35,6 +35,10 @@ use crate::{
     },
 };
 
+/// Deviation from spec - only allow up to 2^31 - 1 capture groups instead of 2^32 - 1.
+/// This guarantees that a capture group index is a valid smi.
+const MAX_CAPTURE_GROUPS: usize = (u32::MAX as usize / 2) - 1;
+
 /// Parser of the full RegExp grammar and static semantics
 ///
 /// Patterns (https://tc39.es/ecma262/#sec-patterns)
@@ -251,8 +255,7 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
         // Capture group indices are 1-indexed
         let index = self.num_capture_groups + 1;
 
-        // Deviation from spec - only allows up to 2^31 - 1 capture groups instead of 2^32 - 1
-        if index >= (u32::MAX as usize / 2) {
+        if index > MAX_CAPTURE_GROUPS {
             return self.error(error_pos, ParseError::TooManyCaptureGroups);
         }
 

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -286,18 +286,37 @@ pub fn create_array_from_list(
     cx: Context,
     elements: &[Handle<Value>],
 ) -> AllocResult<Handle<ArrayObject>> {
-    let array = must_a!(array_create(cx, 0, None));
-
-    // Property key is shared between iterations
-    let mut key = PropertyKey::uninit().to_handle(cx);
+    // TODO: Handle lengths out of u32 range
+    let array = must_a!(array_create(cx, elements.len() as u64, None));
 
     for (index, element) in elements.iter().enumerate() {
-        // TODO: Handle keys out of u32 range
-        key.replace(PropertyKey::array_index(cx, index as u32)?);
-        must_a!(create_data_property_or_throw(cx, array.into(), key, *element));
+        create_dense_data_property(cx, array.into(), index as u32, *element)?;
     }
 
     Ok(array)
+}
+
+/// Same as CreateDataProperty for an index that is already within a newly created array's length,
+/// but writes straight into the array's dense storage instead of going through the generic property
+/// path.
+pub fn create_dense_data_property(
+    cx: Context,
+    array: Handle<ObjectValue>,
+    index: u32,
+    value: Handle<Value>,
+) -> AllocResult<()> {
+    if let Some(mut dense_properties) = array.array_properties().as_dense_opt()
+        && index < dense_properties.len()
+    {
+        dense_properties.set_unchecked(index, *value);
+        return Ok(());
+    }
+
+    // An array long enough to be sparse falls back to the generic path
+    let key = PropertyKey::from_u64_handle(cx, index as u64)?;
+    must_a!(create_data_property_or_throw(cx, array, key, value));
+
+    Ok(())
 }
 
 impl HeapItem for ArrayObject {

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -15,6 +15,7 @@ use crate::{
         alloc_error::AllocResult,
         array_object::{
             ArrayCreateShape, array_create, array_create_in_realm, create_array_from_list,
+            create_dense_data_property,
         },
         bytecode::function::ClosureObject,
         common_shapes::CommonShape,
@@ -1195,6 +1196,9 @@ fn build_match_object(
 
     // Add all capture groups to the result, including implicit 0'th capture group
     for (i, capture) in capture_groups.iter().enumerate() {
+        // Safe since capture group index is guaranteed to be a valid array index
+        let array_index = i as u32;
+
         let captured_value = if let Some(capture) = capture {
             string_value
                 .substring(cx, capture.start, capture.end)?
@@ -1204,8 +1208,7 @@ fn build_match_object(
             cx.undefined()
         };
 
-        let index_key = PropertyKey::from_u64_handle(cx, i as u64)?;
-        must!(create_data_property_or_throw(cx, result_array, index_key, captured_value));
+        create_dense_data_property(cx, result_array, array_index, captured_value)?;
 
         // Add capture indices to indices array if present
         let match_index_pair = if let Some((indices_array, indices_groups)) = indices_result {
@@ -1217,7 +1220,7 @@ fn build_match_object(
                 cx.undefined()
             };
 
-            must!(create_data_property_or_throw(cx, indices_array, index_key, match_index_pair));
+            create_dense_data_property(cx, indices_array, array_index, match_index_pair)?;
             Some((match_index_pair, indices_groups))
         } else {
             None


### PR DESCRIPTION
## Summary

Simple optimization. Avoid a full property lookup when writing into arrays that have been pre-allocated to an expected size. Add a fast-path `create_dense_data_property` alternative to `create_data_property_or_throw` which first tries to allocate in dense storage if the index is in bounds.

Seeing a ~1.2% increase to Octane RegExp benchmark score from this change.

## Tests

- CI