### PR TITLE
[runtime] More presized arrays with direct dense property writes

### DIFF
--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -1,11 +1,11 @@
 use crate::{
-    extend_object, must, must_a,
+    extend_object, must,
     parser::scope_tree::SHADOWED_SCOPE_SLOT_NAME,
     runtime::{
         Context, EvalResult, HeapPtr, Value,
-        abstract_operations::create_data_property_or_throw,
         accessor::Accessor,
         alloc_error::AllocResult,
+        array_object::create_dense_data_property,
         bitmap::ValueBitmap,
         bytecode::function::ClosureObject,
         common_shapes::CommonShape,
@@ -36,7 +36,10 @@ extend_object! {
 
 impl UnmappedArgumentsObject {
     /// CreateUnmappedArgumentsObject (https://tc39.es/ecma262/#sec-createunmappedargumentsobject)
-    pub fn new(cx: Context, arguments: &[Handle<Value>]) -> AllocResult<Handle<ObjectValue>> {
+    ///
+    /// Arguments are read directly out of the caller's stack frame, which is safe since the GC
+    /// updates the stack in place.
+    pub fn new(cx: Context, arguments: &[Value]) -> AllocResult<Handle<ObjectValue>> {
         let mut object = ObjectBuilder::<ObjectValue>::new(cx)
             .common_shape(CommonShape::UnmappedArguments)?
             .build()?
@@ -53,11 +56,16 @@ impl UnmappedArgumentsObject {
 
         object.init_inline_properties(&[length_value, iterator_value.into(), callee.into()]);
 
-        // Set indexed argument properties
-        let mut index_key = PropertyKey::uninit().to_handle(cx);
+        // Presize the indexed properties so that each argument can be stored directly
+        if let Ok(num_arguments) = u32::try_from(arguments.len()) {
+            object.set_array_properties_length(cx, num_arguments)?;
+        }
+
+        // Set indexed argument properties. Handle is shared between iterations.
+        let mut value_handle = Value::uninit().to_handle(cx);
         for (i, argument) in arguments.iter().enumerate() {
-            index_key.replace(PropertyKey::array_index(cx, i as u32)?);
-            must_a!(create_data_property_or_throw(cx, object, index_key, *argument));
+            value_handle.replace(*argument);
+            create_dense_data_property(cx, object, i as u64, value_handle)?;
         }
 
         Ok(object)
@@ -83,10 +91,14 @@ extend_object! {
 impl MappedArgumentsObject {
     pub const VIRTUAL_OBJECT_VTABLE: *const () = extract_virtual_object_vtable::<Self>();
 
+    /// CreateMappedArgumentsObject (https://tc39.es/ecma262/#sec-createmappedargumentsobject)
+    ///
+    /// Arguments are read directly out of the caller's stack frame, which is safe since the GC
+    /// updates the stack in place.
     pub fn new(
         cx: Context,
         callee: Handle<ClosureObject>,
-        arguments: &[Handle<Value>],
+        arguments: &[Value],
         scope: Handle<Scope>,
         num_parameters: usize,
     ) -> EvalResult<Handle<MappedArgumentsObject>> {
@@ -123,12 +135,21 @@ impl MappedArgumentsObject {
             callee.into(),
         ]);
 
-        // Set indexed argument properties, which go through the exotic [[DefineOwnProperty]] so they
-        // are mapped to the enclosing scope.
-        let mut index_key = PropertyKey::uninit().to_handle(cx);
+        // Presize the indexed properties so that each argument can be stored directly
+        if let Ok(num_arguments) = u32::try_from(arguments.len()) {
+            object
+                .as_object()
+                .set_array_properties_length(cx, num_arguments)?;
+        }
+
+        // Set indexed argument properties. These have a fast path to not go through the full exotic
+        // [[DefineOwnProperty]] call, since the arguments are already stored in the scope.
+        //
+        // Handle is shared between iterations.
+        let mut value_handle = Value::uninit().to_handle(cx);
         for (i, argument) in arguments.iter().enumerate() {
-            index_key.replace(PropertyKey::array_index(cx, i as u32)?);
-            must!(create_data_property_or_throw(cx, object.into(), index_key, *argument));
+            value_handle.replace(*argument);
+            create_dense_data_property(cx, object.into(), i as u64, value_handle)?;
         }
 
         Ok(object)

--- a/src/js/runtime/array_object.rs
+++ b/src/js/runtime/array_object.rs
@@ -290,7 +290,7 @@ pub fn create_array_from_list(
     let array = must_a!(array_create(cx, elements.len() as u64, None));
 
     for (index, element) in elements.iter().enumerate() {
-        create_dense_data_property(cx, array.into(), index as u32, *element)?;
+        create_dense_data_property(cx, array.into(), index as u64, *element)?;
     }
 
     Ok(array)
@@ -302,18 +302,18 @@ pub fn create_array_from_list(
 pub fn create_dense_data_property(
     cx: Context,
     array: Handle<ObjectValue>,
-    index: u32,
+    index: u64,
     value: Handle<Value>,
 ) -> AllocResult<()> {
     if let Some(mut dense_properties) = array.array_properties().as_dense_opt()
-        && index < dense_properties.len()
+        && index < dense_properties.len() as u64
     {
-        dense_properties.set_unchecked(index, *value);
+        dense_properties.set_unchecked(index as u32, *value);
         return Ok(());
     }
 
     // An array long enough to be sparse falls back to the generic path
-    let key = PropertyKey::from_u64_handle(cx, index as u64)?;
+    let key = PropertyKey::from_u64_handle(cx, index)?;
     must_a!(create_data_property_or_throw(cx, array, key, value));
 
     Ok(())

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -17,7 +17,9 @@ use crate::{
         },
         accessor::Accessor,
         arguments_object::{MappedArgumentsObject, UnmappedArgumentsObject},
-        array_object::{ArrayObject, array_create, array_create_with_capacity},
+        array_object::{
+            ArrayObject, array_create, array_create_with_capacity, create_dense_data_property,
+        },
         async_generator_object::{AsyncGeneratorObject, async_generator_complete_step},
         boxed_value::BoxedValue,
         bytecode::{
@@ -4655,16 +4657,12 @@ impl VM {
         let scope = self.scope().to_handle();
         let num_parameters = closure.function_ptr().num_parameters() as usize;
 
-        let arguments = self
-            .stack_frame()
-            .args()
-            .iter()
-            .map(|arg| arg.to_handle(self.cx()))
-            .collect::<Vec<_>>();
+        let stack_frame = self.stack_frame();
+        let arguments = stack_frame.args();
 
         // Allocates
         let arguments_object =
-            MappedArgumentsObject::new(self.cx(), closure, &arguments, scope, num_parameters)?;
+            MappedArgumentsObject::new(self.cx(), closure, arguments, scope, num_parameters)?;
 
         self.write_register(dest, *arguments_object.as_value());
 
@@ -4680,16 +4678,12 @@ impl VM {
 
         let dest = instr.dest();
 
-        // Place all arguments (up to argc) behind handles
-        let arguments = self
-            .stack_frame()
-            .args()
-            .iter()
-            .map(|arg| arg.to_handle(self.cx()))
-            .collect::<Vec<_>>();
+        // All arguments (up to argc)
+        let stack_frame = self.stack_frame();
+        let arguments = stack_frame.args();
 
         // Allocates
-        let arguments_object = UnmappedArgumentsObject::new(self.cx(), &arguments)?;
+        let arguments_object = UnmappedArgumentsObject::new(self.cx(), arguments)?;
 
         self.write_register(dest, *arguments_object.as_value());
 
@@ -5890,16 +5884,16 @@ impl VM {
 
         let dest = instr.dest();
 
-        // Allocates
-        let rest_array = must!(array_create(self.cx(), 0, None));
-
-        // Handles are shared between iterations
-        let mut array_key = PropertyKey::uninit().to_handle(self.cx());
-        let mut value_handle = Value::uninit().to_handle(self.cx());
-
         // The arguments between the number of formal parameters and the actual argc supplied will
         // all be added to the rest array.
         let num_parameters = self.closure().function_ptr().num_parameters() as usize;
+        let num_rest_arguments = self.argc().saturating_sub(num_parameters);
+
+        // Allocates. Presized so that each argument can be stored directly.
+        let rest_array = array_create(self.cx(), num_rest_arguments as u64, None)?;
+
+        // Handle is shared between iterations
+        let mut value_handle = Value::uninit().to_handle(self.cx());
 
         // No rest parameter needed if there was underapplication of arguments
         if num_parameters <= self.argc() {
@@ -5907,13 +5901,8 @@ impl VM {
                 .iter()
                 .enumerate()
             {
-                array_key.replace(PropertyKey::array_index(self.cx(), i as u32)?);
                 value_handle.replace(*argument);
-
-                let array_property = Property::default_data(value_handle);
-                rest_array
-                    .as_object()
-                    .set_property(self.cx(), array_key, array_property)?;
+                create_dense_data_property(self.cx(), rest_array.into(), i as u64, value_handle)?;
             }
         }
 

--- a/src/js/runtime/intrinsics/array_constructor.rs
+++ b/src/js/runtime/intrinsics/array_constructor.rs
@@ -8,7 +8,7 @@ use crate::{
             length_of_array_like, set,
         },
         alloc_error::AllocResult,
-        array_object::array_create,
+        array_object::{array_create, create_dense_data_property},
         error::{range_error, type_error},
         get,
         intrinsic_builder::IntrinsicBuilder,
@@ -89,14 +89,9 @@ impl ArrayConstructor {
         } else {
             let array = array_create(cx, arguments.len() as u64, Some(proto))?;
 
-            // Property key is shared between iterations
-            let mut key = PropertyKey::uninit().to_handle(cx);
-
             for index in 0..arguments.len() {
-                key.replace(PropertyKey::array_index(cx, index as u32)?);
                 let value = arguments.get(cx, index);
-
-                must!(create_data_property_or_throw(cx, array.into(), key, value));
+                create_dense_data_property(cx, array.into(), index as u64, value)?;
             }
 
             Ok(array.as_value())

--- a/src/js/runtime/intrinsics/array_prototype.rs
+++ b/src/js/runtime/intrinsics/array_prototype.rs
@@ -12,6 +12,7 @@ use crate::{
         alloc_error::AllocResult,
         array_object::{
             ArrayCreateShape, array_create, array_create_in_realm, array_species_create,
+            create_dense_data_property,
         },
         error::{range_error, type_error},
         get,
@@ -1362,16 +1363,14 @@ impl ArrayPrototype {
 
         let array = array_create(cx, length, None)?;
 
-        // Keys are shared between iterations
+        // Key is shared between iterations
         let mut from_key = PropertyKey::uninit().to_handle(cx);
-        let mut to_key = PropertyKey::uninit().to_handle(cx);
 
         for i in 0..length {
             from_key.replace(PropertyKey::from_u64(cx, length - i - 1)?);
-            to_key.replace(PropertyKey::from_u64(cx, i)?);
 
             let value = get(cx, object, from_key)?;
-            must!(create_data_property_or_throw(cx, array.into(), to_key, value));
+            create_dense_data_property(cx, array.into(), i, value)?;
         }
 
         Ok(array.as_value())
@@ -1397,13 +1396,9 @@ impl ArrayPrototype {
             compare_function_arg,
         )?;
 
-        // Reuse handle between iterations
-        let mut index_key = PropertyKey::uninit().to_handle(cx);
-
         // Copy sorted values into array
         for (i, value) in sorted_values.iter().enumerate() {
-            index_key.replace(PropertyKey::from_u64(cx, i as u64)?);
-            create_data_property_or_throw(cx, sorted_array.into(), index_key, *value)?;
+            create_dense_data_property(cx, sorted_array.into(), i as u64, *value)?;
         }
 
         Ok(sorted_array.as_value())
@@ -1440,30 +1435,28 @@ impl ArrayPrototype {
 
         let array = array_create(cx, new_length, None)?;
 
-        // Keys are shared between iterations
+        // Key is shared between iterations
         let mut from_key = PropertyKey::uninit().to_handle(cx);
-        let mut to_key = PropertyKey::uninit().to_handle(cx);
 
         // Elements before the start index are unchanged and can be copied
         for i in 0..actual_start_index {
             from_key.replace(PropertyKey::from_u64(cx, i)?);
             let value = get(cx, object, from_key)?;
-            must!(create_data_property_or_throw(cx, array.into(), from_key, value));
+            create_dense_data_property(cx, array.into(), i, value)?;
         }
 
         // Insert every element of provided items
         for (i, item) in arguments.iter().skip(2).enumerate() {
-            to_key.replace(PropertyKey::from_u64(cx, actual_start_index + i as u64)?);
-            create_data_property_or_throw(cx, array.into(), to_key, *item)?;
+            let index = actual_start_index + i as u64;
+            create_dense_data_property(cx, array.into(), index, *item)?;
         }
 
         // All remaining elements after the skip count are copied
         for i in (actual_start_index + insert_count)..new_length {
-            to_key.replace(PropertyKey::from_u64(cx, i)?);
             from_key.replace(PropertyKey::from_u64(cx, i - insert_count + actual_skip_count)?);
 
             let value = get(cx, object, from_key)?;
-            must!(create_data_property_or_throw(cx, array.into(), to_key, value));
+            create_dense_data_property(cx, array.into(), i, value)?;
         }
 
         Ok(array.as_value())
@@ -1572,7 +1565,7 @@ impl ArrayPrototype {
                 get(cx, object, key)?
             };
 
-            must!(create_data_property_or_throw(cx, array.into(), key, value));
+            create_dense_data_property(cx, array.into(), i, value)?;
         }
 
         Ok(array.as_value())

--- a/src/js/runtime/intrinsics/json_parser.rs
+++ b/src/js/runtime/intrinsics/json_parser.rs
@@ -5,9 +5,8 @@ use crate::{
     runtime::{
         Context, EvalResult, Handle, PropertyKey, Value,
         abstract_operations::create_data_property_or_throw,
-        array_object::array_create,
+        array_object::{array_create, create_dense_data_property},
         ordinary_object::ordinary_object_create,
-        property::Property,
         string_parsing::{StringLexer, parse_between_ptrs_to_f64, skip_decimal_digits},
         string_value::StringValue,
     },
@@ -311,15 +310,11 @@ impl JSONValue {
             Self::Number { value, .. } => cx.number(*value),
             Self::String { value, .. } => cx.alloc_wtf8_string(value)?.into(),
             Self::Array { elements, .. } => {
-                let array = must_a!(array_create(cx, 0, None));
-
-                // Key is shared between iterations
-                let mut key = PropertyKey::uninit().to_handle(cx);
+                let array = array_create(cx, elements.len() as u64, None)?;
 
                 for (i, value) in elements.iter().enumerate() {
-                    key.replace(PropertyKey::from_u64(cx, i as u64)?);
-                    let desc = Property::default_data(value.to_js_value(cx)?);
-                    array.as_object().set_property(cx, key, desc)?;
+                    let value = value.to_js_value(cx)?;
+                    create_dense_data_property(cx, array.into(), i as u64, value)?;
                 }
 
                 array.into()
@@ -366,21 +361,16 @@ impl JSONValue {
                 Ok(JSONParseRecord::new(string_value, *loc))
             }
             Self::Array { elements, loc } => {
-                let array = must_a!(array_create(cx, 0, None));
+                let array = array_create(cx, elements.len() as u64, None)?;
 
-                // Key is shared between iterations
-                let mut key = PropertyKey::uninit().to_handle(cx);
                 let mut record_elements = vec![];
 
                 for (i, json_value) in elements.iter().enumerate() {
-                    key.replace(PropertyKey::from_u64(cx, i as u64)?);
-
                     let parse_record = json_value.to_json_parse_record(cx)?;
                     let value = parse_record.value;
                     record_elements.push(parse_record);
 
-                    let desc = Property::default_data(value);
-                    array.as_object().set_property(cx, key, desc)?;
+                    create_dense_data_property(cx, array.into(), i as u64, value)?;
                 }
 
                 Ok(JSONParseRecord::new_array(array.as_value(), *loc, record_elements))

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -1196,9 +1196,6 @@ fn build_match_object(
 
     // Add all capture groups to the result, including implicit 0'th capture group
     for (i, capture) in capture_groups.iter().enumerate() {
-        // Safe since capture group index is guaranteed to be a valid array index
-        let array_index = i as u32;
-
         let captured_value = if let Some(capture) = capture {
             string_value
                 .substring(cx, capture.start, capture.end)?
@@ -1208,7 +1205,7 @@ fn build_match_object(
             cx.undefined()
         };
 
-        create_dense_data_property(cx, result_array, array_index, captured_value)?;
+        create_dense_data_property(cx, result_array, i as u64, captured_value)?;
 
         // Add capture indices to indices array if present
         let match_index_pair = if let Some((indices_array, indices_groups)) = indices_result {
@@ -1220,7 +1217,7 @@ fn build_match_object(
                 cx.undefined()
             };
 
-            create_dense_data_property(cx, indices_array, array_index, match_index_pair)?;
+            create_dense_data_property(cx, indices_array, i as u64, match_index_pair)?;
             Some((match_index_pair, indices_groups))
         } else {
             None


### PR DESCRIPTION
## Summary

Add more array presizing and immediate dense array property writes throughout the runtime. Also make `create_dense_data_property` take a full `u64` index and gate internally for simplicity.

- When creating mapped/unmapped arguments, which also read directly from a slice of stack
- When creating rest parameter arrays
- Various `Array` constructor and prototype methods
- In `JSON.parse`

We see a ~1% octane score increase from this change, mostly due to arguments object improvements.

## Tests

- CI