### PR TITLE
[regexp] Fast path for accessing flags getter on RegExp objects

### DIFF
--- a/src/js/runtime/common_shapes.rs
+++ b/src/js/runtime/common_shapes.rs
@@ -25,6 +25,8 @@ pub enum CommonShape {
     AccessorPropertyDescriptor,
     /// A string object: { length }.
     StringObject,
+    /// A RegExp object: { lastIndex }.
+    RegExp,
     /// A RegExp match result array, with named properties: { index, input, groups }.
     RegExpMatch,
     /// An iterator result object: { value, done }.
@@ -73,10 +75,9 @@ impl CommonShapes {
         Ok(())
     }
 
-    pub fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
-        for shape in self.shapes.iter_mut() {
-            visitor.visit_pointer_opt(shape);
-        }
+    #[inline]
+    pub fn is_common_shape(&self, shape: HeapPtr<Shape>, common_shape: CommonShape) -> bool {
+        self.shapes[common_shape as usize].is_some_and(|s| s.ptr_eq(&shape))
     }
 
     /// Return a common shape, building and caching it on first request.
@@ -177,6 +178,11 @@ impl CommonShapes {
                     Intrinsic::StringPrototype,
                     &[(cx.names.length(), none)],
                 ),
+                CommonShape::RegExp => (
+                    HeapItemKind::RegExpObject,
+                    Intrinsic::RegExpPrototype,
+                    &[(cx.names.last_index(), writable)],
+                ),
                 CommonShape::RegExpMatch => (
                     HeapItemKind::ArrayObject,
                     Intrinsic::ArrayPrototype,
@@ -264,5 +270,11 @@ impl CommonShapes {
         debug_assert!(shape.num_properties() as usize == properties.len());
 
         Ok(shape)
+    }
+
+    pub fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+        for shape in self.shapes.iter_mut() {
+            visitor.visit_pointer_opt(shape);
+        }
     }
 }

--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -427,6 +427,12 @@ impl Context {
         self.current_realm().get_intrinsic(intrinsic)
     }
 
+    /// Whether an object is a particular intrinsic of the current realm.
+    #[inline]
+    pub fn is_intrinsic(&self, object: HeapPtr<ObjectValue>, intrinsic: Intrinsic) -> bool {
+        object.ptr_eq(&self.get_intrinsic_ptr(intrinsic))
+    }
+
     pub fn get_common_shape(&self, common_shape: CommonShape) -> AllocResult<Handle<Shape>> {
         self.current_realm().get_common_shape(*self, common_shape)
     }

--- a/src/js/runtime/gc/heap_item.rs
+++ b/src/js/runtime/gc/heap_item.rs
@@ -161,7 +161,13 @@ macro_rules! register_heap_items {
             pub const INLINE_PROPERTIES_OFFSETS: [u8; Self::COUNT] = [
                 $(if (Self::$name as u8) < (Self::Shape as u8) {
                     const OFFSET: usize = std::mem::size_of::<$name>();
-                    $crate::const_assert!(OFFSET <= (u8::MAX as usize));
+
+                    // Ensure that all object sizes are in range
+                    $crate::const_assert!(
+                        OFFSET <= (u8::MAX as usize) ||
+                        (Self::$name as u8) >= (Self::Shape as u8)
+                    );
+
                     OFFSET as u8
                 } else {
                     0

--- a/src/js/runtime/intrinsics/regexp_object.rs
+++ b/src/js/runtime/intrinsics/regexp_object.rs
@@ -1,15 +1,16 @@
 use crate::{
-    extend_object, must, must_a,
+    extend_object, must_a,
     parser::regexp::RegExpFlags,
     runtime::{
-        Context, HeapPtr, PropertyDescriptor, PropertyFlags,
-        abstract_operations::{define_property_or_throw, set},
+        Context, HeapPtr, PropertyDescriptor, PropertyFlags, Value,
+        abstract_operations::define_property_or_throw,
         alloc_error::AllocResult,
+        common_shapes::CommonShape,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
-        ordinary_object::ObjectBuilder,
+        ordinary_object::{ObjectBuilder, get_prototype_from_constructor},
         regexp::compiled_regexp::CompiledRegExp,
         string_value::StringValue,
     },
@@ -28,59 +29,59 @@ impl RegExpObject {
         cx: Context,
         constructor: Handle<ObjectValue>,
     ) -> EvalResult<Handle<RegExpObject>> {
-        let mut object = ObjectBuilder::<RegExpObject>::new(cx)
-            .constructor_proto(constructor, Intrinsic::RegExpPrototype)?
-            .build()?;
+        let proto = get_prototype_from_constructor(cx, constructor, Intrinsic::RegExpPrototype)?;
 
-        // Initialize with default values as allocation may occur before real values are set, so
-        // we must ensure the RegExpObject is in a valid state.
-        set_uninit!(object.compiled_regexp, HeapPtr::uninit());
-
-        let object = object.to_handle();
-
-        Self::define_last_index_property(cx, object)?;
-
-        Ok(object)
+        Ok(Self::new_with_proto(cx, proto, cx.undefined())?)
     }
 
     pub fn new_from_compiled_regexp(
         cx: Context,
         compiled_regexp: Handle<CompiledRegExp>,
     ) -> EvalResult<Handle<RegExpObject>> {
-        let regexp_constructor = cx.get_intrinsic(Intrinsic::RegExpConstructor);
-        let mut object = must!(
-            ObjectBuilder::<RegExpObject>::new(cx)
-                .constructor_proto(regexp_constructor, Intrinsic::RegExpPrototype)
-        )
-        .build()?;
+        let proto = cx.get_intrinsic(Intrinsic::RegExpPrototype);
+        let mut object = Self::new_with_proto(cx, proto, cx.zero())?;
 
-        set_uninit!(object.compiled_regexp, *compiled_regexp);
-
-        let object = object.to_handle();
-
-        Self::define_last_index_property(cx, object)?;
-
-        // Initialize last index property
-        let zero_value = cx.zero();
-        must!(set(cx, object.into(), cx.names.last_index(), zero_value, true));
+        object.set_compiled_regexp(*compiled_regexp);
 
         Ok(object)
     }
 
-    fn define_last_index_property(
+    /// Create a RegExp object with the given prototype, defining the `lastIndex` property on it.
+    fn new_with_proto(
         cx: Context,
-        regexp_object: Handle<RegExpObject>,
-    ) -> AllocResult<()> {
-        let last_index_desc =
-            PropertyDescriptor::data(cx.undefined(), PropertyFlags::empty().writable());
-        must_a!(define_property_or_throw(
-            cx,
-            regexp_object.into(),
-            cx.names.last_index(),
-            last_index_desc
-        ));
+        proto: Handle<ObjectValue>,
+        last_index: Handle<Value>,
+    ) -> AllocResult<Handle<RegExpObject>> {
+        // Fast path using common shape for RegExps created with this realm's `RegExp.prototype`
+        let has_common_shape = cx.is_intrinsic(*proto, Intrinsic::RegExpPrototype);
 
-        Ok(())
+        let builder = ObjectBuilder::<RegExpObject>::new(cx);
+        let mut object = if has_common_shape {
+            builder.common_shape(CommonShape::RegExp)?.build()?
+        } else {
+            builder.proto(proto).build()?
+        };
+
+        // Compiled RegExp is set after creation
+        set_uninit!(object.compiled_regexp, HeapPtr::uninit());
+
+        let object = object.to_handle();
+
+        // Fast path for common shapes
+        if has_common_shape {
+            object.as_object().init_inline_properties(&[last_index]);
+        } else {
+            let last_index_desc =
+                PropertyDescriptor::data(last_index, PropertyFlags::empty().writable());
+            must_a!(define_property_or_throw(
+                cx,
+                object.into(),
+                cx.names.last_index(),
+                last_index_desc
+            ));
+        }
+
+        Ok(object)
     }
 
     #[inline]

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -17,7 +17,6 @@ use crate::{
             ArrayCreateShape, array_create, array_create_in_realm, create_array_from_list,
             create_dense_data_property,
         },
-        bytecode::function::ClosureObject,
         common_shapes::CommonShape,
         error::type_error,
         eval_result::EvalResult,
@@ -28,17 +27,20 @@ use crate::{
             regexp_constructor::{FlagsSource, RegExpSource, as_regexp_object, regexp_init},
             regexp_object::RegExpObject,
             regexp_string_iterator_object::RegExpStringIteratorObject,
-            rust_runtime::RuntimeFunction,
+            rust_runtime::{RuntimeFunction, is_builtin_function},
             string_prototype::{ReplaceValue, SubstitutionTemplate, SubstitutionTemplateParser},
         },
         object_value::ObjectValue,
         ordinary_object::ordinary_object_create_without_proto,
         realm::Realm,
-        regexp::matcher::{Match, run_matcher},
+        regexp::{
+            fast_flags_guard::FastRegExpFlagsGuard,
+            matcher::{Match, run_matcher},
+        },
         string_value::StringValue,
         to_string,
         type_utilities::{
-            is_callable, same_object_value, same_value, to_boolean, to_integer_or_infinity,
+            is_callable, require_object_coercible, same_value, to_boolean, to_integer_or_infinity,
             to_length, to_object, to_uint32,
         },
     },
@@ -128,6 +130,11 @@ impl RegExpPrototype {
     fn flags(cx, this_value, _) {
         let this_object = this_object(cx, this_value, "RegExp.prototype.flags")?;
 
+        // Use the fast path for raw RegExp flag access if possible
+        if let Some(flags) = FastRegExpFlagsGuard::try_get_fast_flags(cx, this_object)? {
+            return Ok(flags_to_string_value(cx, flags)?.as_value());
+        }
+
         let mut flags_string = String::new();
 
         let has_indices_value = get(cx, this_object, cx.names.has_indices())?;
@@ -205,12 +212,10 @@ impl RegExpPrototype {
         let string_arg = arguments.get(cx, 0);
         let string_value = to_string(cx, string_arg)?;
 
-        let flags_string = get(cx, regexp_object, cx.names.flags())?;
-        let flags_string = to_string(cx, flags_string)?;
+        let flags = GenericFlags::new(cx, regexp_object)?;
 
-        let is_global = flags_string_contains(flags_string, 'g' as u32)?;
-        let is_unicode = flags_string_contains(flags_string, 'u' as u32)?
-            || flags_string_contains(flags_string, 'v' as u32)?;
+        let is_global = flags.is_global()?;
+        let is_unicode = flags.has_any_unicode_flag()?;
 
         if !is_global {
             return regexp_exec(cx, regexp_object, string_value, "RegExp.prototype[@@match]")?
@@ -281,8 +286,8 @@ impl RegExpPrototype {
 
         let constructor = species_constructor(cx, regexp_object, Intrinsic::RegExpConstructor)?;
 
-        let flags_string = get(cx, regexp_object, cx.names.flags())?;
-        let flags_string = to_string(cx, flags_string)?;
+        let flags = GenericFlags::new(cx, regexp_object)?;
+        let flags_string = flags.to_flags_string(cx)?;
 
         let matcher =
             construct(cx, constructor, &[regexp_object.into(), flags_string.into()], None)?;
@@ -293,9 +298,8 @@ impl RegExpPrototype {
 
         set(cx, matcher, cx.names.last_index(), last_index_value, true)?;
 
-        let is_global = flags_string_contains(flags_string, 'g' as u32)?;
-        let is_unicode = flags_string_contains(flags_string, 'u' as u32)?
-            || flags_string_contains(flags_string, 'v' as u32)?;
+        let is_global = flags.is_global()?;
+        let is_unicode = flags.has_any_unicode_flag()?;
 
         Ok(
             RegExpStringIteratorObject::new(cx, matcher, string_value, is_global, is_unicode)?
@@ -324,19 +328,10 @@ impl RegExpPrototype {
             ReplaceValue::String(to_string(cx, replace_arg)?)
         };
 
-        // Get flags string, determining if RegExp is unicode or global
-        let flags_value = get(cx, regexp_object, cx.names.flags())?;
-        let flags_string = to_string(cx, flags_value)?;
-
-        let mut is_unicode = false;
-        let mut is_global = false;
-        for code_point in flags_string.iter_code_points()? {
-            if code_point == 'u' as u32 || code_point == 'v' as u32 {
-                is_unicode = true;
-            } else if code_point == 'g' as u32 {
-                is_global = true;
-            }
-        }
+        // Get flags, determining if RegExp is unicode or global
+        let flags = GenericFlags::new(cx, regexp_object)?;
+        let is_unicode = flags.has_any_unicode_flag()?;
+        let is_global = flags.is_global()?;
 
         if is_global {
             let zero_value = cx.zero();
@@ -490,10 +485,7 @@ impl RegExpPrototype {
             let this_object = this_value.as_object();
             if let Some(regexp_object) = this_object.as_opt::<RegExpObject>() {
                 return Ok(regexp_object.escaped_pattern_source().as_value());
-            } else if same_object_value(
-                *this_object,
-                cx.get_intrinsic_ptr(Intrinsic::RegExpPrototype),
-            ) {
+            } else if cx.is_intrinsic(*this_object, Intrinsic::RegExpPrototype) {
                 return Ok(cx.alloc_static_string("(?:)")?.as_value());
             }
         }
@@ -511,25 +503,13 @@ impl RegExpPrototype {
 
         let constructor = species_constructor(cx, regexp_object, Intrinsic::RegExpConstructor)?;
 
-        // Get flags string, determining if a unicode or sticky flag is set
-        let flags_string = get(cx, regexp_object, cx.names.flags())?;
-        let mut flags_string = to_string(cx, flags_string)?;
-
-        let mut is_unicode = false;
-        let mut is_sticky = false;
-        for code_point in flags_string.iter_code_points()? {
-            if code_point == 'u' as u32 || code_point == 'v' as u32 {
-                is_unicode = true;
-            } else if code_point == 'y' as u32 {
-                is_sticky = true;
-            }
-        }
+        // Get flags, determining if a unicode flag is set
+        let flags = GenericFlags::new(cx, regexp_object)?;
+        let is_unicode = flags.has_any_unicode_flag()?;
 
         // Make sure the sticky flag is included in the flags string
-        if !is_sticky {
-            let y_string = cx.alloc_static_string("y")?;
-            flags_string = StringValue::concat(cx, flags_string, y_string)?;
-        }
+        let flags_with_sticky = flags.with_sticky_flag(cx)?;
+        let flags_string = flags_with_sticky.to_flags_string(cx)?;
 
         let splitter =
             construct(cx, constructor, &[regexp_object.into(), flags_string.into()], None)?;
@@ -783,8 +763,7 @@ fn regexp_has_flag(
         if let Some(regexp_object) = this_object.as_opt::<RegExpObject>() {
             let has_flag = regexp_object.flags().contains(flag);
             return Ok(cx.bool(has_flag));
-        } else if same_object_value(*this_object, cx.get_intrinsic_ptr(Intrinsic::RegExpPrototype))
-        {
+        } else if cx.is_intrinsic(*this_object, Intrinsic::RegExpPrototype) {
             return Ok(cx.undefined());
         }
     }
@@ -792,11 +771,103 @@ fn regexp_has_flag(
     type_error(cx, &format!("{method_name} must be called on a RegExp"))
 }
 
+/// Abstraction over various sources of RegExp flags for generic access
+#[derive(Clone, Copy)]
+pub enum GenericFlags {
+    /// Raw flags read directly from a RegExp.
+    Raw(RegExpFlags),
+    /// The string returned by the `flags` getter.
+    String(Handle<StringValue>),
+}
+
+impl GenericFlags {
+    /// Get the flags for a RegExp-like object, taking the fast path for raw flags access if
+    /// possible.
+    fn new(cx: Context, object: Handle<ObjectValue>) -> EvalResult<GenericFlags> {
+        if let Some(flags) = FastRegExpFlagsGuard::try_get_fast_flags(cx, object)? {
+            return Ok(GenericFlags::Raw(flags));
+        }
+
+        // Slow path, fall back to calling `flags` getter
+        let flags_value = get(cx, object, cx.names.flags())?;
+        let flags_string = to_string(cx, flags_value)?;
+
+        Ok(GenericFlags::String(flags_string))
+    }
+
+    /// Get the flags for a RegExp-like object, additionally checking that the value returned by the
+    /// slow path `flags` getter is not nullish.
+    pub fn new_require_coercible(
+        cx: Context,
+        object: Handle<ObjectValue>,
+    ) -> EvalResult<GenericFlags> {
+        if let Some(flags) = FastRegExpFlagsGuard::try_get_fast_flags(cx, object)? {
+            return Ok(GenericFlags::Raw(flags));
+        }
+
+        // Slow path, fall back to calling `flags` getter
+        let flags_value = get(cx, object, cx.names.flags())?;
+        require_object_coercible(cx, flags_value)?;
+        let flags_string = to_string(cx, flags_value)?;
+
+        Ok(GenericFlags::String(flags_string))
+    }
+
+    pub fn is_global(&self) -> AllocResult<bool> {
+        match self {
+            Self::Raw(flags) => Ok(flags.is_global()),
+            Self::String(flags_string) => flags_string_contains(*flags_string, 'g' as u32),
+        }
+    }
+
+    fn has_any_unicode_flag(&self) -> AllocResult<bool> {
+        match self {
+            Self::Raw(flags) => Ok(flags.has_any_unicode_flag()),
+            Self::String(flags_string) => Ok(flags_string_contains(*flags_string, 'u' as u32)?
+                || flags_string_contains(*flags_string, 'v' as u32)?),
+        }
+    }
+
+    /// The flags as a string, matching what the `flags` getter would have returned.
+    fn to_flags_string(self, cx: Context) -> EvalResult<Handle<StringValue>> {
+        match self {
+            Self::Raw(flags) => flags_to_string_value(cx, flags),
+            Self::String(flags_string) => Ok(flags_string),
+        }
+    }
+
+    /// Return the same flags but with the sticky flag set.
+    fn with_sticky_flag(&self, mut cx: Context) -> EvalResult<GenericFlags> {
+        match self {
+            Self::Raw(flags) => Ok(Self::Raw(*flags | RegExpFlags::STICKY)),
+            Self::String(flags_string) => {
+                if flags_string_contains(*flags_string, 'y' as u32)? {
+                    return Ok(Self::String(*flags_string));
+                }
+
+                // Sticky flag is last in a flags string
+                let y_string = cx.alloc_static_string("y")?;
+                let new_flags_string = StringValue::concat(cx, *flags_string, y_string)?;
+
+                Ok(Self::String(new_flags_string))
+            }
+        }
+    }
+}
+
 pub fn flags_string_contains(
     flags_string: Handle<StringValue>,
     flag: CodePoint,
 ) -> AllocResult<bool> {
     Ok(flags_string.iter_code_points()?.any(|c| c == flag))
+}
+
+fn flags_to_string_value(mut cx: Context, flags: RegExpFlags) -> EvalResult<Handle<StringValue>> {
+    if flags.is_empty() {
+        return Ok(cx.names.empty_string().as_string());
+    }
+
+    cx.alloc_string(&flags.to_string())
 }
 
 /// The replacement for a single match in `RegExp.prototype[@@replace]`, along with the position
@@ -1063,13 +1134,7 @@ pub fn regexp_exec(
 /// Realm must match since RegExpBuiltinExec creates the match result array in the realm of the
 /// `exec` function that is called.
 fn is_builtin_regexp_exec(cx: Context, value: Handle<Value>) -> bool {
-    let Some(closure) = value.as_opt::<ClosureObject>() else {
-        return false;
-    };
-
-    closure.function_ptr().runtime_function_id()
-        == Some(RuntimeFunction::RegExpPrototype_exec.to_id())
-        && closure.realm_ptr().ptr_eq(&cx.current_realm_ptr())
+    is_builtin_function(*value, RuntimeFunction::RegExpPrototype_exec, Some(cx.current_realm_ptr()))
 }
 
 /// RegExpBuiltinExec (https://tc39.es/ecma262/#sec-regexpbuiltinexec)

--- a/src/js/runtime/intrinsics/rust_runtime.rs
+++ b/src/js/runtime/intrinsics/rust_runtime.rs
@@ -1,7 +1,8 @@
 use crate::{
     runtime::{
-        Context, EvalResult, Handle, Value, async_generator_object,
+        Context, EvalResult, Handle, HeapPtr, Realm, Value, async_generator_object,
         bound_function_object::BoundFunctionObject,
+        bytecode::function::ClosureObject,
         console_object::ConsoleObject,
         gc_object::GcObject,
         global_names,
@@ -1132,3 +1133,25 @@ runtime_fn! {
 fn return_undefined(cx, _, _) {
     Ok(cx.undefined())
 }}
+
+/// Whether a value is the builtin function for a particular runtime function.
+///
+/// Optionally provide a realm to check that the builtin is in the expected realm.
+pub fn is_builtin_function(
+    value: Value,
+    runtime_function: RuntimeFunction,
+    realm: Option<HeapPtr<Realm>>,
+) -> bool {
+    let Some(closure) = value.as_opt::<ClosureObject>() else {
+        return false;
+    };
+
+    if closure.function_ptr().runtime_function_id() != Some(runtime_function.to_id()) {
+        return false;
+    }
+
+    match realm {
+        Some(realm) => closure.realm_ptr().ptr_eq(&realm),
+        None => true,
+    }
+}

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -1,4 +1,3 @@
-use crate::runtime::intrinsics::regexp_object::RegExpObject;
 use crate::{
     common::{
         icu::ICU,
@@ -23,7 +22,7 @@ use crate::{
         intrinsics::{
             intrinsics::Intrinsic,
             regexp_constructor::{FlagsSource, RegExpSource, regexp_create},
-            regexp_prototype::flags_string_contains,
+            regexp_prototype::GenericFlags,
             rust_runtime::RuntimeFunction,
             string_iterator_object::StringIteratorObject,
         },
@@ -35,8 +34,8 @@ use crate::{
         },
         to_string,
         type_utilities::{
-            is_callable, is_regexp, require_object_coercible, resolve_relative_index_argument,
-            to_integer_or_infinity, to_length, to_number, to_uint32,
+            is_callable, is_regexp, resolve_relative_index_argument, to_integer_or_infinity,
+            to_length, to_number, to_uint32,
         },
         value::Value,
     },
@@ -420,20 +419,9 @@ impl StringPrototype {
         if regexp_arg.is_object() {
             if is_regexp(cx, regexp_arg)? {
                 let regexp_object = regexp_arg.as_object();
+                let flags = GenericFlags::new_require_coercible(cx, regexp_object)?;
 
-                let flags_string = get(cx, regexp_object, cx.names.flags())?;
-                require_object_coercible(cx, flags_string)?;
-
-                let has_global_flag =
-                    if let Some(regexp_object) = regexp_object.as_opt::<RegExpObject>() {
-                        regexp_object.flags().is_global()
-                    } else {
-                        let flags_string = to_string(cx, flags_string)?;
-
-                        flags_string_contains(flags_string, 'g' as u32)?
-                    };
-
-                if !has_global_flag {
+                if !flags.is_global()? {
                     return type_error(
                         cx,
                         "String.prototype.matchAll expects RegExp with global flag",
@@ -696,13 +684,9 @@ impl StringPrototype {
             // If search argument is a RegExp, check that it has the global flag
             if is_regexp(cx, search_arg)? {
                 let search_regexp = search_arg.as_object();
-                let flags_value = get(cx, search_regexp, cx.names.flags())?;
+                let flags = GenericFlags::new_require_coercible(cx, search_regexp)?;
 
-                require_object_coercible(cx, flags_value)?;
-
-                let flags_string = to_string(cx, flags_value)?;
-
-                if !flags_string_contains(flags_string, 'g' as u32)? {
+                if !flags.is_global()? {
                     return type_error(
                         cx,
                         "String.prototype.replaceAll expects RegExp with global flag",

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -23,6 +23,7 @@ use crate::{
             rust_runtime::RuntimeFunction,
         },
         object_value::ObjectValue,
+        regexp::fast_flags_guard::FastRegExpFlagsGuard,
         scope::Scope,
         scope_names::{ScopeFlags, ScopeNameFlags, ScopeNames},
         shape::Shape,
@@ -51,6 +52,8 @@ pub struct Realm {
     /// Timestamp when this realm was created. Times returned from `performance.now` are relative
     /// to this timestamp.
     time_origin: Instant,
+    /// A guard for fast `flags` property access on RegExp objects
+    regexp_flags_guard: FastRegExpFlagsGuard,
     /// Common shapes for objects with a known set of properties.
     pub common_shapes: CommonShapes,
     pub intrinsics: Intrinsics,
@@ -83,6 +86,7 @@ impl Realm {
             set_uninit!(realm.lexical_names, HeapPtr::uninit());
             set_uninit!(realm.empty_function, HeapPtr::uninit());
             set_uninit!(realm.time_origin, Instant::now());
+            set_uninit!(realm.regexp_flags_guard, FastRegExpFlagsGuard::Uninitialized);
             set_uninit!(realm.common_shapes, CommonShapes::new_uninit());
 
             let realm = realm.to_handle();
@@ -100,6 +104,16 @@ impl Realm {
     #[inline]
     pub fn calculate_size_in_bytes() -> usize {
         INTRINSICS_BYTE_OFFSET + Intrinsics::calculate_size_in_bytes()
+    }
+
+    #[inline]
+    pub fn regexp_flags_guard(&self) -> &FastRegExpFlagsGuard {
+        &self.regexp_flags_guard
+    }
+
+    #[inline]
+    pub fn set_regexp_flags_guard(&mut self, guard: FastRegExpFlagsGuard) {
+        self.regexp_flags_guard = guard;
     }
 
     #[inline]
@@ -394,6 +408,7 @@ impl HeapItem for Realm {
         visitor.visit_pointer(&mut realm.global_scopes);
         visitor.visit_pointer(&mut realm.lexical_names);
         visitor.visit_pointer(&mut realm.empty_function);
+        realm.regexp_flags_guard.visit_pointers(visitor);
         realm.common_shapes.visit_pointers(visitor);
         realm.intrinsics.visit_pointers(visitor);
     }

--- a/src/js/runtime/regexp/fast_flags_guard.rs
+++ b/src/js/runtime/regexp/fast_flags_guard.rs
@@ -1,0 +1,137 @@
+use crate::{
+    parser::regexp::RegExpFlags,
+    runtime::{
+        Context, EvalResult, Handle,
+        accessor::Accessor,
+        common_shapes::CommonShape,
+        gc::HeapVisitor,
+        intrinsics::{
+            intrinsics::Intrinsic,
+            regexp_object::RegExpObject,
+            rust_runtime::{RuntimeFunction, is_builtin_function},
+        },
+        object_value::ObjectValue,
+        shape::ValidityGuard,
+    },
+};
+
+/// A guard that allows for fast access to the `flags` property of a RegExp object.
+pub enum FastRegExpFlagsGuard {
+    /// Guard is lazily initialized.
+    Uninitialized,
+    /// Whether the RegExp prototype object is guaranteed to have all `flags` accessors set to their
+    /// builtin functions. Cached for as long as the validity guard is valid, meaning this realm's
+    /// RegExp prototype is unchanged.
+    Cached {
+        all_builtin_flag_getters: bool,
+        validity_guard: ValidityGuard,
+    },
+}
+
+impl FastRegExpFlagsGuard {
+    fn all_builtin_flag_getters(&self) -> Option<bool> {
+        match self {
+            Self::Cached { all_builtin_flag_getters, validity_guard }
+                if validity_guard.is_valid() =>
+            {
+                Some(*all_builtin_flag_getters)
+            }
+            _ => None,
+        }
+    }
+
+    /// Fast path for getting raw flags from a RegExp object.
+    ///
+    /// Fast path is used if the object has the RegExp common shape.
+    pub fn try_get_fast_flags(
+        cx: Context,
+        object: Handle<ObjectValue>,
+    ) -> EvalResult<Option<RegExpFlags>> {
+        let realm = cx.current_realm_ptr();
+
+        // Quick, conservative check to verify that the object
+        // - Is a RegExpObject
+        // - Has RegExp.prototype as its prototype
+        // - Does not have any own properties that could shadow the flag getters on
+        //   RegExp.prototype, since the common shape's only own property is `lastIndex`.
+        if !realm
+            .common_shapes
+            .is_common_shape(object.shape_ptr(), CommonShape::RegExp)
+        {
+            return Ok(None);
+        }
+
+        let regexp_object = object.cast::<RegExpObject>();
+
+        // Fast path is gated by a cached value protected by a validity guard on RegExp.prototype
+        if let Some(all_builtin_flag_getters) =
+            realm.regexp_flags_guard().all_builtin_flag_getters()
+        {
+            return Ok(all_builtin_flag_getters.then(|| regexp_object.flags()));
+        }
+
+        // Guard was invalid or uninitialized, so recompute the guarded value
+        let mut regexp_prototype = cx.get_intrinsic(Intrinsic::RegExpPrototype);
+        let all_builtin_flag_getters =
+            Self::recompute_all_builtin_flag_getters(cx, regexp_prototype);
+
+        // Fetch and create guard for the recomputed value
+        let validity_guard = regexp_prototype.request_own_validity_guard(cx)?;
+
+        // Requesting the guard allocates so refetch realm
+        let mut realm = cx.current_realm_ptr();
+        realm.set_regexp_flags_guard(FastRegExpFlagsGuard::Cached {
+            all_builtin_flag_getters,
+            validity_guard,
+        });
+
+        Ok(all_builtin_flag_getters.then(|| regexp_object.flags()))
+    }
+
+    /// Recompute whether all of the builtin flag getters are present on RegExp.prototype.
+    fn recompute_all_builtin_flag_getters(
+        cx: Context,
+        regexp_prototype: Handle<ObjectValue>,
+    ) -> bool {
+        let flag_getters = [
+            (cx.names.flags(), RuntimeFunction::RegExpPrototype_flags),
+            (cx.names.has_indices(), RuntimeFunction::RegExpPrototype_has_indices),
+            (cx.names.global(), RuntimeFunction::RegExpPrototype_global),
+            (cx.names.ignore_case(), RuntimeFunction::RegExpPrototype_ignore_case),
+            (cx.names.multiline(), RuntimeFunction::RegExpPrototype_multiline),
+            (cx.names.dot_all(), RuntimeFunction::RegExpPrototype_dot_all),
+            (cx.names.unicode(), RuntimeFunction::RegExpPrototype_unicode),
+            (cx.names.unicode_sets(), RuntimeFunction::RegExpPrototype_unicode_sets),
+            (cx.names.sticky(), RuntimeFunction::RegExpPrototype_sticky),
+        ];
+
+        for (name, builtin) in flag_getters {
+            // Own property with the given name exists
+            let Some(property) = regexp_prototype.get_property(cx, name) else {
+                return false;
+            };
+
+            // Property is a getter
+            if !property.is_accessor() {
+                return false;
+            }
+
+            let Some(getter) = Accessor::from_value(*property.value()).get else {
+                return false;
+            };
+
+            // Getter is the expected builtin function. Flag getters do not depend on the realm.
+            if !is_builtin_function(getter.into(), builtin, None) {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    pub fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {
+        if let Self::Cached { validity_guard, .. } = self {
+            validity_guard.visit_pointers(visitor);
+        }
+    }
+}

--- a/src/js/runtime/regexp/mod.rs
+++ b/src/js/runtime/regexp/mod.rs
@@ -1,5 +1,6 @@
 pub mod compiled_regexp;
 pub mod compiler;
+pub mod fast_flags_guard;
 pub mod graphviz;
 pub mod instruction;
 pub mod lexer_stream;

--- a/tests/integration/built-ins/RegExp/flags_fast_path.js
+++ b/tests/integration/built-ins/RegExp/flags_fast_path.js
@@ -1,0 +1,275 @@
+/*---
+description: >
+  RegExp methods read the flags off the RegExp directly instead of calling the `flags` getter where
+  possible. Verify that this gives the same results as calling the getter, and that shadowing,
+  replacing, or deleting any of the getters it reads is still observed.
+includes: [compareArray.js]
+---*/
+
+var singleFlags = [
+  ["d", "hasIndices"],
+  ["g", "global"],
+  ["i", "ignoreCase"],
+  ["m", "multiline"],
+  ["s", "dotAll"],
+  ["u", "unicode"],
+  ["v", "unicodeSets"],
+  ["y", "sticky"],
+];
+
+// Every operation that reads the `flags` property, applied to a freshly created RegExp so that no
+// last index state is carried between them. String.prototype.matchAll requires a global RegExp.
+function runAll(makeRegExp, string) {
+  return {
+    flags: makeRegExp().flags,
+    match: JSON.stringify(string.match(makeRegExp())),
+    matchAll: makeRegExp().global ? JSON.stringify([...string.matchAll(makeRegExp())]) : "",
+    replace: string.replace(makeRegExp(), "<$&|$1>"),
+    split: string.split(makeRegExp()),
+  };
+}
+
+// Two receivers whose flags are observably identical but which cannot be read directly: one has an
+// extra own property, and one is a subclass instance whose prototype is not the RegExp prototype.
+// Both still inherit every flag getter from the RegExp prototype.
+function assertSameResults(source, flags, string) {
+  var Subclass = class extends RegExp {};
+  var message = "/" + source + "/" + flags + " on " + JSON.stringify(string);
+
+  var direct = runAll(function () { return new RegExp(source, flags); }, string);
+
+  [
+    ["own property", function () {
+      var regexp = new RegExp(source, flags);
+      regexp.marker = 1;
+      return regexp;
+    }],
+    ["subclass", function () { return new Subclass(source, flags); }],
+  ].forEach(function (receiver) {
+    var other = runAll(receiver[1], string);
+    var suffix = " (" + receiver[0] + ")";
+
+    assert.sameValue(direct.flags, other.flags, message + " flags" + suffix);
+    assert.sameValue(direct.match, other.match, message + " match" + suffix);
+    assert.sameValue(direct.matchAll, other.matchAll, message + " matchAll" + suffix);
+    assert.sameValue(direct.replace, other.replace, message + " replace" + suffix);
+    assert.compareArray(direct.split, other.split, message + " split" + suffix);
+  });
+}
+
+var sources = ["a", "(a)b", "\u{1F600}"];
+var flagCombinations = ["", "g", "gi", "gy", "gu", "dgimsy"];
+var strings = ["", "aXbXc", "a1b2c", "\u{1F600}a\u{1F600}"];
+
+for (var i = 0; i < sources.length; i++) {
+  for (var j = 0; j < flagCombinations.length; j++) {
+    for (var k = 0; k < strings.length; k++) {
+      assertSameResults(sources[i], flagCombinations[j], strings[k]);
+    }
+  }
+}
+
+// The flags string is exactly what the individual getters report, in `dgimsuvy` order.
+for (var bits = 0; bits < 1 << singleFlags.length; bits++) {
+  var flagsString = "";
+  for (var i = 0; i < singleFlags.length; i++) {
+    if (bits & (1 << i)) {
+      flagsString += singleFlags[i][0];
+    }
+  }
+
+  // The `u` and `v` flags are mutually exclusive
+  if (flagsString.indexOf("u") !== -1 && flagsString.indexOf("v") !== -1) {
+    continue;
+  }
+
+  var regexp = new RegExp("a", flagsString);
+  var message = " for " + JSON.stringify(flagsString);
+
+  assert.sameValue(regexp.flags, flagsString, "flags" + message);
+  for (var i = 0; i < singleFlags.length; i++) {
+    assert.sameValue(
+      regexp[singleFlags[i][1]],
+      (bits & (1 << i)) !== 0,
+      singleFlags[i][1] + message
+    );
+  }
+}
+
+// Writing the last index does not add a property, so the flags are still read directly.
+var withLastIndex = new RegExp("a", "gi");
+withLastIndex.lastIndex = 7;
+assert.sameValue(withLastIndex.flags, "gi", "flags after a last index write");
+
+// An own property shadows the prototype getter that `flags` reads.
+var ownGlobal = new RegExp("a", "");
+Object.defineProperty(ownGlobal, "global", { value: true });
+assert.sameValue(ownGlobal.flags, "g", "own `global` property is read by the `flags` getter");
+
+var ownFlags = new RegExp("a", "g");
+Object.defineProperty(ownFlags, "flags", { value: "" });
+assert.sameValue("aa".replace(ownFlags, "-"), "-a", "own `flags` property is read by @@replace");
+
+// A subclass getter shadows it as well.
+class NotGlobal extends RegExp {
+  get global() {
+    return false;
+  }
+}
+
+assert.sameValue(new NotGlobal("a", "g").flags, "", "subclass getter is read by the `flags` getter");
+assert.sameValue(
+  "aa".replace(new NotGlobal("a", "g"), "-"),
+  "-a",
+  "subclass getter is read by @@replace"
+);
+
+// Replace a getter on the RegExp prototype for the duration of a callback.
+function withGetter(name, value, callback) {
+  var original = Object.getOwnPropertyDescriptor(RegExp.prototype, name);
+  Object.defineProperty(RegExp.prototype, name, {
+    get: function () { return value; },
+    configurable: true,
+  });
+
+  try {
+    return callback();
+  } finally {
+    Object.defineProperty(RegExp.prototype, name, original);
+  }
+}
+
+// Each replaced flag getter is read by the `flags` getter.
+for (var i = 0; i < singleFlags.length; i++) {
+  var getterName = singleFlags[i][1];
+
+  assert.sameValue(
+    withGetter(getterName, true, function () { return new RegExp("a", "").flags; }),
+    singleFlags[i][0],
+    "replaced `" + getterName + "` getter is read by the `flags` getter"
+  );
+}
+
+// A replaced `flags` or `global` getter is read by the methods built on it.
+assert.sameValue(
+  withGetter("flags", "", function () { return "aa".replace(new RegExp("a", "g"), "-"); }),
+  "-a",
+  "replaced `flags` getter is read by @@replace"
+);
+assert.compareArray(
+  withGetter("global", false, function () { return "aa".match(new RegExp("a", "g")); }),
+  ["a"],
+  "replaced `global` getter is read by @@match"
+);
+
+// A `global` of true on a non-global RegExp that matches never terminates, since the builtin `exec`
+// does not advance the last index, so observe it through the last index reset instead.
+var resetsLastIndex = new RegExp("a", "");
+resetsLastIndex.lastIndex = 5;
+withGetter("global", true, function () { return "bbb".replace(resetsLastIndex, "-"); });
+assert.sameValue(resetsLastIndex.lastIndex, 0, "replaced `global` getter makes @@replace reset it");
+
+// Deleting a getter is observed, and restoring it takes effect again.
+var originalGlobal = Object.getOwnPropertyDescriptor(RegExp.prototype, "global");
+delete RegExp.prototype.global;
+assert.sameValue(new RegExp("a", "g").flags, "", "flags after `global` is deleted");
+Object.defineProperty(RegExp.prototype, "global", originalGlobal);
+assert.sameValue(new RegExp("a", "g").flags, "g", "flags after `global` is restored");
+assert.sameValue("aa".replace(new RegExp("a", "g"), "-"), "--", "@@replace after it is restored");
+
+// A change to the RegExp prototype that leaves the getters alone must not change any results.
+RegExp.prototype.unrelatedProperty = 1;
+assert.sameValue(new RegExp("a", "gi").flags, "gi", "flags after an unrelated property is added");
+assert.sameValue(
+  "aa".replace(new RegExp("a", "g"), "-"),
+  "--",
+  "@@replace after an unrelated property is added"
+);
+delete RegExp.prototype.unrelatedProperty;
+assert.sameValue(new RegExp("a", "gi").flags, "gi", "flags after an unrelated property is removed");
+
+// @@split and @@matchAll hand the flags string to their species constructor, with @@split adding
+// the sticky flag if it is not already present. The flags string must be the same whichever path
+// produced it, so run every case against both.
+//
+// Reaching the species constructor through an own `constructor` property adds a property to the
+// receiver, which disables the fast path and reads the flags from the getter. Installing @@species
+// on the RegExp constructor instead leaves the receiver untouched, so the flags are read directly
+// off the RegExp.
+function speciesFlagsFromGetter(regexp, callback) {
+  var seenFlags = null;
+
+  regexp.constructor = {};
+  regexp.constructor[Symbol.species] = function (source, flags) {
+    seenFlags = flags;
+    return new RegExp(source.source, flags);
+  };
+
+  callback(regexp);
+
+  return seenFlags;
+}
+
+function speciesFlagsDirect(regexp, callback) {
+  var seenFlags = null;
+  var original = Object.getOwnPropertyDescriptor(RegExp, Symbol.species);
+
+  Object.defineProperty(RegExp, Symbol.species, {
+    value: function (source, flags) {
+      seenFlags = flags;
+      return new RegExp(source.source, flags);
+    },
+    configurable: true,
+  });
+
+  try {
+    callback(regexp);
+  } finally {
+    Object.defineProperty(RegExp, Symbol.species, original);
+  }
+
+  return seenFlags;
+}
+
+function splitWith(regexp) {
+  "aXb".split(regexp);
+}
+
+function matchAllWith(regexp) {
+  [...regexp[Symbol.matchAll]("a")];
+}
+
+[["from the getter", speciesFlagsFromGetter], ["read directly", speciesFlagsDirect]].forEach(
+  function (variant) {
+    var speciesFlags = variant[1];
+    var suffix = " (" + variant[0] + ")";
+
+    assert.sameValue(
+      speciesFlags(new RegExp("X", ""), splitWith),
+      "y",
+      "@@split adds the sticky flag" + suffix
+    );
+    assert.sameValue(
+      speciesFlags(new RegExp("X", "gi"), splitWith),
+      "giy",
+      "@@split appends it last" + suffix
+    );
+    assert.sameValue(
+      speciesFlags(new RegExp("X", "gy"), splitWith),
+      "gy",
+      "@@split keeps it once" + suffix
+    );
+    assert.sameValue(
+      withGetter("flags", "im", function () {
+        return speciesFlags(new RegExp("X", ""), splitWith);
+      }),
+      "imy",
+      "@@split adds the sticky flag to a replaced `flags` getter" + suffix
+    );
+    assert.sameValue(
+      speciesFlags(new RegExp("a", "gim"), matchAllWith),
+      "gim",
+      "@@matchAll passes the flags string through" + suffix
+    );
+  }
+);

--- a/tests/integration/built-ins/String/flags_global_check.js
+++ b/tests/integration/built-ins/String/flags_global_check.js
@@ -1,0 +1,349 @@
+/*---
+description: >
+  String.prototype.matchAll and String.prototype.replaceAll decide whether their argument is global
+  from the string returned by the `flags` getter, not from the flags stored on the RegExp. Verify
+  that replacing `flags`, replacing a getter that it reads, or shadowing either one on the RegExp
+  itself is observed by both methods, including once the fast path for reading flags directly off a
+  RegExp has already been taken and cached, and that the cache is kept separate between realms.
+includes: [compareArray.js]
+---*/
+
+// No pattern below matches `subject`. A RegExp that only reports itself as global would otherwise
+// loop forever in @@replace, since the builtin `exec` does not advance the last index of a RegExp
+// that is not really global. matchAll is checked against real matches in `matchSubject` instead,
+// which is safe because @@matchAll iterates a species copy that really is global.
+var subject = "zzz";
+var matchSubject = "aaa";
+
+function assertAccepted(makeRegExp, expectedMatches, message) {
+  assert.compareArray(
+    [...matchSubject.matchAll(makeRegExp())].map(function (match) { return match[0]; }),
+    expectedMatches,
+    "String.prototype.matchAll " + message
+  );
+  assert.sameValue(
+    subject.replaceAll(makeRegExp(), "-"),
+    subject,
+    "String.prototype.replaceAll " + message
+  );
+}
+
+function assertRejected(makeRegExp, message) {
+  assert.throws(
+    TypeError,
+    function () { [...subject.matchAll(makeRegExp())]; },
+    "String.prototype.matchAll " + message
+  );
+  assert.throws(
+    TypeError,
+    function () { subject.replaceAll(makeRegExp(), "-"); },
+    "String.prototype.replaceAll " + message
+  );
+}
+
+function withGetter(name, value, callback) {
+  var original = Object.getOwnPropertyDescriptor(RegExp.prototype, name);
+  Object.defineProperty(RegExp.prototype, name, {
+    get: function () { return value; },
+    configurable: true,
+  });
+
+  try {
+    return callback();
+  } finally {
+    Object.defineProperty(RegExp.prototype, name, original);
+  }
+}
+
+// Ordinary use, which is what takes the fast path. This runs before anything below mutates
+// RegExp.prototype: a case that only ever runs against an uninitialized cache cannot tell a correct
+// recompute apart from a stale cached answer.
+function assertOrdinaryUseUnaffected(label) {
+  assert.compareArray(
+    [..."aXbX".matchAll(/X/g)].map(function (match) { return match.index; }),
+    [1, 3],
+    "matchAll on an ordinary global RegExp " + label
+  );
+  assert.sameValue(
+    "aXbX".replaceAll(/X/g, "-"),
+    "a-b-",
+    "replaceAll on an ordinary global RegExp " + label
+  );
+  assert.sameValue(
+    "aXbX".replaceAll("X", "-"),
+    "a-b-",
+    "replaceAll with a string search value " + label
+  );
+  assert.sameValue(/a/gi.flags, "gi", "flags getter " + label);
+  assert.sameValue(/a/.flags, "", "flags getter with no flags " + label);
+
+  assert.throws(
+    TypeError,
+    function () { [..."aXbX".matchAll(/X/)]; },
+    "matchAll rejects an ordinary non-global RegExp " + label
+  );
+  assert.throws(
+    TypeError,
+    function () { "aXbX".replaceAll(/X/, "-"); },
+    "replaceAll rejects an ordinary non-global RegExp " + label
+  );
+}
+
+assertOrdinaryUseUnaffected("(warm-up)");
+
+// A RegExp that is not global is still accepted when the flags string reports that it is.
+withGetter("global", true, function () {
+  assertAccepted(
+    function () { return new RegExp("a", ""); },
+    ["a", "a", "a"],
+    "accepts a non-global RegExp whose replaced `global` getter reports true"
+  );
+});
+
+withGetter("flags", "g", function () {
+  assertAccepted(
+    function () { return new RegExp("a", ""); },
+    ["a", "a", "a"],
+    "accepts a non-global RegExp whose replaced `flags` getter reports \"g\""
+  );
+});
+
+assertAccepted(function () {
+  var regexp = new RegExp("a", "");
+  Object.defineProperty(regexp, "global", { value: true });
+  return regexp;
+}, ["a", "a", "a"], "accepts a non-global RegExp with an own `global` property of true");
+
+assertAccepted(function () {
+  var regexp = new RegExp("a", "");
+  Object.defineProperty(regexp, "flags", { value: "g" });
+  return regexp;
+}, ["a", "a", "a"], "accepts a non-global RegExp with an own `flags` property of \"g\"");
+
+// A global RegExp is rejected when the flags string reports that it is not.
+withGetter("global", false, function () {
+  assertRejected(
+    function () { return new RegExp("a", "g"); },
+    "rejects a global RegExp whose replaced `global` getter reports false"
+  );
+});
+
+withGetter("flags", "", function () {
+  assertRejected(
+    function () { return new RegExp("a", "g"); },
+    "rejects a global RegExp whose replaced `flags` getter reports \"\""
+  );
+});
+
+assertRejected(function () {
+  var regexp = new RegExp("a", "g");
+  Object.defineProperty(regexp, "global", { value: false });
+  return regexp;
+}, "rejects a global RegExp with an own `global` property of false");
+
+assertRejected(function () {
+  var regexp = new RegExp("a", "g");
+  Object.defineProperty(regexp, "flags", { value: "" });
+  return regexp;
+}, "rejects a global RegExp with an own `flags` property of \"\"");
+
+// The argument does not have to be a RegExp at all. IsRegExp is true for any object with a truthy
+// @@match, and the check reads the `flags` property of whatever it is given. Such an object has no
+// @@matchAll or @@replace, so both methods fall back to using its string form as the pattern, which
+// matches neither subject.
+function matchableObject(flags) {
+  var object = {};
+  object[Symbol.match] = true;
+  object.flags = flags;
+  return object;
+}
+
+assertAccepted(
+  function () { return matchableObject("g"); },
+  [],
+  "accepts a non-RegExp object whose `flags` property contains \"g\""
+);
+assertRejected(
+  function () { return matchableObject(""); },
+  "rejects a non-RegExp object whose `flags` property does not contain \"g\""
+);
+
+// The flags value is checked with RequireObjectCoercible before it is converted to a string.
+assertRejected(
+  function () { return matchableObject(undefined); },
+  "rejects a `flags` value of undefined"
+);
+assertRejected(
+  function () { return matchableObject(null); },
+  "rejects a `flags` value of null"
+);
+
+// Repeat the warm/invalidate/restore cycle. A cache that went stale in either direction - kept
+// reporting the builtin getters after they were replaced, or stayed disabled after they were put
+// back - shows up on a later round rather than the first.
+for (var round = 1; round <= 2; round++) {
+  var label = "(round " + round + ")";
+
+  assertOrdinaryUseUnaffected(label);
+
+  withGetter("global", true, function () {
+    assertAccepted(
+      function () { return new RegExp("a", ""); },
+      ["a", "a", "a"],
+      "accepts a non-global RegExp whose replaced `global` getter reports true " + label
+    );
+  });
+
+  withGetter("global", false, function () {
+    assertRejected(
+      function () { return new RegExp("a", "g"); },
+      "rejects a global RegExp whose replaced `global` getter reports false " + label
+    );
+  });
+
+  assertOrdinaryUseUnaffected(label + " after restore");
+}
+
+// It is the identity of each getter that matters, not merely that it is some builtin, so binding a
+// different builtin flag getter under the `global` name must disable the fast path.
+(function () {
+  var stickyGetter = Object.getOwnPropertyDescriptor(RegExp.prototype, "sticky").get;
+  var original = Object.getOwnPropertyDescriptor(RegExp.prototype, "global");
+
+  Object.defineProperty(RegExp.prototype, "global", { get: stickyGetter, configurable: true });
+
+  try {
+    assert.sameValue(
+      new RegExp("a", "y").flags,
+      "gy",
+      "flags getter observes `global` bound to the sticky getter"
+    );
+    assertAccepted(
+      function () { return new RegExp("a", "y"); },
+      ["a", "a", "a"],
+      "accepts a sticky RegExp once `global` is bound to the sticky getter"
+    );
+    assertRejected(
+      function () { return new RegExp("a", "g"); },
+      "rejects a global but non-sticky RegExp once `global` is bound to the sticky getter"
+    );
+  } finally {
+    Object.defineProperty(RegExp.prototype, "global", original);
+  }
+
+  assertOrdinaryUseUnaffected("(after restoring global)");
+})();
+
+// RegExp.prototype[@@matchAll] reads `flags` itself and hands the result to the species
+// constructor, so a replaced getter has to change the flags of the matcher it builds.
+(function () {
+  var seenFlags = null;
+
+  function Species(regexp, flags) {
+    seenFlags = flags;
+    return new RegExp(regexp, flags);
+  }
+
+  function matchAllFlagsFor(regexp) {
+    var original = Object.getOwnPropertyDescriptor(RegExp, Symbol.species);
+    Object.defineProperty(RegExp, Symbol.species, { value: Species, configurable: true });
+    seenFlags = null;
+
+    try {
+      [...regexp[Symbol.matchAll](matchSubject)];
+    } finally {
+      Object.defineProperty(RegExp, Symbol.species, original);
+    }
+
+    return seenFlags;
+  }
+
+  assert.sameValue(
+    matchAllFlagsFor(/a/g),
+    "g",
+    "@@matchAll passes the real flags to the species constructor"
+  );
+  assert.sameValue(
+    withGetter("flags", "gi", function () { return matchAllFlagsFor(/a/g); }),
+    "gi",
+    "@@matchAll passes a replaced `flags` getter to the species constructor"
+  );
+  assert.sameValue(
+    withGetter("multiline", true, function () { return matchAllFlagsFor(/a/g); }),
+    "gm",
+    "@@matchAll observes a replaced individual flag getter"
+  );
+})();
+
+// The fast path is guarded per realm, so tampering in one realm must not change the other.
+(function () {
+  var other = $262.createRealm();
+  var OtherRegExp = other.global.RegExp;
+
+  assert.sameValue(new OtherRegExp("a", "gi").flags, "gi", "foreign RegExp flags before tampering");
+  assertAccepted(
+    function () { return new OtherRegExp("a", "g"); },
+    ["a", "a", "a"],
+    "accepts a foreign global RegExp"
+  );
+
+  other.evalScript(
+    "var savedGlobal = Object.getOwnPropertyDescriptor(RegExp.prototype, 'global');" +
+    "Object.defineProperty(RegExp.prototype, 'global', {" +
+    "  get: function () { return true; }, configurable: true });"
+  );
+
+  assert.sameValue(
+    new OtherRegExp("a", "").flags,
+    "g",
+    "foreign RegExp uses its own realm's replaced `global` getter"
+  );
+  assertAccepted(
+    function () { return new OtherRegExp("a", ""); },
+    ["a", "a", "a"],
+    "accepts a foreign non-global RegExp that its own realm reports as global"
+  );
+  assertOrdinaryUseUnaffected("(while the other realm is tampered with)");
+
+  other.evalScript("Object.defineProperty(RegExp.prototype, 'global', savedGlobal);");
+
+  assert.sameValue(
+    new OtherRegExp("a", "").flags,
+    "",
+    "foreign RegExp flags once the other realm is restored"
+  );
+})();
+
+// A replaced `flags` getter must still be called. Each method reads it once itself and once more
+// from the RegExp method it delegates to, @@matchAll and @@replace respectively.
+function countFlagsReads(callback) {
+  var count = 0;
+  var original = Object.getOwnPropertyDescriptor(RegExp.prototype, "flags");
+
+  Object.defineProperty(RegExp.prototype, "flags", {
+    get: function () {
+      count++;
+      return "g";
+    },
+    configurable: true,
+  });
+
+  try {
+    callback();
+  } finally {
+    Object.defineProperty(RegExp.prototype, "flags", original);
+  }
+
+  return count;
+}
+
+assert.sameValue(
+  countFlagsReads(function () { [...subject.matchAll(new RegExp("a", ""))]; }),
+  2,
+  "String.prototype.matchAll and @@matchAll each read the `flags` getter"
+);
+assert.sameValue(
+  countFlagsReads(function () { subject.replaceAll(new RegExp("a", ""), "-"); }),
+  2,
+  "String.prototype.replaceAll and @@replace each read the `flags` getter"
+);


### PR DESCRIPTION
## Summary

Many RegExp prototype methods call the `flags` getter on a `RegExp` object, which calls additional getters for each individual flag. Let's add a fast path to avoid this where possible. 

The fast path is possible when:
1. The object has the new RegExp common shape. This gaurantees it is a `RegExp` object, it's prototype is `RegExp.prototype`, and there are no own properties on the `RegExp` object that could shadow a getter.
2. All flag getters on `RegExp.prototype` are the original builtins. This is guarded by a validity guard for `RegExp.prototype`.

In this case we can access the raw flags off the compiled RegExp.

We then abstract over either raw flags or the full flags string with a new `GenericFlags` enum. Move flag checks to generic utilities on this new type.

Notes:
- Fixes a spec bug in `String.prototype.{matchAll, replaceAll}` by using the same flags utilities
- Introduce new utilities for checking whether an object is an intrinsic for the current realm, or if an object is a builtin function

Seeing a 7.7% increase to Octane RegExp benchmark from this change.

## Tests

- Added LLM-generated integration tests which exercise new code paths