### PR TITLE
[runtime] Fix mapping bugs in mapped arguments objects

### DIFF
--- a/src/js/parser/parser.rs
+++ b/src/js/parser/parser.rs
@@ -848,6 +848,7 @@ impl<'a> Parser<'a> {
                     is_lexical: !is_var_scoped,
                     is_expression: false,
                     func_node: AstPtr::from_ref(func.as_ref()),
+                    parameter_index: None,
                 };
 
                 id = Some(p!(self, self.parse_binding_identifier(Some(binding_kind))?));
@@ -858,6 +859,7 @@ impl<'a> Parser<'a> {
                     is_lexical: false,
                     is_expression: false,
                     func_node: AstPtr::from_ref(func.as_ref()),
+                    parameter_index: None,
                 };
 
                 let loc = self.mark_loc(start_pos);
@@ -888,6 +890,7 @@ impl<'a> Parser<'a> {
                     is_lexical: false,
                     is_expression: true,
                     func_node: AstPtr::from_ref(func.as_ref()),
+                    parameter_index: None,
                 };
                 self.add_binding(id.as_mut(), binding_kind)?;
             }

--- a/src/js/parser/scope_tree.rs
+++ b/src/js/parser/scope_tree.rs
@@ -257,7 +257,7 @@ impl<'a> ScopeTree<'a> {
     fn add_var_scoped_binding(
         &mut self,
         name: AstStr<'a>,
-        kind: BindingKind<'a>,
+        mut kind: BindingKind<'a>,
     ) -> AddBindingResult<'a> {
         // Walk up to the hoist target scope, checking for conflicting lexical bindings
         let mut node_id = self.current_node_id;
@@ -307,9 +307,18 @@ impl<'a> ScopeTree<'a> {
                     // Function expression names are implicitly added and can always be overwritten
                     || existing_binding
                         .map(|b| b.kind().is_function_expression_name())
-                        .unwrap_or(false);
+                        .unwrap_or(false)
+                    // Function parameters with the same name overwrite earlier parameters
+                    || Self::can_overwrite_function_binding(&existing_binding, &kind);
 
                 if existing_binding.is_none() || can_overwrite {
+                    // A function declaration that overwrites a function parameter shares a single
+                    // binding with that parameter, so it must inherit the parameter's slot.
+                    if let BindingKind::Function { parameter_index, .. } = &mut kind {
+                        *parameter_index =
+                            existing_binding.and_then(|binding| binding.kind().parameter_index());
+                    }
+
                     let vm_location = if in_with_statement {
                         // Var bindings in a with statement require a dynamic lookup at runtime as
                         // they may reference a true var or a property of the with object.
@@ -362,6 +371,28 @@ impl<'a> ScopeTree<'a> {
     pub fn add_binding_to_current_node(&mut self, name: AstStr<'a>, kind: BindingKind<'a>) {
         self.get_ast_node_mut(self.current_node_id)
             .add_binding(name, kind, /* vm_location */ None, /* needs_tdz_check */ false);
+    }
+
+    /// Duplicate parameter names all share a single binding, which refers to the last parameter
+    /// with that name. This means later duplicate parameters must overwrite earlier ones.
+    fn can_overwrite_function_binding(
+        existing_binding: &Option<&Binding>,
+        new_binding_kind: &BindingKind,
+    ) -> bool {
+        let BindingKind::FunctionParameter { index: new_param_index, .. } = new_binding_kind else {
+            return false;
+        };
+
+        let Some(existing_binding) = existing_binding else {
+            return false;
+        };
+
+        let BindingKind::FunctionParameter { index: old_param_index, .. } = existing_binding.kind()
+        else {
+            return false;
+        };
+
+        new_param_index > old_param_index
     }
 
     /// Resolve a use of the given name in the provided AST scope id to the scope where the binding
@@ -646,9 +677,8 @@ impl ScopeTree<'_> {
             }
 
             for (name, binding) in ast_node.bindings.iter_mut() {
-                let arg_index = if let BindingKind::FunctionParameter { index, .. } = binding.kind()
-                {
-                    *index as usize
+                let arg_index = if let Some(index) = binding.kind().parameter_index() {
+                    index as usize
                 } else {
                     continue;
                 };
@@ -673,9 +703,7 @@ impl ScopeTree<'_> {
         // Collect all bindings that must appear in a VM scope node
         for (name, binding) in ast_node.bindings.iter_mut() {
             // Function parameters for mapped arguments object have already been placed in the scope
-            if has_mapped_arguments_object
-                && matches!(binding.kind(), BindingKind::FunctionParameter { .. })
-            {
+            if has_mapped_arguments_object && binding.kind().parameter_index().is_some() {
                 continue;
             }
 
@@ -1041,6 +1069,9 @@ pub enum BindingKind<'a> {
         is_expression: bool,
         /// Function AST node.
         func_node: AstPtr<ast::Function<'a>>,
+        /// If this function declaration overwrote a function parameter with the same name, the
+        /// index of that parameter. Necessary for mapped arguments objects.
+        parameter_index: Option<u32>,
     },
     FunctionParameter {
         /// The source position after which this parameter has been initialized, inclusive.
@@ -1146,6 +1177,16 @@ impl<'a> BindingKind<'a> {
 
     pub fn is_function_parameter(&self) -> bool {
         matches!(self, BindingKind::FunctionParameter { .. })
+    }
+
+    /// If this binding occupies a function parameter's slot, the index of that parameter. Note that
+    /// a function declaration takes over the slot of a parameter with the same name.
+    pub fn parameter_index(&self) -> Option<u32> {
+        match self {
+            BindingKind::FunctionParameter { index, .. } => Some(*index),
+            BindingKind::Function { parameter_index, .. } => *parameter_index,
+            _ => None,
+        }
     }
 
     pub fn is_catch_parameter(&self) -> bool {

--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -114,9 +114,11 @@ impl MappedArgumentsObject {
 
         let mut object = object.to_handle();
 
-        // A parameter is mapped if it has not been shadowed, which we know due to the special
-        // shadowed scope slot name. May allocate.
-        object.mapped_parameters = ValueBitmap::new(cx, num_parameters, |i| {
+        // Only map parameters that:
+        // - Are not shadowed, which we know due to the special shadowed scope slot name
+        // - Actually have an argument passed to them in this call
+        let num_mapped_parameters = num_parameters.min(arguments.len());
+        object.mapped_parameters = ValueBitmap::new(cx, num_mapped_parameters, |i| {
             !scope
                 .scope_names_ptr()
                 .get_slot_name(i)

--- a/tests/integration/language/function/mapped_arguments_bounds_check.js
+++ b/tests/integration/language/function/mapped_arguments_bounds_check.js
@@ -16,20 +16,31 @@ function smallWrite(a, b) {
 }
 assert.sameValue(smallWrite(1, 2), 99);
 
-// Reading and writing past end of a large number of arguments (heap allocated bitmap)
+// Reading and writing past end of a large number of arguments (heap allocated bitmap). At least 33
+// arguments must be supplied so that the bitmap does not fit inline in a smi.
 function largeRead(
   a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,
   a26,a27,a28,a29,a30,a31,a32,a33,a34,
 ) {
   return arguments[100];
 }
-assert.sameValue(largeRead(), undefined);
+assert.sameValue(largeRead(
+  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,
+  26,27,28,29,30,31,32,33,34,
+), undefined);
 
 function largeWrite(
   a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,
   a26,a27,a28,a29,a30,a31,a32,a33,a34,
 ) {
   arguments[100] = 99;
-  return arguments[100];
+  // The out of bounds write must not have clobbered any mapped parameter
+  return [arguments[100], a1, a34];
 }
-assert.sameValue(largeWrite(), 99);
+var largeResult = largeWrite(
+  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,
+  26,27,28,29,30,31,32,33,34,
+);
+assert.sameValue(largeResult[0], 99);
+assert.sameValue(largeResult[1], 1);
+assert.sameValue(largeResult[2], 34);

--- a/tests/integration/language/function/mapped_arguments_duplicates.js
+++ b/tests/integration/language/function/mapped_arguments_duplicates.js
@@ -1,0 +1,50 @@
+/*---
+description: >
+  Duplicate parameter names share a single binding which refers to the last parameter with that
+  name. Only that last index is mapped in a mapped arguments object.
+flags: [noStrict]
+---*/
+
+function duplicates(x, x) {
+  assert.sameValue(x, 2);
+  assert.sameValue(arguments[0], 1);
+  assert.sameValue(arguments[1], 2);
+
+  x = "last";
+  assert.sameValue(arguments[0], 1);
+  assert.sameValue(arguments[1], "last");
+
+  arguments[0] = "zero";
+  assert.sameValue(x, "last");
+
+  arguments[1] = "one";
+  assert.sameValue(x, "one");
+}
+duplicates(1, 2);
+
+function nonAdjacentDuplicates(x, y, x) {
+  assert.sameValue(x, 3);
+  assert.sameValue(y, 2);
+
+  arguments[2] = "third";
+  assert.sameValue(x, "third");
+
+  arguments[0] = "first";
+  assert.sameValue(x, "third");
+}
+nonAdjacentDuplicates(1, 2, 3);
+
+function withoutArgumentsObject(x, x) {
+  return x;
+}
+assert.sameValue(withoutArgumentsObject(1, 2), 2);
+
+function underappliedDuplicates(x, x) {
+  assert.sameValue(x, undefined);
+  assert.sameValue(arguments[0], 1);
+  assert.sameValue(arguments.length, 1);
+
+  x = "assigned";
+  assert.sameValue(arguments[0], 1);
+}
+underappliedDuplicates(1);

--- a/tests/integration/language/function/mapped_arguments_function_declaration.js
+++ b/tests/integration/language/function/mapped_arguments_function_declaration.js
@@ -1,0 +1,82 @@
+/*---
+description: >
+  A function declaration that shares a name with a function parameter shares a single binding with
+  that parameter, so the mapping in a mapped arguments object must be preserved.
+flags: [noStrict]
+---*/
+
+// The function declaration is hoisted and initialized before the body runs, so the mapped index
+// holds the function itself instead of the supplied argument.
+function initialValue(a) {
+  function a() {}
+  assert.sameValue(typeof a, "function");
+  assert.sameValue(arguments[0], a);
+}
+initialValue(1);
+
+// Writes through the binding name are visible through the arguments object
+function writeName(a) {
+  function a() {}
+  a = 7;
+  assert.sameValue(arguments[0], 7);
+}
+writeName(1);
+
+// Writes through the arguments object are visible through the binding name
+function writeArguments(a) {
+  function a() {}
+  arguments[0] = 9;
+  assert.sameValue(a, 9);
+}
+writeArguments(1);
+
+// Only the shadowed parameter is affected, other parameters remain mapped
+function middleParameter(a, b, c) {
+  function b() {}
+  b = "B";
+  assert.sameValue(arguments[1], "B");
+
+  arguments[0] = "A";
+  assert.sameValue(a, "A");
+  arguments[2] = "C";
+  assert.sameValue(c, "C");
+}
+middleParameter(1, 2, 3);
+
+// Duplicate parameters share a binding referring to the last parameter, so only that index is
+// mapped once a function declaration overwrites the binding.
+function duplicateParameters(a, a) {
+  function a() {}
+  a = 7;
+  assert.sameValue(arguments[0], 1);
+  assert.sameValue(arguments[1], 7);
+}
+duplicateParameters(1, 2);
+
+// Multiple function declarations with the same name still keep the mapping
+function multipleDeclarations(a) {
+  function a() {}
+  function a() {}
+  a = 7;
+  assert.sameValue(arguments[0], 7);
+}
+multipleDeclarations(1);
+
+// An Annex B block level function declaration also shares the parameter's binding
+function blockLevelDeclaration(a) {
+  {
+    function a() {}
+  }
+  a = 7;
+  assert.sameValue(arguments[0], 7);
+}
+blockLevelDeclaration(1);
+
+// Parameters that were not supplied an argument are never mapped
+function underapplied(a) {
+  function a() {}
+  a = 7;
+  assert.sameValue(arguments.length, 0);
+  assert.sameValue(arguments[0], undefined);
+}
+underapplied();

--- a/tests/integration/language/function/mapped_arguments_underapplication.js
+++ b/tests/integration/language/function/mapped_arguments_underapplication.js
@@ -1,0 +1,45 @@
+/*---
+description: >
+  A mapped arguments object only maps parameters that were supplied an argument. Indices past the
+  number of supplied arguments are not properties of the arguments object.
+flags: [noStrict]
+---*/
+
+function underapplied(a, b) {
+  b = 5;
+  assert.sameValue(arguments.length, 1);
+  assert.sameValue(1 in arguments, false);
+  assert.sameValue(arguments[1], undefined);
+
+  arguments[1] = 9;
+  assert.sameValue(b, 5);
+  assert.sameValue(arguments[1], 9);
+}
+underapplied(7);
+
+function noArgumentsSupplied(a) {
+  a = 100;
+  assert.sameValue(arguments.length, 0);
+  assert.sameValue(arguments[0], undefined);
+  assert.sameValue(Object.keys(arguments).length, 0);
+}
+noArgumentsSupplied();
+
+function suppliedAreStillMapped(a, b) {
+  a = "A";
+  assert.sameValue(arguments[0], "A");
+
+  arguments[1] = "B";
+  assert.sameValue(b, "B");
+}
+suppliedAreStillMapped(1, 2);
+
+function extraArgumentsAreNotMapped(a) {
+  a = "A";
+  assert.sameValue(arguments[0], "A");
+
+  arguments[1] = "B";
+  assert.sameValue(arguments[1], "B");
+  assert.sameValue(arguments.length, 2);
+}
+extraArgumentsAreNotMapped(1, 2);


### PR DESCRIPTION
## Summary

Fix three bugs in mapped argument mappings:
- If parameters have the same name only the last parameter is mapped. Enforce this by allowing function parameters with the same name to overwrite earlier parameters when building the scope tree.
- Note that function declarations can overwrite parameters with the same name, but should appear in the mapping. Track an optional function parameter index on `BindingKind::Function` to account for this.
- Only arguments that are actually provided are mapped, account for underapplication

## Tests

- Added integration tests for all fixed bugs