### PR TITLE
[runtime] Fix TypedArray.prototype.{filter, with} crashes when buffer is detached or shrunk

### DIFF
--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -434,7 +434,7 @@ impl TypedArrayPrototype {
 
         for (i, value) in kept_values.into_iter().enumerate() {
             index_key.replace(PropertyKey::from_u64(cx, i as u64)?);
-            must!(set(cx, array, index_key, value, true));
+            set(cx, array, index_key, value, true)?;
         }
 
         Ok(array.as_value())
@@ -1586,10 +1586,10 @@ impl TypedArrayPrototype {
             let value = if i == actual_index {
                 new_value
             } else {
-                must!(get(cx, object, key))
+                get(cx, object, key)?
             };
 
-            must!(set(cx, array, key, value, true));
+            set(cx, array, key, value, true)?;
         }
 
         Ok(array.as_value())

--- a/tests/integration/built-ins/TypedArray/filter_source_detached.js
+++ b/tests/integration/built-ins/TypedArray/filter_source_detached.js
@@ -1,0 +1,38 @@
+/*---
+description: >
+  TypedArray.prototype.filter handles the source ArrayBuffer being detached by the callback.
+---*/
+
+// Detaching the buffer from the callback leaves the collection loop reading past
+// the array's end. Those reads produce `undefined`, and writing `undefined` into
+// a BigInt array throws a TypeError rather than aborting.
+const buffer = new ArrayBuffer(8 * 4);
+const ta = new BigInt64Array(buffer);
+
+assert.throws(TypeError, () =>
+  ta.filter((_, i) => {
+    if (i === 0) {
+      buffer.transfer();
+    }
+
+    return true;
+  })
+);
+
+// A number-typed array coerces the out-of-bounds reads to NaN instead, so the
+// same shape completes without throwing.
+const buffer2 = new ArrayBuffer(8 * 4);
+const ta2 = new Float64Array(buffer2);
+ta2[0] = 1;
+
+const result = ta2.filter((_, i) => {
+  if (i === 0) {
+    buffer2.transfer();
+  }
+
+  return true;
+});
+
+assert.sameValue(result.length, 4);
+assert.sameValue(result[0], 1);
+assert.sameValue(result[1], NaN);

--- a/tests/integration/built-ins/TypedArray/with_source_shrunk.js
+++ b/tests/integration/built-ins/TypedArray/with_source_shrunk.js
@@ -1,0 +1,35 @@
+/*---
+description: >
+  TypedArray.prototype.with handles the source ArrayBuffer being resized while coercing the value.
+---*/
+
+// Resizing the buffer smaller during coercion leaves the copy loop reading past
+// the array's new length. Those reads produce `undefined`, and writing
+// `undefined` into a BigInt array throws a TypeError rather than aborting.
+const rab = new ArrayBuffer(8 * 4, { maxByteLength: 8 * 4 });
+const ta = new BigInt64Array(rab);
+
+const value = {
+  valueOf() {
+    rab.resize(8);
+    return 0n;
+  },
+};
+
+assert.throws(TypeError, () => ta.with(0, value));
+
+// A number-typed array coerces the out-of-bounds reads to NaN instead, so the
+// same shape completes without throwing.
+const rab2 = new ArrayBuffer(8 * 4, { maxByteLength: 8 * 4 });
+const ta2 = new Float64Array(rab2);
+const value2 = {
+  valueOf() {
+    rab2.resize(8);
+    return 1;
+  },
+};
+
+const result = ta2.with(0, value2);
+assert.sameValue(result.length, 4);
+assert.sameValue(result[0], 1);
+assert.sameValue(result[1], NaN);


### PR DESCRIPTION
## Summary

As per title, we must remove the some `must` calls that were being hit in valid programs:
- `TypedArray.prototype.with` if the source `ArrayBuffer` shrunk when coercing a value
- `TypedArray.prototype.filter` if the source `ArrayBuffer` was detached during the callback

## Tests

- Added regression tests for these cases