### PR TITLE
[regexp] Fast path for accessing `lastIndex` on RegExp objects with the common shape

### DIFF
--- a/src/js/runtime/common_shapes.rs
+++ b/src/js/runtime/common_shapes.rs
@@ -75,11 +75,6 @@ impl CommonShapes {
         Ok(())
     }
 
-    #[inline]
-    pub fn is_common_shape(&self, shape: HeapPtr<Shape>, common_shape: CommonShape) -> bool {
-        self.shapes[common_shape as usize].is_some_and(|s| s.ptr_eq(&shape))
-    }
-
     /// Return a common shape, building and caching it on first request.
     pub fn get(
         cx: Context,
@@ -276,5 +271,12 @@ impl CommonShapes {
         for shape in self.shapes.iter_mut() {
             visitor.visit_pointer_opt(shape);
         }
+    }
+}
+
+impl Realm {
+    #[inline]
+    pub fn is_common_shape(&self, shape: HeapPtr<Shape>, common_shape: CommonShape) -> bool {
+        self.common_shapes.shapes[common_shape as usize].is_some_and(|s| s.ptr_eq(&shape))
     }
 }

--- a/src/js/runtime/intrinsics/regexp_constructor.rs
+++ b/src/js/runtime/intrinsics/regexp_constructor.rs
@@ -22,7 +22,6 @@ use crate::{
     },
     runtime::{
         Context, Value,
-        abstract_operations::set,
         alloc_error::AllocResult,
         error::{syntax_parse_error, type_error},
         eval_result::EvalResult,
@@ -282,8 +281,7 @@ pub fn regexp_init(
     }
 
     // Initialize last index property
-    let zero_value = cx.zero();
-    set(cx, regexp_object.into(), cx.names.last_index(), zero_value, true)?;
+    RegExpObject::maybe_fast_set_last_index(cx, regexp_object.into(), cx.zero())?;
 
     Ok(regexp_object.as_value())
 }

--- a/src/js/runtime/intrinsics/regexp_object.rs
+++ b/src/js/runtime/intrinsics/regexp_object.rs
@@ -3,16 +3,18 @@ use crate::{
     parser::regexp::RegExpFlags,
     runtime::{
         Context, HeapPtr, PropertyDescriptor, PropertyFlags, Value,
-        abstract_operations::define_property_or_throw,
+        abstract_operations::{define_property_or_throw, set},
         alloc_error::AllocResult,
         common_shapes::CommonShape,
         eval_result::EvalResult,
         gc::{Handle, HeapItem, HeapVisitor},
+        get,
         intrinsics::intrinsics::Intrinsic,
         object_value::ObjectValue,
         ordinary_object::{ObjectBuilder, get_prototype_from_constructor},
         regexp::compiled_regexp::CompiledRegExp,
         string_value::StringValue,
+        type_utilities::{in_length_range, to_length},
     },
     set_uninit,
 };
@@ -107,6 +109,89 @@ impl RegExpObject {
     #[inline]
     pub fn escaped_pattern_source(&self) -> Handle<StringValue> {
         self.compiled_regexp.escaped_pattern_source()
+    }
+
+    /// Byte offset of the `lastIndex` property for a RegExpObject with the common shape.
+    #[inline]
+    fn fast_last_index_byte_offset(&self) -> usize {
+        self.shape_ptr().inline_properties_offset() as usize
+    }
+
+    #[inline]
+    fn fast_last_index(&self) -> Value {
+        self.get_inline_property_unchecked(self.fast_last_index_byte_offset())
+    }
+
+    #[inline]
+    fn fast_set_last_index(&mut self, last_index: Value) {
+        self.set_inline_property_unchecked(self.fast_last_index_byte_offset(), last_index);
+    }
+
+    /// If a RegExpObject has the common shape we statically know the location of its `lastIndex`
+    /// property and can access it directly.
+    #[inline]
+    fn as_fast_last_index_regexp(
+        cx: Context,
+        object: Handle<ObjectValue>,
+    ) -> Option<Handle<RegExpObject>> {
+        let realm = cx.current_realm_ptr();
+        if realm.is_common_shape(object.shape_ptr(), CommonShape::RegExp) {
+            Some(object.cast::<RegExpObject>())
+        } else {
+            None
+        }
+    }
+
+    /// Get the `lastIndex` property, taking the fast path for RegExpObjects with the common shape.
+    pub fn maybe_fast_last_index(
+        cx: Context,
+        object: Handle<ObjectValue>,
+    ) -> EvalResult<Handle<Value>> {
+        if let Some(regexp_object) = Self::as_fast_last_index_regexp(cx, object) {
+            return Ok(regexp_object.fast_last_index().to_handle(cx));
+        }
+
+        get(cx, object, cx.names.last_index())
+    }
+
+    /// Get the `lastIndex` property with ToLength applied, taking the fast path for RegExpObjects
+    /// with the common shape.
+    pub fn maybe_fast_last_index_as_length(
+        cx: Context,
+        object: Handle<ObjectValue>,
+    ) -> EvalResult<u64> {
+        if let Some(regexp_object) = Self::as_fast_last_index_regexp(cx, object) {
+            let last_index = regexp_object.fast_last_index();
+
+            // Directly return length without conversion if value is a number in the length range
+            if last_index.is_number() {
+                let number = last_index.as_number();
+                if in_length_range(number) {
+                    return Ok(number as u64);
+                }
+            }
+
+            return to_length(cx, last_index.to_handle(cx));
+        }
+
+        let last_index = get(cx, object, cx.names.last_index())?;
+
+        to_length(cx, last_index)
+    }
+
+    /// Set the `lastIndex` property, throwing if it could not be set. Takes the fast path for
+    /// RegExpObjects with the common shape.
+    pub fn maybe_fast_set_last_index(
+        cx: Context,
+        object: Handle<ObjectValue>,
+        value: Handle<Value>,
+    ) -> EvalResult<()> {
+        if let Some(mut regexp_object) = Self::as_fast_last_index_regexp(cx, object) {
+            regexp_object.fast_set_last_index(*value);
+            return Ok(());
+        }
+
+        set(cx, object, cx.names.last_index(), value, true)
     }
 }
 

--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -9,7 +9,7 @@ use crate::{
     runtime::{
         Context, Handle, PropertyKey, Value,
         abstract_operations::{
-            call, call_object, construct, create_data_property_or_throw, length_of_array_like, set,
+            call, call_object, construct, create_data_property_or_throw, length_of_array_like,
             species_constructor,
         },
         alloc_error::AllocResult,
@@ -41,7 +41,7 @@ use crate::{
         to_string,
         type_utilities::{
             is_callable, require_object_coercible, same_value, to_boolean, to_integer_or_infinity,
-            to_length, to_object, to_uint32,
+            to_object, to_uint32,
         },
     },
     runtime_fn,
@@ -222,8 +222,7 @@ impl RegExpPrototype {
                 .to_value(cx, string_value);
         }
 
-        let zero_value = cx.zero();
-        set(cx, regexp_object, cx.names.last_index(), zero_value, true)?;
+        RegExpObject::maybe_fast_set_last_index(cx, regexp_object, cx.zero())?;
 
         let result_array = array_create(cx, 0, None)?;
         let mut n = 0;
@@ -264,12 +263,11 @@ impl RegExpPrototype {
             ));
 
             if match_string.is_empty() {
-                let last_index = get(cx, regexp_object, cx.names.last_index())?;
-                let last_index = to_length(cx, last_index)?;
+                let last_index = RegExpObject::maybe_fast_last_index_as_length(cx, regexp_object)?;
 
                 let next_index = advance_u64_string_index(string_value, last_index, is_unicode)?;
                 let next_index_value = cx.number(next_index);
-                set(cx, regexp_object, cx.names.last_index(), next_index_value, true)?;
+                RegExpObject::maybe_fast_set_last_index(cx, regexp_object, next_index_value)?;
             }
 
             n += 1;
@@ -292,11 +290,10 @@ impl RegExpPrototype {
         let matcher =
             construct(cx, constructor, &[regexp_object.into(), flags_string.into()], None)?;
 
-        let last_index = get(cx, regexp_object, cx.names.last_index())?;
-        let last_index = to_length(cx, last_index)?;
+        let last_index = RegExpObject::maybe_fast_last_index_as_length(cx, regexp_object)?;
         let last_index_value = cx.number(last_index);
 
-        set(cx, matcher, cx.names.last_index(), last_index_value, true)?;
+        RegExpObject::maybe_fast_set_last_index(cx, matcher, last_index_value)?;
 
         let is_global = flags.is_global()?;
         let is_unicode = flags.has_any_unicode_flag()?;
@@ -334,8 +331,7 @@ impl RegExpPrototype {
         let is_global = flags.is_global()?;
 
         if is_global {
-            let zero_value = cx.zero();
-            set(cx, regexp_object, cx.names.last_index(), zero_value, true)?;
+            RegExpObject::maybe_fast_set_last_index(cx, regexp_object, cx.zero())?;
         }
 
         // Key is shared between iterations
@@ -386,12 +382,11 @@ impl RegExpPrototype {
 
             // If matched string is empty then increment last index
             if is_empty_match {
-                let this_index = get(cx, regexp_object, cx.names.last_index())?;
-                let this_index = to_length(cx, this_index)?;
+                let this_index = RegExpObject::maybe_fast_last_index_as_length(cx, regexp_object)?;
 
                 let next_index = advance_u64_string_index(target_string, this_index, is_unicode)?;
                 let next_index_value = cx.number(next_index);
-                set(cx, regexp_object, cx.names.last_index(), next_index_value, true)?;
+                RegExpObject::maybe_fast_set_last_index(cx, regexp_object, next_index_value)?;
             }
         }
 
@@ -454,10 +449,10 @@ impl RegExpPrototype {
         let string_value = to_string(cx, string_arg)?;
 
         // Save original last index, resetting to zero for search
-        let previous_last_index = get(cx, regexp_object, cx.names.last_index())?;
+        let previous_last_index = RegExpObject::maybe_fast_last_index(cx, regexp_object)?;
         if !previous_last_index.is_positive_zero() {
             let zero_value = cx.zero();
-            set(cx, regexp_object, cx.names.last_index(), zero_value, true)?;
+            RegExpObject::maybe_fast_set_last_index(cx, regexp_object, zero_value)?;
         }
 
         // Perform RegExp search
@@ -465,9 +460,9 @@ impl RegExpPrototype {
             regexp_exec(cx, regexp_object, string_value, "RegExp.prototype[@@search]")?;
 
         // Restore original last index
-        let current_last_index = get(cx, regexp_object, cx.names.last_index())?;
+        let current_last_index = RegExpObject::maybe_fast_last_index(cx, regexp_object)?;
         if !same_value(current_last_index, previous_last_index)? {
-            set(cx, regexp_object, cx.names.last_index(), previous_last_index, true)?;
+            RegExpObject::maybe_fast_set_last_index(cx, regexp_object, previous_last_index)?;
         }
 
         // Return index of the match, or -1 if no match was found
@@ -551,7 +546,7 @@ impl RegExpPrototype {
         // searched.
         while q < size {
             let q_value = cx.number(q);
-            set(cx, splitter, cx.names.last_index(), q_value, true)?;
+            RegExpObject::maybe_fast_set_last_index(cx, splitter, q_value)?;
 
             enum MatchKind {
                 Raw(Match),
@@ -571,8 +566,7 @@ impl RegExpPrototype {
             };
 
             // Otherwise there was a match so determine end of match
-            let e = get(cx, splitter, cx.names.last_index())?;
-            let e = to_length(cx, e)?;
+            let e = RegExpObject::maybe_fast_last_index_as_length(cx, splitter)?;
             let e = u64::min(e, size as u64) as u32;
 
             // If there was a match but it is empty then advance to next index
@@ -1148,8 +1142,7 @@ fn regexp_builtin_exec(
     let compiled_regexp = regexp_object.compiled_regexp();
     let string_length = string_value.len();
 
-    let last_index = get(cx, regexp_object.into(), cx.names.last_index())?;
-    let mut last_index = to_length(cx, last_index)?;
+    let mut last_index = RegExpObject::maybe_fast_last_index_as_length(cx, regexp_object.into())?;
 
     let flags = regexp_object.flags();
     let is_global = flags.is_global();
@@ -1163,8 +1156,7 @@ fn regexp_builtin_exec(
     // last index under certain flags.
     if last_index > string_length as u64 {
         if is_global || is_sticky {
-            let zero_value = cx.zero();
-            set(cx, regexp_object.into(), cx.names.last_index(), zero_value, true)?;
+            RegExpObject::maybe_fast_set_last_index(cx, regexp_object.into(), cx.zero())?;
         }
 
         return Ok(ExecResult::NoMatch);
@@ -1184,8 +1176,7 @@ fn regexp_builtin_exec(
     // Handle match failure, resetting last index under sticky flag
     let Some(match_) = match_ else {
         if is_global || is_sticky {
-            let zero_value = cx.zero();
-            set(cx, regexp_object.into(), cx.names.last_index(), zero_value, true)?;
+            RegExpObject::maybe_fast_set_last_index(cx, regexp_object.into(), cx.zero())?;
         }
 
         return Ok(ExecResult::NoMatch);
@@ -1194,7 +1185,7 @@ fn regexp_builtin_exec(
     // Update last index to point past end of capture
     if is_global || is_sticky {
         let last_index_value = cx.number(match_.full_capture().end);
-        set(cx, regexp_object.into(), cx.names.last_index(), last_index_value, true)?;
+        RegExpObject::maybe_fast_set_last_index(cx, regexp_object.into(), last_index_value)?;
     }
 
     Ok(ExecResult::Match(regexp_object, match_))

--- a/src/js/runtime/intrinsics/regexp_string_iterator_object.rs
+++ b/src/js/runtime/intrinsics/regexp_string_iterator_object.rs
@@ -2,7 +2,6 @@ use crate::{
     cast_from_value_fn, extend_object, intrinsic_methods,
     runtime::{
         Context, Handle, HeapPtr, PropertyKey, Value,
-        abstract_operations::set,
         alloc_error::AllocResult,
         error::type_error,
         eval_result::EvalResult,
@@ -11,6 +10,7 @@ use crate::{
         intrinsic_builder::IntrinsicBuilder,
         intrinsics::{
             intrinsics::Intrinsic,
+            regexp_object::RegExpObject,
             regexp_prototype::{advance_u64_string_index, regexp_exec},
         },
         iterator::create_iter_result_object,
@@ -19,7 +19,6 @@ use crate::{
         realm::Realm,
         string_value::StringValue,
         to_string,
-        type_utilities::to_length,
     },
     runtime_fn, set_uninit,
 };
@@ -124,13 +123,12 @@ impl RegExpStringIteratorPrototype {
 
         // Increment the lastIndex if the empty string was matched to avoid infinite loops
         if match_string.is_empty() {
-            let last_index = get(cx, regexp_object, cx.names.last_index())?;
-            let last_index = to_length(cx, last_index)?;
+            let last_index = RegExpObject::maybe_fast_last_index_as_length(cx, regexp_object)?;
 
             let next_index =
                 advance_u64_string_index(target_string, last_index, regexp_iterator.is_unicode)?;
             let next_index_value = cx.number(next_index);
-            set(cx, regexp_object, cx.names.last_index(), next_index_value, true)?;
+            RegExpObject::maybe_fast_set_last_index(cx, regexp_object, next_index_value)?;
         }
 
         Ok(create_iter_result_object(cx, match_result, false)?)

--- a/src/js/runtime/regexp/fast_flags_guard.rs
+++ b/src/js/runtime/regexp/fast_flags_guard.rs
@@ -54,10 +54,7 @@ impl FastRegExpFlagsGuard {
         // - Has RegExp.prototype as its prototype
         // - Does not have any own properties that could shadow the flag getters on
         //   RegExp.prototype, since the common shape's only own property is `lastIndex`.
-        if !realm
-            .common_shapes
-            .is_common_shape(object.shape_ptr(), CommonShape::RegExp)
-        {
+        if !realm.is_common_shape(object.shape_ptr(), CommonShape::RegExp) {
             return Ok(None);
         }
 

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -478,6 +478,10 @@ pub fn to_length(cx: Context, value: Handle<Value>) -> EvalResult<u64> {
     Ok(len_u64)
 }
 
+pub fn in_length_range(value: f64) -> bool {
+    (0.0..=MAX_SAFE_INTEGER_F64).contains(&value)
+}
+
 /// Identical to CanonicalNumericIndexString, but for u32 string indices
 pub fn canonical_numeric_string_index_string(
     cx: Context,

--- a/tests/integration/built-ins/RegExp/last_index_fast_path.js
+++ b/tests/integration/built-ins/RegExp/last_index_fast_path.js
@@ -1,0 +1,265 @@
+/*---
+description: RegExp methods read and write `lastIndex` directly where possible.
+includes: [compareArray.js]
+---*/
+
+// Every operation that reads or writes `lastIndex`, reporting the value left behind. The RegExp is
+// created by the caller so that receivers in different states can be compared.
+function runAll(makeRegExp, string) {
+  var forExec = makeRegExp();
+  var forTest = makeRegExp();
+  var forSearch = makeRegExp();
+  forSearch.lastIndex = 2;
+
+  return {
+    exec: JSON.stringify(forExec.exec(string)),
+    execLastIndex: forExec.lastIndex,
+    test: forTest.test(string),
+    testLastIndex: forTest.lastIndex,
+    search: string.search(forSearch),
+    searchLastIndex: forSearch.lastIndex,
+    match: JSON.stringify(string.match(makeRegExp())),
+    matchAll: makeRegExp().global ? JSON.stringify([...string.matchAll(makeRegExp())]) : "",
+    replace: string.replace(makeRegExp(), "<$&>"),
+    split: string.split(makeRegExp()),
+  };
+}
+
+function assertSameResults(makeSlow, source, flags, string, receiverName) {
+  var message =
+    "/" + source + "/" + flags +
+    " on " + JSON.stringify(string) +
+    " (" + receiverName + ")";
+
+  var fast = runAll(function () { return new RegExp(source, flags); }, string);
+  var slow = runAll(function () { return makeSlow(source, flags); }, string);
+
+  assert.sameValue(fast.exec, slow.exec, message + " exec");
+  assert.sameValue(fast.execLastIndex, slow.execLastIndex, message + " exec last index");
+  assert.sameValue(fast.test, slow.test, message + " test");
+  assert.sameValue(fast.testLastIndex, slow.testLastIndex, message + " test last index");
+  assert.sameValue(fast.search, slow.search, message + " search");
+  assert.sameValue(fast.searchLastIndex, slow.searchLastIndex, message + " search last index");
+  assert.sameValue(fast.match, slow.match, message + " match");
+  assert.sameValue(fast.matchAll, slow.matchAll, message + " matchAll");
+  assert.sameValue(fast.replace, slow.replace, message + " replace");
+  assert.compareArray(fast.split, slow.split, message + " split");
+}
+
+// A RegExp with enough own properties to leave the shape's array mode, so `lastIndex` no longer has
+// a fixed location and every access goes through the ordinary path.
+function inMapMode(source, flags) {
+  var regexp = new RegExp(source, flags);
+  for (var i = 0; i < 64; i++) {
+    regexp["property" + i] = i;
+  }
+
+  // Deleting a property also forces map mode
+  delete regexp.property0;
+
+  return regexp;
+}
+
+// A RegExp that is somebody's prototype. Becoming a prototype is not by itself enough: the shape is
+// cloned into a per-object prototype shape only when an inline cache first caches a lookup through
+// it, so the inherited read below is what actually moves `regexp` off the common shape.
+function asPrototype(source, flags) {
+  var regexp = new RegExp(source, flags);
+  var child = Object.create(regexp);
+  void child.lastIndex;
+
+  return regexp;
+}
+
+var sources = ["a", "(a)b", "\u{1F600}"];
+var flagCombinations = ["", "g", "y", "gy", "gu", "dgimsy"];
+var strings = ["", "abc", "aXbXc", "\u{1F600}a\u{1F600}"];
+
+for (var i = 0; i < sources.length; i++) {
+  for (var j = 0; j < flagCombinations.length; j++) {
+    for (var k = 0; k < strings.length; k++) {
+      assertSameResults(inMapMode, sources[i], flagCombinations[j], strings[k], "map mode");
+      assertSameResults(asPrototype, sources[i], flagCombinations[j], strings[k], "prototype");
+    }
+  }
+}
+
+// A last index that is not a small integer must still be converted by ToLength.
+var coercionTarget = "abcd";
+var coercions = [
+  ["1", 1],
+  [1.9, 1],
+  [-1, 0],
+  [-0.5, 0],
+  [NaN, 0],
+  [-Infinity, 0],
+  [null, 0],
+  [undefined, 0],
+  [false, 0],
+  [true, 1],
+  [{ valueOf: function () { return 1; } }, 1],
+  [[2], 2],
+  ["3", 3],
+  // Values at and beyond the ToLength maximum, which straddle the fast path's range check
+  [Math.pow(2, 53) - 1, null],
+  [Math.pow(2, 53), null],
+  [Math.pow(2, 53) + 2, null],
+  [Infinity, null],
+  [1e21, null],
+  ["1e21", null],
+];
+
+for (var i = 0; i < coercions.length; i++) {
+  var sticky = new RegExp(".", "y");
+  sticky.lastIndex = coercions[i][0];
+
+  var expectedIndex = coercions[i][1];
+  var match = sticky.exec(coercionTarget);
+  var message = " for a last index of " + String(coercions[i][0]);
+
+  if (expectedIndex === null) {
+    assert.sameValue(match, null, "no sticky match" + message);
+    assert.sameValue(sticky.lastIndex, 0, "resulting last index" + message);
+  } else {
+    assert.notSameValue(match, null, "sticky match" + message);
+    assert.sameValue(match.index, expectedIndex, "match index" + message);
+    assert.sameValue(sticky.lastIndex, expectedIndex + 1, "resulting last index" + message);
+  }
+}
+
+// A last index past the end of the string always fails and is reset.
+var pastEnd = new RegExp("a", "g");
+pastEnd.lastIndex = 100;
+assert.sameValue(pastEnd.exec("abc"), null, "exec with a last index past the end");
+assert.sameValue(pastEnd.lastIndex, 0, "last index reset after failing past the end");
+
+// @@search restores the exact value it found, not a coerced one, and does so without writing when
+// the value is already zero.
+var searchValues = ["abc", 1.5, -3, NaN, null];
+for (var i = 0; i < searchValues.length; i++) {
+  var searched = new RegExp("b", "g");
+  searched.lastIndex = searchValues[i];
+
+  assert.sameValue("abc".search(searched), 1, "search result for " + String(searchValues[i]));
+  assert.sameValue(
+    searched.lastIndex,
+    searchValues[i],
+    "search restores the exact last index " + String(searchValues[i])
+  );
+}
+
+// A non-writable last index makes every write fail, which is a TypeError for a global RegExp.
+var nonWritable = new RegExp("a", "g");
+Object.defineProperty(nonWritable, "lastIndex", { writable: false });
+assert.sameValue(nonWritable.lastIndex, 0, "non-writable last index keeps its value");
+assert.throws(TypeError, function () {
+  nonWritable.exec("aa");
+}, "exec on a global RegExp with a non-writable last index");
+assert.throws(TypeError, function () {
+  "aa".replace(nonWritable, "-");
+}, "@@replace with a non-writable last index");
+
+// A non-global, non-sticky RegExp never writes its last index, so it does not throw.
+var nonWritableLocal = new RegExp("a", "");
+Object.defineProperty(nonWritableLocal, "lastIndex", { writable: false });
+assert.compareArray(nonWritableLocal.exec("aa"), ["a"], "exec that never writes the last index");
+assert.sameValue(nonWritableLocal.lastIndex, 0, "last index of a non-global RegExp is untouched");
+
+// A RegExp used as a prototype has its last index read through the prototype chain, so a write must
+// be visible to everything that inherits it. The repeated reads give any inline cache a chance to
+// settle on the value it saw first.
+var protoRegExp = new RegExp("a", "g");
+var child = Object.create(protoRegExp);
+for (var i = 0; i < 20; i++) {
+  assert.sameValue(child.lastIndex, 0, "inherited last index before matching");
+}
+
+protoRegExp.exec("aa");
+assert.sameValue(protoRegExp.lastIndex, 1, "last index after matching");
+
+for (var i = 0; i < 20; i++) {
+  assert.sameValue(child.lastIndex, 1, "inherited last index after matching");
+}
+
+// The matchAll iterator advances the last index itself when it matches the empty string.
+var emptyMatches = [..."ab".matchAll(new RegExp("", "g"))];
+assert.sameValue(emptyMatches.length, 3, "matchAll over an empty pattern terminates");
+assert.compareArray(
+  emptyMatches.map(function (match) { return match.index; }),
+  [0, 1, 2],
+  "matchAll empty match indices"
+);
+
+var unicodeMatches = [..."\u{1F600}a".matchAll(new RegExp("", "gu"))];
+assert.compareArray(
+  unicodeMatches.map(function (match) { return match.index; }),
+  [0, 2, 3],
+  "matchAll advances by whole code points when unicode"
+);
+
+// Constructing a RegExp resets the last index, including when reusing an existing RegExp.
+var reset = new RegExp("a", "g");
+reset.lastIndex = 5;
+assert.sameValue(new RegExp(reset).lastIndex, 0, "a copied RegExp starts at zero");
+assert.sameValue(new RegExp(reset, "y").lastIndex, 0, "a copied RegExp with flags starts at zero");
+
+// A subclass instance still has its own last index in the usual place.
+class Subclass extends RegExp {}
+var subclass = new Subclass("a", "g");
+assert.compareArray(subclass.exec("xa"), ["a"], "subclass exec");
+assert.sameValue(subclass.lastIndex, 2, "subclass last index");
+assert.sameValue("aa".replace(subclass, "-"), "--", "subclass replace");
+
+// A plain object standing in for a RegExp goes through the ordinary property path throughout.
+var plain = {
+  flags: "g",
+  global: true,
+  lastIndex: 0,
+  exec: function (string) {
+    if (this.lastIndex >= string.length) {
+      this.lastIndex = 0;
+      return null;
+    }
+
+    var index = this.lastIndex;
+    this.lastIndex = index + 1;
+
+    return { 0: string[index], index: index, length: 1 };
+  },
+};
+
+assert.sameValue(
+  RegExp.prototype[Symbol.replace].call(plain, "abc", "-"),
+  "---",
+  "@@replace on a plain object with its own last index"
+);
+assert.sameValue(plain.lastIndex, 0, "plain object last index after @@replace");
+
+// A proxy has no own last index of its own, so every access must go through its traps.
+var trapped = [];
+var proxied = new Proxy(plain, {
+  get: function (target, key, receiver) {
+    trapped.push("get " + String(key));
+    return Reflect.get(target, key, receiver);
+  },
+  set: function (target, key, value, receiver) {
+    trapped.push("set " + String(key));
+    return Reflect.set(target, key, value, receiver);
+  },
+});
+
+assert.sameValue(
+  RegExp.prototype[Symbol.replace].call(proxied, "abc", "-"),
+  "---",
+  "@@replace on a proxied RegExp stand-in"
+);
+assert.sameValue(
+  trapped.indexOf("set lastIndex") !== -1,
+  true,
+  "the proxy set trap is called for the last index"
+);
+assert.sameValue(
+  trapped.indexOf("get lastIndex") !== -1,
+  true,
+  "the proxy get trap is called for the last index"
+);


### PR DESCRIPTION
## Summary

The `lastIndex` property is frequently accessed across RegExp operations but currently always requires a full property lookup. Let's add a fast path for the common case - the object is a `RegExpObject` with the common shape. In this case we can access the inline `lastIndex` property directly with just a shape check.

- Also provide a fast-with-length-conversion utility which is used frequently
- Move `is_common_shape` method to `Realm` for easier access

Seeing a +21% increase on the Octane RegExp benchmark from this change.

## Tests

- Added LLM-generated tests covering new paths