### PR TITLE
[regexp] Fast path for accessing exec on RegExp objects with the common shape

### DIFF
--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -34,7 +34,7 @@ use crate::{
         ordinary_object::ordinary_object_create_without_proto,
         realm::Realm,
         regexp::{
-            fast_flags_guard::FastRegExpFlagsGuard,
+            fast_proto_guard::FastRegExpProtoGuard,
             matcher::{Match, run_matcher},
         },
         string_value::StringValue,
@@ -131,7 +131,7 @@ impl RegExpPrototype {
         let this_object = this_object(cx, this_value, "RegExp.prototype.flags")?;
 
         // Use the fast path for raw RegExp flag access if possible
-        if let Some(flags) = FastRegExpFlagsGuard::try_get_fast_flags(cx, this_object)? {
+        if let Some(flags) = FastRegExpProtoGuard::try_get_fast_flags(cx, this_object)? {
             return Ok(flags_to_string_value(cx, flags)?.as_value());
         }
 
@@ -778,7 +778,7 @@ impl GenericFlags {
     /// Get the flags for a RegExp-like object, taking the fast path for raw flags access if
     /// possible.
     fn new(cx: Context, object: Handle<ObjectValue>) -> EvalResult<GenericFlags> {
-        if let Some(flags) = FastRegExpFlagsGuard::try_get_fast_flags(cx, object)? {
+        if let Some(flags) = FastRegExpProtoGuard::try_get_fast_flags(cx, object)? {
             return Ok(GenericFlags::Raw(flags));
         }
 
@@ -795,7 +795,7 @@ impl GenericFlags {
         cx: Context,
         object: Handle<ObjectValue>,
     ) -> EvalResult<GenericFlags> {
-        if let Some(flags) = FastRegExpFlagsGuard::try_get_fast_flags(cx, object)? {
+        if let Some(flags) = FastRegExpProtoGuard::try_get_fast_flags(cx, object)? {
             return Ok(GenericFlags::Raw(flags));
         }
 
@@ -1093,6 +1093,12 @@ pub fn regexp_exec(
     string_value: Handle<StringValue>,
     method_name: &str,
 ) -> EvalResult<ExecResult> {
+    // If the `exec` property is known to be the builtin `RegExp.prototype.exec` then we can skip
+    // looking it up at all, and perform RegExpBuiltinExec directly.
+    if FastRegExpProtoGuard::has_fast_builtin_exec(cx, regexp_object)? {
+        return regexp_builtin_exec(cx, regexp_object.cast::<RegExpObject>(), string_value);
+    }
+
     let exec = get(cx, regexp_object, cx.names.exec())?;
 
     // If the `exec` property is the builtin `RegExp.prototype.exec` then we can skip the call and

--- a/src/js/runtime/realm.rs
+++ b/src/js/runtime/realm.rs
@@ -23,7 +23,7 @@ use crate::{
             rust_runtime::RuntimeFunction,
         },
         object_value::ObjectValue,
-        regexp::fast_flags_guard::FastRegExpFlagsGuard,
+        regexp::fast_proto_guard::FastRegExpProtoGuard,
         scope::Scope,
         scope_names::{ScopeFlags, ScopeNameFlags, ScopeNames},
         shape::Shape,
@@ -52,8 +52,8 @@ pub struct Realm {
     /// Timestamp when this realm was created. Times returned from `performance.now` are relative
     /// to this timestamp.
     time_origin: Instant,
-    /// A guard for fast `flags` property access on RegExp objects
-    regexp_flags_guard: FastRegExpFlagsGuard,
+    /// A guard for fast access to the properties of the RegExp prototype
+    regexp_proto_guard: FastRegExpProtoGuard,
     /// Common shapes for objects with a known set of properties.
     pub common_shapes: CommonShapes,
     pub intrinsics: Intrinsics,
@@ -86,7 +86,7 @@ impl Realm {
             set_uninit!(realm.lexical_names, HeapPtr::uninit());
             set_uninit!(realm.empty_function, HeapPtr::uninit());
             set_uninit!(realm.time_origin, Instant::now());
-            set_uninit!(realm.regexp_flags_guard, FastRegExpFlagsGuard::Uninitialized);
+            set_uninit!(realm.regexp_proto_guard, FastRegExpProtoGuard::Uninitialized);
             set_uninit!(realm.common_shapes, CommonShapes::new_uninit());
 
             let realm = realm.to_handle();
@@ -107,13 +107,13 @@ impl Realm {
     }
 
     #[inline]
-    pub fn regexp_flags_guard(&self) -> &FastRegExpFlagsGuard {
-        &self.regexp_flags_guard
+    pub fn regexp_proto_guard(&self) -> &FastRegExpProtoGuard {
+        &self.regexp_proto_guard
     }
 
     #[inline]
-    pub fn set_regexp_flags_guard(&mut self, guard: FastRegExpFlagsGuard) {
-        self.regexp_flags_guard = guard;
+    pub fn set_regexp_proto_guard(&mut self, guard: FastRegExpProtoGuard) {
+        self.regexp_proto_guard = guard;
     }
 
     #[inline]
@@ -408,7 +408,7 @@ impl HeapItem for Realm {
         visitor.visit_pointer(&mut realm.global_scopes);
         visitor.visit_pointer(&mut realm.lexical_names);
         visitor.visit_pointer(&mut realm.empty_function);
-        realm.regexp_flags_guard.visit_pointers(visitor);
+        realm.regexp_proto_guard.visit_pointers(visitor);
         realm.common_shapes.visit_pointers(visitor);
         realm.intrinsics.visit_pointers(visitor);
     }

--- a/src/js/runtime/regexp/fast_proto_guard.rs
+++ b/src/js/runtime/regexp/fast_proto_guard.rs
@@ -3,6 +3,7 @@ use crate::{
     runtime::{
         Context, EvalResult, Handle,
         accessor::Accessor,
+        alloc_error::AllocResult,
         common_shapes::CommonShape,
         gc::HeapVisitor,
         intrinsics::{
@@ -15,26 +16,40 @@ use crate::{
     },
 };
 
-/// A guard that allows for fast access to the `flags` property of a RegExp object.
-pub enum FastRegExpFlagsGuard {
+/// A guard that allows for cached access to information about the RegExp prototype object.
+pub enum FastRegExpProtoGuard {
     /// Guard is lazily initialized.
     Uninitialized,
-    /// Whether the RegExp prototype object is guaranteed to have all `flags` accessors set to their
+    /// Which properties of the RegExp prototype object are guaranteed to still be set to their
     /// builtin functions. Cached for as long as the validity guard is valid, meaning this realm's
     /// RegExp prototype is unchanged.
     Cached {
-        all_builtin_flag_getters: bool,
+        builtin_properties: BuiltinProtoProperties,
         validity_guard: ValidityGuard,
     },
 }
 
-impl FastRegExpFlagsGuard {
+#[derive(Clone, Copy)]
+pub struct BuiltinProtoProperties {
+    /// Whether all of the flag accessors are set to their builtin functions.
+    all_builtin_flag_getters: bool,
+    /// Whether the `exec` method is set to its builtin function.
+    has_builtin_exec: bool,
+}
+
+impl FastRegExpProtoGuard {
     fn all_builtin_flag_getters(&self) -> Option<bool> {
+        Some(self.builtin_properties()?.all_builtin_flag_getters)
+    }
+
+    fn has_builtin_exec(&self) -> Option<bool> {
+        Some(self.builtin_properties()?.has_builtin_exec)
+    }
+
+    fn builtin_properties(&self) -> Option<BuiltinProtoProperties> {
         match self {
-            Self::Cached { all_builtin_flag_getters, validity_guard }
-                if validity_guard.is_valid() =>
-            {
-                Some(*all_builtin_flag_getters)
+            Self::Cached { builtin_properties, validity_guard } if validity_guard.is_valid() => {
+                Some(*builtin_properties)
             }
             _ => None,
         }
@@ -62,27 +77,64 @@ impl FastRegExpFlagsGuard {
 
         // Fast path is gated by a cached value protected by a validity guard on RegExp.prototype
         if let Some(all_builtin_flag_getters) =
-            realm.regexp_flags_guard().all_builtin_flag_getters()
+            realm.regexp_proto_guard().all_builtin_flag_getters()
         {
             return Ok(all_builtin_flag_getters.then(|| regexp_object.flags()));
         }
 
-        // Guard was invalid or uninitialized, so recompute the guarded value
+        // Guard was invalid or uninitialized, so recompute the guarded values
+        let all_builtin_flag_getters = Self::recompute(cx)?.all_builtin_flag_getters;
+
+        Ok(all_builtin_flag_getters.then(|| regexp_object.flags()))
+    }
+
+    /// Fast path for looking up the `exec` method, returning whether the lookup is guaranteed to
+    /// return the builtin `RegExp.prototype.exec` of the current realm.
+    ///
+    /// Fast path is used if the object has the RegExp common shape.
+    pub fn has_fast_builtin_exec(cx: Context, object: Handle<ObjectValue>) -> EvalResult<bool> {
+        let realm = cx.current_realm_ptr();
+
+        // Quick, conservative check to verify that the object
+        // - Is a RegExpObject
+        // - Has RegExp.prototype as its prototype
+        // - Does not have an own `exec` property that could shadow the one on RegExp.prototype,
+        //   since the common shape's only own property is `lastIndex`.
+        if !realm.is_common_shape(object.shape_ptr(), CommonShape::RegExp) {
+            return Ok(false);
+        }
+
+        // Fast path is gated by a cached value protected by a validity guard on RegExp.prototype
+        if let Some(has_builtin_exec) = realm.regexp_proto_guard().has_builtin_exec() {
+            return Ok(has_builtin_exec);
+        }
+
+        // Guard was invalid or uninitialized, so recompute the guarded values
+        Ok(Self::recompute(cx)?.has_builtin_exec)
+    }
+
+    /// Recompute the guarded properties of the RegExp prototype object, caching them protected by
+    /// a new validity guard.
+    fn recompute(cx: Context) -> AllocResult<BuiltinProtoProperties> {
         let mut regexp_prototype = cx.get_intrinsic(Intrinsic::RegExpPrototype);
+
         let all_builtin_flag_getters =
             Self::recompute_all_builtin_flag_getters(cx, regexp_prototype);
+        let has_builtin_exec = Self::recompute_has_builtin_exec(cx, regexp_prototype);
+        let builtin_properties =
+            BuiltinProtoProperties { all_builtin_flag_getters, has_builtin_exec };
 
-        // Fetch and create guard for the recomputed value
+        // Fetch and create guard for the recomputed values
         let validity_guard = regexp_prototype.request_own_validity_guard(cx)?;
 
         // Requesting the guard allocates so refetch realm
         let mut realm = cx.current_realm_ptr();
-        realm.set_regexp_flags_guard(FastRegExpFlagsGuard::Cached {
-            all_builtin_flag_getters,
+        realm.set_regexp_proto_guard(FastRegExpProtoGuard::Cached {
             validity_guard,
+            builtin_properties,
         });
 
-        Ok(all_builtin_flag_getters.then(|| regexp_object.flags()))
+        Ok(builtin_properties)
     }
 
     /// Recompute whether all of the builtin flag getters are present on RegExp.prototype.
@@ -124,6 +176,26 @@ impl FastRegExpFlagsGuard {
         }
 
         true
+    }
+
+    /// Recompute whether the builtin `exec` method is present on RegExp.prototype.
+    fn recompute_has_builtin_exec(cx: Context, regexp_prototype: Handle<ObjectValue>) -> bool {
+        // Own data property with the name `exec` exists
+        let Some(property) = regexp_prototype.get_property(cx, cx.names.exec()) else {
+            return false;
+        };
+
+        if property.is_accessor() {
+            return false;
+        }
+
+        // Value is the expected builtin function. Realm must match since RegExpBuiltinExec creates
+        // the match result array in the realm of the `exec` function that is called.
+        is_builtin_function(
+            *property.value(),
+            RuntimeFunction::RegExpPrototype_exec,
+            Some(cx.current_realm_ptr()),
+        )
     }
 
     pub fn visit_pointers(&mut self, visitor: &mut impl HeapVisitor) {

--- a/src/js/runtime/regexp/mod.rs
+++ b/src/js/runtime/regexp/mod.rs
@@ -1,6 +1,6 @@
 pub mod compiled_regexp;
 pub mod compiler;
-pub mod fast_flags_guard;
+pub mod fast_proto_guard;
 pub mod graphviz;
 pub mod instruction;
 pub mod lexer_stream;

--- a/tests/integration/built-ins/RegExp/exec_fast_path.js
+++ b/tests/integration/built-ins/RegExp/exec_fast_path.js
@@ -1,0 +1,182 @@
+/*---
+description: >
+  RegExpExec skips looking up `exec` entirely when it is known to be the builtin on the RegExp
+  prototype. Verify that replacing, shadowing, deleting, or restoring it is still observed, and that
+  the lookup is still performed whenever it could be intercepted.
+includes: [compareArray.js]
+---*/
+
+var builtinExec = RegExp.prototype.exec;
+
+// Every operation built on RegExpExec, applied to a freshly created RegExp so that no last index
+// state is carried between them.
+function runAll(string) {
+  return {
+    test: new RegExp("b", "g").test(string),
+    search: string.search(new RegExp("b", "g")),
+    match: JSON.stringify(string.match(new RegExp("b", "g"))),
+    matchAll: JSON.stringify([...string.matchAll(new RegExp("b", "g"))]),
+    replace: string.replace(new RegExp("b", "g"), "<$&>"),
+    split: string.split(new RegExp("b", "g")),
+    exec: JSON.stringify(new RegExp("b", "g").exec(string)),
+  };
+}
+
+function assertAllUseBuiltin(message) {
+  var results = runAll("abcb");
+
+  assert.sameValue(results.test, true, message + " test");
+  assert.sameValue(results.search, 1, message + " search");
+  assert.sameValue(results.match, '["b","b"]', message + " match");
+  assert.sameValue(results.replace, "a<b>c<b>", message + " replace");
+  assert.compareArray(results.split, ["a", "c", ""], message + " split");
+  assert.sameValue(results.matchAll, '[["b"],["b"]]', message + " matchAll");
+  assert.sameValue(results.exec, '["b"]', message + " exec");
+}
+
+// Run first so that the fast path is taken and its guard is established before it is invalidated
+// below. Every case afterwards must be observed even though a guard is already in place.
+assertAllUseBuiltin("with the builtin `exec`");
+
+// Replace `exec` on the prototype for the duration of a callback, by plain assignment. Assigning to
+// an existing data property does not change the prototype's shape, so this is the case most likely
+// to be missed by a stale guard.
+function withReplacedExec(replacement, callback) {
+  RegExp.prototype.exec = replacement;
+
+  try {
+    return callback();
+  } finally {
+    RegExp.prototype.exec = builtinExec;
+  }
+}
+
+var neverMatches = function () {
+  return null;
+};
+
+withReplacedExec(neverMatches, function () {
+  assert.sameValue(new RegExp("b", "g").test("abcb"), false, "replaced `exec` is used by test");
+  assert.sameValue("abcb".search(new RegExp("b", "g")), -1, "replaced `exec` is used by @@search");
+  assert.sameValue("abcb".match(new RegExp("b", "g")), null, "replaced `exec` is used by @@match");
+  assert.sameValue(
+    "abcb".replace(new RegExp("b", "g"), "X"),
+    "abcb",
+    "replaced `exec` is used by @@replace"
+  );
+  assert.compareArray(
+    "abcb".split(new RegExp("b", "g")),
+    ["abcb"],
+    "replaced `exec` is used by @@split"
+  );
+});
+
+assertAllUseBuiltin("after `exec` is restored");
+
+// Defining `exec` with a descriptor rather than assigning it is observed the same way.
+var originalExec = Object.getOwnPropertyDescriptor(RegExp.prototype, "exec");
+Object.defineProperty(RegExp.prototype, "exec", { value: neverMatches, configurable: true });
+assert.sameValue(new RegExp("b", "g").test("abcb"), false, "defined `exec` is used");
+Object.defineProperty(RegExp.prototype, "exec", originalExec);
+
+assertAllUseBuiltin("after the `exec` descriptor is restored");
+
+// An `exec` accessor on the prototype must be called, since a getter is observable.
+var lookups = 0;
+Object.defineProperty(RegExp.prototype, "exec", {
+  configurable: true,
+  get: function () {
+    lookups++;
+    return builtinExec;
+  },
+});
+
+// Two matches in "abcb" plus the final failed attempt.
+assert.sameValue("abcb".replace(new RegExp("b", "g"), "X"), "aXcX", "prototype `exec` getter result");
+assert.sameValue(lookups, 3, "prototype `exec` getter is called once per attempt");
+
+Object.defineProperty(RegExp.prototype, "exec", originalExec);
+
+assertAllUseBuiltin("after the `exec` getter is removed");
+
+// Deleting `exec` leaves no callable to find, so RegExpBuiltinExec is performed directly.
+delete RegExp.prototype.exec;
+assert.sameValue(new RegExp("b", "g").test("abcb"), true, "test with no `exec` at all");
+assert.sameValue("abcb".replace(new RegExp("b", "g"), "X"), "aXcX", "@@replace with no `exec`");
+Object.defineProperty(RegExp.prototype, "exec", originalExec);
+
+assertAllUseBuiltin("after `exec` is added back");
+
+// A change to the RegExp prototype that leaves `exec` alone must not change any results.
+RegExp.prototype.unrelatedProperty = 1;
+assertAllUseBuiltin("after an unrelated property is added");
+delete RegExp.prototype.unrelatedProperty;
+assertAllUseBuiltin("after an unrelated property is removed");
+
+// An own `exec` shadows the prototype's, so the lookup must still find it.
+var shadowed = new RegExp("b", "g");
+shadowed.exec = neverMatches;
+assert.sameValue("abcb".replace(shadowed, "X"), "abcb", "own `exec` shadows the prototype");
+
+// A receiver that is not on the RegExp common shape still inherits the builtin `exec` and matches
+// the same way, reached through the ordinary lookup instead.
+var withOwnProperty = new RegExp("b", "g");
+withOwnProperty.marker = 1;
+assert.sameValue(
+  "abcb".replace(withOwnProperty, "X"),
+  "aXcX",
+  "an extra own property does not change the result"
+);
+
+// Writing the last index does not add a property, so the fast path still applies.
+var withLastIndex = new RegExp("b", "g");
+withLastIndex.lastIndex = 3;
+assert.sameValue(withLastIndex.test("abcb"), true, "test resuming from a written last index");
+assert.sameValue(withLastIndex.lastIndex, 4, "last index after matching");
+
+// The fast path is guarded per realm, and only accepts an `exec` belonging to the realm whose
+// methods are running, so tampering in one realm must not change the other.
+(function () {
+  var other = $262.createRealm();
+  var OtherRegExp = other.global.RegExp;
+
+  // Take the fast path in both realms so that each has established its guard
+  assertAllUseBuiltin("before the other realm is tampered with");
+  other.evalScript('var replaced = "abcb".replace(/b/g, "X");');
+  assert.sameValue(other.global.replaced, "aXcX", "the other realm uses its own builtin `exec`");
+
+  other.evalScript(
+    "var savedExec = RegExp.prototype.exec;" +
+    "RegExp.prototype.exec = function () { return null; };"
+  );
+
+  assertAllUseBuiltin("while the other realm is tampered with");
+  other.evalScript('replaced = "abcb".replace(/b/g, "X");');
+  assert.sameValue(other.global.replaced, "abcb", "the other realm observes its own replaced `exec`");
+
+  // A foreign RegExp is matched by its own realm's methods, so it uses the replacement as well.
+  assert.sameValue(
+    "abcb".replace(new OtherRegExp("b", "g"), "X"),
+    "abcb",
+    "a foreign RegExp uses its own realm's replaced `exec`"
+  );
+
+  other.evalScript("RegExp.prototype.exec = savedExec;");
+
+  assertAllUseBuiltin("once the other realm is restored");
+  assert.sameValue(
+    "abcb".replace(new OtherRegExp("b", "g"), "X"),
+    "aXcX",
+    "a foreign RegExp once its own realm is restored"
+  );
+
+  // The other realm's builtin `exec` is a different function to this realm's, so the lookup is
+  // still performed and the call builds its match result array in the realm of the `exec` that ran.
+  withReplacedExec(OtherRegExp.prototype.exec, function () {
+    assert.sameValue(
+      Object.getPrototypeOf("abcb".match(new RegExp("b", ""))),
+      other.global.Array.prototype,
+      "a foreign builtin `exec` builds its match result in its own realm"
+    );
+  });
+})();


### PR DESCRIPTION
## Summary

RegExp methods currently start with a full property lookup for the `exec` method on an object. Add a fast path that calls `RegExpBuiltinExec` directly if we can guarantee that the looked up `exec` method is the builtin exec method.

This has the same shape as the flags fast path. Let's refactor `FastRegExpFlagsGuard` to be the more generic `FastRegExpProtoGuard`, which recomputes both "all flag getters are builtins" and "exec is the builtin" at the same time.

Seeing a +6% increase to Octane RegExp benchmark from this change.

## Tests

- Added LLM-generated tests for the new fast paths