### PR TITLE
[regexp] Fast path for RegExp.prototype[@@split] with a common RegExp splitter

### DIFF
--- a/src/js/runtime/intrinsics/regexp_prototype.rs
+++ b/src/js/runtime/intrinsics/regexp_prototype.rs
@@ -35,7 +35,7 @@ use crate::{
         realm::Realm,
         regexp::{
             fast_proto_guard::FastRegExpProtoGuard,
-            matcher::{Match, run_matcher},
+            matcher::{Match, MatchSearch, run_matcher},
         },
         string_value::StringValue,
         to_string,
@@ -532,7 +532,22 @@ impl RegExpPrototype {
 
             let zero_key = PropertyKey::from_u8(0).to_handle(cx);
             create_data_property_or_throw(cx, result_array, zero_key, string_value.into())?;
+
+            return Ok(result_array.as_value());
         }
+
+        // Fast path for the splitter if it is a RegExpObject that uses the builtin `exec` method,
+        // meaning we can run the matcher directly.
+        //
+        // Note that we also check that the splitter was created by the intrinsic RegExp constructor
+        // so that we know it is not observable and does not need to have `lastIndex` updated.
+        let fast_splitter = if cx.is_intrinsic(*constructor, Intrinsic::RegExpConstructor)
+            && FastRegExpProtoGuard::has_fast_builtin_exec(cx, splitter)?
+        {
+            Some(splitter.cast::<RegExpObject>().compiled_regexp())
+        } else {
+            None
+        };
 
         // Property keys are shared between iterations
         let mut key = PropertyKey::uninit().to_handle(cx);
@@ -545,29 +560,52 @@ impl RegExpPrototype {
         // Keep executing RegExp until there are no more matches or the entire string has been
         // searched.
         while q < size {
-            let q_value = cx.number(q);
-            RegExpObject::maybe_fast_set_last_index(cx, splitter, q_value)?;
-
             enum MatchKind {
                 Raw(Match),
                 Object(Handle<ObjectValue>),
             }
 
-            // Execute RegExp at current index, advancing to next index if there is no match
-            let exec_result = regexp_exec(cx, splitter, string_value, "RegExp.prototype[@@split]")?;
+            // Find the next match at or after the current index, moving the current index to the
+            // start of that match.
+            let (e, captures) = if let Some(compiled_regexp) = fast_splitter {
+                let Some(match_) =
+                    run_matcher(cx, compiled_regexp, string_value, q, MatchSearch::Leftmost)?
+                else {
+                    break;
+                };
 
-            let captures = match exec_result {
-                ExecResult::NoMatch => {
-                    q = advance_string_index(string_value, q, is_unicode)?;
-                    continue;
+                // Ignore matches starting at the end of the string since no split can occur at that
+                // position.
+                let match_bounds = match_.full_capture();
+                if match_bounds.start >= size {
+                    break;
                 }
-                ExecResult::Match(_, match_) => MatchKind::Raw(match_),
-                ExecResult::Object(exec_result) => MatchKind::Object(exec_result),
-            };
 
-            // Otherwise there was a match so determine end of match
-            let e = RegExpObject::maybe_fast_last_index_as_length(cx, splitter)?;
-            let e = u64::min(e, size as u64) as u32;
+                q = match_bounds.start;
+
+                (match_bounds.end, MatchKind::Raw(match_))
+            } else {
+                let q_value = cx.number(q);
+                RegExpObject::maybe_fast_set_last_index(cx, splitter, q_value)?;
+
+                // Execute RegExp at current index, advancing to next index if there is no match
+                let exec_result =
+                    regexp_exec(cx, splitter, string_value, "RegExp.prototype[@@split]")?;
+
+                let captures = match exec_result {
+                    ExecResult::NoMatch => {
+                        q = advance_string_index(string_value, q, is_unicode)?;
+                        continue;
+                    }
+                    ExecResult::Match(_, match_) => MatchKind::Raw(match_),
+                    ExecResult::Object(exec_result) => MatchKind::Object(exec_result),
+                };
+
+                // Otherwise there was a match so determine end of match
+                let e = RegExpObject::maybe_fast_last_index_as_length(cx, splitter)?;
+
+                (u64::min(e, size as u64) as u32, captures)
+            };
 
             // If there was a match but it is empty then advance to next index
             if e == p {
@@ -1176,8 +1214,15 @@ fn regexp_builtin_exec(
         last_index
     };
 
+    // Sticky regexps only attempt a match at the exact start position
+    let search = if is_sticky {
+        MatchSearch::StartOnly
+    } else {
+        MatchSearch::Leftmost
+    };
+
     // Run the matching engine on the regexp and input string
-    let match_ = run_matcher(cx, compiled_regexp, string_value, matcher_start_index)?;
+    let match_ = run_matcher(cx, compiled_regexp, string_value, matcher_start_index, search)?;
 
     // Handle match failure, resetting last index under sticky flag
     let Some(match_) = match_ else {

--- a/src/js/runtime/regexp/matcher.rs
+++ b/src/js/runtime/regexp/matcher.rs
@@ -304,9 +304,8 @@ impl<T: RegExpLexerStream> MatchEngine<T> {
         self.loop_registers[loop_register_index as usize] = value;
     }
 
-    fn run(&mut self) -> Result<Match, MatchError> {
-        // Sticky regexps only attempt a match at the exact start position
-        if self.regexp.flags.is_sticky() {
+    fn run(&mut self, search: MatchSearch) -> Result<Match, MatchError> {
+        if search == MatchSearch::StartOnly {
             self.execute_bytecode::<FORWARD>()?;
             return Ok(self.build_match());
         }
@@ -926,14 +925,23 @@ impl<T: RegExpLexerStream> MatchEngine<T> {
     }
 }
 
+#[derive(Clone, Copy, PartialEq)]
+pub enum MatchSearch {
+    /// Find the leftmost match at or after the start index.
+    Leftmost,
+    /// Match only at the start index, as a sticky RegExp does.
+    StartOnly,
+}
+
 fn match_lexer_stream(
     mut lexer_stream: impl RegExpLexerStream,
     regexp: HeapPtr<CompiledRegExp>,
     start_index: u32,
+    search: MatchSearch,
 ) -> Result<Match, MatchError> {
     lexer_stream.advance_n(start_index as usize);
     let mut match_engine = MatchEngine::new(regexp, lexer_stream);
-    match_engine.run()
+    match_engine.run(search)
 }
 
 pub fn run_matcher(
@@ -941,6 +949,7 @@ pub fn run_matcher(
     regexp: Handle<CompiledRegExp>,
     target_string: Handle<StringValue>,
     start_index: u32,
+    search: MatchSearch,
 ) -> EvalResult<Option<Match>> {
     // May allocate, after this point no more allocations can occur
     let flat_string = target_string.flatten()?;
@@ -950,17 +959,17 @@ pub fn run_matcher(
     let result = match flat_string.width() {
         StringWidth::OneByte => {
             let lexer_stream = HeapOneByteLexerStream::new(flat_string.as_one_byte_slice());
-            match_lexer_stream(lexer_stream, regexp, start_index)
+            match_lexer_stream(lexer_stream, regexp, start_index, search)
         }
         StringWidth::TwoByte => {
             if regexp.flags.has_any_unicode_flag() {
                 let lexer_stream =
                     HeapTwoByteCodePointLexerStream::new(flat_string.as_two_byte_slice());
-                match_lexer_stream(lexer_stream, regexp, start_index)
+                match_lexer_stream(lexer_stream, regexp, start_index, search)
             } else {
                 let lexer_stream =
                     HeapTwoByteCodeUnitLexerStream::new(flat_string.as_two_byte_slice(), None);
-                match_lexer_stream(lexer_stream, regexp, start_index)
+                match_lexer_stream(lexer_stream, regexp, start_index, search)
             }
         }
     };

--- a/tests/integration/built-ins/RegExp/split_fast_path.js
+++ b/tests/integration/built-ins/RegExp/split_fast_path.js
@@ -1,0 +1,185 @@
+/*---
+description: RegExp.prototype[@@split] fast path if splitter is a RegExp with builtin `exec`.
+includes: [compareArray.js]
+---*/
+
+var builtinExec = RegExp.prototype.exec;
+
+// A subclass whose `exec` is a user-provided function is never eligible for the fast path, so it
+// still matches the splitter at each index in turn. Its results are the reference the leftmost
+// search is compared against.
+function makeWrappedExecClass() {
+  return class extends RegExp {
+    exec(string) {
+      return builtinExec.call(this, string);
+    }
+  };
+}
+
+function assertSameSplit(source, flags, string, limit) {
+  var WrappedExecRegExp = makeWrappedExecClass();
+  var message =
+    "/" + source + "/" + flags +
+    " on " + JSON.stringify(string) +
+    " with limit " + String(limit);
+
+  assert.compareArray(
+    string.split(new RegExp(source, flags), limit),
+    string.split(new WrappedExecRegExp(source, flags), limit),
+    message
+  );
+}
+
+// Anchors and patterns that can match the empty string at the end of the input. The leftmost search
+// can find a match starting at the end of the string, which matching at each index never reaches
+// because it stops before the final index.
+var endOfStringPatterns = [
+  ["$", ""],
+  ["$", "m"],
+  ["^", ""],
+  ["^", "m"],
+  ["b*$", ""],
+  ["x*$", ""],
+  ["(?=$)", ""],
+  ["(?!x)$", ""],
+  ["\\b", ""],
+  ["\\B", ""],
+  ["(?:)$", ""],
+  ["c?$", ""],
+];
+
+var strings = ["", "a", "ab", "abc", "abcbd", "bb", "a\nb", "ab\n", "\n", "a\u{1F600}b"];
+var limits = [undefined, 0, 1, 2, 3, 100];
+
+for (var i = 0; i < endOfStringPatterns.length; i++) {
+  for (var j = 0; j < strings.length; j++) {
+    for (var k = 0; k < limits.length; k++) {
+      assertSameSplit(endOfStringPatterns[i][0], endOfStringPatterns[i][1], strings[j], limits[k]);
+    }
+  }
+}
+
+// A match at the very end of the string is not a split point, so the input is left whole rather
+// than gaining a trailing empty string.
+assert.compareArray("ab".split(/$/), ["ab"], "$ does not split at the end of the input");
+assert.compareArray("ab".split(/(?=$)/), ["ab"], "a lookahead at the end does not split");
+assert.compareArray("ab".split(/x*$/), ["ab"], "an empty match at the end does not split");
+assert.compareArray("ab".split(/b*$/), ["a", ""], "a non-empty match ending at the end splits");
+
+// The splitter always has the sticky flag set, but is searched for the leftmost match, so the
+// receiver's own flags do not change where the splits occur.
+assert.compareArray("a1b2c".split(/\d/), ["a", "b", "c"], "no flags");
+assert.compareArray("a1b2c".split(/\d/g), ["a", "b", "c"], "global receiver");
+assert.compareArray("a1b2c".split(/\d/y), ["a", "b", "c"], "sticky receiver");
+assert.compareArray("a1b2c".split(/\d/gy), ["a", "b", "c"], "global and sticky receiver");
+
+// The receiver's last index is never consulted or written, since the splitter is a separate object.
+var receiver = /\d/g;
+receiver.lastIndex = 4;
+assert.compareArray("a1b2c".split(receiver), ["a", "b", "c"], "receiver last index is ignored");
+assert.sameValue(receiver.lastIndex, 4, "receiver last index is left alone");
+
+// Replacing `exec` on the prototype must be observed, since the fast path stands in for a call to
+// the builtin `exec`.
+function withReplacedExec(replacement, callback) {
+  RegExp.prototype.exec = replacement;
+
+  try {
+    return callback();
+  } finally {
+    RegExp.prototype.exec = builtinExec;
+  }
+}
+
+withReplacedExec(function () { return null; }, function () {
+  assert.compareArray("a1b2c".split(/\d/), ["a1b2c"], "a replaced `exec` that never matches");
+});
+
+assert.compareArray("a1b2c".split(/\d/), ["a", "b", "c"], "after `exec` is restored");
+
+// The limit is coerced after the splitter is constructed, so its `valueOf` runs before the loop and
+// can still replace `exec`.
+var replacingLimit = {
+  valueOf: function () {
+    RegExp.prototype.exec = function () { return null; };
+    return 100;
+  },
+};
+
+try {
+  assert.compareArray(
+    "a1b2c".split(/\d/, replacingLimit),
+    ["a1b2c"],
+    "`exec` replaced while coercing the limit"
+  );
+} finally {
+  RegExp.prototype.exec = builtinExec;
+}
+
+// The replacement must be the `exec` that is called, not just a reason to leave the fast path.
+var calls = 0;
+var countingLimit = {
+  valueOf: function () {
+    RegExp.prototype.exec = function (string) {
+      calls++;
+      return builtinExec.call(this, string);
+    };
+    return 100;
+  },
+};
+
+try {
+  assert.compareArray(
+    "a1b2c".split(/\d/, countingLimit),
+    ["a", "b", "c"],
+    "an `exec` wrapper installed while coercing the limit"
+  );
+} finally {
+  RegExp.prototype.exec = builtinExec;
+}
+
+assert.sameValue(calls > 0, true, "the `exec` installed while coercing the limit is called");
+
+// An `exec` accessor on the prototype is observable, so it must still be called.
+var originalExec = Object.getOwnPropertyDescriptor(RegExp.prototype, "exec");
+var lookups = 0;
+Object.defineProperty(RegExp.prototype, "exec", {
+  configurable: true,
+  get: function () {
+    lookups++;
+    return builtinExec;
+  },
+});
+
+assert.compareArray("a1b2c".split(/\d/), ["a", "b", "c"], "prototype `exec` getter result");
+assert.sameValue(lookups > 0, true, "prototype `exec` getter is called");
+
+Object.defineProperty(RegExp.prototype, "exec", originalExec);
+
+assert.compareArray("a1b2c".split(/\d/), ["a", "b", "c"], "after the `exec` getter is removed");
+
+// The last index the spec's loop leaves on the splitter is observable whenever @@species hands back
+// a splitter that user code kept a reference to, so such a splitter cannot take the fast path.
+// The final match here ends exactly at the end of the string, which is the only case where the
+// value differs from the zero a freshly constructed splitter starts at.
+var leaked = null;
+var leakingReceiver = /,/;
+leakingReceiver.constructor = {
+  [Symbol.species]: function (pattern, flags) {
+    leaked = new RegExp(pattern, flags);
+    return leaked;
+  },
+};
+
+assert.compareArray("a,".split(leakingReceiver), ["a", ""], "a leaked splitter splits normally");
+assert.sameValue(leaked.lastIndex, 2, "a leaked splitter keeps the last index the loop leaves");
+
+// A species that returns a splitter matching a different pattern is still used as the splitter.
+var otherReceiver = /,/;
+otherReceiver.constructor = {
+  [Symbol.species]: function () {
+    return /\d/y;
+  },
+};
+
+assert.compareArray("a1b,c".split(otherReceiver), ["a", "b,c"], "the species splitter is used");

--- a/tests/integration/built-ins/RegExp/split_raw_match_captures.js
+++ b/tests/integration/built-ins/RegExp/split_raw_match_captures.js
@@ -45,6 +45,9 @@ var splitPatterns = [
   ["(\\d)(\\d)?", ""],
   [".", "s"],
   ["B", "i"],
+  ["^", "m"],
+  ["$", "m"],
+  ["b*$", ""],
 ];
 
 var strings = ["", "a", "abc", "abcbd", "a1b22c", "bb", "a\u{1F600}b", "\n"];


### PR DESCRIPTION
## Summary

Speed up `RegExp.prototype[@@split]` with a new fast path used when the splitter is a common `RegExpObject`. This fast path finds all split points by directly calling the matcher instead of going through the exec path.

Notes:
- We must check both that the splitter has a `exec` builtin AND that it's constructor is the `RegExp` constructor. This is subtle but guarantees that the splitter is not observable so we don't have to update it's `lastIndex` properly.
- Early return in the empty string path

This change causes a massive +25% increase to the Octane RegExp benchmark.

## CI

- Added LLM-generated tests for the new fast path