### PR TITLE
[runtime] Fast path for CanonicalNumericIndexString(string) on string objects

### DIFF
--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -497,8 +497,19 @@ pub fn canonical_numeric_string_index_string(
             Ok(None)
         }
     } else if key.is_string() {
-        // Otherwise must convert to number then back to string
+        // Otherwise only valid if string round trips after ToNumber conversion
         let key_string = key.as_string();
+        if key_string.is_empty() {
+            return Ok(None);
+        }
+
+        // Only strings starting with a digit can be a canonical numeric index string
+        let first_code_unit = key_string.as_flat().code_unit_at(0);
+        if !(b'0' as u16..=b'9' as u16).contains(&first_code_unit) {
+            return Ok(None);
+        }
+
+        // Otherwise must convert to number then back to string
         let number_value = must_a!(to_number(cx, key_string.into()));
 
         // If string representations are equal, must be canonical numeric index
@@ -519,12 +530,6 @@ pub fn canonical_numeric_string_index_string(
             }
 
             Ok(Some(number as u32))
-        } else if (*key_string)
-            .as_flat()
-            .eq(&cx.names.negative_zero.as_string().as_flat())
-        {
-            // The string "-0" is a canonical numeric index but is never valid as an index
-            Ok(None)
         } else {
             Ok(None)
         }


### PR DESCRIPTION
## Summary

Quick improvement to `CanonicalNumericIndexString` specialized for string objects. If the key is a string then immediately check if the first code unit could be the start of a number to early exit before going through the full `ToNumber/ToString` round trip.

+1.6% to Octane overall, concentrated in a handful of benchmarks.

| Benchmark | 52d77fe99 (base) | 803190159 | Change |
|-----------|------------------|-----------|--------|
| Richards | 2,732 med 2,694 ±24.1 n=4 | 2,729 med 2,710 ±31.2 n=4 | -0.1% |
| DeltaBlue | 2,699 med 2,693 ±35.4 n=4 | 2,698 med 2,687 ±17.4 n=4 | -0.0% |
| Crypto | 3,191 med 3,182 ±27.6 n=4 | 3,233 med 3,228 ±7.4 n=4 | +1.3% |
| RayTrace | 3,474 med 3,449 ±62.9 n=4 | 3,450 med 3,444 ±13.5 n=4 | -0.7% |
| EarleyBoyer | 5,774 med 5,747 ±58.5 n=4 | 5,772 med 5,732 ±40.6 n=4 | -0.0% |
| RegExp | 1,224 med 1,217 ±20.0 n=4 | 1,247 med 1,239 ±9.3 n=4 | +1.9% |
| Splay | 5,072 med 4,973 ±78.5 n=4 | 5,191 med 5,168 ±20.8 n=4 | +2.3% |
| SplayLatency | 9,849 med 9,683 ±269 n=4 | 10,292 med 10,249 ±65.4 n=4 | +4.5% |
| NavierStokes | 4,130 med 4,106 ±60.9 n=4 | 4,139 med 4,072 ±40.2 n=4 | +0.2% |
| PdfJS | 6,618 med 6,602 ±44.9 n=4 | 6,969 med 6,949 ±17.6 n=4 | +5.3% |
| Mandreel | 3,148 med 3,143 ±35.4 n=4 | 3,162 med 3,148 ±9.8 n=4 | +0.4% |
| MandreelLatency | 22,763 med 22,609 ±174 n=4 | 22,763 med 22,763 ±0.0 n=4 | +0.0% |
| Gameboy | 5,337 med 5,272 ±50.6 n=4 | 5,409 med 5,355 ±44.1 n=4 | +1.3% |
| CodeLoad | 49,149 med 48,661 ±779 n=4 | 48,927 med 48,809 ±211 n=4 | -0.5% |
| Box2D | 9,740 med 9,631 ±134 n=4 | 9,750 med 9,697 ±32.2 n=4 | +0.1% |
| zlib | 5,998 med 5,995 ±40.6 n=4 | 5,990 med 5,988 ±10.7 n=4 | -0.1% |
| Typescript | 19,345 med 19,286 ±53.5 n=4 | 21,002 med 20,927 ±77.7 n=4 | +8.6% |
| **Total (octane)** | **5,973 med 5,949 ±47.9 n=4** | **6,066 med 6,053 ±17.8 n=4** | **+1.6%** |

## Tests

- CI