### PR TITLE
[runtime] GetNamedPropertyCache variant for primitive string length access

### DIFF
--- a/src/js/runtime/bytecode/cache.rs
+++ b/src/js/runtime/bytecode/cache.rs
@@ -62,7 +62,7 @@ impl Cache {
             Cache::Uninitialized => caches.set(cache_index, new_entry),
             // Monomorphic cache already exists, so either replace or promote to polymorphic
             existing @ (Cache::GetNamedProperty(_) | Cache::SetNamedProperty(_)) => {
-                if Self::same_receiver_shapes(existing, new_entry) {
+                if Self::same_receiver_keys(existing, new_entry) {
                     caches.set(cache_index, new_entry);
                 } else {
                     // A second shape was seen, promote to a polymorphic cache with both entries
@@ -80,8 +80,8 @@ impl Cache {
                             entries.set(i, new_entry);
                             return;
                         }
-                        // Replace entries with the same shape
-                        entry if Self::same_receiver_shapes(entry, new_entry) => {
+                        // Replace entries with the same receiver key
+                        entry if Self::same_receiver_keys(entry, new_entry) => {
                             entries.set(i, new_entry);
                             return;
                         }
@@ -96,19 +96,34 @@ impl Cache {
         }
     }
 
-    fn same_receiver_shapes(cache_a: Cache, cache_b: Cache) -> bool {
-        match (cache_a.receiver_shape(), cache_b.receiver_shape()) {
-            (Some(shape_a), Some(shape_b)) => shape_a.ptr_eq(&shape_b),
-            (None, None) => true,
-            _ => false,
-        }
+    fn same_receiver_keys(cache_a: Cache, cache_b: Cache) -> bool {
+        cache_a.receiver_key().matches(cache_b.receiver_key())
     }
 
-    fn receiver_shape(&self) -> Option<HeapPtr<Shape>> {
+    fn receiver_key(&self) -> CacheReceiverKey {
         match self {
-            Self::GetNamedProperty(cache) => cache.receiver_shape(),
-            Self::SetNamedProperty(cache) => Some(cache.receiver_shape()),
-            _ => unreachable!("cache does not have a receiver shape"),
+            Self::GetNamedProperty(cache) => cache.receiver_key(),
+            Self::SetNamedProperty(cache) => CacheReceiverKey::Shape(cache.receiver_shape()),
+            _ => unreachable!("cache does not have a receiver key"),
+        }
+    }
+}
+
+/// A generic receiver key for comparing whether two cache entries depend on the same shape or kind
+/// of the receiver.
+#[derive(Clone, Copy)]
+enum CacheReceiverKey {
+    Shape(HeapPtr<Shape>),
+    ArrayObject,
+    String,
+}
+
+impl CacheReceiverKey {
+    fn matches(&self, other: CacheReceiverKey) -> bool {
+        match (self, other) {
+            (Self::Shape(shape), Self::Shape(other_shape)) => shape.ptr_eq(&other_shape),
+            (Self::ArrayObject, Self::ArrayObject) | (Self::String, Self::String) => true,
+            _ => false,
         }
     }
 }
@@ -134,6 +149,8 @@ pub enum GetNamedPropertyCache {
     NotFound { shape: HeapPtr<Shape>, guard: Option<ValidityGuard> },
     /// Receiver is an array object and the property is `length`.
     ArrayLength,
+    /// Receiver is a string primitive and the property is `length`.
+    StringLength,
 }
 
 pub enum GetNamedPropertyCacheResult {
@@ -148,13 +165,16 @@ pub enum GetNamedPropertyCacheResult {
 }
 
 impl GetNamedPropertyCache {
-    /// Match the cache against a receiver object and return the cached property if it is still
+    /// Match the cache against a receiver value and return the cached property if it is still
     /// valid. If the cache is invalid, returns a result indicating why it is invalid.
     #[inline]
-    pub fn try_match(&self, receiver: HeapPtr<ObjectValue>) -> GetNamedPropertyCacheResult {
+    pub fn try_match(&self, receiver: Value) -> GetNamedPropertyCacheResult {
+        debug_assert!(receiver.is_pointer());
+        let receiver_shape = receiver.as_pointer().shape();
+
         match *self {
-            Self::Own { shape, location, is_accessor } if shape.ptr_eq(&receiver.shape_ptr()) => {
-                let value = receiver.lookup_location_unchecked(location);
+            Self::Own { shape, location, is_accessor } if shape.ptr_eq(&receiver_shape) => {
+                let value = receiver.as_object().lookup_location_unchecked(location);
                 if is_accessor {
                     let accessor = Accessor::from_value(value);
                     if let Some(getter) = accessor.get {
@@ -168,7 +188,7 @@ impl GetNamedPropertyCache {
                 }
             }
             Self::Proto { shape, guard, proto, location, is_accessor }
-                if shape.ptr_eq(&receiver.shape_ptr()) =>
+                if shape.ptr_eq(&receiver_shape) =>
             {
                 if guard.is_valid() {
                     let value = proto.lookup_location_unchecked(location);
@@ -187,30 +207,43 @@ impl GetNamedPropertyCache {
                     GetNamedPropertyCacheResult::InvalidGuard
                 }
             }
-            Self::NotFound { shape, guard } if shape.ptr_eq(&receiver.shape_ptr()) => {
+            Self::NotFound { shape, guard } if shape.ptr_eq(&receiver_shape) => {
                 if guard.is_none() || matches!(guard, Some(guard) if guard.is_valid()) {
                     GetNamedPropertyCacheResult::Data(Value::undefined())
                 } else {
                     GetNamedPropertyCacheResult::InvalidGuard
                 }
             }
-            Self::ArrayLength if receiver.is::<ArrayObject>() => {
-                GetNamedPropertyCacheResult::Data(Value::number(receiver.array_properties_length()))
+            Self::ArrayLength if receiver_shape.kind() == HeapItemKind::ArrayObject => {
+                GetNamedPropertyCacheResult::Data(Value::number(
+                    receiver.as_object().array_properties_length(),
+                ))
+            }
+            Self::StringLength if receiver_shape.kind() == HeapItemKind::StringValue => {
+                GetNamedPropertyCacheResult::Data(Value::number(receiver.as_string().len()))
             }
             _ => GetNamedPropertyCacheResult::DifferentShape,
         }
     }
 
-    /// Fill the cache if possible for accessing a property key on a receiver object.
+    /// Fill the cache if possible for accessing a property key on a receiver.
+    ///
+    /// Takes both the original receiver and the receiver coerced to an object since some caches
+    /// depend on the original receiver.
     ///
     /// Returns None if the property access is not cacheable.
     pub fn fill(
         cx: Context,
+        original_receiver: Handle<Value>,
         mut receiver: Handle<ObjectValue>,
         key: Handle<PropertyKey>,
     ) -> AllocResult<Option<Self>> {
-        // Array length is not stored as a regular property. As long as the receiver is an array
-        // object it can be cached as a special case.
+        // Neither string length nor array length is stored as a regular property, so as long as the
+        // receiver has the right kind they can be cached as special cases.
+        if original_receiver.is_string() && *key == *cx.names.length() {
+            return Ok(Some(Self::StringLength));
+        }
+
         if receiver.is::<ArrayObject>() && *key == *cx.names.length() {
             return Ok(Some(Self::ArrayLength));
         }
@@ -279,7 +312,18 @@ impl GetNamedPropertyCache {
             Self::Own { shape, .. } | Self::Proto { shape, .. } | Self::NotFound { shape, .. } => {
                 Some(*shape)
             }
-            Self::ArrayLength => None,
+            Self::ArrayLength | Self::StringLength => None,
+        }
+    }
+
+    /// The receiver shape or key this cache is keyed on.
+    fn receiver_key(&self) -> CacheReceiverKey {
+        match self {
+            Self::Own { shape, .. } | Self::Proto { shape, .. } | Self::NotFound { shape, .. } => {
+                CacheReceiverKey::Shape(*shape)
+            }
+            Self::ArrayLength => CacheReceiverKey::ArrayObject,
+            Self::StringLength => CacheReceiverKey::String,
         }
     }
 
@@ -300,7 +344,7 @@ impl GetNamedPropertyCache {
                     guard.visit_pointers(visitor);
                 }
             }
-            Self::ArrayLength => {}
+            Self::ArrayLength | Self::StringLength => {}
         }
     }
 }

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -4956,14 +4956,13 @@ impl VM {
         &mut self,
         instr: &GetNamedPropertyInstruction<W>,
     ) -> bool {
-        let object_value = self.read_register(instr.object());
-        if !object_value.is_object() {
+        let receiver_value = self.read_register(instr.object());
+        if !receiver_value.is_pointer() {
             return false;
         }
-        let object = object_value.as_object();
 
         let result =
-            Self::try_match_get_named_property(self.get_cache(instr.cache_index()), object);
+            Self::try_match_get_named_property(self.get_cache(instr.cache_index()), receiver_value);
         if let Some(GetNamedPropertyCacheResult::Data(value)) = result {
             self.write_register(instr.dest(), value);
             true
@@ -4977,17 +4976,21 @@ impl VM {
         &mut self,
         instr: &GetNamedPropertyInstruction<W>,
     ) -> EvalResult<()> {
-        let object_value = self.read_register(instr.object());
+        let receiver_value = self.read_register(instr.object());
 
         let fill_cache = 'full_path: {
-            if !object_value.is_object() {
+            if !receiver_value.is_object() {
+                if self.is_cacheable_primitive_get_named_property(instr, receiver_value) {
+                    let is_failed = matches!(self.get_cache(instr.cache_index()), Cache::Failed);
+                    break 'full_path /* fill_cache */ !is_failed;
+                }
+
                 break 'full_path /* fill_cache */ false;
             }
 
-            let object = object_value.as_object();
             let cache = self.get_cache(instr.cache_index());
 
-            let result = match Self::try_match_get_named_property(cache, object) {
+            let result = match Self::try_match_get_named_property(cache, receiver_value) {
                 Some(result) => result,
                 None => match cache {
                     Cache::Uninitialized => break 'full_path /* fill_cache */ true,
@@ -4999,7 +5002,11 @@ impl VM {
             match result {
                 GetNamedPropertyCacheResult::Data(_) => unreachable!("handled by fast path"),
                 GetNamedPropertyCacheResult::Accessor(getter) => {
-                    return self.get_named_property_accessor(instr, object, getter);
+                    return self.get_named_property_accessor(
+                        instr,
+                        receiver_value.as_object(),
+                        getter,
+                    );
                 }
                 // Either the prototype chain changed or a new shape was seen. Refill the cache,
                 // promoting to a polymorphic cache if necessary.
@@ -5013,13 +5020,34 @@ impl VM {
         self.get_named_property_full(instr, fill_cache)
     }
 
+    /// Whether a named property access on a primitive receiver is cacheable.
+    ///
+    /// Only the `length` property of string primitives is cacheable.
+    #[inline(always)]
+    fn is_cacheable_primitive_get_named_property<W: Width>(
+        &self,
+        instr: &GetNamedPropertyInstruction<W>,
+        receiver_value: Value,
+    ) -> bool {
+        if !receiver_value.is_string() {
+            return false;
+        }
+
+        let name = self.get_property_key_constant(instr.name_constant_index());
+        if name != *self.cx().names.length() {
+            return false;
+        }
+
+        true
+    }
+
     #[inline(always)]
     fn try_match_get_named_property(
         cache: Cache,
-        object: HeapPtr<ObjectValue>,
+        receiver: Value,
     ) -> Option<GetNamedPropertyCacheResult> {
         match cache {
-            Cache::GetNamedProperty(cache) => Some(cache.try_match(object)),
+            Cache::GetNamedProperty(cache) => Some(cache.try_match(receiver)),
             Cache::Polymorphic(entries) => {
                 for entry in entries.as_slice() {
                     // First uninitialized slot signals there are no more entries to check
@@ -5027,7 +5055,7 @@ impl VM {
                         break;
                     };
 
-                    match cache.try_match(object) {
+                    match cache.try_match(receiver) {
                         GetNamedPropertyCacheResult::DifferentShape => {}
                         result => return Some(result),
                     }
@@ -5104,7 +5132,8 @@ impl VM {
                     _ => None,
                 };
 
-                let cache = GetNamedPropertyCache::fill(self.cx(), coerced_object, property_key)?;
+                let cache =
+                    GetNamedPropertyCache::fill(self.cx(), object, coerced_object, property_key)?;
 
                 Cache::insert(
                     self.caches(),

--- a/tests/integration/language/expression/member/get_named_property_cache/string_length.js
+++ b/tests/integration/language/expression/member/get_named_property_cache/string_length.js
@@ -1,0 +1,356 @@
+/*---
+description: String primitive length reads are cached, only checking that the receiver is a string.
+---*/
+
+// Each site is read in a loop so the inline cache is filled and then re-matched.
+function readLength(s) {
+  var last;
+  for (var i = 0; i < 100; i++) {
+    last = s.length;
+  }
+  return last;
+}
+
+// A single cache entry must serve every string, not just the first one seen
+assert.sameValue(readLength(""), 0);
+assert.sameValue(readLength("a"), 1);
+assert.sameValue(readLength("abcdef"), 6);
+
+// Every string representation is matched by the same entry: flat strings, ropes built by
+// concatenation, substrings, and strings produced by builtins
+(function () {
+  var flat = "abcdefgh";
+  var rope = "abcd" + "efgh";
+  var nestedRope = ("ab" + "cd") + ("ef" + "gh");
+  var sliced = "xxabcdefghxx".slice(2, 10);
+  var repeated = "abcd".repeat(2);
+  var fromCharCode = String.fromCharCode(97, 98, 99, 100, 101, 102, 103, 104);
+  var converted = String(12345678);
+  var templated = `abcd${"efgh"}`;
+
+  var strings = [flat, rope, nestedRope, sliced, repeated, fromCharCode, converted, templated];
+  for (var round = 0; round < 3; round++) {
+    for (var i = 0; i < strings.length; i++) {
+      assert.sameValue(readLength(strings[i]), 8);
+    }
+  }
+})();
+
+// Length is the number of UTF-16 code units, not code points or bytes
+(function () {
+  assert.sameValue(readLength("éé"), 2);
+  assert.sameValue(readLength("中文"), 2);
+
+  // Astral characters are a surrogate pair, so they count as two code units
+  assert.sameValue(readLength("\u{1f600}"), 2);
+  assert.sameValue(readLength("a\u{1f600}b"), 4);
+
+  // A lone surrogate is a single code unit
+  assert.sameValue(readLength("\ud83d"), 1);
+
+  // A two byte rope keeps its length without being flattened
+  assert.sameValue(readLength("中" + "文" + "abc"), 5);
+})();
+
+// Strings are immutable, so a cached length can never go stale for a given receiver. Reassigning
+// the variable produces a different string, which the same entry must still match.
+(function () {
+  var s = "abc";
+  assert.sameValue(readLength(s), 3);
+  s += "de";
+  assert.sameValue(readLength(s), 5);
+  s = s.slice(1);
+  assert.sameValue(readLength(s), 4);
+})();
+
+// String.prototype has its own non-configurable length, so a length accessor can never be installed
+// anywhere a string primitive would reach it.
+(function () {
+  assert.sameValue(readLength("abcde"), 5);
+
+  var descriptor = Object.getOwnPropertyDescriptor(String.prototype, "length");
+  assert.sameValue(descriptor.configurable, false);
+  assert.sameValue(descriptor.writable, false);
+  assert.sameValue(descriptor.value, 0);
+
+  assert.throws(TypeError, function () {
+    Object.defineProperty(String.prototype, "length", { get: function () { return 99; } });
+  });
+  assert.sameValue(readLength("abcde"), 5);
+
+  assert.throws(TypeError, function () {
+    "use strict";
+    delete String.prototype.length;
+  });
+  assert.sameValue(readLength("abcde"), 5);
+})();
+
+// A length further up the prototype chain is shadowed by the own length of the object that ToObject
+// creates, so it must never be observed.
+(function () {
+  assert.sameValue(readLength("abcde"), 5);
+
+  Object.prototype.length = 99;
+  assert.sameValue(readLength("abcde"), 5);
+  assert.sameValue("ab".length, 2);
+  delete Object.prototype.length;
+
+  Object.defineProperty(Object.prototype, "length", {
+    get: function () { return 99; },
+    configurable: true,
+  });
+  assert.sameValue(readLength("abcde"), 5);
+  delete Object.prototype.length;
+
+  assert.sameValue(readLength("abcde"), 5);
+})();
+
+// Reading length off a primitive never leaks a wrapper object as the receiver
+(function () {
+  function readInStrict(s) {
+    "use strict";
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = s.length;
+    }
+    return last;
+  }
+
+  assert.sameValue(readInStrict("abcd"), 4);
+  assert.sameValue(readLength("abcd"), 4);
+})();
+
+// A String wrapper object is a different receiver from a string primitive. Its length is an
+// ordinary own property, and both must stay correct at a shared callsite.
+(function () {
+  function len(o) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = o.length;
+    }
+    return last;
+  }
+
+  assert.sameValue(len("abc"), 3);
+  assert.sameValue(len(new String("abcd")), 4);
+  assert.sameValue(len("abc"), 3);
+  assert.sameValue(len(String.prototype), 0);
+
+  // String subclass instances are wrapper objects too
+  class Sub extends String {}
+  assert.sameValue(len(new Sub("abcde")), 5);
+  assert.sameValue(len("abc"), 3);
+})();
+
+// Strings and arrays are both matched on the receiver's kind rather than a shape. They must not
+// replace each other in a monomorphic cache, in either fill order.
+(function () {
+  function len(o) {
+    return o.length;
+  }
+
+  var arr = [1, 2, 3];
+  for (var i = 0; i < 100; i++) {
+    assert.sameValue(len("abcdefg"), 7);
+    assert.sameValue(len(arr), 3);
+  }
+
+  // Both entries stay live as their receivers change
+  arr.push(4);
+  assert.sameValue(len(arr), 4);
+  assert.sameValue(len("ab"), 2);
+  assert.sameValue(len(arr), 4);
+})();
+
+(function () {
+  function len(o) {
+    return o.length;
+  }
+
+  // Fill the array entry first this time
+  var arr = [1, 2];
+  for (var i = 0; i < 100; i++) {
+    assert.sameValue(len(arr), 2);
+    assert.sameValue(len("abc"), 3);
+  }
+
+  arr.length = 0;
+  assert.sameValue(len(arr), 0);
+  assert.sameValue(len("abcd"), 4);
+})();
+
+// A callsite that sees strings, arrays, plain objects and a wrapper holds all four kinds at once
+(function () {
+  function len(o) {
+    return o.length;
+  }
+
+  var arr = [1, 2, 3];
+  var plain = { length: 7 };
+  var wrapper = new String("ab");
+
+  for (var round = 0; round < 100; round++) {
+    assert.sameValue(len("abcde"), 5);
+    assert.sameValue(len(arr), 3);
+    assert.sameValue(len(plain), 7);
+    assert.sameValue(len(wrapper), 2);
+  }
+
+  arr.push(4);
+  plain.length = 8;
+  assert.sameValue(len("abcde"), 5);
+  assert.sameValue(len(arr), 4);
+  assert.sameValue(len(plain), 8);
+})();
+
+// A string fills a polymorphic slot like any other entry. A fifth receiver overflows the cache and
+// caching stops, but every receiver still reads correctly, including the string.
+(function () {
+  function len(o) {
+    return o.length;
+  }
+
+  var arr = [1, 2];
+  var one = { length: 3 };
+  var two = { pad: 0, length: 4 };
+  var fifth = { pad: 0, pad2: 0, length: 5 };
+
+  // Fill and hit all four entries before introducing a fifth receiver
+  for (var round = 0; round < 2; round++) {
+    assert.sameValue(len("a"), 1);
+    assert.sameValue(len(arr), 2);
+    assert.sameValue(len(one), 3);
+    assert.sameValue(len(two), 4);
+  }
+
+  // The fifth shape does not fit, so caching stops at this callsite
+  assert.sameValue(len(fifth), 5);
+
+  for (var round2 = 0; round2 < 2; round2++) {
+    assert.sameValue(len("a"), 1);
+    assert.sameValue(len(arr), 2);
+    assert.sameValue(len(one), 3);
+    assert.sameValue(len(two), 4);
+    assert.sameValue(len(fifth), 5);
+  }
+
+  // Receivers are still read live once caching has stopped
+  arr.push(0);
+  one.length = 9;
+  assert.sameValue(len("abcd"), 4);
+  assert.sameValue(len(arr), 3);
+  assert.sameValue(len(one), 9);
+})();
+
+// Named properties other than length are not cached for string primitives, and reading them must
+// not disturb a length site or return a wrong value.
+(function () {
+  function get(o, key) {
+    return o[key];
+  }
+
+  assert.sameValue(readLength("abcd"), 4);
+  assert.sameValue("abcd".charCodeAt(0), 97);
+  assert.sameValue("abcd".slice(1), "bcd");
+  assert.sameValue("abcd".nonexistent, undefined);
+  assert.sameValue(readLength("abcd"), 4);
+
+  // Computed access reaches the same value through a different opcode
+  for (var i = 0; i < 100; i++) {
+    assert.sameValue(get("abcde", "length"), 5);
+  }
+  assert.sameValue(get("abcde", "0"), "a");
+  assert.sameValue(get("abcde", 0), "a");
+})();
+
+// Methods added to String.prototype after a length site is warm are still found
+(function () {
+  assert.sameValue(readLength("abcd"), 4);
+
+  String.prototype.myLength = function () { return this.length; };
+  assert.sameValue("abcde".myLength(), 5);
+  assert.sameValue(readLength("abcd"), 4);
+  delete String.prototype.myLength;
+})();
+
+// Values that are not strings at a warm string length site behave normally
+(function () {
+  function len(o) {
+    return o.length;
+  }
+
+  for (var i = 0; i < 100; i++) {
+    assert.sameValue(len("abc"), 3);
+  }
+
+  assert.throws(TypeError, function () { len(null); });
+  assert.throws(TypeError, function () { len(undefined); });
+  assert.sameValue(len(5), undefined);
+  assert.sameValue(len(true), undefined);
+  assert.sameValue(len(Symbol("x")), undefined);
+  assert.sameValue(len(10n), undefined);
+  assert.sameValue(len(function (a, b) {}), 2);
+
+  assert.sameValue(len("abcd"), 4);
+})();
+
+// A proxy that reports a length is not a string and must still route through its trap
+(function () {
+  function len(o) {
+    return o.length;
+  }
+
+  assert.sameValue(len("abc"), 3);
+
+  var trapped = 0;
+  var proxy = new Proxy({ length: 4 }, {
+    get: function (target, key, receiver) {
+      if (key === "length") {
+        trapped++;
+      }
+      return Reflect.get(target, key, receiver);
+    },
+  });
+
+  for (var i = 0; i < 10; i++) {
+    assert.sameValue(len(proxy), 4);
+    assert.sameValue(len("abc"), 3);
+  }
+  assert.sameValue(trapped, 10);
+})();
+
+// The cache survives garbage collection
+(function () {
+  function len(o) {
+    return o.length;
+  }
+
+  var arr = [1, 2, 3];
+  assert.sameValue(len("abcd"), 4);
+  assert.sameValue(len(arr), 3);
+
+  $262.gc();
+
+  assert.sameValue(len("abcd"), 4);
+  assert.sameValue(len(arr), 3);
+
+  // A rope allocated after the collection is matched by the same entry
+  $262.gc();
+  assert.sameValue(len("ab" + "cde"), 5);
+})();
+
+// Strings from another realm are ordinary strings, so a shared callsite stays monomorphic
+(function () {
+  var other = $262.createRealm();
+  other.evalScript("globalThis.make = function () { return 'abcdefg'; };");
+
+  function len(o) {
+    return o.length;
+  }
+
+  var theirs = other.global.make();
+  for (var i = 0; i < 100; i++) {
+    assert.sameValue(len("abc"), 3);
+    assert.sameValue(len(theirs), 7);
+  }
+})();


### PR DESCRIPTION
## Summary

Accessing the `length` property of a primitive string is a common operation that currently as not handled by the `GetNamedPropertyCache`. Let's add a new cache variant - modeled after the similar `ArrayLength` variant - that speeds up access via a single kind check.

Notes:
- A bit of refactoring required and checking a more generic shape or key enum instead of just shapes, since this is the first non-object receiver in these paths.

Noisy, but neutral-to-slightly-negative on Octane itself. Still seems like a good idea overall.

## Tests

- Added LLM-generated tests covering the new paths