### PR TITLE
[runtime] Check that content types match in TypedArray.prototype.set

### DIFF
--- a/src/js/runtime/intrinsics/typed_array_prototype.rs
+++ b/src/js/runtime/intrinsics/typed_array_prototype.rs
@@ -993,6 +993,16 @@ impl TypedArrayPrototype {
             return range_error(cx, "TypedArray.prototype.set offset is out of range");
         }
 
+        if source.content_type() != target.content_type() {
+            return type_error(
+                cx,
+                &format!(
+                    "TypedArray.prototype.set source array must contain {}",
+                    target.content_type().format()
+                ),
+            );
+        }
+
         let source_byte_index =
             if same_object_value(*source_buffer.as_object(), *target_buffer.as_object()) {
                 let source_byte_length = typed_array_byte_length(&source_record);

--- a/tests/integration/built-ins/TypedArray/set_content_type_mismatch.js
+++ b/tests/integration/built-ins/TypedArray/set_content_type_mismatch.js
@@ -1,0 +1,18 @@
+/*---
+description: >
+  TypedArray.prototype.set checks the source and target content types.
+---*/
+
+// Content type check occurs, even for empty arrays
+assert.throws(TypeError, () => new BigInt64Array(0).set(new Float64Array(0)));
+assert.throws(TypeError, () => new BigInt64Array(1).set(new Float64Array(1)));
+assert.throws(TypeError, () => new Float64Array(0).set(new BigInt64Array(0)));
+
+// Matching content types
+const target = new BigUint64Array(2);
+target.set(new BigInt64Array([1n, 2n]));
+assert.sameValue(target[0], 1n);
+assert.sameValue(target[1], 2n);
+
+// Offset RangeError is thrown before content type check
+assert.throws(RangeError, () => new BigInt64Array(0).set(new Float64Array(0), 1));


### PR DESCRIPTION
## Summary

We were missing an explicit check for matching content types in `TypedArray.prototype.set`. This was implicitly happening when converting elements below which masked the issue, but an empty array was never erroring.

## Tests

- Added integration test which catches this bug