### PR TITLE
[runtime] Fix GC-unsafe Map/Set iteration when the collection is resized during iteration

### DIFF
--- a/src/js/runtime/collections/index_map.rs
+++ b/src/js/runtime/collections/index_map.rs
@@ -462,17 +462,6 @@ pub trait IndexMapInstance:
         BsIndexMap::<Self::K, Self::V, Self::H>::min_capacity_needed(num_elements)
     }
 
-    fn fix_iterator_for_resized_map(
-        tombstone_map: HeapPtr<Self>,
-        next_entry_index: &mut usize,
-    ) -> HeapPtr<Self> {
-        BsIndexMap::<Self::K, Self::V, Self::H>::fix_iterator_for_resized_map(
-            tombstone_map.cast(),
-            next_entry_index,
-        )
-        .cast()
-    }
-
     fn visit_pointers_impl<Visitor: HeapVisitor>(
         map: HeapPtr<Self>,
         visitor: &mut Visitor,
@@ -727,8 +716,14 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BsBuildHasher> Iterator for GcSafeEntrie
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        // TODO: Handle when map data is moved to a new map e.g. when growing. Must write info for
-        // switching iterator to point to new map in place of the old map.
+        // The map data may have been moved to a new map during a resize, meaning the map we point
+        // to is now a tombstone. Follow tombstone objects, fixing up the iterator as needed. This
+        // may be a chain of tombstone objects and we need to fix up the iterator at each step.
+        while self.map.is_tombstone() {
+            let new_map =
+                BsIndexMap::fix_iterator_for_resized_map(*self.map, &mut self.next_entry_index);
+            self.map.replace(new_map);
+        }
 
         let mut current_entry_index = self.next_entry_index;
 

--- a/src/js/runtime/collections/index_set.rs
+++ b/src/js/runtime/collections/index_set.rs
@@ -105,17 +105,6 @@ pub trait IndexSetInstance:
         BsIndexSet::<Self::T, Self::H>::calculate_size_in_bytes(capacity)
     }
 
-    fn fix_iterator_for_resized_map(
-        tombstone_map: HeapPtr<Self>,
-        next_entry_index: &mut usize,
-    ) -> HeapPtr<Self> {
-        InnerMap::<Self::T, Self::H>::fix_iterator_for_resized_map(
-            tombstone_map.cast(),
-            next_entry_index,
-        )
-        .cast()
-    }
-
     fn visit_pointers_impl<Visitor: HeapVisitor>(
         map: HeapPtr<Self>,
         visitor: &mut Visitor,

--- a/src/js/runtime/intrinsics/map_iterator_object.rs
+++ b/src/js/runtime/intrinsics/map_iterator_object.rs
@@ -4,10 +4,7 @@ use crate::{
         Context, Handle, HeapPtr,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
-        collections::{
-            HashDosResistantHasher,
-            index_map::{GcSafeEntriesIter, IndexMapInstance},
-        },
+        collections::{HashDosResistantHasher, index_map::GcSafeEntriesIter},
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
@@ -103,16 +100,8 @@ impl MapIteratorPrototype {
             return Ok(create_iter_result_object(cx, cx.undefined(), true)?);
         }
 
-        // Follow tombstone objects, fixing up iterator as needed. This may be a chain of tombstone
-        // objects and we need to fix up the iterator at each step.
-        while map_iterator.map.is_tombstone() {
-            map_iterator.map = ValueIndexMap::fix_iterator_for_resized_map(
-                map_iterator.map,
-                &mut map_iterator.next_entry_index,
-            );
-        }
-
-        // Perform a single iteration, mutating iterator object
+        // Perform a single iteration, mutating iterator object. The iterator follows tombstone
+        // objects itself if the map was resized since the last iteration.
         let mut iter = map_iterator.get_iter();
         let iter_result = iter.next();
         map_iterator.store_iter(iter);

--- a/src/js/runtime/intrinsics/set_iterator_object.rs
+++ b/src/js/runtime/intrinsics/set_iterator_object.rs
@@ -4,9 +4,7 @@ use crate::{
         Context, Handle, HeapPtr, Value,
         alloc_error::AllocResult,
         array_object::create_array_from_list,
-        collections::{
-            BsIndexMap, HashDosResistantHasher, IndexSetInstance, index_map::GcSafeEntriesIter,
-        },
+        collections::{HashDosResistantHasher, index_map::GcSafeEntriesIter},
         error::type_error,
         eval_result::EvalResult,
         gc::{HeapItem, HeapVisitor},
@@ -71,10 +69,6 @@ impl SetIteratorObject {
         self.set = (*set).cast();
         self.next_entry_index = next_entry_index;
     }
-
-    fn set_inner_map(&self) -> HeapPtr<BsIndexMap<ValueCollectionKey, (), HashDosResistantHasher>> {
-        self.set.cast()
-    }
 }
 
 /// The %SetIteratorPrototype% Object (https://tc39.es/ecma262/#sec-%setiteratorprototype%-object)
@@ -106,16 +100,8 @@ impl SetIteratorPrototype {
             return Ok(create_iter_result_object(cx, cx.undefined(), true)?);
         }
 
-        // Follow tombstone objects, fixing up iterator as needed. This may be a chain of tombstone
-        // objects and we need to fix up the iterator at each step.
-        while set_iterator.set_inner_map().is_tombstone() {
-            set_iterator.set = ValueIndexSet::fix_iterator_for_resized_map(
-                set_iterator.set,
-                &mut set_iterator.next_entry_index,
-            );
-        }
-
-        // Perform a single iteration, mutating iterator object
+        // Perform a single iteration, mutating iterator object. The iterator follows tombstone
+        // objects itself if the set was resized since the last iteration.
         let mut iter = set_iterator.get_iter();
         let iter_result = iter.next();
         set_iterator.store_iter(iter);

--- a/tests/integration/built-ins/Map/resizing_iterator.js
+++ b/tests/integration/built-ins/Map/resizing_iterator.js
@@ -81,6 +81,32 @@ description: Map can be modified while iterating, causing underlying map to be r
   }
 })();
 
+(function testGrowthWhileIteratingGcSafety() {
+  var x = new Map([['0', 0], ['1', 1], ['2', 2], ['3', 3]]);
+  var i = 4;
+  var visited = [];
+
+  x.forEach((v, k) => {
+    if (i < 100) {
+      x.set(`${i}`, i);
+
+      // Collect the map that was resized away, so that continuing to read from it causes a crash
+      $262.gc();
+    }
+
+    visited.push([k, v]);
+
+    i++;
+  });
+
+  assert.sameValue(visited.length, 100);
+
+  for (var i = 0; i < 100; i++) {
+    assert.sameValue(visited[i][0], `${i}`);
+    assert.sameValue(visited[i][1], i);
+  }
+})();
+
 (function testGrowthWithDeletionWhileIterating() {
   var x = new Map([['0', 0], ['1', 1], ['2', 2], ['3', 3]]);
 

--- a/tests/integration/built-ins/Set/resizing_iterator.js
+++ b/tests/integration/built-ins/Set/resizing_iterator.js
@@ -78,6 +78,31 @@ description: Set can be modified while iterating, causing underlying map to be r
   }
 })();
 
+(function testGrowthWhileIteratingGcSafety() {
+  var x = new Set([0, 1, 2, 3]);
+  var i = 4;
+  var visited = [];
+
+  x.forEach((e) => {
+    if (i < 100) {
+      x.add(i);
+
+      // Collect the set that was resized away, so that continuing to read from it causes a crash
+      $262.gc();
+    }
+
+    visited.push(e);
+
+    i++;
+  });
+
+  assert.sameValue(visited.length, 100);
+
+  for (var i = 0; i < 100; i++) {
+    assert.sameValue(visited[i], i);
+  }
+})();
+
 (function testGrowthWithDeletionWhileIterating() {
   var x = new Set([0, 1, 2, 3]);
 

--- a/tests/integration/built-ins/Set/resizing_set_operations.js
+++ b/tests/integration/built-ins/Set/resizing_set_operations.js
@@ -1,0 +1,60 @@
+/*---
+description: Set operations handle resizing the set that is being iterated over.
+---*/
+
+function growingSetLike(x, visited, hasResult) {
+  return {
+    size: 1000,
+    has(value) {
+      visited.push(value);
+
+      if (x.size < 100) {
+        x.add(x.size);
+
+        // Collect the set that was resized away, so that continuing to read from it causes a crash
+        $262.gc();
+      }
+
+      return hasResult;
+    },
+    keys() {
+      throw new Error();
+    },
+  };
+}
+
+function assertVisitedAllElements(x, visited) {
+  assert.sameValue(x.size, 100);
+  assert.sameValue(visited.length, 100);
+
+  for (var i = 0; i < 100; i++) {
+    assert.sameValue(visited[i], i);
+  }
+}
+
+(function testGrowthWhileIteratingInIntersection() {
+  var x = new Set([0, 1, 2, 3]);
+  var visited = [];
+
+  assert.sameValue(x.intersection(growingSetLike(x, visited, false)).size, 0);
+
+  assertVisitedAllElements(x, visited);
+})();
+
+(function testGrowthWhileIteratingInIsDisjointFrom() {
+  var x = new Set([0, 1, 2, 3]);
+  var visited = [];
+
+  assert.sameValue(x.isDisjointFrom(growingSetLike(x, visited, false)), true);
+
+  assertVisitedAllElements(x, visited);
+})();
+
+(function testGrowthWhileIteratingInIsSubsetOf() {
+  var x = new Set([0, 1, 2, 3]);
+  var visited = [];
+
+  assert.sameValue(x.isSubsetOf(growingSetLike(x, visited, true)), true);
+
+  assertVisitedAllElements(x, visited);
+})();


### PR DESCRIPTION
## Summary

Fix an existing GC safety bug for `Map/Set` iteration when the underlying collection is resized during iteration. The `GcSafeEntriesIter` itself now follows tombstones on each `next` - and is the sole place tombstones are resolved.

This affected `Map.prototype.forEach` and `Set.prototype.{forEach, intersection, isDisjointFrom, isSubsetOf}`.

## Tests

- Added integration tests for GC-safe iteration over a resized collection in all affected `Map/Set` methods