### PR TITLE
[runtime] Fix Map/Set iteration clearing underlying collection during iteration

### DIFF
--- a/src/js/runtime/collections/index_map.rs
+++ b/src/js/runtime/collections/index_map.rs
@@ -173,9 +173,14 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BsBuildHasher> BsIndexMap<K, V, H> {
         // Clear indices array
         self.indices.init_with(self.capacity(), EMPTY_INDEX);
 
-        // Entries array does not need to be changed, updating number of entries is sufficient
+        // Mark all used entries as deleted so that iterators that are in flight will skip over them
+        let num_entries_used = self.num_entries_used();
+        for entry in &mut self.entries_as_slice_mut()[..num_entries_used] {
+            *entry = Entry::Deleted { chain: EMPTY_INDEX };
+        }
+
         self.num_occupied = 0;
-        self.num_deleted = 0;
+        self.num_deleted = num_entries_used;
     }
 
     /// Return an iterator over the entries of the map. Iterator is not GC-safe, so make sure there

--- a/tests/integration/built-ins/Map/clear_during_iteration.js
+++ b/tests/integration/built-ins/Map/clear_during_iteration.js
@@ -1,0 +1,79 @@
+/*---
+description: Map can be cleared while iterating, and values added afterwards are still iterated.
+---*/
+
+function assertVisited(visited, expected) {
+  assert.sameValue(visited.length, expected.length);
+
+  for (var i = 0; i < expected.length; i++) {
+    assert.sameValue(visited[i], expected[i]);
+  }
+}
+
+(function testAddAfterClearWhileIterating() {
+  var x = new Map([['0', 0], ['1', 1], ['2', 2], ['3', 3]]);
+  var visited = [];
+
+  x.forEach((v, k) => {
+    visited.push(k);
+
+    // Entries added after the clear must not reuse the indices of the cleared entries, which are
+    // behind the iterator.
+    if (k === '1') {
+      x.clear();
+      x.set('4', 4);
+    }
+  });
+
+  assertVisited(visited, ['0', '1', '4']);
+  assert.sameValue(x.size, 1);
+})();
+
+(function testAddManyAfterClearWhileIterating() {
+  var x = new Map([['0', 0], ['1', 1], ['2', 2], ['3', 3], ['4', 4]]);
+  var visited = [];
+
+  x.forEach((v, k) => {
+    visited.push(k);
+
+    // Add more entries than were cleared, resizing the map
+    if (k === '2') {
+      x.clear();
+
+      for (var i = 5; i < 11; i++) {
+        x.set(`${i}`, i);
+      }
+    }
+  });
+
+  assertVisited(visited, ['0', '1', '2', '5', '6', '7', '8', '9', '10']);
+})();
+
+(function testClearWithoutAddWhileIterating() {
+  var x = new Map([['0', 0], ['1', 1], ['2', 2], ['3', 3]]);
+  var visited = [];
+
+  x.forEach((v, k) => {
+    visited.push(k);
+    x.clear();
+  });
+
+  assertVisited(visited, ['0']);
+  assert.sameValue(x.size, 0);
+})();
+
+(function testClearWhileIteratingWithForOf() {
+  var x = new Map([['0', 0], ['1', 1], ['2', 2], ['3', 3]]);
+  var visited = [];
+
+  for (var [k, v] of x) {
+    visited.push(k);
+
+    if (k === '1') {
+      x.clear();
+      x.set('4', 4);
+    }
+  }
+
+  assertVisited(visited, ['0', '1', '4']);
+})();

--- a/tests/integration/built-ins/Set/clear_during_iteration.js
+++ b/tests/integration/built-ins/Set/clear_during_iteration.js
@@ -1,0 +1,79 @@
+/*---
+description: Set can be cleared while iterating, and values added afterwards are still iterated.
+---*/
+
+function assertVisited(visited, expected) {
+  assert.sameValue(visited.length, expected.length);
+
+  for (var i = 0; i < expected.length; i++) {
+    assert.sameValue(visited[i], expected[i]);
+  }
+}
+
+(function testAddAfterClearWhileIterating() {
+  var x = new Set([0, 1, 2, 3]);
+  var visited = [];
+
+  x.forEach((e) => {
+    visited.push(e);
+
+    // Values added after the clear must not reuse the indices of the cleared values, which are
+    // behind the iterator.
+    if (e === 1) {
+      x.clear();
+      x.add(4);
+    }
+  });
+
+  assertVisited(visited, [0, 1, 4]);
+  assert.sameValue(x.size, 1);
+})();
+
+(function testAddManyAfterClearWhileIterating() {
+  var x = new Set([0, 1, 2, 3, 4]);
+  var visited = [];
+
+  x.forEach((e) => {
+    visited.push(e);
+
+    // Add more values than were cleared, resizing the set
+    if (e === 2) {
+      x.clear();
+
+      for (var i = 5; i < 11; i++) {
+        x.add(i);
+      }
+    }
+  });
+
+  assertVisited(visited, [0, 1, 2, 5, 6, 7, 8, 9, 10]);
+})();
+
+(function testClearWithoutAddWhileIterating() {
+  var x = new Set([0, 1, 2, 3]);
+  var visited = [];
+
+  x.forEach((e) => {
+    visited.push(e);
+    x.clear();
+  });
+
+  assertVisited(visited, [0]);
+  assert.sameValue(x.size, 0);
+})();
+
+(function testClearWhileIteratingWithForOf() {
+  var x = new Set([0, 1, 2, 3]);
+  var visited = [];
+
+  for (var e of x) {
+    visited.push(e);
+
+    if (e === 1) {
+      x.clear();
+      x.add(4);
+    }
+  }
+
+  assertVisited(visited, [0, 1, 4]);
+})();


### PR DESCRIPTION
## Summary

Fix an existing correctness bug for `Map/Set` iteration when the underlying collection is cleared during iteration. Clearing must mark all used entries as deleted so that any in-flight iterators will skip over them.

## Tests

- Added integration tests for clearing while iterating `Map/Set`