### PR TITLE
[runtime] GetNamedPropertyCache handles primitive prototype access

### DIFF
--- a/src/js/runtime/bytecode/cache.rs
+++ b/src/js/runtime/bytecode/cache.rs
@@ -137,6 +137,8 @@ pub enum GetNamedPropertyCache {
         is_accessor: bool,
     },
     /// Property is found at this location on a prototype object in the receiver's prototype chain.
+    ///
+    /// Can be a primitive receiver, in which case the shape is the primitive's singleton shape.
     Proto {
         shape: HeapPtr<Shape>,
         guard: ValidityGuard,
@@ -248,6 +250,10 @@ impl GetNamedPropertyCache {
             return Ok(Some(Self::ArrayLength));
         }
 
+        if !original_receiver.is_object() {
+            return Self::fill_primitive(cx, original_receiver, receiver, key);
+        }
+
         if !is_cacheable_named_property(cx, *receiver, *key) {
             return Ok(None);
         }
@@ -262,47 +268,128 @@ impl GetNamedPropertyCache {
             }));
         }
 
-        // Walk the prototype chain looking for the property. Does not allocate.
-        let mut next_proto = shape.prototype_ptr();
+        match Self::lookup_prototype_chain(cx, shape.prototype_ptr(), key) {
+            PrototypeLookup::Uncacheable => Ok(None),
+            PrototypeLookup::Found { proto, location, is_accessor } => {
+                let proto = proto.to_handle();
+
+                // May allocate
+                let guard = receiver.request_prototype_validity_guard(cx)?.unwrap();
+
+                Ok(Some(Self::Proto {
+                    shape: receiver.shape_ptr(),
+                    guard,
+                    proto: *proto,
+                    location,
+                    is_accessor,
+                }))
+            }
+            PrototypeLookup::NotFound => {
+                // May allocate
+                let guard = receiver.request_prototype_validity_guard(cx)?;
+
+                Ok(Some(Self::NotFound { shape: receiver.shape_ptr(), guard }))
+            }
+        }
+    }
+
+    /// Fill the cache for a property access on a primitive receiver.
+    fn fill_primitive(
+        cx: Context,
+        original_receiver: Handle<Value>,
+        mut receiver: Handle<ObjectValue>,
+        key: Handle<PropertyKey>,
+    ) -> AllocResult<Option<Self>> {
+        if !Self::is_cacheable_primitive(*original_receiver) {
+            return Ok(None);
+        }
+
+        if key.is_array_index() {
+            return Ok(None);
+        }
+
+        match Self::lookup_prototype_chain(cx, receiver.shape_ptr().prototype_ptr(), key) {
+            PrototypeLookup::Uncacheable => Ok(None),
+            PrototypeLookup::Found { proto, location, is_accessor } => {
+                // Accessors take the slow path since the coerced receiver is visible
+                if is_accessor {
+                    return Ok(None);
+                }
+
+                let proto = proto.to_handle();
+
+                // May allocate
+                let guard = receiver.request_prototype_validity_guard(cx)?.unwrap();
+
+                Ok(Some(Self::Proto {
+                    shape: original_receiver.as_pointer().shape(),
+                    guard,
+                    proto: *proto,
+                    location,
+                    is_accessor: false,
+                }))
+            }
+            PrototypeLookup::NotFound => {
+                // May allocate
+                let guard = receiver.request_prototype_validity_guard(cx)?;
+
+                Ok(Some(Self::NotFound { shape: original_receiver.as_pointer().shape(), guard }))
+            }
+        }
+    }
+
+    /// The receiver shape used for a fill of this cache.
+    pub fn fill_receiver_shape(
+        original_receiver: Value,
+        receiver: HeapPtr<ObjectValue>,
+    ) -> HeapPtr<Shape> {
+        if Self::is_cacheable_primitive(original_receiver) {
+            original_receiver.as_pointer().shape()
+        } else {
+            receiver.shape_ptr()
+        }
+    }
+
+    /// Whether a named property access on a primitive receiver is cacheable.
+    #[inline(always)]
+    pub fn is_cacheable_primitive(receiver_value: Value) -> bool {
+        // Only primitives that are heap items are cacheable since the cache needs a shape
+        receiver_value.is_string() || receiver_value.is_symbol() || receiver_value.is_bigint()
+    }
+
+    /// Walk a prototype chain looking for a property. Does not allocate.
+    fn lookup_prototype_chain(
+        cx: Context,
+        mut next_proto: Option<HeapPtr<ObjectValue>>,
+        key: Handle<PropertyKey>,
+    ) -> PrototypeLookup {
         while let Some(proto) = next_proto {
             let proto_shape = proto.shape_ptr();
 
             // Cannot cache exotic object behavior
             if has_exotic_named_property_access(cx, proto, *key) {
-                return Ok(None);
+                return PrototypeLookup::Uncacheable;
             }
 
             if proto_shape.is_map_mode() {
                 // Properties stored on map mode objects cannot be cached
                 let map = proto.named_properties_map_opt().unwrap();
                 if map.contains_key(&key) {
-                    return Ok(None);
+                    return PrototypeLookup::Uncacheable;
                 }
             } else if let Some(def) = proto_shape.lookup_own_property(*key) {
-                // Property is stored in the prototype object's array
-                let proto = proto.to_handle();
-                let location = def.location;
-                let is_accessor = def.attributes.is_accessor();
-
-                // May allocate
-                let guard = receiver.request_prototype_validity_guard(cx)?.unwrap();
-
-                return Ok(Some(Self::Proto {
-                    shape: receiver.shape_ptr(),
-                    guard,
-                    proto: *proto,
-                    location,
-                    is_accessor,
-                }));
+                // Property is stored in the prototype object's own properties
+                return PrototypeLookup::Found {
+                    proto,
+                    location: def.location,
+                    is_accessor: def.attributes.is_accessor(),
+                };
             }
 
             next_proto = proto_shape.prototype_ptr();
         }
 
-        // May allocate
-        let guard = receiver.request_prototype_validity_guard(cx)?;
-
-        Ok(Some(Self::NotFound { shape: receiver.shape_ptr(), guard }))
+        PrototypeLookup::NotFound
     }
 
     /// The receiver shape this cache is keyed on, if any. Returns None if the cache is instead
@@ -600,6 +687,20 @@ impl SetNamedPropertyCache {
     }
 }
 
+/// The result of looking for a property on a prototype chain.
+enum PrototypeLookup {
+    /// Property was found at this location on this prototype object.
+    Found {
+        proto: HeapPtr<ObjectValue>,
+        location: PropertyLocation,
+        is_accessor: bool,
+    },
+    /// Property was not found anywhere on the prototype chain.
+    NotFound,
+    /// The prototype chain has behavior that cannot be cached.
+    Uncacheable,
+}
+
 /// Whether a named property access on this object can be cached at all.
 fn is_cacheable_named_property(
     cx: Context,
@@ -628,16 +729,38 @@ fn has_exotic_named_property_access(
     match object.shape_ptr().kind() {
         // Exotic objects with special behavior for named property access
         HeapItemKind::ProxyObject
-        | HeapItemKind::StringObject
         | HeapItemKind::ModuleNamespaceObject
         | HeapItemKind::MappedArgumentsObject
         | HeapItemKind::GlobalObject => true,
+        // StringObjects only have exotic behavior if the key is a canonical numeric index string.
+        // Other named accesses are ordinary and can be cached.
+        HeapItemKind::StringObject => is_possible_canonical_numeric_index_string(key),
         // Arrays only intercept named access to their length property
         HeapItemKind::ArrayObject => key == *cx.names.length(),
         // Typed arrays intercept canonical numeric keys which we don't detect here, so reject
         _ if object.is_typed_array() => true,
         _ => false,
     }
+}
+
+/// Whether a key may be a canonical numeric index string. Is conservative and cheap.
+fn is_possible_canonical_numeric_index_string(key: PropertyKey) -> bool {
+    if key.is_array_index() {
+        return true;
+    }
+
+    if !key.is_string() {
+        return false;
+    }
+
+    let key_string = key.as_string();
+    if key_string.is_empty() {
+        return false;
+    }
+
+    // Numeric index strings must start with a digit
+    let first_code_unit = key_string.as_flat().code_unit_at(0);
+    (b'0' as u16..=b'9' as u16).contains(&first_code_unit)
 }
 
 #[derive(Clone, Copy)]

--- a/src/js/runtime/bytecode/vm.rs
+++ b/src/js/runtime/bytecode/vm.rs
@@ -4980,7 +4980,7 @@ impl VM {
 
         let fill_cache = 'full_path: {
             if !receiver_value.is_object() {
-                if self.is_cacheable_primitive_get_named_property(instr, receiver_value) {
+                if GetNamedPropertyCache::is_cacheable_primitive(receiver_value) {
                     let is_failed = matches!(self.get_cache(instr.cache_index()), Cache::Failed);
                     break 'full_path /* fill_cache */ !is_failed;
                 }
@@ -5018,27 +5018,6 @@ impl VM {
         };
 
         self.get_named_property_full(instr, fill_cache)
-    }
-
-    /// Whether a named property access on a primitive receiver is cacheable.
-    ///
-    /// Only the `length` property of string primitives is cacheable.
-    #[inline(always)]
-    fn is_cacheable_primitive_get_named_property<W: Width>(
-        &self,
-        instr: &GetNamedPropertyInstruction<W>,
-        receiver_value: Value,
-    ) -> bool {
-        if !receiver_value.is_string() {
-            return false;
-        }
-
-        let name = self.get_property_key_constant(instr.name_constant_index());
-        if name != *self.cx().names.length() {
-            return false;
-        }
-
-        true
     }
 
     #[inline(always)]
@@ -5123,9 +5102,12 @@ impl VM {
                 // Preallocate the polymorphic cache if promotion is possible
                 let new_polymorphic_cache = match self.get_cache(cache_index) {
                     Cache::GetNamedProperty(cache)
-                        if cache
-                            .receiver_shape()
-                            .is_none_or(|shape| !shape.ptr_eq(&coerced_object.shape_ptr())) =>
+                        if cache.receiver_shape().is_none_or(|shape| {
+                            !shape.ptr_eq(&GetNamedPropertyCache::fill_receiver_shape(
+                                *object,
+                                *coerced_object,
+                            ))
+                        }) =>
                     {
                         Some(CacheArray::new_polymorphic(self.cx())?)
                     }

--- a/tests/integration/ignored_tests.jsonc
+++ b/tests/integration/ignored_tests.jsonc
@@ -2,6 +2,10 @@
   // Slow tests which are ignored in GC stress test runs. Aim to ignore all tests over 5 seconds.
   "gc_stress_test": {
     "tests": [
+      "built-ins/Array/indexed_property_storage.js",
+      "built-ins/RegExp/canonicalize.js",
+      "built-ins/RegExp/flags_only_copy.js",
+      "built-ins/RegExp/last_index_fast_path.js",
       "regression/000016.js",
       "regression/000019.js"
     ]

--- a/tests/integration/language/expression/member/get_named_property_cache/primitive_prototype.js
+++ b/tests/integration/language/expression/member/get_named_property_cache/primitive_prototype.js
@@ -1,0 +1,371 @@
+/*---
+description: Caching of named property accesses on primitive receivers.
+---*/
+
+// A single cache entry serves every string, whatever its representation
+(function () {
+  function read(o) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = o.myProperty;
+    }
+    return last;
+  }
+
+  String.prototype.myProperty = "found";
+
+  var strings = [
+    "abcdefgh",
+    "abcd" + "efgh",
+    ("ab" + "cd") + ("ef" + "gh"),
+    "xxabcdefghxx".slice(2, 10),
+    "中文",
+    "\u{1f600}",
+    "",
+  ];
+
+  for (var round = 0; round < 3; round++) {
+    for (var i = 0; i < strings.length; i++) {
+      assert.sameValue(read(strings[i]), "found");
+    }
+  }
+})();
+
+// The property is read live from the prototype, so overwriting it needs no invalidation
+(function () {
+  function read(o) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = o.myProperty;
+    }
+    return last;
+  }
+
+  String.prototype.myProperty = "first";
+  assert.sameValue(read("abc"), "first");
+
+  String.prototype.myProperty = "second";
+  assert.sameValue(read("abc"), "second");
+})();
+
+// Methods are found and called with the primitive as the receiver
+(function () {
+  function charAt(s) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = s.charCodeAt(0);
+    }
+    return last;
+  }
+
+  assert.sameValue(charAt("abc"), 97);
+  assert.sameValue(charAt("b" + "cd"), 98);
+  assert.sameValue("abcd".slice(1), "bcd");
+
+  // Whether `this` is the primitive or a wrapper depends on the strictness of the method, so only
+  // a method with its own directive is checked here.
+  String.prototype.strictThis = function () { "use strict"; return typeof this; };
+  String.prototype.thisAsString = function () { return String(this); };
+
+  for (var i = 0; i < 100; i++) {
+    assert.sameValue("abc".strictThis(), "string");
+    assert.sameValue("abc".thisAsString(), "abc");
+  }
+})();
+
+// Symbols and bigints are cached on their own kinds and share a callsite with strings
+(function () {
+  function read(o) {
+    return o.myProperty;
+  }
+
+  var sym = Symbol("s");
+
+  String.prototype.myProperty = "string";
+  Symbol.prototype.myProperty = "symbol";
+  BigInt.prototype.myProperty = "bigint";
+
+  for (var round = 0; round < 100; round++) {
+    assert.sameValue(read("abc"), "string");
+    assert.sameValue(read(sym), "symbol");
+    assert.sameValue(read(10n), "bigint");
+  }
+
+  // Each entry reads from its own holder
+  Symbol.prototype.myProperty = "symbol2";
+  assert.sameValue(read(sym), "symbol2");
+  assert.sameValue(read("abc"), "string");
+  assert.sameValue(read(10n), "bigint");
+})();
+
+// A string's length is served by its own cache and is unaffected by the prototype chain
+(function () {
+  function len(s) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = s.length;
+    }
+    return last;
+  }
+
+  function read(o) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = o.myProperty;
+    }
+    return last;
+  }
+
+  String.prototype.myProperty = "found";
+  assert.sameValue(len("abcde"), 5);
+  assert.sameValue(read("abcde"), "found");
+  assert.sameValue(len("ab"), 2);
+})();
+
+// Wrapper objects are a different receiver from primitives and stay correct alongside them
+(function () {
+  function read(o) {
+    return o.myProperty;
+  }
+
+  String.prototype.myProperty = "shared";
+
+  var wrapper = new String("ab");
+  for (var round = 0; round < 100; round++) {
+    assert.sameValue(read("abc"), "shared");
+    assert.sameValue(read(wrapper), "shared");
+  }
+
+  // An own property on the wrapper shadows the prototype for that receiver only
+  wrapper.myProperty = "own";
+  assert.sameValue(read(wrapper), "own");
+  assert.sameValue(read("abc"), "shared");
+})();
+
+// Receivers with no prototype chain to reach behave normally at a warm callsite
+(function () {
+  function read(o) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = o.myProperty;
+    }
+    return last;
+  }
+
+  String.prototype.myProperty = "found";
+  assert.sameValue(read("abc"), "found");
+
+  assert.throws(TypeError, function () { read(null); });
+  assert.throws(TypeError, function () { read(undefined); });
+  assert.sameValue(read({}), undefined);
+  assert.sameValue(read("abc"), "found");
+})();
+
+// Numbers and booleans have no shape so they are never cached, but must still read correctly
+(function () {
+  function read(o) {
+    var last;
+    for (var i = 0; i < 10; i++) {
+      last = o.myProperty;
+    }
+    return last;
+  }
+
+  Number.prototype.myProperty = "number";
+  Boolean.prototype.myProperty = "boolean";
+
+  for (var round = 0; round < 10; round++) {
+    assert.sameValue(read(5), "number");
+    assert.sameValue(read(1.5), "number");
+    assert.sameValue(read(true), "boolean");
+  }
+
+  Number.prototype.myProperty = "number2";
+  assert.sameValue(read(5), "number2");
+
+  assert.sameValue((5).toFixed(2), "5.00");
+  assert.sameValue(true.toString(), "true");
+})();
+
+// The cache survives garbage collection
+(function () {
+  function read(o) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = o.myProperty;
+    }
+    return last;
+  }
+
+  String.prototype.myProperty = "found";
+
+  assert.sameValue(read("abc"), "found");
+  $262.gc();
+  assert.sameValue(read("abc"), "found");
+
+  $262.gc();
+  assert.sameValue(read("de" + "fg"), "found");
+})();
+
+// A primitive from another realm resolves through the prototype of the realm that is running, so a
+// shared callsite stays on a single entry
+(function () {
+  function read(o) {
+    return o.myProperty;
+  }
+
+  var other = $262.createRealm();
+  other.evalScript("globalThis.make = function () { return 'abcdefg'; };");
+  other.evalScript("String.prototype.myProperty = 'theirs';");
+  var theirs = other.global.make();
+
+  String.prototype.myProperty = "mine";
+
+  for (var i = 0; i < 100; i++) {
+    assert.sameValue(read("abc"), "mine");
+    assert.sameValue(read(theirs), "mine");
+  }
+})();
+
+// Accessors are never cached for primitive receivers, but must still run on every read
+(function () {
+  function read(o) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = o.accessorProperty;
+    }
+    return last;
+  }
+
+  var calls = 0;
+  Object.defineProperty(String.prototype, "accessorProperty", {
+    get: function () { calls++; return String(this); },
+    configurable: true,
+  });
+
+  assert.sameValue(read("abc"), "abc");
+  assert.sameValue(calls, 100);
+})();
+
+// Keys that may be canonical numeric index strings are intercepted by the string itself and are
+// never cached on the prototype
+(function () {
+  function read(o, key) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = o[key];
+    }
+    return last;
+  }
+
+  String.prototype["0"] = "proto zero";
+  String.prototype["1.5"] = "proto fraction";
+
+  // An in range index comes from the string, not the prototype
+  assert.sameValue(read("abc", "0"), "a");
+  // An out of range index falls through to the prototype
+  assert.sameValue(read("", "0"), "proto zero");
+  // A numeric string that is not an index never comes from the string
+  assert.sameValue(read("abc", "1.5"), "proto fraction");
+})();
+
+// A wrapper object returned by ToObject has exactly the shape a primitive coerces to, while an
+// entry for a primitive receiver is keyed on the primitive's own shape. A callsite that sees the
+// wrapper first must still promote to a polymorphic cache once it sees the primitive.
+(function () {
+  // Each kind reads at its own callsite so that each one fills its own cache
+  function readString(o) { return o.wrapperFirst; }
+  function readAbsent(o) { return o.wrapperFirstAbsent; }
+  function readSymbol(o) { return o.wrapperFirst; }
+  function readBigInt(o) { return o.wrapperFirst; }
+
+  String.prototype.wrapperFirst = "string";
+  Symbol.prototype.wrapperFirst = "symbol";
+  BigInt.prototype.wrapperFirst = "bigint";
+
+  var sym = Symbol("s");
+
+  // Note that Object() returns a wrapper with the shape that ToObject produces, while
+  // new String() does not, so only the former shares a shape with a coerced primitive.
+  assert.sameValue(readString(Object("abc")), "string");
+  assert.sameValue(readString("abc"), "string");
+  assert.sameValue(readString(Object("abc")), "string");
+  assert.sameValue(readString("abc"), "string");
+
+  // An absent property is cached as well, and is keyed the same way
+  assert.sameValue(readAbsent(Object("abc")), undefined);
+  assert.sameValue(readAbsent("abc"), undefined);
+
+  assert.sameValue(readSymbol(Object(sym)), "symbol");
+  assert.sameValue(readSymbol(sym), "symbol");
+
+  assert.sameValue(readBigInt(Object(10n)), "bigint");
+  assert.sameValue(readBigInt(10n), "bigint");
+})();
+
+// Everything below deletes from String.prototype, which makes later accesses uncacheable.
+
+// An absent property is cached too, and is found once it appears on the prototype chain
+(function () {
+  function read(o) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = o.absentProperty;
+    }
+    return last;
+  }
+
+  assert.sameValue(read("abc"), undefined);
+  assert.sameValue(read("de"), undefined);
+
+  String.prototype.absentProperty = "appeared";
+  assert.sameValue(read("abc"), "appeared");
+
+  delete String.prototype.absentProperty;
+  assert.sameValue(read("abc"), undefined);
+})();
+
+// A property further up the prototype chain is found through String.prototype, and a closer
+// property added later shadows it
+(function () {
+  function read(o) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = o.shadowedProperty;
+    }
+    return last;
+  }
+
+  Object.prototype.shadowedProperty = "from Object.prototype";
+  assert.sameValue(read("abc"), "from Object.prototype");
+
+  String.prototype.shadowedProperty = "from String.prototype";
+  assert.sameValue(read("abc"), "from String.prototype");
+
+  delete String.prototype.shadowedProperty;
+  assert.sameValue(read("abc"), "from Object.prototype");
+
+  delete Object.prototype.shadowedProperty;
+  assert.sameValue(read("abc"), undefined);
+})();
+
+// Replacing the prototype of String.prototype invalidates entries that reach through it
+(function () {
+  function read(o) {
+    var last;
+    for (var i = 0; i < 100; i++) {
+      last = o.movedProperty;
+    }
+    return last;
+  }
+
+  String.prototype.movedProperty = "on String.prototype";
+  assert.sameValue(read("abc"), "on String.prototype");
+
+  Object.setPrototypeOf(String.prototype, { movedProperty: "on a new grandparent" });
+  delete String.prototype.movedProperty;
+  assert.sameValue(read("abc"), "on a new grandparent");
+
+  Object.setPrototypeOf(String.prototype, Object.prototype);
+  assert.sameValue(read("abc"), undefined);
+})();


### PR DESCRIPTION
## Summary

Extend the `GetNamedPropertyCache::Proto` variant to also handle primitive receivers.

- Avoids allocating entirely for cached property lookups on a primitive receiver
- Only works for primitives that are heap items since a shape is required
- Extracted lookup in `GetNamedPropertyCache::fill` into a shared utility
- Refine which named properties of `StringObjects` are considered exotic for caching

+1.3% on Octane, due to Typescript +13.8%, RegExp +3.8%, and  PdfJS +6.8%

| Benchmark | 402e6ba6b (base) | c420d6858 | Change |
|-----------|------------------|-----------|--------|
| Richards | 2,708 ±30.5 n=4 | 2,706 ±11.2 n=4 | -0.1% |
| DeltaBlue | 2,652 ±21.0 n=4 | 2,655 ±13.4 n=4 | +0.1% |
| Crypto | 3,360 ±37.8 n=4 | 3,411 ±7.1 n=4 | +1.5% |
| RayTrace | 3,461 ±55.9 n=4 | 3,456 ±9.7 n=4 | -0.1% |
| EarleyBoyer | 5,664 ±68.4 n=4 | 5,709 ±7.7 n=4 | +0.8% |
| RegExp | 1,279 ±15.8 n=4 | 1,327 ±2.6 n=4 | +3.8% |
| Splay | 5,073 ±99.5 n=4 | 4,936 ±39.5 n=4 | -2.7% |
| SplayLatency | 9,689 ±199 n=4 | 9,418 ±46.0 n=4 | -2.8% |
| NavierStokes | 4,121 ±33.3 n=4 | 4,129 ±19.3 n=4 | +0.2% |
| PdfJS | 7,045 ±31.8 n=4 | 7,521 ±31.5 n=4 | +6.8% |
| Mandreel | 3,110 ±25.3 n=4 | 3,127 ±3.7 n=4 | +0.5% |
| MandreelLatency | 22,609 ±132 n=4 | 22,816 ±60.6 n=4 | +0.9% |
| Gameboy | 5,308 ±46.3 n=4 | 5,403 ±42.0 n=4 | +1.8% |
| CodeLoad | 48,580 ±200 n=4 | 48,685 ±156 n=4 | +0.2% |
| Box2D | 9,702 ±52.4 n=4 | 9,682 ±14.5 n=4 | -0.2% |
| zlib | 5,906 ±24.0 n=4 | 5,923 ±14.1 n=4 | +0.3% |
| Typescript | 21,105 ±41.6 n=4 | 24,009 ±147 n=4 | +13.8% |
| **Total (octane)** | **6,042 ±43.5 n=4** | **6,121 ±9.4 n=4** | **+1.3%** |

## Tests

- Added LLM-generated tests for new cache paths