### PR TITLE
[regexp] Analyze RegExp to determine longest required literal

### DIFF
--- a/src/js/parser/printer.rs
+++ b/src/js/parser/printer.rs
@@ -1376,6 +1376,7 @@ impl<'a> Printer<'a> {
         }
 
         self.property("is_inverted", class.is_inverted, Printer::print_bool);
+        self.property("may_contain_strings", class.may_contain_strings, Printer::print_bool);
         self.array_property("ranges", &class.operands, Printer::print_regexp_character_class_range);
         self.end_node();
     }

--- a/src/js/parser/regexp.rs
+++ b/src/js/parser/regexp.rs
@@ -295,6 +295,10 @@ pub struct CharacterClass<'a> {
     pub expression_type: ClassExpressionType,
     /// Whether to only match characters not listed in this class
     pub is_inverted: bool,
+    /// Whether this class may match strings instead of only single code points, e.g. due to a
+    /// string disjunction or a unicode property of strings. Is a conservative approximation, but if
+    /// false then the class is guaranteed to only match single code points.
+    pub may_contain_strings: bool,
     /// Collection of operands to this class expression
     pub operands: AstSlice<'a, ClassRange<'a>>,
 }

--- a/src/js/parser/regexp_parser.rs
+++ b/src/js/parser/regexp_parser.rs
@@ -557,12 +557,11 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
             }
             '[' => {
                 if self.flags.has_unicode_sets_flag() {
-                    let (character_class, may_contain_strings) =
-                        self.parse_unicode_sets_character_class()?;
+                    let character_class = self.parse_unicode_sets_character_class()?;
 
                     // We don't know what strings were included yet but since it's possible for the
                     // empty string to match we cannot assume this class always consumes input.
-                    class_always_consumes = !may_contain_strings;
+                    class_always_consumes = !character_class.may_contain_strings;
 
                     Term::CharacterClass(character_class)
                 } else {
@@ -754,11 +753,17 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
     }
 
     fn character_class_from_shorthand(&self, shorthand: ClassRange<'a>) -> CharacterClass<'a> {
+        let may_contain_strings = matches!(
+            shorthand,
+            ClassRange::UnicodeProperty(UnicodeProperty::BinaryPropertyOfStrings(_))
+        );
+
         let operands = self.alloc_vec_with_element(shorthand);
 
         CharacterClass {
             expression_type: ClassExpressionType::Union,
             is_inverted: false,
+            may_contain_strings,
             operands: operands.build(),
         }
     }
@@ -1217,6 +1222,7 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
         Ok(Term::CharacterClass(CharacterClass {
             expression_type: ClassExpressionType::Union,
             is_inverted,
+            may_contain_strings: false,
             operands: ranges.build(),
         }))
     }
@@ -1337,23 +1343,19 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
     }
 
     /// Parse a character class when in `v` mode.
-    ///
-    /// Return whether the character class may contain strings.
-    fn parse_unicode_sets_character_class(&mut self) -> ParseResult<(CharacterClass<'a>, bool)> {
+    fn parse_unicode_sets_character_class(&mut self) -> ParseResult<CharacterClass<'a>> {
         self.advance();
 
         let is_inverted = self.eat('^');
 
         // Character class may be empty
         if self.eat(']') {
-            return Ok((
-                CharacterClass {
-                    expression_type: ClassExpressionType::Union,
-                    is_inverted,
-                    operands: AstSlice::new_empty(),
-                },
-                false,
-            ));
+            return Ok(CharacterClass {
+                expression_type: ClassExpressionType::Union,
+                is_inverted,
+                may_contain_strings: false,
+                operands: AstSlice::new_empty(),
+            });
         }
 
         let first_operand_pos = self.pos();
@@ -1433,16 +1435,19 @@ impl<'a, T: LexerStream> RegExpParser<'a, T> {
                 .error(first_operand_pos, ParseError::InvertedCharacterClassCannotContainStrings);
         }
 
-        Ok((
-            CharacterClass { expression_type, is_inverted, operands: operands.build() },
+        Ok(CharacterClass {
+            expression_type,
+            is_inverted,
             may_contain_strings,
-        ))
+            operands: operands.build(),
+        })
     }
 
     /// Parse a single ClassSetOperand, returning whether it MayContainStrings.
     fn parse_class_set_operand(&mut self) -> ParseResult<(ClassRange<'a>, bool)> {
         if self.current() == '[' as u32 {
-            let (nested_class, may_contain_strings) = self.parse_unicode_sets_character_class()?;
+            let nested_class = self.parse_unicode_sets_character_class()?;
+            let may_contain_strings = nested_class.may_contain_strings;
             return Ok((ClassRange::NestedClass(nested_class), may_contain_strings));
         }
 

--- a/src/js/runtime/regexp/compiled_regexp.rs
+++ b/src/js/runtime/regexp/compiled_regexp.rs
@@ -14,6 +14,7 @@ use crate::{
             graphviz::compiled_regexp_to_dot_graph,
             instruction::InstructionIterator,
             match_start_filter::{MatchStartAnalysis, MatchStartFilter},
+            required_literal_filter::RequiredLiteralFilter,
         },
         shape::Shape,
         string_value::{FlatString, StringValue},
@@ -39,6 +40,9 @@ pub struct CompiledRegExp {
     /// Filter describing where a match must start in the input, used to quickly scan for match start
     /// positions.
     match_start_filter: MatchStartFilter,
+    /// Filter describing a literal that must be present in the input for this RegExp to match, as
+    /// well as bounds to narrow down the search anchored around that literal.
+    required_literal_filter: RequiredLiteralFilter,
     /// Array of bytecode instructions
     instructions: InlineArray<u32>,
     /// Array of capture groups, optionally containing capture group name. Field should not be
@@ -57,6 +61,7 @@ impl CompiledRegExp {
         num_progress_points: u32,
         num_loop_registers: u32,
         match_start_filter: MatchStartFilter,
+        required_literal_filter: RequiredLiteralFilter,
     ) -> AllocResult<Handle<CompiledRegExp>> {
         let num_capture_groups = regexp.capture_groups.len() as u32;
         let mut has_named_capture_groups = false;
@@ -88,6 +93,7 @@ impl CompiledRegExp {
         set_uninit!(object.num_progress_points, num_progress_points);
         set_uninit!(object.num_loop_registers, num_loop_registers);
         set_uninit!(object.match_start_filter, match_start_filter);
+        set_uninit!(object.required_literal_filter, required_literal_filter);
 
         object.instructions.init_from_slice(&instructions);
 
@@ -131,6 +137,11 @@ impl CompiledRegExp {
     #[inline]
     pub fn match_start_filter(&self) -> &MatchStartFilter {
         &self.match_start_filter
+    }
+
+    #[inline]
+    pub fn required_literal_filter(&self) -> &RequiredLiteralFilter {
+        &self.required_literal_filter
     }
 
     // Capture groups accessors
@@ -242,6 +253,11 @@ impl HeapPtr<CompiledRegExp> {
         if let Some(regexp_match_start) = regexp_match_start {
             printer.write_indent();
             printer.write(&format!("Match Start: {}\n", regexp_match_start));
+        }
+
+        if !self.required_literal_filter.is_empty() {
+            printer.write_indent();
+            printer.write(&format!("Required Literal: {}\n", self.required_literal_filter));
         }
 
         let mut offset = 0;

--- a/src/js/runtime/regexp/compiler.rs
+++ b/src/js/runtime/regexp/compiler.rs
@@ -36,6 +36,7 @@ use crate::{
                 WordBoundaryMoveToPreviousInstruction,
             },
             match_start_filter::{MatchStartAnalyzer, MatchStartFilter},
+            required_literal_filter::{RequiredLiteralAnalyzer, RequiredLiteralFilter},
         },
         string_value::StringValue,
     },
@@ -264,6 +265,7 @@ impl RegExpCompiler {
         cx: Context,
         regexp: &RegExp,
         match_start_filter: MatchStartFilter,
+        required_literal_filter: RequiredLiteralFilter,
     ) -> AllocResult<Handle<CompiledRegExp>> {
         // Prime with new block
         self.new_block();
@@ -285,6 +287,7 @@ impl RegExpCompiler {
             self.num_progress_points,
             self.num_loop_registers,
             match_start_filter,
+            required_literal_filter,
         )
     }
 
@@ -1009,9 +1012,10 @@ pub fn compile_regexp(
 ) -> AllocResult<Handle<CompiledRegExp>> {
     let match_start_analysis = MatchStartAnalyzer::analyze(regexp);
     let match_start_filter = MatchStartFilter::new(&match_start_analysis);
+    let required_literal = RequiredLiteralAnalyzer::analyze(regexp);
 
     let mut compiler = RegExpCompiler::new(regexp, source);
-    let compiled_regexp = compiler.compile(cx, regexp, match_start_filter)?;
+    let compiled_regexp = compiler.compile(cx, regexp, match_start_filter, required_literal)?;
 
     if cx.options.print_regexp_bytecode {
         let bytecode_string =

--- a/src/js/runtime/regexp/mod.rs
+++ b/src/js/runtime/regexp/mod.rs
@@ -7,3 +7,4 @@ pub mod instruction;
 pub mod lexer_stream;
 pub mod match_start_filter;
 pub mod matcher;
+pub mod required_literal_filter;

--- a/src/js/runtime/regexp/required_literal_filter.rs
+++ b/src/js/runtime/regexp/required_literal_filter.rs
@@ -1,0 +1,334 @@
+use std::{cmp::Ordering, fmt};
+
+use crate::{
+    common::unicode::{
+        CodePoint, is_ascii, is_ascii_alphabetic, is_latin1, to_string_or_unicode_escape_sequence,
+    },
+    parser::{
+        ast::AstStr,
+        regexp::{Alternative, Disjunction, RegExp, RegExpFlags, Term},
+    },
+    runtime::regexp::{code_point_set::CodePointSetBuilder, compiler::RegExpFlagsStack},
+};
+
+/// Maximum number of code points in a required literal filter. Longer literals are truncated.
+const MAX_LITERAL_LEN: usize = 16;
+
+/// Literals shorter than this aren't worth it and rely on the MatchStartFilter scan.
+const MIN_LITERAL_LEN: usize = 3;
+
+/// A sequence of Latin1 code points that must appear for a RegExp to match. Stored on a
+/// CompiledRegExp and used to efficiently scan for possible match start positions in the input.
+#[repr(C)]
+pub struct RequiredLiteralFilter {
+    /// Number of bytes aka Latin1 code points in the literal. Zero if there is no literal.
+    len: u8,
+    /// Bytes aka Latin1 code points of the literal.
+    bytes: [u8; MAX_LITERAL_LEN],
+    /// The number of code points between the start of a match and the start of the literal.
+    offset: Width,
+}
+
+impl RequiredLiteralFilter {
+    fn new_at(offset: Width) -> Self {
+        Self { len: 0, bytes: [0; MAX_LITERAL_LEN], offset }
+    }
+
+    fn new_none() -> Self {
+        Self::new_at(Width::new_unbounded())
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    #[inline]
+    fn bytes(&self) -> &[u8] {
+        &self.bytes[..self.len as usize]
+    }
+}
+
+impl fmt::Display for RequiredLiteralFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("\"")?;
+        for byte in self.bytes() {
+            f.write_str(&to_string_or_unicode_escape_sequence(*byte as CodePoint))?;
+        }
+        f.write_str("\"")?;
+
+        write!(f, " at {}-", self.offset.min)?;
+        if self.offset.is_unbounded() {
+            f.write_str("any")
+        } else {
+            write!(f, "{}", self.offset.max)
+        }
+    }
+}
+
+const UNBOUNDED_WIDTH: u32 = u32::MAX;
+
+/// Inclusive range for the number of code points that a pattern may consume. Max may be
+/// `UNBOUNDED_WIDTH` if there is no upper bound on the number of code points consumed.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct Width {
+    min: u32,
+    max: u32,
+}
+
+impl Width {
+    fn new_exact(width: u32) -> Width {
+        Width { min: width, max: width }
+    }
+
+    fn new_unbounded() -> Width {
+        Width { min: 0, max: UNBOUNDED_WIDTH }
+    }
+
+    fn is_unbounded(&self) -> bool {
+        self.max == UNBOUNDED_WIDTH
+    }
+
+    /// Combine the widths of two adjacent patterns.
+    fn concat(self, other: Width) -> Width {
+        Width {
+            min: self.min.saturating_add(other.min),
+            max: self.max.saturating_add(other.max),
+        }
+    }
+
+    /// Combine the widths of two patterns matched as alternatives of each other.
+    fn union(self, other: Width) -> Width {
+        Width { min: self.min.min(other.min), max: self.max.max(other.max) }
+    }
+
+    /// The width of a pattern repeated a minimum and optional maximum number of times.
+    fn repeat(self, min_repetitions: u64, max_repetitions: Option<u64>) -> Width {
+        let min = Self::repeat_until_unbounded(self.min, min_repetitions);
+        let max = max_repetitions
+            .map_or(UNBOUNDED_WIDTH, |count| Self::repeat_until_unbounded(self.max, count));
+
+        Width { min, max }
+    }
+
+    /// Repeat a width with a maximum of `UNBOUNDED_WIDTH`.
+    fn repeat_until_unbounded(width: u32, count: u64) -> u32 {
+        (width as u64)
+            .saturating_mul(count)
+            .min(UNBOUNDED_WIDTH as u64) as u32
+    }
+}
+
+/// The result of walking a subpattern for the literal it requires.
+struct LiteralAnalysis {
+    /// The longest required literal found in this subpattern, if any.
+    literal: Option<RequiredLiteralFilter>,
+    /// Width of the entire subpattern itself (not just the required literal).
+    width: Width,
+}
+
+impl LiteralAnalysis {
+    fn new(literal: Option<RequiredLiteralFilter>, width: Width) -> LiteralAnalysis {
+        LiteralAnalysis { literal, width }
+    }
+
+    fn new_width_only(width: Width) -> LiteralAnalysis {
+        LiteralAnalysis { literal: None, width }
+    }
+}
+
+pub struct RequiredLiteralAnalyzer {
+    flags: RegExpFlagsStack,
+}
+
+impl RequiredLiteralAnalyzer {
+    fn new(flags: RegExpFlags) -> Self {
+        RequiredLiteralAnalyzer { flags: RegExpFlagsStack::new(flags) }
+    }
+
+    /// Find the longest literal that must be present in the input for the RegExp to match.
+    ///
+    /// Note that this analysis is conservative and may be an under-approximation.
+    pub fn analyze(regexp: &RegExp) -> RequiredLiteralFilter {
+        let mut analyzer = RequiredLiteralAnalyzer::new(regexp.flags);
+        let analysis = analyzer.analyze_disjunction(&regexp.disjunction);
+
+        analysis
+            .literal
+            .unwrap_or_else(RequiredLiteralFilter::new_none)
+    }
+
+    fn analyze_disjunction(&mut self, disjunction: &Disjunction) -> LiteralAnalysis {
+        // We do not analyze multiple alternatives for a shared literal, so a required literal can
+        // only be found when there is exactly one alternative.
+        if let [alternative] = &*disjunction.alternatives {
+            return self.analyze_alternative(alternative);
+        }
+
+        // Otherwise only the width of the disjunction is needed, which is the union of the widths
+        // of all alternatives. Disjunction is guaranteed to have at least one alternative.
+        let (first_alternative, rest) = disjunction.alternatives.split_first().unwrap();
+
+        let mut width = self.analyze_alternative(first_alternative).width;
+        for alternative in rest {
+            width = width.union(self.analyze_alternative(alternative).width);
+        }
+
+        LiteralAnalysis::new_width_only(width)
+    }
+
+    fn analyze_alternative(&mut self, alternative: &Alternative) -> LiteralAnalysis {
+        let mut best_literal: Option<RequiredLiteralFilter> = None;
+
+        // Width of all terms visited so far in the alternative
+        let mut current_width = Width::new_exact(0);
+
+        for term in alternative.terms.iter() {
+            let analysis = self.analyze_term(term);
+
+            // Literal from the term must be offset by the width of all previous terms
+            if let Some(mut literal) = analysis.literal {
+                literal.offset = literal.offset.concat(current_width);
+                Self::update_best_literal(&mut best_literal, literal);
+            }
+
+            current_width = current_width.concat(analysis.width);
+        }
+
+        LiteralAnalysis::new(best_literal, current_width)
+    }
+
+    fn analyze_term(&mut self, term: &Term) -> LiteralAnalysis {
+        match term {
+            // A literal term finds the best required literal within it
+            Term::Literal(literal) => self.analyze_literal(literal),
+            Term::Wildcard => LiteralAnalysis::new_width_only(Width::new_exact(1)),
+            // A character class matches a single code point, unless it may contain strings in which
+            // case strings of any length can be matched.
+            Term::CharacterClass(character_class) => {
+                let width = if character_class.may_contain_strings {
+                    Width::new_unbounded()
+                } else {
+                    Width::new_exact(1)
+                };
+
+                LiteralAnalysis::new_width_only(width)
+            }
+            // Quantifiers require the literal of their inner term if there is at least one required
+            // repetition.
+            Term::Quantifier(quantifier) => {
+                let analysis = self.analyze_term(&quantifier.term);
+
+                let literal = if quantifier.min >= 1 {
+                    analysis.literal
+                } else {
+                    None
+                };
+
+                let width = analysis.width.repeat(quantifier.min, quantifier.max);
+
+                LiteralAnalysis::new(literal, width)
+            }
+            // Assertions and lookarounds have no width
+            Term::Assertion(_) | Term::Lookaround(_) => {
+                LiteralAnalysis::new_width_only(Width::new_exact(0))
+            }
+            // Descend into groups, updating the flags if necessary
+            Term::CaptureGroup(group) => self.analyze_disjunction(&group.disjunction),
+            Term::AnonymousGroup(group) => {
+                let updated_flags = self.flags.push_group_flags(group);
+
+                let analysis = self.analyze_disjunction(&group.disjunction);
+
+                if updated_flags {
+                    self.flags.pop_group_flags();
+                }
+
+                analysis
+            }
+            // Backreference is unbounded since we cannot statically determine width
+            Term::Backreference(_) => LiteralAnalysis::new_width_only(Width::new_unbounded()),
+        }
+    }
+
+    /// Whether a code point can be searched for verbatim in the input.
+    fn is_searchable_code_point(&self, code_point: CodePoint) -> bool {
+        // Only one-byte (Latin1) code points are stored in the filter
+        if !is_latin1(code_point) {
+            return false;
+        }
+
+        // In case insensitive mode only code points without case variants can be searched directly
+        let flags = self.flags.current();
+        if !flags.is_case_insensitive() {
+            return true;
+        }
+
+        // Fast path for ASCII code points, as only alphabetic code points have case variants
+        if is_ascii(code_point) {
+            !is_ascii_alphabetic(code_point)
+        } else {
+            CodePointSetBuilder::code_point_to_set(code_point, flags).size() == 1
+        }
+    }
+
+    /// Prefer longer literals and bounded offsets for stronger filtering.
+    fn update_best_literal(
+        best_literal: &mut Option<RequiredLiteralFilter>,
+        literal: RequiredLiteralFilter,
+    ) {
+        if (literal.len as usize) < MIN_LITERAL_LEN {
+            return;
+        }
+
+        let is_better = match best_literal {
+            None => true,
+            Some(best_literal) => match literal.len.cmp(&best_literal.len) {
+                Ordering::Greater => true,
+                Ordering::Less => false,
+                Ordering::Equal => {
+                    best_literal.offset.is_unbounded() && !literal.offset.is_unbounded()
+                }
+            },
+        };
+
+        if is_better {
+            *best_literal = Some(literal);
+        }
+    }
+
+    fn analyze_literal(&self, literal: AstStr) -> LiteralAnalysis {
+        let mut best_literal = None;
+        let mut count = 0;
+
+        // Accumulator building searchable code points into a literal
+        let mut literal_acc = RequiredLiteralFilter::new_at(Width::new_exact(0));
+
+        for code_point in literal.iter_code_points() {
+            count += 1;
+
+            // Stop accumulating if literal is already at the maximum length
+            if (literal_acc.len as usize) == MAX_LITERAL_LEN {
+                continue;
+            }
+
+            if self.is_searchable_code_point(code_point) {
+                literal_acc.bytes[literal_acc.len as usize] = code_point as u8;
+                literal_acc.len += 1;
+            } else {
+                // Literal is interrupted - complete it, start a new one, and update best seen
+                let completed_literal = std::mem::replace(
+                    &mut literal_acc,
+                    RequiredLiteralFilter::new_at(Width::new_exact(count)),
+                );
+                Self::update_best_literal(&mut best_literal, completed_literal);
+            }
+        }
+
+        // Complete the final literal
+        Self::update_best_literal(&mut best_literal, literal_acc);
+
+        LiteralAnalysis::new(best_literal, Width::new_exact(count))
+    }
+}

--- a/tests/snapshot/parser/expression/regexp.exp
+++ b/tests/snapshot/parser/expression/regexp.exp
@@ -76,6 +76,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(a)",
                     "Single(s)",
@@ -113,6 +114,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(a)",
                     "Single(s)",

--- a/tests/snapshot/parser/regexp/basic.exp
+++ b/tests/snapshot/parser/regexp/basic.exp
@@ -319,6 +319,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "\w",
                   ],
@@ -326,6 +327,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "\W",
                   ],
@@ -333,6 +335,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "\s",
                   ],
@@ -340,6 +343,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "\S",
                   ],
@@ -347,6 +351,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "\d",
                   ],
@@ -354,6 +359,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "\D",
                   ],

--- a/tests/snapshot/parser/regexp/class.exp
+++ b/tests/snapshot/parser/regexp/class.exp
@@ -22,6 +22,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [],
                 },
               ],
@@ -50,6 +51,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(a)",
                     "Single(b)",
@@ -82,6 +84,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Range(a, z)",
                   ],
@@ -112,6 +115,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Range(a, z)",
                     "Range(A, Z)",
@@ -145,6 +149,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "\w",
                     "\W",
@@ -180,6 +185,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: true,
+                  may_contain_strings: false,
                   ranges: [],
                 },
               ],
@@ -208,6 +214,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: true,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(a)",
                     "Single(b)",
@@ -240,6 +247,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: true,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(^)",
                     "Single(^)",
@@ -271,6 +279,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(-)",
                   ],
@@ -301,6 +310,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(-)",
                     "Single(-)",
@@ -332,6 +342,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Range(-, -)",
                   ],
@@ -362,6 +373,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(a)",
                     "Single(-)",
@@ -393,6 +405,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Range(+, -)",
                   ],
@@ -423,6 +436,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(-)",
                     "Single(a)",
@@ -454,6 +468,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Range(-, a)",
                   ],
@@ -484,6 +499,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(\r)",
                     "Single(\n)",
@@ -519,6 +535,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(a)",
                     "Single(b)",
@@ -550,6 +567,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(a)",
                     "Single(b)",
@@ -581,6 +599,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(\t)",
                   ],
@@ -611,6 +630,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(\)",
                     "Single(/)",
@@ -658,6 +678,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(\)",
                     "Single(/)",
@@ -702,6 +723,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(\x00)",
                     "Single(a)",
@@ -735,6 +757,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "UnicodeProperty(BinaryProperty(ASCII))",
                   ],
@@ -765,6 +788,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "NotUnicodeProperty(BinaryProperty(ASCIIHexDigit))",
                   ],
@@ -795,6 +819,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: true,
                   ranges: [
                     "UnicodeProperty(BinaryPropertyOfStrings(BasicEmoji))",
                   ],

--- a/tests/snapshot/parser/regexp/class_string_disjunction.exp
+++ b/tests/snapshot/parser/regexp/class_string_disjunction.exp
@@ -22,6 +22,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: true,
                   ranges: [
                     {
                       type: "StringDisjunction",
@@ -57,6 +58,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     {
                       type: "StringDisjunction",
@@ -92,6 +94,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: true,
                   ranges: [
                     {
                       type: "StringDisjunction",
@@ -127,6 +130,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     {
                       type: "StringDisjunction",
@@ -163,6 +167,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: true,
                   ranges: [
                     {
                       type: "StringDisjunction",
@@ -200,6 +205,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: true,
                   ranges: [
                     {
                       type: "StringDisjunction",
@@ -236,6 +242,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: true,
                   ranges: [
                     {
                       type: "StringDisjunction",
@@ -274,6 +281,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: true,
                   ranges: [
                     {
                       type: "StringDisjunction",
@@ -310,6 +318,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: true,
                   ranges: [
                     {
                       type: "StringDisjunction",
@@ -348,6 +357,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: true,
                   ranges: [
                     {
                       type: "StringDisjunction",
@@ -386,6 +396,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     {
                       type: "StringDisjunction",
@@ -421,6 +432,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     {
                       type: "StringDisjunction",
@@ -456,6 +468,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     {
                       type: "StringDisjunction",

--- a/tests/snapshot/parser/regexp/unicode.exp
+++ b/tests/snapshot/parser/regexp/unicode.exp
@@ -49,6 +49,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(\uD842)",
                     "Single(\uDFB7)",

--- a/tests/snapshot/parser/regexp/unicode_sets.exp
+++ b/tests/snapshot/parser/regexp/unicode_sets.exp
@@ -22,6 +22,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [],
                 },
               ],
@@ -50,6 +51,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(a)",
                     "Single(b)",
@@ -82,6 +84,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Range(a, z)",
                   ],
@@ -112,6 +115,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Range(a, z)",
                     "Range(A, Z)",
@@ -145,6 +149,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "\w",
                     "\W",
@@ -180,6 +185,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: true,
+                  may_contain_strings: false,
                   ranges: [],
                 },
               ],
@@ -208,6 +214,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: true,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(a)",
                     "Single(b)",
@@ -240,6 +247,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(\r)",
                     "Single(\n)",
@@ -275,6 +283,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(a)",
                     "Single(b)",
@@ -306,6 +315,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(a)",
                     "Single(b)",
@@ -337,6 +347,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(\t)",
                   ],
@@ -367,6 +378,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(\x00)",
                     "Single(a)",
@@ -400,6 +412,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(/)",
                     "Single(-)",
@@ -445,6 +458,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "Single(&)",
                     "Single(-)",
@@ -488,6 +502,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "UnicodeProperty(BinaryProperty(ASCII))",
                   ],
@@ -518,6 +533,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "NotUnicodeProperty(BinaryProperty(ASCIIHexDigit))",
                   ],
@@ -548,6 +564,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: true,
                   ranges: [
                     "UnicodeProperty(BinaryPropertyOfStrings(BasicEmoji))",
                   ],
@@ -578,6 +595,7 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: true,
                   ranges: [
                     "UnicodeProperty(BinaryPropertyOfStrings(BasicEmoji))",
                   ],
@@ -609,6 +627,7 @@
                   type: "CharacterClass",
                   expression_type: "Intersection",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "\w",
                     "\d",
@@ -641,6 +660,7 @@
                   type: "CharacterClass",
                   expression_type: "Intersection",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "\w",
                     "\d",
@@ -675,10 +695,12 @@
                   type: "CharacterClass",
                   expression_type: "Intersection",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     {
                       type: "CharacterClass",
                       is_inverted: false,
+                      may_contain_strings: false,
                       ranges: [
                         "Range(a, z)",
                       ],
@@ -687,6 +709,7 @@
                     {
                       type: "CharacterClass",
                       is_inverted: false,
+                      may_contain_strings: false,
                       ranges: [
                         "Single(a)",
                       ],
@@ -720,6 +743,7 @@
                   type: "CharacterClass",
                   expression_type: "Intersection",
                   is_inverted: true,
+                  may_contain_strings: false,
                   ranges: [
                     "\w",
                     "\d",
@@ -752,6 +776,7 @@
                   type: "CharacterClass",
                   expression_type: "Difference",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "\w",
                     "\d",
@@ -784,6 +809,7 @@
                   type: "CharacterClass",
                   expression_type: "Difference",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     "\w",
                     "\d",
@@ -818,10 +844,12 @@
                   type: "CharacterClass",
                   expression_type: "Difference",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     {
                       type: "CharacterClass",
                       is_inverted: false,
+                      may_contain_strings: false,
                       ranges: [
                         "Range(a, z)",
                       ],
@@ -830,6 +858,7 @@
                     {
                       type: "CharacterClass",
                       is_inverted: false,
+                      may_contain_strings: false,
                       ranges: [
                         "Single(a)",
                       ],
@@ -863,6 +892,7 @@
                   type: "CharacterClass",
                   expression_type: "Difference",
                   is_inverted: true,
+                  may_contain_strings: false,
                   ranges: [
                     "\w",
                     "\d",
@@ -894,10 +924,12 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     {
                       type: "CharacterClass",
                       is_inverted: false,
+                      may_contain_strings: false,
                       ranges: [
                         "Range(a, z)",
                       ],
@@ -930,14 +962,17 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     {
                       type: "CharacterClass",
                       is_inverted: false,
+                      may_contain_strings: false,
                       ranges: [
                         {
                           type: "CharacterClass",
                           is_inverted: false,
+                          may_contain_strings: false,
                           ranges: [
                             "Range(a, z)",
                           ],
@@ -972,14 +1007,17 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     {
                       type: "CharacterClass",
                       is_inverted: false,
+                      may_contain_strings: false,
                       ranges: [
                         {
                           type: "CharacterClass",
                           is_inverted: false,
+                          may_contain_strings: false,
                           ranges: [],
                         },
                       ],
@@ -1012,16 +1050,19 @@
                 {
                   type: "CharacterClass",
                   is_inverted: false,
+                  may_contain_strings: false,
                   ranges: [
                     {
                       type: "CharacterClass",
                       expression_type: "Difference",
                       is_inverted: false,
+                      may_contain_strings: false,
                       ranges: [
                         {
                           type: "CharacterClass",
                           expression_type: "Intersection",
                           is_inverted: false,
+                          may_contain_strings: false,
                           ranges: [
                             "\w",
                             "\s",
@@ -1030,6 +1071,7 @@
                         {
                           type: "CharacterClass",
                           is_inverted: false,
+                          may_contain_strings: false,
                           ranges: [
                             "Range(a, z)",
                           ],

--- a/tests/snapshot/regexp_bytecode/literal/basic.exp
+++ b/tests/snapshot/regexp_bytecode/literal/basic.exp
@@ -10,6 +10,7 @@
 [CompiledRegExp: /abc/] {
   Flags: ""
   Match Start: Code Points("a")
+  Required Literal: "abc" at 0-0
      0: MarkCapturePoint(0)
      2: Literal(a)
      3: Literal(b)

--- a/tests/snapshot/regexp_bytecode/match_start/first_code_points.exp
+++ b/tests/snapshot/regexp_bytecode/match_start/first_code_points.exp
@@ -10,6 +10,7 @@
 [CompiledRegExp: /abc/] {
   Flags: ""
   Match Start: Code Points("a")
+  Required Literal: "abc" at 0-0
      0: MarkCapturePoint(0)
      2: Literal(a)
      3: Literal(b)
@@ -325,6 +326,7 @@
 [CompiledRegExp: /\bfoo/] {
   Flags: ""
   Match Start: Code Points("f")
+  Required Literal: "foo" at 0-0
      0: MarkCapturePoint(0)
      2: CompareBetween(0, 9)
      4: CompareBetween(A, Z)
@@ -346,6 +348,7 @@
 [CompiledRegExp: /(?=x)foo/] {
   Flags: ""
   Match Start: Code Points("f")
+  Required Literal: "foo" at 0-0
      0: MarkCapturePoint(0)
      2: Lookaround(true, true, 10)
      4: Literal(f)
@@ -360,6 +363,7 @@
 [CompiledRegExp: /(?!x)foo/] {
   Flags: ""
   Match Start: Code Points("f")
+  Required Literal: "foo" at 0-0
      0: MarkCapturePoint(0)
      2: Lookaround(true, false, 10)
      4: Literal(f)
@@ -374,6 +378,7 @@
 [CompiledRegExp: /(?<=x)foo/] {
   Flags: ""
   Match Start: Code Points("f")
+  Required Literal: "foo" at 0-0
      0: MarkCapturePoint(0)
      2: Lookaround(false, true, 10)
      4: Literal(f)

--- a/tests/snapshot/regexp_bytecode/required_literal.exp
+++ b/tests/snapshot/regexp_bytecode/required_literal.exp
@@ -1,0 +1,1016 @@
+[CompiledRegExp: /abc/] {
+  Flags: ""
+  Match Start: Code Points("a")
+  Required Literal: "abc" at 0-0
+     0: MarkCapturePoint(0)
+     2: Literal(a)
+     3: Literal(b)
+     4: Literal(c)
+     5: MarkCapturePoint(1)
+     7: Accept
+}
+
+[CompiledRegExp: /foobar/] {
+  Flags: ""
+  Match Start: Code Points("f")
+  Required Literal: "foobar" at 0-0
+     0: MarkCapturePoint(0)
+     2: Literal(f)
+     3: Literal(o)
+     4: Literal(o)
+     5: Literal(b)
+     6: Literal(a)
+     7: Literal(r)
+     8: MarkCapturePoint(1)
+    10: Accept
+}
+
+[CompiledRegExp: /café123/] {
+  Flags: ""
+  Match Start: Code Points("c")
+  Required Literal: "café123" at 0-0
+     0: MarkCapturePoint(0)
+     2: Literal(c)
+     3: Literal(a)
+     4: Literal(f)
+     5: Literal(é)
+     6: Literal(1)
+     7: Literal(2)
+     8: Literal(3)
+     9: MarkCapturePoint(1)
+    11: Accept
+}
+
+[CompiledRegExp: /ab/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: Literal(a)
+     3: Literal(b)
+     4: MarkCapturePoint(1)
+     6: Accept
+}
+
+[CompiledRegExp: /abcdefghijklmnopqrstuvwxyz/] {
+  Flags: ""
+  Match Start: Code Points("a")
+  Required Literal: "abcdefghijklmnop" at 0-0
+     0: MarkCapturePoint(0)
+     2: Literal(a)
+     3: Literal(b)
+     4: Literal(c)
+     5: Literal(d)
+     6: Literal(e)
+     7: Literal(f)
+     8: Literal(g)
+     9: Literal(h)
+    10: Literal(i)
+    11: Literal(j)
+    12: Literal(k)
+    13: Literal(l)
+    14: Literal(m)
+    15: Literal(n)
+    16: Literal(o)
+    17: Literal(p)
+    18: Literal(q)
+    19: Literal(r)
+    20: Literal(s)
+    21: Literal(t)
+    22: Literal(u)
+    23: Literal(v)
+    24: Literal(w)
+    25: Literal(x)
+    26: Literal(y)
+    27: Literal(z)
+    28: MarkCapturePoint(1)
+    30: Accept
+}
+
+[CompiledRegExp: /abcdefghijklmnopqrstĀuvwxyz/] {
+  Flags: ""
+  Match Start: Code Points("a")
+  Required Literal: "abcdefghijklmnop" at 0-0
+     0: MarkCapturePoint(0)
+     2: Literal(a)
+     3: Literal(b)
+     4: Literal(c)
+     5: Literal(d)
+     6: Literal(e)
+     7: Literal(f)
+     8: Literal(g)
+     9: Literal(h)
+    10: Literal(i)
+    11: Literal(j)
+    12: Literal(k)
+    13: Literal(l)
+    14: Literal(m)
+    15: Literal(n)
+    16: Literal(o)
+    17: Literal(p)
+    18: Literal(q)
+    19: Literal(r)
+    20: Literal(s)
+    21: Literal(t)
+    22: Literal(Ā)
+    23: Literal(u)
+    24: Literal(v)
+    25: Literal(w)
+    26: Literal(x)
+    27: Literal(y)
+    28: Literal(z)
+    29: MarkCapturePoint(1)
+    31: Accept
+}
+
+[CompiledRegExp: /Āabcdefgh/] {
+  Flags: ""
+  Match Start: Code Points("Ā")
+  Required Literal: "abcdefgh" at 1-1
+     0: MarkCapturePoint(0)
+     2: Literal(Ā)
+     3: Literal(a)
+     4: Literal(b)
+     5: Literal(c)
+     6: Literal(d)
+     7: Literal(e)
+     8: Literal(f)
+     9: Literal(g)
+    10: Literal(h)
+    11: MarkCapturePoint(1)
+    13: Accept
+}
+
+[CompiledRegExp: /abcĀdefgh/] {
+  Flags: ""
+  Match Start: Code Points("a")
+  Required Literal: "defgh" at 4-4
+     0: MarkCapturePoint(0)
+     2: Literal(a)
+     3: Literal(b)
+     4: Literal(c)
+     5: Literal(Ā)
+     6: Literal(d)
+     7: Literal(e)
+     8: Literal(f)
+     9: Literal(g)
+    10: Literal(h)
+    11: MarkCapturePoint(1)
+    13: Accept
+}
+
+[CompiledRegExp: /abcdefĀghijkl/] {
+  Flags: ""
+  Match Start: Code Points("a")
+  Required Literal: "abcdef" at 0-0
+     0: MarkCapturePoint(0)
+     2: Literal(a)
+     3: Literal(b)
+     4: Literal(c)
+     5: Literal(d)
+     6: Literal(e)
+     7: Literal(f)
+     8: Literal(Ā)
+     9: Literal(g)
+    10: Literal(h)
+    11: Literal(i)
+    12: Literal(j)
+    13: Literal(k)
+    14: Literal(l)
+    15: MarkCapturePoint(1)
+    17: Accept
+}
+
+[CompiledRegExp: /aĀĀbbbĀcccc/] {
+  Flags: ""
+  Match Start: Code Points("a")
+  Required Literal: "cccc" at 7-7
+     0: MarkCapturePoint(0)
+     2: Literal(a)
+     3: Literal(Ā)
+     4: Literal(Ā)
+     5: Literal(b)
+     6: Literal(b)
+     7: Literal(b)
+     8: Literal(Ā)
+     9: Literal(c)
+    10: Literal(c)
+    11: Literal(c)
+    12: Literal(c)
+    13: MarkCapturePoint(1)
+    15: Accept
+}
+
+[CompiledRegExp: /abĀcd/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: Literal(a)
+     3: Literal(b)
+     4: Literal(Ā)
+     5: Literal(c)
+     6: Literal(d)
+     7: MarkCapturePoint(1)
+     9: Accept
+}
+
+[CompiledRegExp: /😀foobar/] {
+  Flags: "u"
+  Match Start: Code Points("😀")
+  Required Literal: "foobar" at 1-1
+     0: MarkCapturePoint(0)
+     2: Literal(😀)
+     3: Literal(f)
+     4: Literal(o)
+     5: Literal(o)
+     6: Literal(b)
+     7: Literal(a)
+     8: Literal(r)
+     9: MarkCapturePoint(1)
+    11: Accept
+}
+
+[CompiledRegExp: /😀foobar/] {
+  Flags: ""
+  Match Start: Code Points("\uD83D")
+  Required Literal: "foobar" at 2-2
+     0: MarkCapturePoint(0)
+     2: Literal(\uD83D)
+     3: Literal(\uDE00)
+     4: Literal(f)
+     5: Literal(o)
+     6: Literal(o)
+     7: Literal(b)
+     8: Literal(a)
+     9: Literal(r)
+    10: MarkCapturePoint(1)
+    12: Accept
+}
+
+[CompiledRegExp: /Āabcdefgh.*xyz/] {
+  Flags: ""
+  Match Start: Code Points("Ā")
+  Required Literal: "abcdefgh" at 1-1
+     0: MarkCapturePoint(0)
+     2: Literal(Ā)
+     3: Literal(a)
+     4: Literal(b)
+     5: Literal(c)
+     6: Literal(d)
+     7: Literal(e)
+     8: Literal(f)
+     9: Literal(g)
+    10: Literal(h)
+    11: Branch(14, 18)
+    14: WildcardNoNewline
+    15: Branch(14, 18)
+    18: Literal(x)
+    19: Literal(y)
+    20: Literal(z)
+    21: MarkCapturePoint(1)
+    23: Accept
+}
+
+[CompiledRegExp: /Āabc.*uvwxyz/] {
+  Flags: ""
+  Match Start: Code Points("Ā")
+  Required Literal: "uvwxyz" at 4-any
+     0: MarkCapturePoint(0)
+     2: Literal(Ā)
+     3: Literal(a)
+     4: Literal(b)
+     5: Literal(c)
+     6: Branch(9, 13)
+     9: WildcardNoNewline
+    10: Branch(9, 13)
+    13: Literal(u)
+    14: Literal(v)
+    15: Literal(w)
+    16: Literal(x)
+    17: Literal(y)
+    18: Literal(z)
+    19: MarkCapturePoint(1)
+    21: Accept
+}
+
+[CompiledRegExp: /a(?:bcdef)g/] {
+  Flags: ""
+  Match Start: Code Points("a")
+  Required Literal: "bcdef" at 1-1
+     0: MarkCapturePoint(0)
+     2: Literal(a)
+     3: Literal(b)
+     4: Literal(c)
+     5: Literal(d)
+     6: Literal(e)
+     7: Literal(f)
+     8: Literal(g)
+     9: MarkCapturePoint(1)
+    11: Accept
+}
+
+[CompiledRegExp: /abc.def.ghij/] {
+  Flags: ""
+  Match Start: Code Points("a")
+  Required Literal: "ghij" at 8-8
+     0: MarkCapturePoint(0)
+     2: Literal(a)
+     3: Literal(b)
+     4: Literal(c)
+     5: WildcardNoNewline
+     6: Literal(d)
+     7: Literal(e)
+     8: Literal(f)
+     9: WildcardNoNewline
+    10: Literal(g)
+    11: Literal(h)
+    12: Literal(i)
+    13: Literal(j)
+    14: MarkCapturePoint(1)
+    16: Accept
+}
+
+[CompiledRegExp: /(abc)+def/] {
+  Flags: ""
+  Match Start: Code Points("a")
+  Required Literal: "abc" at 0-0
+     0: MarkCapturePoint(0)
+     2: MarkCapturePoint(2)
+     4: Literal(a)
+     5: Literal(b)
+     6: Literal(c)
+     7: MarkCapturePoint(3)
+     9: Branch(12, 24)
+    12: ClearCapture(1)
+    14: MarkCapturePoint(2)
+    16: Literal(a)
+    17: Literal(b)
+    18: Literal(c)
+    19: MarkCapturePoint(3)
+    21: Branch(12, 24)
+    24: Literal(d)
+    25: Literal(e)
+    26: Literal(f)
+    27: MarkCapturePoint(1)
+    29: Accept
+}
+
+[CompiledRegExp: /(abcd)+xy/] {
+  Flags: ""
+  Match Start: Code Points("a")
+  Required Literal: "abcd" at 0-0
+     0: MarkCapturePoint(0)
+     2: MarkCapturePoint(2)
+     4: Literal(a)
+     5: Literal(b)
+     6: Literal(c)
+     7: Literal(d)
+     8: MarkCapturePoint(3)
+    10: Branch(13, 26)
+    13: ClearCapture(1)
+    15: MarkCapturePoint(2)
+    17: Literal(a)
+    18: Literal(b)
+    19: Literal(c)
+    20: Literal(d)
+    21: MarkCapturePoint(3)
+    23: Branch(13, 26)
+    26: Literal(x)
+    27: Literal(y)
+    28: MarkCapturePoint(1)
+    30: Accept
+}
+
+[CompiledRegExp: /(abcde)?xyz/] {
+  Flags: ""
+  Match Start: Code Points("a", "x")
+  Required Literal: "xyz" at 0-5
+     0: MarkCapturePoint(0)
+     2: Branch(11, 5)
+     5: Literal(x)
+     6: Literal(y)
+     7: Literal(z)
+     8: MarkCapturePoint(1)
+    10: Accept
+    11: MarkCapturePoint(2)
+    13: Literal(a)
+    14: Literal(b)
+    15: Literal(c)
+    16: Literal(d)
+    17: Literal(e)
+    18: MarkCapturePoint(3)
+    20: Jump(5)
+}
+
+[CompiledRegExp: /x{3}foobar/] {
+  Flags: ""
+  Match Start: Code Points("x")
+  Required Literal: "foobar" at 3-3
+     0: MarkCapturePoint(0)
+     2: Literal(x)
+     3: Literal(x)
+     4: Literal(x)
+     5: Literal(f)
+     6: Literal(o)
+     7: Literal(o)
+     8: Literal(b)
+     9: Literal(a)
+    10: Literal(r)
+    11: MarkCapturePoint(1)
+    13: Accept
+}
+
+[CompiledRegExp: /x{2,5}foobar/] {
+  Flags: ""
+  Match Start: Code Points("x")
+  Required Literal: "foobar" at 2-5
+     0: MarkCapturePoint(0)
+     2: Literal(x)
+     3: Literal(x)
+     4: Branch(16, 7)
+     7: Literal(f)
+     8: Literal(o)
+     9: Literal(o)
+    10: Literal(b)
+    11: Literal(a)
+    12: Literal(r)
+    13: MarkCapturePoint(1)
+    15: Accept
+    16: Literal(x)
+    17: Branch(20, 7)
+    20: Literal(x)
+    21: Branch(24, 7)
+    24: Literal(x)
+    25: Jump(7)
+}
+
+[CompiledRegExp: /x+foobar/] {
+  Flags: ""
+  Match Start: Code Points("x")
+  Required Literal: "foobar" at 1-any
+     0: MarkCapturePoint(0)
+     2: Literal(x)
+     3: Branch(6, 10)
+     6: Literal(x)
+     7: Branch(6, 10)
+    10: Literal(f)
+    11: Literal(o)
+    12: Literal(o)
+    13: Literal(b)
+    14: Literal(a)
+    15: Literal(r)
+    16: MarkCapturePoint(1)
+    18: Accept
+}
+
+[CompiledRegExp: /.*foobar/] {
+  Flags: ""
+  Match Start: Unknown
+  Required Literal: "foobar" at 0-any
+     0: MarkCapturePoint(0)
+     2: Branch(5, 9)
+     5: WildcardNoNewline
+     6: Branch(5, 9)
+     9: Literal(f)
+    10: Literal(o)
+    11: Literal(o)
+    12: Literal(b)
+    13: Literal(a)
+    14: Literal(r)
+    15: MarkCapturePoint(1)
+    17: Accept
+}
+
+[CompiledRegExp: /x{2,5}abĀvwxyz/] {
+  Flags: ""
+  Match Start: Code Points("x")
+  Required Literal: "vwxyz" at 5-8
+     0: MarkCapturePoint(0)
+     2: Literal(x)
+     3: Literal(x)
+     4: Branch(18, 7)
+     7: Literal(a)
+     8: Literal(b)
+     9: Literal(Ā)
+    10: Literal(v)
+    11: Literal(w)
+    12: Literal(x)
+    13: Literal(y)
+    14: Literal(z)
+    15: MarkCapturePoint(1)
+    17: Accept
+    18: Literal(x)
+    19: Branch(22, 7)
+    22: Literal(x)
+    23: Branch(26, 7)
+    26: Literal(x)
+    27: Jump(7)
+}
+
+[CompiledRegExp: /[xy]foobar/] {
+  Flags: ""
+  Match Start: Code Points("x"-"y")
+  Required Literal: "foobar" at 1-1
+     0: MarkCapturePoint(0)
+     2: CompareBetween(x, y)
+     4: ConsumeIfTrue
+     5: Literal(f)
+     6: Literal(o)
+     7: Literal(o)
+     8: Literal(b)
+     9: Literal(a)
+    10: Literal(r)
+    11: MarkCapturePoint(1)
+    13: Accept
+}
+
+[CompiledRegExp: /[xy]foobar/] {
+  Flags: "v"
+  Match Start: Code Points("x"-"y")
+  Required Literal: "foobar" at 1-1
+     0: MarkCapturePoint(0)
+     2: CompareBetween(x, y)
+     4: ConsumeIfTrue
+     5: Literal(f)
+     6: Literal(o)
+     7: Literal(o)
+     8: Literal(b)
+     9: Literal(a)
+    10: Literal(r)
+    11: MarkCapturePoint(1)
+    13: Accept
+}
+
+[CompiledRegExp: /[xy\q{zz}]foobar/] {
+  Flags: "v"
+  Match Start: Code Points("x"-"z")
+  Required Literal: "foobar" at 0-any
+     0: MarkCapturePoint(0)
+     2: Branch(14, 18)
+     5: Literal(f)
+     6: Literal(o)
+     7: Literal(o)
+     8: Literal(b)
+     9: Literal(a)
+    10: Literal(r)
+    11: MarkCapturePoint(1)
+    13: Accept
+    14: Literal(z)
+    15: Literal(z)
+    16: Jump(5)
+    18: CompareBetween(x, y)
+    20: ConsumeIfTrue
+    21: Jump(5)
+}
+
+[CompiledRegExp: /\p{ASCII_Hex_Digit}foobar/] {
+  Flags: "v"
+  Match Start: Code Points("0"-"9", "A"-"F", "a"-"f")
+  Required Literal: "foobar" at 1-1
+     0: MarkCapturePoint(0)
+     2: CompareBetween(0, 9)
+     4: CompareBetween(A, F)
+     6: CompareBetween(a, f)
+     8: ConsumeIfTrue
+     9: Literal(f)
+    10: Literal(o)
+    11: Literal(o)
+    12: Literal(b)
+    13: Literal(a)
+    14: Literal(r)
+    15: MarkCapturePoint(1)
+    17: Accept
+}
+
+[CompiledRegExp: /\p{Emoji_Keycap_Sequence}foobar/] {
+  Flags: "v"
+  Match Start: Code Points("#", "*", "0"-"9")
+  Required Literal: "foobar" at 0-any
+     0: MarkCapturePoint(0)
+     2: Branch(47, 14)
+     5: Literal(f)
+     6: Literal(o)
+     7: Literal(o)
+     8: Literal(b)
+     9: Literal(a)
+    10: Literal(r)
+    11: MarkCapturePoint(1)
+    13: Accept
+    14: Branch(52, 17)
+    17: Branch(57, 20)
+    20: Branch(62, 23)
+    23: Branch(67, 26)
+    26: Branch(72, 29)
+    29: Branch(77, 32)
+    32: Branch(82, 35)
+    35: Branch(87, 38)
+    38: Branch(92, 41)
+    41: Branch(97, 44)
+    44: Branch(102, 107)
+    47: Literal(#)
+    48: Literal(️)
+    49: Literal(⃣)
+    50: Jump(5)
+    52: Literal(*)
+    53: Literal(️)
+    54: Literal(⃣)
+    55: Jump(5)
+    57: Literal(0)
+    58: Literal(️)
+    59: Literal(⃣)
+    60: Jump(5)
+    62: Literal(1)
+    63: Literal(️)
+    64: Literal(⃣)
+    65: Jump(5)
+    67: Literal(2)
+    68: Literal(️)
+    69: Literal(⃣)
+    70: Jump(5)
+    72: Literal(3)
+    73: Literal(️)
+    74: Literal(⃣)
+    75: Jump(5)
+    77: Literal(4)
+    78: Literal(️)
+    79: Literal(⃣)
+    80: Jump(5)
+    82: Literal(5)
+    83: Literal(️)
+    84: Literal(⃣)
+    85: Jump(5)
+    87: Literal(6)
+    88: Literal(️)
+    89: Literal(⃣)
+    90: Jump(5)
+    92: Literal(7)
+    93: Literal(️)
+    94: Literal(⃣)
+    95: Jump(5)
+    97: Literal(8)
+    98: Literal(️)
+    99: Literal(⃣)
+   100: Jump(5)
+   102: Literal(9)
+   103: Literal(️)
+   104: Literal(⃣)
+   105: Jump(5)
+   107: ConsumeIfTrue
+   108: Jump(5)
+}
+
+[CompiledRegExp: /.foobar/] {
+  Flags: ""
+  Match Start: Unknown
+  Required Literal: "foobar" at 1-1
+     0: MarkCapturePoint(0)
+     2: WildcardNoNewline
+     3: Literal(f)
+     4: Literal(o)
+     5: Literal(o)
+     6: Literal(b)
+     7: Literal(a)
+     8: Literal(r)
+     9: MarkCapturePoint(1)
+    11: Accept
+}
+
+[CompiledRegExp: /^foobar$/] {
+  Flags: ""
+  Match Start: Input Start
+  Required Literal: "foobar" at 0-0
+     0: MarkCapturePoint(0)
+     2: AssertStart
+     3: Literal(f)
+     4: Literal(o)
+     5: Literal(o)
+     6: Literal(b)
+     7: Literal(a)
+     8: Literal(r)
+     9: AssertEnd
+    10: MarkCapturePoint(1)
+    12: Accept
+}
+
+[CompiledRegExp: /(?=abcdef)xyz/] {
+  Flags: ""
+  Match Start: Code Points("x")
+  Required Literal: "xyz" at 0-0
+     0: MarkCapturePoint(0)
+     2: Lookaround(true, true, 10)
+     4: Literal(x)
+     5: Literal(y)
+     6: Literal(z)
+     7: MarkCapturePoint(1)
+     9: Accept
+    10: Literal(a)
+    11: Literal(b)
+    12: Literal(c)
+    13: Literal(d)
+    14: Literal(e)
+    15: Literal(f)
+    16: Accept
+}
+
+[CompiledRegExp: /(\w{3})\1foobar/] {
+  Flags: ""
+  Match Start: Code Points("0"-"9", "A"-"Z", "_", "a"-"z")
+  Required Literal: "foobar" at 3-any
+     0: MarkCapturePoint(0)
+     2: MarkCapturePoint(2)
+     4: CompareBetween(0, 9)
+     6: CompareBetween(A, Z)
+     8: CompareEquals(_)
+     9: CompareBetween(a, z)
+    11: ConsumeIfTrue
+    12: CompareBetween(0, 9)
+    14: CompareBetween(A, Z)
+    16: CompareEquals(_)
+    17: CompareBetween(a, z)
+    19: ConsumeIfTrue
+    20: CompareBetween(0, 9)
+    22: CompareBetween(A, Z)
+    24: CompareEquals(_)
+    25: CompareBetween(a, z)
+    27: ConsumeIfTrue
+    28: MarkCapturePoint(3)
+    30: Backreference(1, false)
+    32: Literal(f)
+    33: Literal(o)
+    34: Literal(o)
+    35: Literal(b)
+    36: Literal(a)
+    37: Literal(r)
+    38: MarkCapturePoint(1)
+    40: Accept
+}
+
+[CompiledRegExp: /foobar|bazqux/] {
+  Flags: ""
+  Match Start: Code Points("b", "f")
+     0: MarkCapturePoint(0)
+     2: Branch(8, 16)
+     5: MarkCapturePoint(1)
+     7: Accept
+     8: Literal(f)
+     9: Literal(o)
+    10: Literal(o)
+    11: Literal(b)
+    12: Literal(a)
+    13: Literal(r)
+    14: Jump(5)
+    16: Literal(b)
+    17: Literal(a)
+    18: Literal(z)
+    19: Literal(q)
+    20: Literal(u)
+    21: Literal(x)
+    22: Jump(5)
+}
+
+[CompiledRegExp: /(?:foo|bar)abcdef/] {
+  Flags: ""
+  Match Start: Code Points("b", "f")
+  Required Literal: "abcdef" at 3-3
+     0: MarkCapturePoint(0)
+     2: Branch(14, 19)
+     5: Literal(a)
+     6: Literal(b)
+     7: Literal(c)
+     8: Literal(d)
+     9: Literal(e)
+    10: Literal(f)
+    11: MarkCapturePoint(1)
+    13: Accept
+    14: Literal(f)
+    15: Literal(o)
+    16: Literal(o)
+    17: Jump(5)
+    19: Literal(b)
+    20: Literal(a)
+    21: Literal(r)
+    22: Jump(5)
+}
+
+[CompiledRegExp: /(?:ab|cde)foobar/] {
+  Flags: ""
+  Match Start: Code Points("a", "c")
+  Required Literal: "foobar" at 2-3
+     0: MarkCapturePoint(0)
+     2: Branch(14, 18)
+     5: Literal(f)
+     6: Literal(o)
+     7: Literal(o)
+     8: Literal(b)
+     9: Literal(a)
+    10: Literal(r)
+    11: MarkCapturePoint(1)
+    13: Accept
+    14: Literal(a)
+    15: Literal(b)
+    16: Jump(5)
+    18: Literal(c)
+    19: Literal(d)
+    20: Literal(e)
+    21: Jump(5)
+}
+
+[CompiledRegExp: /foobar/] {
+  Flags: "i"
+  Match Start: Code Points("F", "f")
+     0: MarkCapturePoint(0)
+     2: CompareEquals(F)
+     3: CompareEquals(f)
+     4: ConsumeIfTrue
+     5: CompareEquals(O)
+     6: CompareEquals(o)
+     7: ConsumeIfTrue
+     8: CompareEquals(O)
+     9: CompareEquals(o)
+    10: ConsumeIfTrue
+    11: CompareEquals(B)
+    12: CompareEquals(b)
+    13: ConsumeIfTrue
+    14: CompareEquals(A)
+    15: CompareEquals(a)
+    16: ConsumeIfTrue
+    17: CompareEquals(R)
+    18: CompareEquals(r)
+    19: ConsumeIfTrue
+    20: MarkCapturePoint(1)
+    22: Accept
+}
+
+[CompiledRegExp: /123456/] {
+  Flags: "i"
+  Match Start: Code Points("1")
+  Required Literal: "123456" at 0-0
+     0: MarkCapturePoint(0)
+     2: Literal(1)
+     3: Literal(2)
+     4: Literal(3)
+     5: Literal(4)
+     6: Literal(5)
+     7: Literal(6)
+     8: MarkCapturePoint(1)
+    10: Accept
+}
+
+[CompiledRegExp: /foo_123_bar/] {
+  Flags: "i"
+  Match Start: Code Points("F", "f")
+  Required Literal: "_123_" at 3-3
+     0: MarkCapturePoint(0)
+     2: CompareEquals(F)
+     3: CompareEquals(f)
+     4: ConsumeIfTrue
+     5: CompareEquals(O)
+     6: CompareEquals(o)
+     7: ConsumeIfTrue
+     8: CompareEquals(O)
+     9: CompareEquals(o)
+    10: ConsumeIfTrue
+    11: Literal(_)
+    12: Literal(1)
+    13: Literal(2)
+    14: Literal(3)
+    15: Literal(_)
+    16: CompareEquals(B)
+    17: CompareEquals(b)
+    18: ConsumeIfTrue
+    19: CompareEquals(A)
+    20: CompareEquals(a)
+    21: ConsumeIfTrue
+    22: CompareEquals(R)
+    23: CompareEquals(r)
+    24: ConsumeIfTrue
+    25: MarkCapturePoint(1)
+    27: Accept
+}
+
+[CompiledRegExp: /é12345/] {
+  Flags: "i"
+  Match Start: Code Points("É", "é")
+  Required Literal: "12345" at 1-1
+     0: MarkCapturePoint(0)
+     2: CompareEquals(É)
+     3: CompareEquals(é)
+     4: ConsumeIfTrue
+     5: Literal(1)
+     6: Literal(2)
+     7: Literal(3)
+     8: Literal(4)
+     9: Literal(5)
+    10: MarkCapturePoint(1)
+    12: Accept
+}
+
+[CompiledRegExp: /×12345/] {
+  Flags: "i"
+  Match Start: Code Points("×")
+  Required Literal: "×12345" at 0-0
+     0: MarkCapturePoint(0)
+     2: Literal(×)
+     3: Literal(1)
+     4: Literal(2)
+     5: Literal(3)
+     6: Literal(4)
+     7: Literal(5)
+     8: MarkCapturePoint(1)
+    10: Accept
+}
+
+[CompiledRegExp: /(?i:foobar)xyz/] {
+  Flags: ""
+  Match Start: Code Points("F", "f")
+  Required Literal: "xyz" at 6-6
+     0: MarkCapturePoint(0)
+     2: CompareEquals(F)
+     3: CompareEquals(f)
+     4: ConsumeIfTrue
+     5: CompareEquals(O)
+     6: CompareEquals(o)
+     7: ConsumeIfTrue
+     8: CompareEquals(O)
+     9: CompareEquals(o)
+    10: ConsumeIfTrue
+    11: CompareEquals(B)
+    12: CompareEquals(b)
+    13: ConsumeIfTrue
+    14: CompareEquals(A)
+    15: CompareEquals(a)
+    16: ConsumeIfTrue
+    17: CompareEquals(R)
+    18: CompareEquals(r)
+    19: ConsumeIfTrue
+    20: Literal(x)
+    21: Literal(y)
+    22: Literal(z)
+    23: MarkCapturePoint(1)
+    25: Accept
+}
+
+[CompiledRegExp: /(?-i:foobar)xyz/] {
+  Flags: "i"
+  Match Start: Code Points("f")
+  Required Literal: "foobar" at 0-0
+     0: MarkCapturePoint(0)
+     2: Literal(f)
+     3: Literal(o)
+     4: Literal(o)
+     5: Literal(b)
+     6: Literal(a)
+     7: Literal(r)
+     8: CompareEquals(X)
+     9: CompareEquals(x)
+    10: ConsumeIfTrue
+    11: CompareEquals(Y)
+    12: CompareEquals(y)
+    13: ConsumeIfTrue
+    14: CompareEquals(Z)
+    15: CompareEquals(z)
+    16: ConsumeIfTrue
+    17: MarkCapturePoint(1)
+    19: Accept
+}
+
+[CompiledRegExp: /(?i:error404)xyz/] {
+  Flags: ""
+  Match Start: Code Points("E", "e")
+  Required Literal: "404" at 5-5
+     0: MarkCapturePoint(0)
+     2: CompareEquals(E)
+     3: CompareEquals(e)
+     4: ConsumeIfTrue
+     5: CompareEquals(R)
+     6: CompareEquals(r)
+     7: ConsumeIfTrue
+     8: CompareEquals(R)
+     9: CompareEquals(r)
+    10: ConsumeIfTrue
+    11: CompareEquals(O)
+    12: CompareEquals(o)
+    13: ConsumeIfTrue
+    14: CompareEquals(R)
+    15: CompareEquals(r)
+    16: ConsumeIfTrue
+    17: Literal(4)
+    18: Literal(0)
+    19: Literal(4)
+    20: Literal(x)
+    21: Literal(y)
+    22: Literal(z)
+    23: MarkCapturePoint(1)
+    25: Accept
+}
+
+[CompiledRegExp: /\u0000\u0000\u0000/] {
+  Flags: ""
+  Match Start: Code Points("\x00")
+  Required Literal: "\x00\x00\x00" at 0-0
+     0: MarkCapturePoint(0)
+     2: Literal(\x00)
+     3: Literal(\x00)
+     4: Literal(\x00)
+     5: MarkCapturePoint(1)
+     7: Accept
+}

--- a/tests/snapshot/regexp_bytecode/required_literal.js
+++ b/tests/snapshot/regexp_bytecode/required_literal.js
@@ -1,0 +1,83 @@
+// Full pattern is a required literal
+/abc/;
+/foobar/;
+/café123/;
+
+// Literal below minimum length
+/ab/;
+
+// Only a prefix of long literals is stored
+/abcdefghijklmnopqrstuvwxyz/;
+/abcdefghijklmnopqrstĀuvwxyz/;
+
+// Literals interrupted by a non-Latin1 code point
+/Āabcdefgh/;
+/abcĀdefgh/;
+/abcdefĀghijkl/;
+/aĀĀbbbĀcccc/;
+
+// Literals interrupted before reaching the minimum length
+/abĀcd/;
+
+// Count offsets in code points, accounting for unicode mode
+/😀foobar/u;
+/😀foobar/;
+
+// Use the longest literal if there are multiple
+/Āabcdefgh.*xyz/;
+/Āabc.*uvwxyz/;
+
+// Non-literal terms break up consecutive literals
+/a(?:bcdef)g/;
+/abc.def.ghij/;
+
+// Prefer bounded offsets
+/(abc)+def/;
+
+// Quantifiers require a literal only if they have a required repetition
+/(abcd)+xy/;
+/(abcde)?xyz/;
+/x{3}foobar/;
+/x{2,5}foobar/;
+/x+foobar/;
+/.*foobar/;
+
+// Quantifiers have a width range
+/x{2,5}abĀvwxyz/;
+
+// Character classes consume one code point, except when they may contain strings
+/[xy]foobar/;
+/[xy]foobar/v;
+/[xy\q{zz}]foobar/v;
+/\p{ASCII_Hex_Digit}foobar/v;
+/\p{Emoji_Keycap_Sequence}foobar/v;
+
+// Wildcards have a width of one
+/.foobar/;
+
+// Assertions and lookarounds have no width
+/^foobar$/;
+/(?=abcdef)xyz/;
+
+// Backreferences have unbounded width
+/(\w{3})\1foobar/;
+
+// Disjunctions with multiple alternatives have no required literal
+/foobar|bazqux/;
+/(?:foo|bar)abcdef/;
+/(?:ab|cde)foobar/;
+
+// Case insensitive literals are broken by code points with case variants
+/foobar/i;
+/123456/i;
+/foo_123_bar/i;
+/é12345/i;
+/×12345/i;
+
+// Modifier groups are accounted for
+/(?i:foobar)xyz/;
+/(?-i:foobar)xyz/i;
+/(?i:error404)xyz/;
+
+// Null bytes are a valid required literal
+/\u0000\u0000\u0000/;


### PR DESCRIPTION
## Summary

Introduce a new analysis pass for RegExps that determines the best required literal that must be present in the input for it to match the RegExp. The required literal must be a sequence of 3-16 Latin1 code points that are search for directly, i.e. we don't support case variants in case insensitive mode. The required literal also tracks its minimum and optional maximum offset from the start of a match, which will be used to narrow down possible match start positions.

This analysis pass is performed in the new `RequiredLiteralAnalyzer`, which tracks the best (aka longest, bounded) searchable literal found along with its offsets. This analysis must track the min/max widths of every subpattern before the literal in order to determine the literal min/max offsets.

The resulting `RequiredLiteralFilter` is stored on the compiled RegExp and will be used to optimize matching in an upcoming PR.

Note that we track `may_contain_strings` on the RegExp AST now and use it during this new analysis. We already had this information during parsing, we just need to save it.

Seeing a ~1.4% regression on the Octane RegExp benchmark due to the added analysis. This is more than made up for by the ~60% increase to this benchmark once the search is added.

## Tests

- Added RegExp bytecode snapshot tests verifying the result of the required literal analysis