### PR TITLE
[regexp] Use required literal filter to speed up matching

### DIFF
--- a/src/js/common/unicode.rs
+++ b/src/js/common/unicode.rs
@@ -503,3 +503,9 @@ pub fn to_string_or_unicode_escape_sequence(code_point: CodePoint) -> String {
     // Code points in the surrogate pair range are encoded as a \uXXXX unicode escape sequence
     format!("\\u{code_point:X}")
 }
+
+/// Reinterpret a slice of two byte code units as a slice of bytes in native endianness.
+#[inline]
+pub fn two_byte_slice_as_bytes(slice: &[CodeUnit]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u8, size_of_val(slice)) }
+}

--- a/src/js/runtime/regexp/lexer_stream.rs
+++ b/src/js/runtime/regexp/lexer_stream.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::unicode::{is_newline, needs_surrogate_pair},
+    common::unicode::{is_newline, needs_surrogate_pair, two_byte_slice_as_bytes},
     parser::{
         lexer_stream::{
             EOF_CHAR, HeapOneByteLexerStream, HeapTwoByteCodePointLexerStream,
@@ -7,11 +7,17 @@ use crate::{
         },
         loc::Pos,
     },
-    runtime::regexp::match_start_filter::MatchStartFilter,
+    runtime::regexp::{
+        match_start_filter::MatchStartFilter,
+        required_literal_filter::{RequiredLiteralFilter, RequiredLiteralSearcher},
+    },
 };
 
 /// An extension of the LexerStream trait with additional methods for use in the RegExp engine.
 pub trait RegExpLexerStream: LexerStream {
+    /// Maximum number of code units used to encode a single code point in this stream.
+    const MAX_CODE_UNITS_PER_CODE_POINT: usize;
+
     /// Move backward N units in the input stream
     fn advance_backwards_n(&mut self, n: usize);
 
@@ -42,6 +48,36 @@ pub trait RegExpLexerStream: LexerStream {
     /// Note that the underlying buffer may not be a buffer of bytes but we always take in a byte
     /// slice.
     fn slice_equals(&self, start: Pos, slice: &[u8]) -> bool;
+
+    /// Whether the remaining stream matches the required literal at any position.
+    fn matches_required_literal_anywhere(
+        &self,
+        required_literal_filter: &RequiredLiteralFilter,
+    ) -> bool;
+
+    /// Whether a match starting at the current position may contain the required literal.
+    ///
+    /// Uses literal's known bounds within the match to restrict search window. Conservatively
+    /// returns true if there are no bounds on the literal within the match.
+    fn may_match_required_literal_at_current_pos(
+        &self,
+        required_literal_filter: &RequiredLiteralFilter,
+    ) -> bool;
+
+    /// Create a searcher for finding the required literal in the stream, or None if this stream
+    /// does not support this kind of search.
+    fn required_literal_searcher(
+        &self,
+        required_literal_filter: &RequiredLiteralFilter,
+    ) -> Option<RequiredLiteralSearcher>;
+
+    /// Find the required literal starting from the given position, returning the position of the
+    /// first occurrence if any.
+    fn find_required_literal(
+        &self,
+        searcher: &mut RequiredLiteralSearcher,
+        start_pos: Pos,
+    ) -> Option<Pos>;
 
     /// Advance until the current code point is a member of the filter. Returns false if the end of
     /// the input was reached without finding a member.
@@ -74,6 +110,8 @@ pub trait RegExpLexerStream: LexerStream {
 }
 
 impl<'a> RegExpLexerStream for HeapOneByteLexerStream<'a> {
+    const MAX_CODE_UNITS_PER_CODE_POINT: usize = 1;
+
     #[inline]
     fn advance_backwards_n(&mut self, n: usize) {
         match self.pos().checked_sub(n) {
@@ -130,6 +168,40 @@ impl<'a> RegExpLexerStream for HeapOneByteLexerStream<'a> {
         &self.buf()[start..end] == slice
     }
 
+    fn matches_required_literal_anywhere(&self, filter: &RequiredLiteralFilter) -> bool {
+        filter.matches_one_byte(&self.buf()[self.pos()..])
+    }
+
+    fn may_match_required_literal_at_current_pos(&self, filter: &RequiredLiteralFilter) -> bool {
+        let buf = self.buf();
+
+        // If the offset is known we can compare directly at the expected position
+        if filter.has_exact_offset() {
+            return filter.matches_one_byte_at(buf, self.pos() + filter.min_offset());
+        }
+
+        match filter.search_window(self.pos(), buf.len(), Self::MAX_CODE_UNITS_PER_CODE_POINT) {
+            Some(window) => filter.matches_one_byte(&buf[window]),
+            None => true,
+        }
+    }
+
+    fn required_literal_searcher(
+        &self,
+        filter: &RequiredLiteralFilter,
+    ) -> Option<RequiredLiteralSearcher> {
+        Some(RequiredLiteralSearcher::new_one_byte(filter))
+    }
+
+    #[inline]
+    fn find_required_literal(
+        &self,
+        searcher: &mut RequiredLiteralSearcher,
+        start_pos: Pos,
+    ) -> Option<Pos> {
+        searcher.find_one_byte(self.buf(), start_pos)
+    }
+
     fn scan_to_code_point_in_filter(&mut self, filter: &MatchStartFilter) -> bool {
         let remaining_buf = &self.buf()[self.pos()..];
 
@@ -163,6 +235,8 @@ impl<'a> RegExpLexerStream for HeapOneByteLexerStream<'a> {
 }
 
 impl<'a> RegExpLexerStream for HeapTwoByteCodeUnitLexerStream<'a> {
+    const MAX_CODE_UNITS_PER_CODE_POINT: usize = 1;
+
     #[inline]
     fn advance_backwards_n(&mut self, n: usize) {
         match self.pos().checked_sub(n) {
@@ -206,8 +280,7 @@ impl<'a> RegExpLexerStream for HeapTwoByteCodeUnitLexerStream<'a> {
     }
 
     fn slice(&self, start: Pos, end: Pos) -> &[u8] {
-        let u16_slice = &self.buf()[start..end];
-        unsafe { std::slice::from_raw_parts(u16_slice.as_ptr() as *const u8, u16_slice.len() * 2) }
+        two_byte_slice_as_bytes(&self.buf()[start..end])
     }
 
     fn slice_equals(&self, start: Pos, slice: &[u8]) -> bool {
@@ -222,9 +295,45 @@ impl<'a> RegExpLexerStream for HeapTwoByteCodeUnitLexerStream<'a> {
 
         &self.buf()[start..end] == slice
     }
+
+    fn matches_required_literal_anywhere(&self, filter: &RequiredLiteralFilter) -> bool {
+        filter.matches_two_byte(&self.buf()[self.pos()..])
+    }
+
+    fn may_match_required_literal_at_current_pos(&self, filter: &RequiredLiteralFilter) -> bool {
+        let buf = self.buf();
+
+        // If the offset is known we can compare directly at the expected position
+        if filter.has_exact_offset() {
+            return filter.matches_two_byte_at(buf, self.pos() + filter.min_offset());
+        }
+
+        match filter.search_window(self.pos(), buf.len(), Self::MAX_CODE_UNITS_PER_CODE_POINT) {
+            Some(window) => filter.matches_two_byte(&buf[window]),
+            None => true,
+        }
+    }
+
+    fn required_literal_searcher(
+        &self,
+        filter: &RequiredLiteralFilter,
+    ) -> Option<RequiredLiteralSearcher> {
+        Some(RequiredLiteralSearcher::new_two_byte(filter))
+    }
+
+    #[inline]
+    fn find_required_literal(
+        &self,
+        searcher: &mut RequiredLiteralSearcher,
+        start_pos: Pos,
+    ) -> Option<Pos> {
+        searcher.find_two_byte(self.buf(), start_pos)
+    }
 }
 
 impl<'a> RegExpLexerStream for HeapTwoByteCodePointLexerStream<'a> {
+    const MAX_CODE_UNITS_PER_CODE_POINT: usize = 2;
+
     #[inline]
     fn advance_backwards_n(&mut self, n: usize) {
         match self.pos().checked_sub(n) {
@@ -285,8 +394,7 @@ impl<'a> RegExpLexerStream for HeapTwoByteCodePointLexerStream<'a> {
     }
 
     fn slice(&self, start: Pos, end: Pos) -> &[u8] {
-        let u16_slice = &self.buf()[start..end];
-        unsafe { std::slice::from_raw_parts(u16_slice.as_ptr() as *const u8, u16_slice.len() * 2) }
+        two_byte_slice_as_bytes(&self.buf()[start..end])
     }
 
     fn slice_equals(&self, start: Pos, slice: &[u8]) -> bool {
@@ -302,5 +410,30 @@ impl<'a> RegExpLexerStream for HeapTwoByteCodePointLexerStream<'a> {
         }
 
         &self.buf()[start..end] == slice
+    }
+
+    fn matches_required_literal_anywhere(&self, filter: &RequiredLiteralFilter) -> bool {
+        filter.matches_two_byte(&self.buf()[self.pos()..])
+    }
+
+    fn may_match_required_literal_at_current_pos(&self, filter: &RequiredLiteralFilter) -> bool {
+        let buf = self.buf();
+        match filter.search_window(self.pos(), buf.len(), Self::MAX_CODE_UNITS_PER_CODE_POINT) {
+            Some(window) => filter.matches_two_byte(&buf[window]),
+            None => true,
+        }
+    }
+
+    fn required_literal_searcher(
+        &self,
+        _: &RequiredLiteralFilter,
+    ) -> Option<RequiredLiteralSearcher> {
+        // Searchers do not support code units encoded as surrogate pairs, since they assume a 1:1
+        // code unit to code point mapping.
+        None
+    }
+
+    fn find_required_literal(&self, _: &mut RequiredLiteralSearcher, _: Pos) -> Option<Pos> {
+        panic!("HeapTwoByteCodePointLexerStream does not support required literal scans");
     }
 }

--- a/src/js/runtime/regexp/matcher.rs
+++ b/src/js/runtime/regexp/matcher.rs
@@ -29,6 +29,7 @@ use crate::{
             },
             lexer_stream::RegExpLexerStream,
             match_start_filter::MatchStartKind,
+            required_literal_filter::RequiredLiteralSearcher,
         },
         string_value::StringValue,
     },
@@ -305,21 +306,127 @@ impl<T: RegExpLexerStream> MatchEngine<T> {
     }
 
     fn run(&mut self, search: MatchSearch) -> Result<Match, MatchError> {
-        if search == MatchSearch::StartOnly {
+        // Required literal scan is the fastest search if possible
+        if let Some(searcher) = self.required_literal_scan_searcher(search) {
+            return self.run_with_required_literal_scan(searcher);
+        }
+
+        let match_start_kind = self.regexp.match_start_filter().kind();
+        let match_must_start_at_current_pos =
+            search == MatchSearch::StartOnly || match_start_kind == MatchStartKind::InputStart;
+
+        // Use the required literal filter to determine whether a match is possible at all in the
+        // input, given the requirements on match start position.
+        let may_match = if match_must_start_at_current_pos {
+            self.string_lexer
+                .may_match_required_literal_at_current_pos(self.regexp.required_literal_filter())
+        } else {
+            self.string_lexer
+                .matches_required_literal_anywhere(self.regexp.required_literal_filter())
+        };
+
+        if !may_match {
+            return Err(MatchError::NoMatch);
+        }
+
+        // Only need to run the matcher once if match must start at the current position
+        if match_must_start_at_current_pos {
             self.execute_bytecode::<FORWARD>()?;
             return Ok(self.build_match());
         }
 
-        match self.regexp.match_start_filter().kind() {
-            // Only need to run the engine once at the start of the input
-            MatchStartKind::InputStart => {
-                self.execute_bytecode::<FORWARD>()?;
-                Ok(self.build_match())
-            }
+        match match_start_kind {
             MatchStartKind::CodePoints => self.run_from_code_point_set(),
             MatchStartKind::Line => self.run_from_line_start(),
             MatchStartKind::Unknown => self.run_from_any_start(),
+            MatchStartKind::InputStart => unreachable!(),
         }
+    }
+
+    /// Return the required literal searcher to use for a fast required literal scan, if this type
+    /// of scan should be used.
+    ///
+    /// Only used for non-anchored search where the required literal has bounds that can be used to
+    /// narrow down potential match start positions.
+    fn required_literal_scan_searcher(
+        &self,
+        search: MatchSearch,
+    ) -> Option<RequiredLiteralSearcher> {
+        let match_start_kind = self.regexp.match_start_filter().kind();
+        let required_literal = self.regexp.required_literal_filter();
+
+        let should_scan = search == MatchSearch::Leftmost
+            && matches!(match_start_kind, MatchStartKind::CodePoints | MatchStartKind::Unknown)
+            && !required_literal.is_empty()
+            && required_literal.has_bounded_offset();
+
+        if !should_scan {
+            return None;
+        }
+
+        self.string_lexer
+            .required_literal_searcher(required_literal)
+    }
+
+    /// Run the engine from each position allowed by the required literal filter
+    fn run_with_required_literal_scan(
+        &mut self,
+        mut searcher: RequiredLiteralSearcher,
+    ) -> Result<Match, MatchError> {
+        self.scan_to_required_literal_match_start(&mut searcher)?;
+
+        self.execute_loop(|this| {
+            this.advance_code_point_in_direction::<FORWARD>();
+            this.scan_to_required_literal_match_start(&mut searcher)
+        })
+    }
+
+    /// Advance to the next position where a match could potentially start, according to the
+    /// required literal filter.
+    fn scan_to_required_literal_match_start(
+        &mut self,
+        searcher: &mut RequiredLiteralSearcher,
+    ) -> MatchResult {
+        let required_literal = self.regexp.required_literal_filter();
+        let match_start_filter = self.regexp.match_start_filter();
+        let string_lexer = &mut self.string_lexer;
+        let has_code_point_filter = match_start_filter.kind() == MatchStartKind::CodePoints;
+
+        while string_lexer.has_current() {
+            let pos = string_lexer.pos();
+
+            // For this position to be the start of a match the required literal must appear after
+            // its minimum required offset from the start of a match.
+            let literal_pos = string_lexer
+                .find_required_literal(searcher, pos + required_literal.min_offset())
+                .ok_or(MatchError::NoMatch)?;
+
+            // The literal is too far ahead to be part of a match starting at this position, so skip
+            // to the earliest possible position that could reach it.
+            if literal_pos > pos + required_literal.max_offset() {
+                let next_possible_pos = literal_pos - required_literal.max_offset();
+                string_lexer.advance_n(next_possible_pos - pos);
+                continue;
+            }
+
+            // Possible match start position according to the required literal filter. Next apply
+            // the code point set match start filter to further filter out start positions.
+            if has_code_point_filter {
+                if !string_lexer.scan_to_code_point_in_filter(match_start_filter) {
+                    return Err(MatchError::NoMatch);
+                }
+
+                // Match start filter advanced even further, so this position cannot match and we
+                // should resume the required literal check at the new position.
+                if string_lexer.pos() != pos {
+                    continue;
+                }
+            }
+
+            return Ok(());
+        }
+
+        Err(MatchError::NoMatch)
     }
 
     /// Run the engine from each position that matches the a set of code points

--- a/src/js/runtime/regexp/required_literal_filter.rs
+++ b/src/js/runtime/regexp/required_literal_filter.rs
@@ -1,8 +1,11 @@
-use std::{cmp::Ordering, fmt};
+use std::{cmp::Ordering, fmt, ops::Range};
+
+use memchr::memmem;
 
 use crate::{
     common::unicode::{
         CodePoint, is_ascii, is_ascii_alphabetic, is_latin1, to_string_or_unicode_escape_sequence,
+        two_byte_slice_as_bytes,
     },
     parser::{
         ast::AstStr,
@@ -44,8 +47,102 @@ impl RequiredLiteralFilter {
     }
 
     #[inline]
+    pub fn min_offset(&self) -> usize {
+        self.offset.min as usize
+    }
+
+    #[inline]
+    pub fn max_offset(&self) -> usize {
+        self.offset.max as usize
+    }
+
+    #[inline]
+    pub fn has_bounded_offset(&self) -> bool {
+        !self.offset.is_unbounded()
+    }
+
+    /// Whether the literal appears at a single known offset within the match.
+    #[inline]
+    pub fn has_exact_offset(&self) -> bool {
+        !self.offset.is_unbounded() && self.offset.min == self.offset.max
+    }
+
+    /// The range of positions that must be searched to determine whether the literal is present
+    /// for a match starting at `pos`, None if the literal's offset is unbounded in the match.
+    ///
+    /// Must specify the maximum number of code units per code point in the buffer so that we can
+    /// conservatively widen the search range to account for multi-unit code points.
+    pub fn search_window(
+        &self,
+        pos: usize,
+        buf_len: usize,
+        max_code_units_per_code_point: usize,
+    ) -> Option<Range<usize>> {
+        if self.offset.is_unbounded() {
+            return None;
+        }
+
+        let window_len = (self.max_offset() + self.len as usize) * max_code_units_per_code_point;
+
+        let start = (pos + self.min_offset()).min(buf_len);
+        let end = (pos + window_len).min(buf_len).max(start);
+
+        Some(start..end)
+    }
+
+    #[inline]
     fn bytes(&self) -> &[u8] {
         &self.bytes[..self.len as usize]
+    }
+
+    /// Widen the literal to two byte code units so that it can be searched for in a two byte string
+    fn widen_two_byte_literal<'a>(&self, literal: &'a mut [u8]) -> &'a [u8] {
+        let literal = &mut literal[..(self.len as usize) * 2];
+        for (code_unit, byte) in literal.chunks_exact_mut(2).zip(self.bytes()) {
+            code_unit.copy_from_slice(&(*byte as u16).to_ne_bytes());
+        }
+
+        literal
+    }
+
+    /// Whether a one byte (Latin1) buffer contains the required literal.
+    #[inline]
+    pub fn matches_one_byte(&self, buf: &[u8]) -> bool {
+        self.is_empty() || memmem::find(buf, self.bytes()).is_some()
+    }
+
+    /// Whether a two byte buffer contains the required literal.
+    #[inline]
+    pub fn matches_two_byte(&self, buf: &[u16]) -> bool {
+        if self.is_empty() {
+            return true;
+        }
+
+        let mut wide_literal = [0; MAX_LITERAL_LEN * 2];
+        let wide_literal = self.widen_two_byte_literal(&mut wide_literal);
+
+        find_two_byte_with(&memmem::Finder::new(wide_literal), buf).is_some()
+    }
+
+    /// Whether the literal appears at exactly the given position in a one byte (Latin1) buffer.
+    #[inline]
+    pub fn matches_one_byte_at(&self, buf: &[u8], pos: usize) -> bool {
+        match buf.get(pos..pos + self.len as usize) {
+            Some(slice) => slice == self.bytes(),
+            None => false,
+        }
+    }
+
+    /// Whether the literal appears at exactly the given position in a two byte buffer.
+    #[inline]
+    pub fn matches_two_byte_at(&self, buf: &[u16], pos: usize) -> bool {
+        match buf.get(pos..pos + self.len as usize) {
+            Some(slice) => slice
+                .iter()
+                .zip(self.bytes())
+                .all(|(code_unit, byte)| *code_unit == *byte as u16),
+            None => false,
+        }
     }
 }
 
@@ -331,4 +428,92 @@ impl RequiredLiteralAnalyzer {
 
         LiteralAnalysis::new(best_literal, Width::new_exact(count))
     }
+}
+
+/// Utility for repeatedly searching for a required literal in a buffer.
+pub struct RequiredLiteralSearcher {
+    /// Finder for the literal's bytes, matching target buffer encoding.
+    finder: memmem::Finder<'static>,
+    /// Cache containing the most recently found occurrence of the literal. Positions are searched
+    /// in increasing order so this can be used to avoid searching multiple times if the most recent
+    /// search still applies to the next search position.
+    found_pos: Option<usize>,
+}
+
+impl RequiredLiteralSearcher {
+    /// Create a searcher for repeatedly finding a literal in a one byte (Latin1) buffer.
+    pub fn new_one_byte(filter: &RequiredLiteralFilter) -> Self {
+        Self::new(filter.bytes())
+    }
+
+    /// Create a searcher for repeatedly finding a literal in a two byte buffer.
+    pub fn new_two_byte(filter: &RequiredLiteralFilter) -> Self {
+        let mut wide_literal = [0; MAX_LITERAL_LEN * 2];
+        let wide_literal = filter.widen_two_byte_literal(&mut wide_literal);
+
+        Self::new(wide_literal)
+    }
+
+    fn new(literal_bytes: &[u8]) -> Self {
+        Self {
+            finder: memmem::Finder::new(literal_bytes).into_owned(),
+            found_pos: None,
+        }
+    }
+
+    #[inline]
+    pub fn find_one_byte(&mut self, buf: &[u8], start_pos: usize) -> Option<usize> {
+        self.find_with(buf.len(), start_pos, |finder| finder.find(&buf[start_pos..]))
+    }
+
+    #[inline]
+    pub fn find_two_byte(&mut self, buf: &[u16], start_pos: usize) -> Option<usize> {
+        self.find_with(buf.len(), start_pos, |finder| find_two_byte_with(finder, &buf[start_pos..]))
+    }
+
+    /// Find the literal in a buffer starting at the given position. Return the offset of the first
+    /// occurrence, or None if not found.
+    #[inline]
+    fn find_with(
+        &mut self,
+        buf_len: usize,
+        start_pos: usize,
+        search: impl FnOnce(&memmem::Finder) -> Option<usize>,
+    ) -> Option<usize> {
+        // Use the cached position if it is still applicable to the requested start position
+        if let Some(found_pos) = self.found_pos
+            && start_pos <= found_pos
+        {
+            return Some(found_pos);
+        }
+
+        if start_pos >= buf_len {
+            return None;
+        }
+
+        let found_pos = start_pos + search(&self.finder)?;
+        self.found_pos = Some(found_pos);
+
+        Some(found_pos)
+    }
+}
+
+/// Find a widened literal in a two byte string buffer, returning the offset in code units of the
+/// first occurrence.
+fn find_two_byte_with(finder: &memmem::Finder, buf: &[u16]) -> Option<usize> {
+    let bytes = two_byte_slice_as_bytes(buf);
+
+    let mut start = 0;
+    while let Some(offset) = finder.find(&bytes[start..]) {
+        let offset = start + offset;
+
+        // Match must occur at an even byte offset in order to match a full code unit
+        if offset % 2 == 0 {
+            return Some(offset / 2);
+        }
+
+        start = offset + 1;
+    }
+
+    None
 }

--- a/tests/integration/built-ins/RegExp/required_literal_filter.js
+++ b/tests/integration/built-ins/RegExp/required_literal_filter.js
@@ -1,0 +1,201 @@
+/*---
+description: >
+  Test the RegExp's required literal filter in a variety of situations. Should be transparent but
+  return correct results.
+includes: [compareArray.js]
+---*/
+
+// Wrapping a pattern in a disjunction with an empty class, which never matches, leaves the language
+// and the capture groups unchanged but leaves no literal that every alternative requires.
+function withoutRequiredLiteral(source) {
+  return "(?:" + source + "|[])";
+}
+
+// Every operation that runs the matcher, reporting the result it produced.
+function runAll(source, flags, string) {
+  return {
+    exec: JSON.stringify(new RegExp(source, flags).exec(string)),
+    test: new RegExp(source, flags).test(string),
+    search: string.search(new RegExp(source, flags)),
+    match: JSON.stringify(string.match(new RegExp(source, flags))),
+    replace: string.replace(new RegExp(source, flags), "<$&>"),
+    split: string.split(new RegExp(source, flags)),
+  };
+}
+
+function assertSameResults(source, flags, string) {
+  var message = "/" + source + "/" + flags + " on " + JSON.stringify(string);
+
+  var filtered = runAll(source, flags, string);
+  var unfiltered = runAll(withoutRequiredLiteral(source), flags, string);
+
+  assert.sameValue(filtered.exec, unfiltered.exec, message + " exec");
+  assert.sameValue(filtered.test, unfiltered.test, message + " test");
+  assert.sameValue(filtered.search, unfiltered.search, message + " search");
+  assert.sameValue(filtered.match, unfiltered.match, message + " match");
+  assert.sameValue(filtered.replace, unfiltered.replace, message + " replace");
+  assert.compareArray(filtered.split, unfiltered.split, message + " split");
+}
+
+var sources = [
+  // A single run of literal code points
+  "foobar",
+  // Runs broken up by terms that require nothing, so only the longest run is required
+  "a(?:bcdef)g",
+  "[xy]abcde[xy]",
+  // A run inside a term that always matches at least once
+  "(abcd)+xy",
+  // A run that is longer than the stored literal, so only a prefix of it is searched for
+  "abcdefghijklmnopqrstuvwxyz",
+  // Non-Latin1 code points interrupt a literal and a new literal starts after the interruption,
+  // with the longest literal searched for. A full literal ignores later interruptions.
+  "abcdefĀghijkl",
+  "abcĀdefgh",
+  "aĀĀbbbĀcccc",
+  "x{2,5}abĀvwxyz",
+  "Āabcdefgh.*xyz",
+  "abcdefghijklmnopqrstĀuvwxyz",
+  // Astral code points count as one code point in unicode mode and two surrogates otherwise
+  "😀😀foobar",
+  // Case insensitive mode searches only for stretches of code points without case variants
+  "123456",
+  "foo_123_bar",
+  "é12345",
+  "(?i:error404)xyz",
+  // Runs that are only reachable on some paths, or not at the start of the match
+  "(?:abcdef)?xy",
+  "(?=abcdef)abc",
+  "foobar|bazqux",
+  // The shape of the pattern this filter was written for: a leading group that consumes at most one
+  // code point, followed by a long required run.
+  "(^|[^\\\\])\"\\\\/Date\\((-?[0-9]+)\\)",
+  // Literals at a fixed distance into the match, which pins a match start to one position per
+  // occurrence of the literal
+  "x{3}foobar",
+  "(?=xx)x{2}foobar",
+  // Literals at a bounded range of distances, so several positions must be tried per occurrence
+  "x{2,5}foobar",
+  "(?:ab|cde)foobar",
+  // Literals that may appear arbitrarily far into the match, which can only rule out an input
+  "(\\w)\\1foobar",
+  ".*foobar",
+  // A line anchored pattern scans line starts while still using the literal to rule out inputs
+  "^x*foobar",
+  // Literals containing NUL code points, whose widened two byte form can overlap itself at a
+  // misaligned offset in a two byte input
+  "\\u0000\\u0000\\u0000",
+  "\\u0000bc",
+  "a\\u0000\\u0000\\u0000",
+];
+
+var flagCombinations = ["", "g", "i", "gi", "y", "gy", "u", "gu", "dgimsy"];
+
+var strings = [
+  "",
+  // The literal present, absent, repeated, and in case variants
+  "foobar",
+  "xxfoobarxx",
+  "foobarfoobar",
+  "xxxxxxxxxx",
+  "xxFooBarxx",
+  "xx123456xx",
+  // Inputs for the patterns that are not plain runs
+  "xabcdex",
+  "abcdabcdxy",
+  "abcdefghijklmnopqrstuvwxyz",
+  "abcdefghijklmnop",
+  "abc",
+  "xyz",
+  "bazqux",
+  // Inputs with line terminators for the line anchored pattern
+  "zz\nxfoobar",
+  "foobar\nzz",
+  '{"d":"\\/Date(12345)\\/"}',
+  // Inputs holding interrupted literals exactly and at surrounding offsets
+  "abcdefĀghijkl",
+  "abcĀdefgh",
+  "xxabcĀdefghxx",
+  "defgh",
+  "aĀĀbbbĀcccc",
+  "ccccxxxx",
+  "xabĀvwxyz",
+  "xxabĀvwxyz",
+  "xxxxxabĀvwxyz",
+  "xxxxxxabĀvwxyz",
+  "abcdefghijklmnopqrstĀuvwxyz",
+  "Āabcdefghxxxxyz",
+  "\u0100abcdefghxyz",
+  // Astral inputs around the required literal
+  "😀😀foobar",
+  "x😀😀foobar",
+  "😀foobar",
+  // Case variants of the stretch patterns
+  "FOO_123_BAR",
+  "foo_123_barxx",
+  "foo_123_bar‰",
+  "ERROR404xyz",
+  "error404XYZ",
+  "É12345",
+  "é12345",
+  // A two byte input holds the same code points, but is searched for the literal differently. The
+  // trailing code point is what forces the string to be stored as two bytes.
+  "xxfoobarxx‰",
+  "xxxxxxxxxx‰",
+  "xx123456xx‰",
+  '{"d":"\\/Date(12345)\\/"}‰',
+  // A lone surrogate cannot be part of the literal, but must not be matched into either
+  "xxfoo\uD83Dbarxx",
+  "xxfoobarxx\uD83D",
+  // The literal at each distance around the bounds of the patterns above, so that a match starting
+  // at exactly the earliest and latest viable position is covered, as well as just outside both.
+  "xfoobar",
+  "xxfoobar",
+  "xxxfoobar",
+  "xxxxfoobar",
+  "xxxxxfoobar",
+  "xxxxxxfoobar",
+  "zzfoobarxxxfoobar",
+  "abfoobar",
+  "cdefoobar",
+  "xxxfoobar‰",
+  "xxxxxfoobar‰",
+  // Two byte inputs where a misaligned occurrence of a NUL literal's widened form overlaps and
+  // precedes the real aligned occurrence
+  "a\u0000\u0000\u0000\u1234",
+  "\u00ff\u0000\u0000\u0000\u1234",
+  "\u1234a\u0000\u0000\u0000",
+  "A\u6200\u6300\u0000bc",
+  // One byte inputs holding the same NUL literals
+  "a\u0000\u0000\u0000",
+  "\u0000\u0000\u0000bc",
+];
+
+for (var i = 0; i < sources.length; i++) {
+  for (var j = 0; j < flagCombinations.length; j++) {
+    for (var k = 0; k < strings.length; k++) {
+      assertSameResults(sources[i], flagCombinations[j], strings[k]);
+    }
+  }
+}
+
+// A last index past the required literal must not find a match behind it.
+var afterLiteral = new RegExp("foobar", "g");
+afterLiteral.lastIndex = 8;
+assert.sameValue(afterLiteral.exec("foobar__"), null, "literal entirely before the last index");
+assert.sameValue(afterLiteral.lastIndex, 0, "last index reset after failing past the literal");
+
+var straddling = new RegExp("foobar", "g");
+straddling.lastIndex = 2;
+assert.sameValue(straddling.exec("__foobar__")[0], "foobar", "literal found after the last index");
+assert.sameValue(straddling.lastIndex, 8, "last index after matching");
+
+// A sticky match must respect the required literal window at a nonzero last index.
+var stickyInWindow = new RegExp("x{2,5}foobar", "y");
+stickyInWindow.lastIndex = 2;
+assert.sameValue(stickyInWindow.exec("zzxxxfoobar")[0], "xxxfoobar", "sticky start within the literal window");
+assert.sameValue(stickyInWindow.lastIndex, 11, "last index after sticky match");
+
+var stickyOutsideWindow = new RegExp("x{2,5}foobar", "y");
+stickyOutsideWindow.lastIndex = 4;
+assert.sameValue(stickyOutsideWindow.exec("zzxxxfoobar"), null, "sticky start past the literal window");
+assert.sameValue(stickyOutsideWindow.lastIndex, 0, "last index reset after sticky failure");


### PR DESCRIPTION
## Summary

Use the `RequiredLiteralFilter` introduced in https://github.com/Hans-Halverson/brimstone/pull/501 during matching. This filter allows us to 1) filter out any inputs that never contain the required literal and 2) if the literal has a known bound from the start of the match, restricts match start positions that need to be checked. Is used in combination with the `MatchStartFilter` in order to further optimize where the backtracking matcher even needs to be run.

Notes:
- Required literal search is specialized for the "matches can only appear at the start" case by restricting search to bounded window, if possible.
- We must conservatively widen the search window in `HeapTwoByteCodePointLexerStream` to account for code points that take two code units.

Seeing a massive +62.6% increase to Octane RegExp benchmark score from this change, an a +3.3% overall improvement to Octane score.

## Tests

- Added LLM-generated integration tests exercising the required literal filter in a variety of situations