### PR TITLE
[regexp] GreedyLoop instruction for greedy matching of single code point quantifier body using a single backtrack stack entry

### DIFF
--- a/src/js/parser/lexer_stream.rs
+++ b/src/js/parser/lexer_stream.rs
@@ -84,6 +84,11 @@ pub trait LexerStream {
     fn has_current(&self) -> bool {
         self.current() != EOF_CHAR
     }
+
+    /// Prime the input stream for forwards traversal.
+    fn prime_forwards(&mut self) {
+        self.advance_n(0);
+    }
 }
 
 /// An input stream over a valid UTF-8 string.

--- a/src/js/runtime/regexp/code_point_set_builder.rs
+++ b/src/js/runtime/regexp/code_point_set_builder.rs
@@ -426,6 +426,15 @@ static NOT_DIGIT_CASE_INSENSITIVE_V_MODE_SET: LazyLock<CodePointInversionList> =
         case_insensitive_unicode_sets_complement(&set_builder.build())
     });
 
+/// Set of all newline characters.
+pub static NEWLINE_SET: LazyLock<CodePointInversionList> = LazyLock::new(|| {
+    let mut set_builder = CodePointInversionListBuilder::new();
+    set_builder.add_char('\n');
+    set_builder.add_char('\r');
+    set_builder.add_range('\u{2028}'..='\u{2029}');
+    set_builder.build()
+});
+
 fn create_word_set_builder() -> CodePointInversionListBuilder {
     let mut set_builder = CodePointInversionListBuilder::new();
 

--- a/src/js/runtime/regexp/compiler.rs
+++ b/src/js/runtime/regexp/compiler.rs
@@ -27,7 +27,7 @@ use crate::{
         regexp::{
             code_point_set::{CodePointSetFlags, EncodedCodePointSet},
             code_point_set_builder::{
-                CodePointSetBuilder, WORD_CASE_INSENSITIVE_UNICODE_SET, WORD_SET,
+                CodePointSetBuilder, NEWLINE_SET, WORD_CASE_INSENSITIVE_UNICODE_SET, WORD_SET,
             },
             compiled_regexp::CompiledRegExp,
             graphviz::save_regexp_dotfile_if_needed,
@@ -36,8 +36,8 @@ use crate::{
                 AssertStartInstruction, AssertStartOrNewlineInstruction,
                 AssertWordBoundaryInstruction, BackreferenceInstruction, BranchInstruction,
                 ClearCaptureInstruction, CodePointLiteralInstruction, CodePointSetInstruction,
-                FailInstruction, Instruction, InstructionIterator, InstructionIteratorMut,
-                JumpInstruction, LookaroundInstruction, LoopInstruction,
+                FailInstruction, GreedyLoopInstruction, Instruction, InstructionIterator,
+                InstructionIteratorMut, JumpInstruction, LookaroundInstruction, LoopInstruction,
                 MarkCapturePointInstruction, OneByteStringLiteralInstruction, OpCode,
                 ProgressInstruction, SetProgressInstruction, TwoByteStringLiteralInstruction,
                 WildcardInstruction, WildcardNoNewlineInstruction,
@@ -166,6 +166,10 @@ impl RegExpCompiler {
 
     fn emit_code_point_set_instruction(&mut self, flags: CodePointSetFlags, set_offset: u32) {
         CodePointSetInstruction::write(self.current_block_buf(), flags, set_offset)
+    }
+
+    fn emit_greedy_loop_instruction(&mut self, flags: CodePointSetFlags, set_offset: u32) {
+        GreedyLoopInstruction::write(self.current_block_buf(), flags, set_offset)
     }
 
     fn emit_wildcard_instruction(&mut self) {
@@ -784,6 +788,13 @@ impl RegExpCompiler {
 
             // Quantifier ends at start of join block
             self.set_current_block(join_block_id);
+        } else if quantifier.is_greedy
+            && let Some((set, is_inverted)) = self.as_simple_greedy_loop_body(&quantifier.term)
+        {
+            // Emit a greedy loop instruction for a simple body that consumes exactly one code point
+            // which can be matched by a single code point set.
+            let (flags, set_offset) = self.add_encoded_code_point_set(&set, is_inverted)?;
+            self.emit_greedy_loop_instruction(flags, set_offset);
         } else {
             // Any number of future repetitions
             let term_block_id = self.new_block();
@@ -840,6 +851,66 @@ impl RegExpCompiler {
         }
 
         self.emit_term(&quantifier.term)
+    }
+
+    /// Simple greedy loop bodies consume exactly one code point and can be matched by a single code
+    /// point set. This allows for the more efficient GreedyLoop instruction to be used.
+    ///
+    /// Return the code point set and whether the set is inverted if the term is a simple greedy
+    /// loop body, otherwise return None.
+    fn as_simple_greedy_loop_body<'a>(
+        &self,
+        term: &Term,
+    ) -> Option<(CodePointInversionList<'a>, bool)> {
+        let flags = self.current_flags();
+        match term {
+            // Literals can be a greedy loop body if they have exactly one code point
+            Term::Literal(string) => {
+                let mut code_points = string.iter_code_points();
+                if let Some(code_point) = code_points.next()
+                    && code_points.next().is_none()
+                {
+                    let set = CodePointSetBuilder::code_point_to_set(code_point, flags);
+                    Some((set, /* is_inverted */ false))
+                } else {
+                    None
+                }
+            }
+            // Character classes without strings are always a greedy loop body
+            Term::CharacterClass(character_class) if !character_class.may_contain_strings => {
+                let (set, _) = CodePointSetBuilder::character_class_to_set(character_class, flags);
+
+                // In unicode sets mode the set was eagerly inverted instead of inverting at the end
+                let is_inverted = character_class.is_inverted && !flags.has_unicode_sets_flag();
+
+                Some((set, is_inverted))
+            }
+            // Wildcards can be a greedy loop body, and are represented as either the set of all
+            // code points or the set of all code points except newlines depending on the dotAll
+            // flag.
+            Term::Wildcard => {
+                let mut set_builder = CodePointInversionListBuilder::new();
+
+                if !flags.is_dot_all() {
+                    set_builder.add_set(&NEWLINE_SET);
+                }
+
+                Some((set_builder.build(), /* is_inverted */ true))
+            }
+            // Descend into simple anonymous groups
+            Term::AnonymousGroup(group)
+                if group.positive_modifiers.is_empty() && group.negative_modifiers.is_empty() =>
+            {
+                if let [alternative] = group.disjunction.alternatives.as_ref()
+                    && let [term] = alternative.terms.as_ref()
+                {
+                    self.as_simple_greedy_loop_body(term)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
     }
 
     fn emit_capture_group(&mut self, group: &CaptureGroup) -> EmitResult<()> {
@@ -937,9 +1008,21 @@ impl RegExpCompiler {
             return Ok(());
         }
 
-        // Otherwise we must emit a code point set comparison instruction. We can choose to emit the
-        // set or its complement so we choose whichever is cheaper (i.e. has fewer non-Latin1
-        // ranges) and flip the inversion flag if necessary.
+        let (flags, set_offset) = self.add_encoded_code_point_set(set, is_inverted)?;
+        self.emit_code_point_set_instruction(flags, set_offset);
+
+        Ok(())
+    }
+
+    /// Encode a code point set and add it to the constant table, returning the set instruction
+    /// flags and the offset of the encoded set in the constant table.
+    fn add_encoded_code_point_set(
+        &mut self,
+        set: &CodePointInversionList,
+        is_inverted: bool,
+    ) -> EmitResult<(CodePointSetFlags, u32)> {
+        // We can choose to encode the set or its complement so we choose whichever is cheaper
+        // (i.e. has fewer non-Latin1 ranges) and flip the inversion flag if necessary.
         //
         // The complement has one fewer range exactly when the set contains both endpoints of the
         // non-Latin1 range.
@@ -965,9 +1048,7 @@ impl RegExpCompiler {
             flags |= CodePointSetFlags::IS_INVERTED;
         }
 
-        self.emit_code_point_set_instruction(flags, set_offset);
-
-        Ok(())
+        Ok((flags, set_offset))
     }
 
     fn emit_class_string_disjunction(

--- a/src/js/runtime/regexp/instruction.rs
+++ b/src/js/runtime/regexp/instruction.rs
@@ -41,6 +41,13 @@ pub enum OpCode {
     /// Layout: [[opcode: u8] [flags: u8] [padding: u16] [set_offset: u32]]
     CodePointSet,
 
+    /// Greedily consume as many code points as possible while they are members of the encoded code
+    /// point set stored in the constant table. Uses the same encoding scheme and flags as the
+    /// CodePointSet instruction. May match no code points.
+    ///
+    /// Layout: [[opcode: u8] [flags: u8] [padding: u16] [set_offset: u32]]
+    GreedyLoop,
+
     /// Consume a single code point, failing if there is no code point to consume. This is the
     /// behavior of the wildcard with the `s` flag.
     ///
@@ -155,6 +162,8 @@ impl OpCode {
             OpCode::CodePointLiteral => CodePointLiteralInstruction::SIZE,
             OpCode::OneByteStringLiteral => OneByteStringLiteralInstruction::SIZE,
             OpCode::TwoByteStringLiteral => TwoByteStringLiteralInstruction::SIZE,
+            OpCode::CodePointSet => CodePointSetInstruction::SIZE,
+            OpCode::GreedyLoop => GreedyLoopInstruction::SIZE,
             OpCode::Wildcard => WildcardInstruction::SIZE,
             OpCode::WildcardNoNewline => WildcardNoNewlineInstruction::SIZE,
             OpCode::Jump => JumpInstruction::SIZE,
@@ -172,7 +181,6 @@ impl OpCode {
             OpCode::AssertEndOrNewline => AssertEndOrNewlineInstruction::SIZE,
             OpCode::AssertWordBoundary => AssertWordBoundaryInstruction::SIZE,
             OpCode::Backreference => BackreferenceInstruction::SIZE,
-            OpCode::CodePointSet => CodePointSetInstruction::SIZE,
             OpCode::Lookaround => LookaroundInstruction::SIZE,
         }
     }
@@ -213,6 +221,12 @@ impl Instruction {
             OpCode::TwoByteStringLiteral => self
                 .cast::<TwoByteStringLiteralInstruction>()
                 .debug_print(constants_data),
+            OpCode::CodePointSet => self
+                .cast::<CodePointSetInstruction>()
+                .debug_print(constants_data),
+            OpCode::GreedyLoop => self
+                .cast::<GreedyLoopInstruction>()
+                .debug_print(constants_data),
             OpCode::Wildcard => self.cast::<WildcardInstruction>().debug_print(),
             OpCode::WildcardNoNewline => self.cast::<WildcardNoNewlineInstruction>().debug_print(),
             OpCode::Jump => self.cast::<JumpInstruction>().debug_print(),
@@ -236,9 +250,6 @@ impl Instruction {
                 self.cast::<AssertWordBoundaryInstruction>().debug_print()
             }
             OpCode::Backreference => self.cast::<BackreferenceInstruction>().debug_print(),
-            OpCode::CodePointSet => self
-                .cast::<CodePointSetInstruction>()
-                .debug_print(constants_data),
             OpCode::Lookaround => self.cast::<LookaroundInstruction>().debug_print(),
         }
     }
@@ -445,6 +456,50 @@ regexp_bytecode_instruction!(
 );
 
 impl CodePointSetInstruction {
+    #[inline]
+    fn flags(&self) -> CodePointSetFlags {
+        let encoded_flags = get_packed_u8_operand(self.0.as_ptr(), 1);
+        CodePointSetFlags::from_bits_retain(encoded_flags)
+    }
+
+    #[inline]
+    fn set_base(&self, constants_base: *const u8) -> *const u32 {
+        unsafe { constants_base.add(self.0[1] as usize).cast::<u32>() }
+    }
+
+    #[inline]
+    pub fn set_data(&self, constants_base: *const u8) -> EncodedCodePointSet {
+        let flags = self.flags();
+        let encoded_base = self.set_base(constants_base);
+
+        EncodedCodePointSet { flags, encoded_base }
+    }
+
+    pub fn write(buf: &mut Vec<u32>, flags: CodePointSetFlags, set_offset: u32) {
+        write_u32!(buf, (Self::OPCODE as u32) | ((flags.bits() as u32) << 8));
+        write_u32!(buf, set_offset);
+    }
+}
+
+regexp_bytecode_instruction!(
+    GreedyLoopInstruction,
+    OpCode::GreedyLoop,
+    2,
+    impl {
+        fn debug_print(&self, constants_data: &[u8]) -> String {
+            let set = self.set_data(constants_data.as_ptr());
+            let set_string = set.debug_format();
+
+            if self.flags().is_inverted() {
+                format!("{:?}(inverted, {})", Self::OPCODE, set_string)
+            } else {
+                format!("{:?}({})", Self::OPCODE, set_string)
+            }
+        }
+    }
+);
+
+impl GreedyLoopInstruction {
     #[inline]
     fn flags(&self) -> CodePointSetFlags {
         let encoded_flags = get_packed_u8_operand(self.0.as_ptr(), 1);

--- a/src/js/runtime/regexp/lexer_stream.rs
+++ b/src/js/runtime/regexp/lexer_stream.rs
@@ -120,6 +120,11 @@ pub trait RegExpLexerStream: LexerStream {
 
         false
     }
+
+    /// Prime the input stream for backwards traversal.
+    fn prime_backwards(&mut self) {
+        self.advance_backwards_n(0);
+    }
 }
 
 impl<'a> RegExpLexerStream for HeapOneByteLexerStream<'a> {

--- a/src/js/runtime/regexp/matcher.rs
+++ b/src/js/runtime/regexp/matcher.rs
@@ -18,16 +18,17 @@ use crate::{
         Context, EvalResult, Handle, HeapPtr,
         error::range_error,
         regexp::{
+            code_point_set::EncodedCodePointSet,
             compiled_regexp::CompiledRegExp,
             instruction::{
                 AssertEndInstruction, AssertEndOrNewlineInstruction, AssertStartInstruction,
                 AssertStartOrNewlineInstruction, AssertWordBoundaryInstruction,
                 BackreferenceInstruction, BranchInstruction, ClearCaptureInstruction,
-                CodePointLiteralInstruction, CodePointSetInstruction, Instruction, JumpInstruction,
-                LookaroundInstruction, LoopInstruction, MarkCapturePointInstruction,
-                OneByteStringLiteralInstruction, OpCode, ProgressInstruction,
-                SetProgressInstruction, TInstruction, TwoByteStringLiteralInstruction,
-                WildcardInstruction, WildcardNoNewlineInstruction,
+                CodePointLiteralInstruction, CodePointSetInstruction, GreedyLoopInstruction,
+                Instruction, JumpInstruction, LookaroundInstruction, LoopInstruction,
+                MarkCapturePointInstruction, OneByteStringLiteralInstruction, OpCode,
+                ProgressInstruction, SetProgressInstruction, TInstruction,
+                TwoByteStringLiteralInstruction, WildcardInstruction, WildcardNoNewlineInstruction,
             },
             lexer_stream::RegExpLexerStream,
             match_start_filter::MatchStartKind,
@@ -73,6 +74,8 @@ enum BacktrackEntry {
     ProgressPoint(u32, u32),
     /// Restore a loop register to a given value (loop register index, value)
     LoopRegister(u32, usize),
+    /// Give back one repetition of a greedy loop and resume execution after the loop
+    GreedyLoopState(GreedyLoopState),
     /// Restore the backtrack stack to a given size, backtracking through all entries
     /// above that size.
     RestoreBacktrackStack(usize),
@@ -105,6 +108,17 @@ struct ClearedCaptureGroup {
     start_string_index: u32,
     /// Saved string index of the end of the capture group before being cleared
     end_string_index: u32,
+}
+
+struct GreedyLoopState {
+    /// Target string state when the current iteration of the greedy loop was started.
+    saved_string_state: SavedLexerStreamState,
+    /// Address of the next instruction to execute after the greedy loop.
+    pc: *const u32,
+    /// Index in the target string where the greedy loop started matching.
+    string_start_index: u32,
+    /// Direction of traversal when the greedy loop was executed.
+    direction: bool,
 }
 
 #[derive(Debug)]
@@ -215,6 +229,40 @@ impl<T: RegExpLexerStream> MatchEngine<T> {
 
                     // Continue backtracking
                 }
+                BacktrackEntry::GreedyLoopState(loop_state) => {
+                    self.string_lexer.restore(&loop_state.saved_string_state);
+
+                    // Move back one iteration of the greedy loop and resume
+                    if self.string_lexer.pos() != loop_state.string_start_index as usize {
+                        self.pc = loop_state.pc;
+
+                        // Greedy loop consumes a single code point per iteration, so advance one
+                        // code point in the opposite direction of traversal.
+                        match loop_state.direction {
+                            FORWARD => {
+                                self.string_lexer.prime_backwards();
+                                self.string_lexer.advance_backwards_code_point();
+                                self.string_lexer.prime_forwards();
+                            }
+                            BACKWARD => {
+                                self.string_lexer.prime_forwards();
+                                self.string_lexer.advance_code_point();
+                                self.string_lexer.prime_backwards();
+                            }
+                        }
+
+                        self.backtrack_stack.push(BacktrackEntry::GreedyLoopState(
+                            GreedyLoopState {
+                                saved_string_state: self.string_lexer.save(),
+                                ..loop_state
+                            },
+                        ));
+
+                        return Ok(());
+                    }
+
+                    // Backtracked through all iterations of the loop, continue backtracking
+                }
                 BacktrackEntry::RestoreBacktrackStack(backtrack_stack_size) => {
                     self.backtrack_to_stack_size(backtrack_stack_size);
 
@@ -247,7 +295,9 @@ impl<T: RegExpLexerStream> MatchEngine<T> {
                 BacktrackEntry::LoopRegister(loop_register_index, value) => {
                     self.set_loop_register(loop_register_index, value);
                 }
-                BacktrackEntry::RestoreState(_) | BacktrackEntry::RestoreBacktrackStack(_) => {}
+                BacktrackEntry::RestoreState(_)
+                | BacktrackEntry::RestoreBacktrackStack(_)
+                | BacktrackEntry::GreedyLoopState(_) => {}
             }
         }
     }
@@ -565,19 +615,36 @@ impl<T: RegExpLexerStream> MatchEngine<T> {
                     let instr = instr.cast::<CodePointSetInstruction>();
                     let set = instr.set_data(self.constants_base);
 
-                    let current = self.string_lexer.current();
-                    let is_member = set.contains::<T>(current);
-
-                    // EOF_CHAR is never a member of a set, so must explicitly exclude it when
-                    // checking for an inverted match.
-                    let is_match =
-                        (is_member != set.flags.is_inverted()) & self.string_lexer.has_current();
-
-                    if is_match {
+                    if self.set_contains_current(&set) {
                         self.advance_code_point_in_direction::<DIRECTION>();
                         self.advance_instruction::<CodePointSetInstruction>();
                     } else {
                         self.backtrack()?;
+                    }
+                }
+                OpCode::GreedyLoop => {
+                    let instr = instr.cast::<GreedyLoopInstruction>();
+                    let set = instr.set_data(self.constants_base);
+                    let string_start_index = self.string_lexer.pos();
+
+                    // Greedily match as many single code point repetitions as possible
+                    while self.set_contains_current(&set) {
+                        self.advance_code_point_in_direction::<DIRECTION>();
+                    }
+
+                    self.advance_instruction::<GreedyLoopInstruction>();
+
+                    // Push a single backtrack entry that allows backtracking through all
+                    // repetitions in constant space on the backtrack stack.
+                    if self.string_lexer.pos() != string_start_index {
+                        self.push_backtrack_entry(BacktrackEntry::GreedyLoopState(
+                            GreedyLoopState {
+                                saved_string_state: self.string_lexer.save(),
+                                pc: self.pc,
+                                string_start_index: string_start_index as u32,
+                                direction: DIRECTION,
+                            },
+                        ))?;
                     }
                 }
                 OpCode::Wildcard => {
@@ -734,12 +801,10 @@ impl<T: RegExpLexerStream> MatchEngine<T> {
                     self.set_next_instruction(body_branch);
 
                     let match_result = if is_ahead {
-                        // Prime lexer for forwards traversal
-                        self.string_lexer.advance_n(0);
+                        self.string_lexer.prime_forwards();
                         self.execute_bytecode::<FORWARD>()
                     } else {
-                        // Prime lexer for backwards traversal
-                        self.string_lexer.advance_backwards_n(0);
+                        self.string_lexer.prime_backwards();
                         self.execute_bytecode::<BACKWARD>()
                     };
 
@@ -810,6 +875,17 @@ impl<T: RegExpLexerStream> MatchEngine<T> {
             // peek at the next code point.
             BACKWARD => self.string_lexer.peek_next_code_point(),
         }
+    }
+
+    /// Whether the current code point is a member of the given set.
+    #[inline]
+    fn set_contains_current(&self, set: &EncodedCodePointSet) -> bool {
+        let current = self.string_lexer.current();
+        let is_member = set.contains::<T>(current);
+
+        // EOF_CHAR is never a member of a set, so must explicitly exclude it when checking for an
+        // inverted match.
+        (is_member != set.flags.is_inverted()) & self.string_lexer.has_current()
     }
 
     /// Starting position at which a string with the given length in code units would be matched in

--- a/tests/snapshot/regexp_bytecode/match_start/anchored.exp
+++ b/tests/snapshot/regexp_bytecode/match_start/anchored.exp
@@ -260,11 +260,9 @@
   Match Start: Input Start
      0: MarkCapturePoint(0)
      2: AssertStart
-     3: Branch(6, 10)
-     6: CodePointLiteral(a)
-     7: Branch(6, 10)
-    10: MarkCapturePoint(1)
-    12: Accept
+     3: GreedyLoop("a")
+     5: MarkCapturePoint(1)
+     7: Accept
 }
 
 [CompiledRegExp: /^.*a/] {
@@ -272,12 +270,10 @@
   Match Start: Input Start
      0: MarkCapturePoint(0)
      2: AssertStart
-     3: Branch(6, 10)
-     6: WildcardNoNewline
-     7: Branch(6, 10)
-    10: CodePointLiteral(a)
-    11: MarkCapturePoint(1)
-    13: Accept
+     3: GreedyLoop(inverted, "\n", "\r", "\u{2028}"-"\u{2029}")
+     5: CodePointLiteral(a)
+     6: MarkCapturePoint(1)
+     8: Accept
 }
 
 [CompiledRegExp: /^\1(a)/] {

--- a/tests/snapshot/regexp_bytecode/match_start/first_code_points.exp
+++ b/tests/snapshot/regexp_bytecode/match_start/first_code_points.exp
@@ -123,12 +123,10 @@
   Flags: ""
   Match Start: Code Points("a"-"b")
      0: MarkCapturePoint(0)
-     2: Branch(5, 9)
-     5: CodePointLiteral(a)
-     6: Branch(5, 9)
-     9: CodePointLiteral(b)
-    10: MarkCapturePoint(1)
-    12: Accept
+     2: GreedyLoop("a")
+     4: CodePointLiteral(b)
+     5: MarkCapturePoint(1)
+     7: Accept
 }
 
 [CompiledRegExp: /a+b/] {
@@ -136,12 +134,10 @@
   Match Start: Code Points("a")
      0: MarkCapturePoint(0)
      2: CodePointLiteral(a)
-     3: Branch(6, 10)
-     6: CodePointLiteral(a)
-     7: Branch(6, 10)
-    10: CodePointLiteral(b)
-    11: MarkCapturePoint(1)
-    13: Accept
+     3: GreedyLoop("a")
+     5: CodePointLiteral(b)
+     6: MarkCapturePoint(1)
+     8: Accept
 }
 
 [CompiledRegExp: /a{0}b/] {
@@ -222,11 +218,9 @@
   Flags: ""
   Match Start: Unknown
      0: MarkCapturePoint(0)
-     2: Branch(5, 9)
-     5: CodePointLiteral(a)
-     6: Branch(5, 9)
-     9: MarkCapturePoint(1)
-    11: Accept
+     2: GreedyLoop("a")
+     4: MarkCapturePoint(1)
+     6: Accept
 }
 
 [CompiledRegExp: /a|/] {
@@ -390,11 +384,9 @@
   Match Start: Code Points("0"-"9")
      0: MarkCapturePoint(0)
      2: CodePointSet("0"-"9")
-     4: Branch(7, 12)
-     7: CodePointSet("0"-"9")
-     9: Branch(7, 12)
-    12: MarkCapturePoint(1)
-    14: Accept
+     4: GreedyLoop("0"-"9")
+     6: MarkCapturePoint(1)
+     8: Accept
 }
 
 [CompiledRegExp: /\w/] {

--- a/tests/snapshot/regexp_bytecode/quantifiers/greedy_loop.exp
+++ b/tests/snapshot/regexp_bytecode/quantifiers/greedy_loop.exp
@@ -1,0 +1,178 @@
+[CompiledRegExp: /ax*b/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: GreedyLoop("x")
+     5: CodePointLiteral(b)
+     6: MarkCapturePoint(1)
+     8: Accept
+}
+
+[CompiledRegExp: /ax*b/] {
+  Flags: "i"
+  Match Start: Code Points("A", "a")
+     0: MarkCapturePoint(0)
+     2: CodePointSet("A", "a")
+     4: GreedyLoop("X", "x")
+     6: CodePointSet("B", "b")
+     8: MarkCapturePoint(1)
+    10: Accept
+}
+
+[CompiledRegExp: /a[a-z]*b/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: GreedyLoop("a"-"z")
+     5: CodePointLiteral(b)
+     6: MarkCapturePoint(1)
+     8: Accept
+}
+
+[CompiledRegExp: /a[^a-z]*b/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: GreedyLoop(inverted, "a"-"z")
+     5: CodePointLiteral(b)
+     6: MarkCapturePoint(1)
+     8: Accept
+}
+
+[CompiledRegExp: /a[^a-z]*b/] {
+  Flags: "v"
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: GreedyLoop(inverted, "a"-"z")
+     5: CodePointLiteral(b)
+     6: MarkCapturePoint(1)
+     8: Accept
+}
+
+[CompiledRegExp: /a.*b/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: GreedyLoop(inverted, "\n", "\r", "\u{2028}"-"\u{2029}")
+     5: CodePointLiteral(b)
+     6: MarkCapturePoint(1)
+     8: Accept
+}
+
+[CompiledRegExp: /a.*b/] {
+  Flags: "s"
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: GreedyLoop(inverted, )
+     5: CodePointLiteral(b)
+     6: MarkCapturePoint(1)
+     8: Accept
+}
+
+[CompiledRegExp: /a(?:x)*b/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: GreedyLoop("x")
+     5: CodePointLiteral(b)
+     6: MarkCapturePoint(1)
+     8: Accept
+}
+
+[CompiledRegExp: /a(?:(?:(?:x)))*b/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: GreedyLoop("x")
+     5: CodePointLiteral(b)
+     6: MarkCapturePoint(1)
+     8: Accept
+}
+
+[CompiledRegExp: /ax+/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: CodePointLiteral(x)
+     4: GreedyLoop("x")
+     6: MarkCapturePoint(1)
+     8: Accept
+}
+
+[CompiledRegExp: /ax{100,}b/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: Loop(0, 100, 10)
+     7: CodePointLiteral(x)
+     8: Jump(3)
+    10: GreedyLoop("x")
+    12: CodePointLiteral(b)
+    13: MarkCapturePoint(1)
+    15: Accept
+}
+
+[CompiledRegExp: /ax*?b/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: Branch(10, 6)
+     6: CodePointLiteral(x)
+     7: Branch(10, 6)
+    10: CodePointLiteral(b)
+    11: MarkCapturePoint(1)
+    13: Accept
+}
+
+[CompiledRegExp: /a(?:xy)*b/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: Branch(6, 11)
+     6: OneByteStringLiteral("xy")
+     8: Branch(6, 11)
+    11: CodePointLiteral(b)
+    12: MarkCapturePoint(1)
+    14: Accept
+}
+
+[CompiledRegExp: /a(x)*b/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: Branch(6, 16)
+     6: ClearCapture(1)
+     8: MarkCapturePoint(2)
+    10: CodePointLiteral(x)
+    11: MarkCapturePoint(3)
+    13: Branch(6, 16)
+    16: CodePointLiteral(b)
+    17: MarkCapturePoint(1)
+    19: Accept
+}
+
+[CompiledRegExp: /a(?i:x)*b/] {
+  Flags: ""
+  Match Start: Code Points("a")
+     0: MarkCapturePoint(0)
+     2: CodePointLiteral(a)
+     3: Branch(6, 11)
+     6: CodePointSet("X", "x")
+     8: Branch(6, 11)
+    11: CodePointLiteral(b)
+    12: MarkCapturePoint(1)
+    14: Accept
+}

--- a/tests/snapshot/regexp_bytecode/quantifiers/greedy_loop.js
+++ b/tests/snapshot/regexp_bytecode/quantifiers/greedy_loop.js
@@ -1,0 +1,26 @@
+// Literal greedy loop bodies
+/ax*b/;
+/ax*b/i;
+
+// Character class greedy loop bodies
+/a[a-z]*b/;
+/a[^a-z]*b/;
+/a[^a-z]*b/v;
+
+// Wildcard greedy loop bodies
+/a.*b/;
+/a.*b/s;
+
+// Descend into simple anonymous groups
+/a(?:x)*b/;
+/a(?:(?:(?:x)))*b/;
+
+// Greedy loop can appear after required repetitions
+/ax+/;
+/ax{100,}b/;
+
+// Not greedy loop bodies
+/ax*?b/;
+/a(?:xy)*b/;
+/a(x)*b/;
+/a(?i:x)*b/;

--- a/tests/snapshot/regexp_bytecode/quantifiers/simple.exp
+++ b/tests/snapshot/regexp_bytecode/quantifiers/simple.exp
@@ -17,12 +17,10 @@
      0: MarkCapturePoint(0)
      2: CodePointLiteral(a)
      3: CodePointLiteral(x)
-     4: Branch(7, 11)
-     7: CodePointLiteral(x)
-     8: Branch(7, 11)
-    11: CodePointLiteral(b)
-    12: MarkCapturePoint(1)
-    14: Accept
+     4: GreedyLoop("x")
+     6: CodePointLiteral(b)
+     7: MarkCapturePoint(1)
+     9: Accept
 }
 
 [CompiledRegExp: /ax*b/] {
@@ -30,12 +28,10 @@
   Match Start: Code Points("a")
      0: MarkCapturePoint(0)
      2: CodePointLiteral(a)
-     3: Branch(6, 10)
-     6: CodePointLiteral(x)
-     7: Branch(6, 10)
-    10: CodePointLiteral(b)
-    11: MarkCapturePoint(1)
-    13: Accept
+     3: GreedyLoop("x")
+     5: CodePointLiteral(b)
+     6: MarkCapturePoint(1)
+     8: Accept
 }
 
 [CompiledRegExp: /ax{3,4}b/] {
@@ -110,12 +106,10 @@
      2: CodePointLiteral(a)
      3: CodePointLiteral(x)
      4: CodePointLiteral(x)
-     5: Branch(8, 12)
-     8: CodePointLiteral(x)
-     9: Branch(8, 12)
-    12: CodePointLiteral(b)
-    13: MarkCapturePoint(1)
-    15: Accept
+     5: GreedyLoop("x")
+     7: CodePointLiteral(b)
+     8: MarkCapturePoint(1)
+    10: Accept
 }
 
 [CompiledRegExp: /ax{3}b/] {

--- a/tests/snapshot/regexp_bytecode/required_literal.exp
+++ b/tests/snapshot/regexp_bytecode/required_literal.exp
@@ -132,12 +132,10 @@
   Required Literal: "abcdefgh" at 1-1
      0: MarkCapturePoint(0)
      2: TwoByteStringLiteral("Āabcdefgh")
-     4: Branch(7, 11)
-     7: WildcardNoNewline
-     8: Branch(7, 11)
-    11: OneByteStringLiteral("xyz")
-    13: MarkCapturePoint(1)
-    15: Accept
+     4: GreedyLoop(inverted, "\n", "\r", "\u{2028}"-"\u{2029}")
+     6: OneByteStringLiteral("xyz")
+     8: MarkCapturePoint(1)
+    10: Accept
 }
 
 [CompiledRegExp: /Āabc.*uvwxyz/] {
@@ -146,12 +144,10 @@
   Required Literal: "uvwxyz" at 4-any
      0: MarkCapturePoint(0)
      2: TwoByteStringLiteral("Āabc")
-     4: Branch(7, 11)
-     7: WildcardNoNewline
-     8: Branch(7, 11)
-    11: OneByteStringLiteral("uvwxyz")
-    13: MarkCapturePoint(1)
-    15: Accept
+     4: GreedyLoop(inverted, "\n", "\r", "\u{2028}"-"\u{2029}")
+     6: OneByteStringLiteral("uvwxyz")
+     8: MarkCapturePoint(1)
+    10: Accept
 }
 
 [CompiledRegExp: /a(?:bcdef)g/] {
@@ -271,12 +267,10 @@
   Required Literal: "foobar" at 1-any
      0: MarkCapturePoint(0)
      2: CodePointLiteral(x)
-     3: Branch(6, 10)
-     6: CodePointLiteral(x)
-     7: Branch(6, 10)
-    10: OneByteStringLiteral("foobar")
-    12: MarkCapturePoint(1)
-    14: Accept
+     3: GreedyLoop("x")
+     5: OneByteStringLiteral("foobar")
+     7: MarkCapturePoint(1)
+     9: Accept
 }
 
 [CompiledRegExp: /.*foobar/] {
@@ -284,12 +278,10 @@
   Match Start: Unknown
   Required Literal: "foobar" at 0-any
      0: MarkCapturePoint(0)
-     2: Branch(5, 9)
-     5: WildcardNoNewline
-     6: Branch(5, 9)
-     9: OneByteStringLiteral("foobar")
-    11: MarkCapturePoint(1)
-    13: Accept
+     2: GreedyLoop(inverted, "\n", "\r", "\u{2028}"-"\u{2029}")
+     4: OneByteStringLiteral("foobar")
+     6: MarkCapturePoint(1)
+     8: Accept
 }
 
 [CompiledRegExp: /x{2,5}abĀvwxyz/] {

--- a/tests/test262/ignored_tests.jsonc
+++ b/tests/test262/ignored_tests.jsonc
@@ -219,9 +219,14 @@
       "language/literals/regexp/S7.8.5_A2.4_T2.js",
       "built-ins/Array/prototype/concat/Array.prototype.concat_large-typed-array.js",
       "built-ins/Function/prototype/toString/built-in-function-object.js",
+      "built-ins/RegExp/CharacterClassEscapes/character-class-digit-class-escape-negative-cases.js",
+      "built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-positive-cases.js",
+      "built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-positive-cases.js",
+      "built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-positive-cases.js",
+      "built-ins/RegExp/CharacterClassEscapes/character-class-whitespace-class-escape-negative-cases.js",
+      "built-ins/RegExp/CharacterClassEscapes/character-class-word-class-escape-negative-cases.js",
       "built-ins/RegExp/character-class-escape-non-whitespace.js",
-      "built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-upper-p.js",
-      "built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-upper-w.js",
+      "built-ins/RegExp/property-escapes/generated/*.js",
       "built-ins/TypedArray/prototype/set/typedarray-arg-src-backed-by-resizable-buffer.js",
       "built-ins/TypedArray/prototype/sort/stability.js",
       "built-ins/parseFloat/S15.1.2.3_A6.js",
@@ -267,11 +272,7 @@
       "built-ins/Array/prototype/some/15.4.4.17-7-c-ii-2.js",
       "built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached.js",
       "built-ins/TypedArray/prototype/copyWithin/coerced-values-end-detached-prototype.js",
-      "built-ins/TypedArray/prototype/copyWithin/coerced-values-start-detached.js",
-
-      // Crashing due to RegExp stack overflow but are correct - they pass if limit is raised.
-      "built-ins/RegExp/CharacterClassEscapes/*.js",
-      "built-ins/RegExp/property-escapes/generated/*.js"
+      "built-ins/TypedArray/prototype/copyWithin/coerced-values-start-detached.js"
     ]
   },
   // Slow tests which are ignored in GC stress test runs. Aim to ignore all tests over 5 seconds.
@@ -292,7 +293,6 @@
       "built-ins/Object/defineProperties/typedarray-backed-by-resizable-buffer.js",
       "built-ins/Object/defineProperty/typedarray-backed-by-resizable-buffer.js",
       "built-ins/Proxy/get-fn-realm-recursive.js",
-      "built-ins/RegExp/canonicalize.js",
       "built-ins/String/prototype/repeat/repeat-string-n-times.js",
       "built-ins/TypedArray/prototype/copyWithin/coerced-values-start.js",
       "built-ins/TypedArray/prototype/copyWithin/coerced-values-target.js",


### PR DESCRIPTION
## Summary

Greedy loops in RegExps currently add a backtrack stack entry for every code point in the input stream. This can quickly cause a RegExp stack overflow for long input strings. A more efficient option is possible for greedy quantifiers whose term matches exactly one code point and can be expressed as a single code point set.

Detect these cases and emit a new `GreedyLoop` instruction which uses the recently added code point set in the RegExp's constant table. Then at match time only a single backtrack entry is needed for the entire loop. We first greedily match as much as the input as possible using the code point set and add a backtrack entry for the entire loop, marking the direction and loop start index. Then when backtracking we simply advance a single code point in the opposite direction until the loop start index is found.

This is supported for quantifier bodies that are single code point literals, character classes without strings, and wildcards (which are represented as either the full set or the all code points except newlines, depending on the dotAll flag).

Seeing a +10.4% increase to the Octane RegExp benchmark from this change.

## Tests

- Added RegExp bytecode snapshot tests covering all cases of the new GreedyLoop instruction
- Updated existing RegExp bytecode snapshot tests affected by this change
- Verified that test262 `built-ins/RegExp/CharacterClassEscapes/*.js` and `built-ins/RegExp/property-escapes/generated/*.js` tests all now pass without crashing due to RegExp stack overflow. Most of these are still slow so keep them suppressed, but enable the few that are fast enough to run with the regular suite.