### PR TITLE
[regexp] Share match engine buffers in Context between executions to avoid reallocating

### DIFF
--- a/src/js/runtime/context.rs
+++ b/src/js/runtime/context.rs
@@ -49,6 +49,7 @@ use crate::{
         },
         object_value::{NamedPropertiesMap, ObjectValue},
         realm::Realm,
+        regexp::matcher::MatchEngineCache,
         shape::Shape,
         shape_registry::ShapeRegistry,
         string_value::{FlatString, StringValue},
@@ -135,6 +136,9 @@ pub struct ContextCell {
     /// Random number generator used within this context.
     pub rand: StdRng,
 
+    /// Shared buffers used by the match engine to avoid having to reallocate on every match.
+    pub regexp_match_engine_cache: MatchEngineCache,
+
     /// If set, this is the unix time in nanoseconds.
     mocked_unix_time_nanos: Option<u128>,
 
@@ -175,6 +179,7 @@ impl Context {
             // We want the initial heap generation to be deterministic so use seeded PRNG. After
             // initial heap has been set up switch to a PRNG seeded from a random source.
             rand: StdRng::from_seed([0; 32]),
+            regexp_match_engine_cache: MatchEngineCache::default(),
             mocked_unix_time_nanos: None,
             temporal_provider: CompiledTzdbProvider::default(),
         });

--- a/src/js/runtime/regexp/matcher.rs
+++ b/src/js/runtime/regexp/matcher.rs
@@ -63,6 +63,15 @@ pub struct MatchEngine<T: RegExpLexerStream> {
     backtrack_stack_base: usize,
 }
 
+/// Shared buffers used by the match engine to avoid having to reallocate on every match.
+#[derive(Default)]
+pub struct MatchEngineCache {
+    backtrack_stack: Vec<BacktrackEntry>,
+    capture_points: Vec<u32>,
+    progress_points: Vec<u32>,
+    loop_registers: Vec<usize>,
+}
+
 enum BacktrackEntry {
     /// Backtrack to an (instruction, string index) state
     RestoreState(BacktrackRestoreState),
@@ -91,6 +100,9 @@ struct BacktrackRestoreState {
 /// Cap backtrack stack size
 const MAX_BACKTRACK_STACK_SIZE: usize = 4 * MEGABYTE_BYTES;
 const MAX_BACKTRACK_ENTRIES: usize = MAX_BACKTRACK_STACK_SIZE / size_of::<BacktrackEntry>();
+
+/// Cap the number of elements in each of the engine's shared buffers.
+const MAX_RETAINED_VEC_SIZE: usize = 4096;
 
 const EMPTY_STRING_INDEX: u32 = u32::MAX;
 
@@ -160,21 +172,64 @@ enum MatchError {
 type MatchResult = Result<(), MatchError>;
 
 impl<T: RegExpLexerStream> MatchEngine<T> {
-    fn new(regexp: HeapPtr<CompiledRegExp>, string_lexer: T) -> Self {
+    fn new(
+        regexp: HeapPtr<CompiledRegExp>,
+        string_lexer: T,
+        match_engine_cache: MatchEngineCache,
+    ) -> Self {
         let num_capture_points = (regexp.num_capture_groups as usize + 1) * 2;
         let instructions_base = regexp.instructions_as_slice().as_ptr();
+
+        // Reuse and reset all cached buffers
+        let mut backtrack_stack = match_engine_cache.backtrack_stack;
+        backtrack_stack.clear();
+
+        let mut capture_points = match_engine_cache.capture_points;
+        capture_points.clear();
+        capture_points.resize(num_capture_points, EMPTY_STRING_INDEX);
+
+        let mut progress_points = match_engine_cache.progress_points;
+        progress_points.clear();
+        progress_points.resize(regexp.num_progress_points as usize, EMPTY_STRING_INDEX);
+
+        let mut loop_registers = match_engine_cache.loop_registers;
+        loop_registers.clear();
+        loop_registers.resize(regexp.num_loop_registers as usize, 0);
 
         Self {
             regexp,
             string_lexer,
             pc: instructions_base,
             instructions_base,
-            backtrack_stack: Vec::new(),
-            capture_points: vec![EMPTY_STRING_INDEX; num_capture_points],
-            progress_points: vec![EMPTY_STRING_INDEX; regexp.num_progress_points as usize],
-            loop_registers: vec![0; regexp.num_loop_registers as usize],
+            backtrack_stack,
+            capture_points,
+            progress_points,
+            loop_registers,
             backtrack_stack_base: 0,
             constants_base: regexp.constants_as_ptr(),
+        }
+    }
+
+    /// Must be called after matching is complete. Returns the shared match engine buffers capped
+    /// at a maximum size.
+    fn take_cached_match_engine_state(&mut self) -> MatchEngineCache {
+        self.backtrack_stack.clear();
+        self.backtrack_stack.shrink_to(MAX_RETAINED_VEC_SIZE);
+
+        self.capture_points.clear();
+        self.capture_points.shrink_to(MAX_RETAINED_VEC_SIZE);
+
+        self.progress_points.clear();
+        self.progress_points.shrink_to(MAX_RETAINED_VEC_SIZE);
+
+        self.loop_registers.clear();
+        self.loop_registers.shrink_to(MAX_RETAINED_VEC_SIZE);
+
+        MatchEngineCache {
+            backtrack_stack: std::mem::take(&mut self.backtrack_stack),
+            capture_points: std::mem::take(&mut self.capture_points),
+            progress_points: std::mem::take(&mut self.progress_points),
+            loop_registers: std::mem::take(&mut self.loop_registers),
         }
     }
 
@@ -1113,14 +1168,25 @@ pub enum MatchSearch {
 }
 
 fn match_lexer_stream(
+    mut cx: Context,
     mut lexer_stream: impl RegExpLexerStream,
     regexp: HeapPtr<CompiledRegExp>,
     start_index: u32,
     search: MatchSearch,
 ) -> Result<Match, MatchError> {
     lexer_stream.advance_n(start_index as usize);
-    let mut match_engine = MatchEngine::new(regexp, lexer_stream);
-    match_engine.run(search)
+
+    // Create match engine, reusing cached buffers from the context
+    let match_engine_cache = std::mem::take(&mut cx.regexp_match_engine_cache);
+    let mut match_engine = MatchEngine::new(regexp, lexer_stream, match_engine_cache);
+
+    // Run the match engine on the input stream
+    let result = match_engine.run(search);
+
+    // Return the buffers to the context for reuse in future matches
+    cx.regexp_match_engine_cache = match_engine.take_cached_match_engine_state();
+
+    result
 }
 
 pub fn run_matcher(
@@ -1138,17 +1204,17 @@ pub fn run_matcher(
     let result = match flat_string.width() {
         StringWidth::OneByte => {
             let lexer_stream = HeapOneByteLexerStream::new(flat_string.as_one_byte_slice());
-            match_lexer_stream(lexer_stream, regexp, start_index, search)
+            match_lexer_stream(cx, lexer_stream, regexp, start_index, search)
         }
         StringWidth::TwoByte => {
             if regexp.flags.has_any_unicode_flag() {
                 let lexer_stream =
                     HeapTwoByteCodePointLexerStream::new(flat_string.as_two_byte_slice());
-                match_lexer_stream(lexer_stream, regexp, start_index, search)
+                match_lexer_stream(cx, lexer_stream, regexp, start_index, search)
             } else {
                 let lexer_stream =
                     HeapTwoByteCodeUnitLexerStream::new(flat_string.as_two_byte_slice(), None);
-                match_lexer_stream(lexer_stream, regexp, start_index, search)
+                match_lexer_stream(cx, lexer_stream, regexp, start_index, search)
             }
         }
     };


### PR DESCRIPTION
## Summary

For small RegExps the allocation cost of the match engine's internal buffers starts to dominate. Let's reuse these internal buffers between allocations (up to a capped size), storing them in the Context in between executions.

This change alone cases a +8.3% increase on the Octane RegExp benchmark.

## Tests

- CI