### PR TITLE
[runtime] StringValue::flatten returns pointer instead of handle by default, outline slow path

### DIFF
--- a/src/js/runtime/intrinsics/date_prototype.rs
+++ b/src/js/runtime/intrinsics/date_prototype.rs
@@ -1089,15 +1089,15 @@ impl DatePrototype {
         let hint = arguments.get(cx, 0);
         if hint.is_string() {
             let hint = hint.as_string().flatten()?;
-            if *hint == cx.names.default.as_string().as_flat()
-                || *hint == cx.names.string_.as_string().as_flat()
+            if hint == cx.names.default.as_string().as_flat()
+                || hint == cx.names.string_.as_string().as_flat()
             {
                 return ordinary_to_primitive(
                     cx,
                     this_value.as_object(),
                     ToPrimitivePreferredType::String,
                 );
-            } else if *hint == cx.names.number_.as_string().as_flat() {
+            } else if hint == cx.names.number_.as_string().as_flat() {
                 return ordinary_to_primitive(
                     cx,
                     this_value.as_object(),

--- a/src/js/runtime/intrinsics/encodings.rs
+++ b/src/js/runtime/intrinsics/encodings.rs
@@ -205,7 +205,7 @@ pub fn decode_base64(
         return Ok(DecodeResult { bytes, read, error: None });
     }
 
-    let string = string.flatten()?;
+    let string = string.flatten_to_handle()?;
     let length = string.len();
 
     let mut i = 0;

--- a/src/js/runtime/intrinsics/globals.rs
+++ b/src/js/runtime/intrinsics/globals.rs
@@ -386,6 +386,7 @@ fn decode<const INCLUDE_URI_UNESCAPED: bool>(
 ) -> EvalResult<Handle<Value>> {
     let mut decoded_string = Wtf8String::new();
 
+    // Safe to hold as a pointer since no allocations occur except immediately before returning
     let flat_string = string.flatten()?;
     let string_length = flat_string.len();
 

--- a/src/js/runtime/intrinsics/json_object.rs
+++ b/src/js/runtime/intrinsics/json_object.rs
@@ -247,7 +247,7 @@ pub fn json_parse(
         let root_name = cx.names.empty_string();
         must!(create_data_property_or_throw(cx, root, root_name, parse_record.value));
 
-        let flat_text_string = text_string.flatten()?;
+        let flat_text_string = text_string.flatten_to_handle()?;
 
         return internalize_json_property(
             cx,

--- a/src/js/runtime/intrinsics/string_prototype.rs
+++ b/src/js/runtime/intrinsics/string_prototype.rs
@@ -457,7 +457,7 @@ impl StringPrototype {
         let form = if form_arg.is_undefined() {
             NormalizationForm::NFC
         } else {
-            let form_string = *to_string(cx, form_arg)?.flatten()?;
+            let form_string = to_string(cx, form_arg)?.flatten()?;
             if form_string == cx.names.nfc.as_string().as_flat() {
                 NormalizationForm::NFC
             } else if form_string == cx.names.nfd.as_string().as_flat() {
@@ -1056,7 +1056,7 @@ impl StringPrototype {
         let object = this_object_coercible_value(cx, this_value, "iterator")?;
         let string = to_string(cx, object)?;
 
-        let flat_string = string.flatten()?;
+        let flat_string = string.flatten_to_handle()?;
 
         Ok(StringIteratorObject::new(cx, flat_string)?.as_value())
     }}
@@ -1356,7 +1356,7 @@ fn normalize_string<I: Iterator<Item = char>>(
     string: Handle<StringValue>,
     f: impl Fn(CharIterator) -> I,
 ) -> EvalResult<Handle<StringValue>> {
-    let parts = to_valid_string_parts(*string.flatten()?);
+    let parts = to_valid_string_parts(string.flatten()?);
 
     let mut normalized_string = Wtf8String::new();
 
@@ -1502,7 +1502,7 @@ impl SubstitutionTemplateParser {
         cx: Context,
         template: Handle<StringValue>,
     ) -> AllocResult<SubstitutionTemplate> {
-        let template = template.flatten()?;
+        let template = template.flatten_to_handle()?;
         let template_length = template.len();
 
         while self.pos < template_length {

--- a/src/js/runtime/intrinsics/symbol_constructor.rs
+++ b/src/js/runtime/intrinsics/symbol_constructor.rs
@@ -78,7 +78,7 @@ impl SymbolConstructor {
     /// Symbol.for (https://tc39.es/ecma262/#sec-symbol.for)
     fn for_(cx, _, arguments) {
         let argument = arguments.get(cx, 0);
-        let string_key = to_string(cx, argument)?.flatten()?;
+        let string_key = to_string(cx, argument)?.flatten_to_handle()?;
         if let Some(symbol_value) = cx.global_symbol_registry().get(&string_key) {
             return Ok(symbol_value.to_handle().into());
         }

--- a/src/js/runtime/module/execute.rs
+++ b/src/js/runtime/module/execute.rs
@@ -606,11 +606,11 @@ pub fn dynamic_import(
                 // Intern the key and value strings
                 let key_string = must!(to_string(cx, key));
                 let key_flat_string = key_string.flatten()?;
-                let key_interned_string = InternedStrings::get(cx, *key_flat_string)?.to_handle();
+                let key_interned_string = InternedStrings::get(cx, key_flat_string)?.to_handle();
 
                 let value_flat_string = value.as_string().flatten()?;
                 let value_interned_string =
-                    InternedStrings::get(cx, *value_flat_string)?.to_handle();
+                    InternedStrings::get(cx, value_flat_string)?.to_handle();
 
                 attribute_pairs.push((key_interned_string, value_interned_string));
             }
@@ -627,7 +627,7 @@ pub fn dynamic_import(
     };
 
     let specifier = specifier.flatten()?;
-    let specifier = InternedStrings::get(cx, *specifier)?.to_handle();
+    let specifier = InternedStrings::get(cx, specifier)?.to_handle();
 
     let module_request = ModuleRequest { specifier, attributes };
 

--- a/src/js/runtime/property_key.rs
+++ b/src/js/runtime/property_key.rs
@@ -61,7 +61,7 @@ impl PropertyKey {
     ) -> AllocResult<PropertyKey> {
         // Enforce that all string property keys are interned
         let flat_string = value.flatten()?;
-        let interned_string = InternedStrings::get(cx, *flat_string)?.as_string();
+        let interned_string = InternedStrings::get(cx, flat_string)?.as_string();
         Ok(PropertyKey { value: interned_string.into() })
     }
 

--- a/src/js/runtime/string_value.rs
+++ b/src/js/runtime/string_value.rs
@@ -196,7 +196,7 @@ impl Handle<StringValue> {
     /// range of code units in the string. This function does not bounds check, so caller must make
     /// sure that 0 <= start <= end < string length.
     pub fn substring(&self, cx: Context, start: u32, end: u32) -> AllocResult<Handle<FlatString>> {
-        let flat_string = self.flatten()?;
+        let flat_string = self.flatten_to_handle()?;
         flat_string.substring(cx, start, end)
     }
 
@@ -311,20 +311,47 @@ impl Handle<StringValue> {
 
     /// If this string is a concat string, flatten it into a single buffer. This modifies the string
     /// value in-place and switches it from a concat string to a sequential string type.
-    pub fn flatten(&self) -> AllocResult<Handle<FlatString>> {
-        let mut concat_string = if let Some(concat_string) = self.as_concat_opt() {
-            // Is a forwarding concat string when right is None
-            if concat_string.right.is_none() {
-                return Ok(concat_string.left.as_flat().to_handle());
-            } else {
-                // Other concat strings need to be flattened
-                concat_string
-            }
-        } else {
-            // Otherwise is already flat
+    ///
+    /// Returns a pointer to the flattened string.
+    #[inline]
+    pub fn flatten(&self) -> AllocResult<HeapPtr<FlatString>> {
+        let Some(concat_string) = self.as_concat_opt() else {
+            // Already flat
+            return Ok(*self.as_flat());
+        };
+
+        // Is a forwarding concat string when right is None
+        if concat_string.right.is_none() {
+            return Ok(concat_string.left.as_flat());
+        }
+
+        Ok(*self.flatten_concat_string(concat_string)?)
+    }
+
+    /// If this string is a concat string, flatten it into a single buffer. This modifies the string
+    /// value in-place and switches it from a concat string to a sequential string type.
+    ///
+    /// Returns a handle to the flattened string.
+    #[inline]
+    pub fn flatten_to_handle(&self) -> AllocResult<Handle<FlatString>> {
+        let Some(concat_string) = self.as_concat_opt() else {
+            // Already flat
             return Ok(self.as_flat());
         };
 
+        // Is a forwarding concat string when right is None
+        if concat_string.right.is_none() {
+            return Ok(concat_string.left.as_flat().to_handle());
+        }
+
+        self.flatten_concat_string(concat_string)
+    }
+
+    #[inline(never)]
+    fn flatten_concat_string(
+        &self,
+        mut concat_string: Handle<ConcatString>,
+    ) -> AllocResult<Handle<FlatString>> {
         let length = concat_string.len;
         let mut index = 0;
 
@@ -547,7 +574,7 @@ impl Handle<StringValue> {
             }
             StringWidth::TwoByte => {
                 // Two byte slow path - must convert to valid str ranges for to_lowercase function
-                let iter = UnsafeCodePointIterator::from_two_byte(*flat_string);
+                let iter = UnsafeCodePointIterator::from_two_byte(flat_string);
                 let lowercased = map_valid_substrings(iter, |str| str.to_lowercase());
 
                 Ok(FlatString::from_wtf8(cx, lowercased.as_bytes())?.to_handle())
@@ -576,9 +603,9 @@ impl Handle<StringValue> {
                     return Ok(FlatString::new_one_byte(cx, &uppercased)?.to_handle());
                 }
 
-                UnsafeCodePointIterator::from_one_byte(*flat_string)
+                UnsafeCodePointIterator::from_one_byte(flat_string)
             }
-            StringWidth::TwoByte => UnsafeCodePointIterator::from_two_byte(*flat_string),
+            StringWidth::TwoByte => UnsafeCodePointIterator::from_two_byte(flat_string),
         };
 
         // Slow path - must convert to valid str ranges for to_uppercase function
@@ -613,10 +640,10 @@ impl Handle<StringValue> {
 
         match flat_string.width() {
             StringWidth::OneByte => {
-                Ok(UnsafeCodeUnitIterator::from_one_byte_slice(*flat_string, start, end))
+                Ok(UnsafeCodeUnitIterator::from_one_byte_slice(flat_string, start, end))
             }
             StringWidth::TwoByte => {
-                Ok(UnsafeCodeUnitIterator::from_two_byte_slice(*flat_string, start, end))
+                Ok(UnsafeCodeUnitIterator::from_two_byte_slice(flat_string, start, end))
             }
         }
     }
@@ -632,10 +659,10 @@ impl Handle<StringValue> {
 
         match flat_string.width() {
             StringWidth::OneByte => {
-                Ok(UnsafeCodePointIterator::from_one_byte_slice(*flat_string, start, end))
+                Ok(UnsafeCodePointIterator::from_one_byte_slice(flat_string, start, end))
             }
             StringWidth::TwoByte => {
-                Ok(UnsafeCodePointIterator::from_two_byte_slice(*flat_string, start, end))
+                Ok(UnsafeCodePointIterator::from_two_byte_slice(flat_string, start, end))
             }
         }
     }
@@ -657,18 +684,18 @@ impl Handle<StringValue> {
         }
 
         // First flatten so that we do not allocate while iterating
-        let flat_string_1 = self.flatten()?;
+        let flat_string_1 = self.flatten_to_handle()?;
         let flat_string_2 = other.flatten()?;
 
-        Ok(flat_string_1 == flat_string_2)
+        Ok(*flat_string_1 == flat_string_2)
     }
 
     pub fn compare(&self, other: &Self) -> AllocResult<Ordering> {
         // First flatten so that we do not allocate while iterating
-        let flat_string_1 = self.flatten()?;
+        let flat_string_1 = self.flatten_to_handle()?;
         let flat_string_2 = other.flatten()?;
 
-        Ok(flat_string_1.cmp(&flat_string_2))
+        Ok((*flat_string_1).cmp(&flat_string_2))
     }
 }
 

--- a/src/js/runtime/symbol_value.rs
+++ b/src/js/runtime/symbol_value.rs
@@ -30,7 +30,7 @@ impl SymbolValue {
         description: Option<Handle<StringValue>>,
         is_private: bool,
     ) -> AllocResult<Handle<SymbolValue>> {
-        let description = description.map(|d| d.flatten()).transpose()?;
+        let description = description.map(|d| d.flatten_to_handle()).transpose()?;
         let mut symbol = cx.alloc_uninit::<SymbolValue>()?;
 
         set_uninit!(symbol.shape, cx.shapes.get(HeapItemKind::SymbolValue));

--- a/src/js/runtime/value.rs
+++ b/src/js/runtime/value.rs
@@ -639,7 +639,7 @@ impl ValueCollectionKey {
     pub fn from(value: Handle<Value>) -> AllocResult<Self> {
         if value.is_string() {
             let flat_string = value.as_string().flatten()?;
-            return Ok(ValueCollectionKey(*flat_string.as_value()));
+            return Ok(ValueCollectionKey(flat_string.as_string().into()));
         }
 
         Ok(ValueCollectionKey(*value))
@@ -714,7 +714,7 @@ impl ValueCollectionKeyHandle {
     /// Identical to ValueCollectionKey::from but stores a handle instead.
     pub fn new(value: Handle<Value>) -> AllocResult<Self> {
         if value.is_string() {
-            let flat_string = value.as_string().flatten()?;
+            let flat_string = value.as_string().flatten_to_handle()?;
             return Ok(ValueCollectionKeyHandle(flat_string.as_string().into()));
         }
 


### PR DESCRIPTION
## Summary

It turns out that ~3/4 of calls to `StringValue::flatten` only need to result to be a `HeapPtr` instead of a `Handle`. Let's return the pointer by default and only call the new `StringValue::flatten_to_handle` where actually needed.

Additionally let's mark both of these functions `#[inline]` but split out a cold, outlined slow path that actually performs the flattening. This allows these utilities to be inlined without bringing in the large cold path.

Seeing a ~1.5% increase to overall Octane score from this change.

| Benchmark | ba027b0b1 (base) | e6f092f3b | Change |
|-----------|------------------|-----------|--------|
| Richards | 2,623 med 2,616 ±11.9 n=4 | 2,690 med 2,675 ±13.8 n=4 | +2.6% |
| DeltaBlue | 2,512 med 2,510 ±7.1 n=4 | 2,602 med 2,588 ±12.7 n=4 | +3.6% |
| Crypto | 3,207 med 3,203 ±3.9 n=4 | 3,498 med 3,495 ±4.5 n=4 | +9.1% |
| RayTrace | 3,323 med 3,309 ±11.3 n=4 | 3,340 med 3,327 ±8.0 n=4 | +0.5% |
| EarleyBoyer | 5,694 med 5,634 ±64.1 n=4 | 5,677 med 5,674 ±30.4 n=4 | -0.3% |
| RegExp | 3,683 med 3,676 ±9.4 n=4 | 3,792 med 3,755 ±21.3 n=4 | +3.0% |
| Splay | 4,979 med 4,914 ±58.5 n=4 | 5,020 med 4,987 ±157 n=4 | +0.8% |
| SplayLatency | 10,008 med 9,963 ±53.3 n=4 | 10,103 med 10,038 ±162 n=4 | +0.9% |
| NavierStokes | 4,070 med 4,052 ±27.5 n=4 | 4,062 med 4,027 ±22.5 n=4 | -0.2% |
| PdfJS | 7,310 med 7,301 ±17.2 n=4 | 7,384 med 7,361 ±24.9 n=4 | +1.0% |
| Mandreel | 3,126 med 3,124 ±5.7 n=4 | 3,123 med 3,120 ±3.9 n=4 | -0.1% |
| MandreelLatency | 22,660 med 22,660 ±51.5 n=4 | 22,660 med 22,660 ±51.5 n=4 | +0.0% |
| Gameboy | 5,343 med 5,312 ±28.1 n=4 | 5,383 med 5,330 ±81.0 n=4 | +0.7% |
| CodeLoad | 48,057 med 47,937 ±115 n=4 | 48,000 med 47,904 ±132 n=4 | -0.1% |
| Box2D | 9,340 med 9,340 ±4.5 n=4 | 9,559 med 9,532 ±46.3 n=4 | +2.3% |
| zlib | 5,924 med 5,914 ±16.9 n=4 | 5,848 med 5,840 ±6.2 n=4 | -1.3% |
| Typescript | 23,595 med 23,355 ±136 n=4 | 23,873 med 23,780 ±123 n=4 | +1.2% |
| **Total (octane)** | **6,388 med 6,381 ±8.1 n=4** | **6,487 med 6,462 ±27.0 n=4** | **+1.5%** |

## Tests

- CI, verified that integration tests run in GC stress test still pass