### PR TITLE
[runtime] Fix Promise.try when called with no arguments

### DIFF
--- a/src/js/runtime/intrinsics/promise_constructor.rs
+++ b/src/js/runtime/intrinsics/promise_constructor.rs
@@ -692,7 +692,7 @@ impl PromiseConstructor {
 
         let callback = arguments.get(cx, 0);
 
-        let mut callback_args = Vec::with_capacity(arguments.len() - 1);
+        let mut callback_args = Vec::with_capacity(arguments.len().saturating_sub(1));
         for argument in arguments.iter().skip(1) {
             callback_args.push(argument.to_handle(cx));
         }

--- a/tests/integration/built-ins/Promise/try_no_args.js
+++ b/tests/integration/built-ins/Promise/try_no_args.js
@@ -1,0 +1,15 @@
+/*---
+description: Promise.try with no arguments returns a promise that rejects.
+flags: [async]
+---*/
+
+Promise.try()
+  .then(
+    () => {
+      throw new Test262Error("Promise should not resolve");
+    },
+    (error) => {
+      assert(error instanceof TypeError);
+    }
+  )
+  .then($DONE, $DONE);


### PR DESCRIPTION
## Summary

Preexisting bug noticed during https://github.com/Hans-Halverson/brimstone/pull/515. Avoid integer overflow when `Promise.try` is called with no arguments.

## Tests

- Added integration test for this case