### PR TITLE
[runtime] PropertyKey::from_value fast path for smis

### DIFF
--- a/src/js/runtime/property_key.rs
+++ b/src/js/runtime/property_key.rs
@@ -11,7 +11,7 @@ use crate::{
         string_parsing::{StringLexer, parse_string_to_u32},
         string_value::{FlatString, StringValue},
         to_string,
-        type_utilities::is_integral_number,
+        type_utilities::is_integral_double,
     },
 };
 
@@ -128,19 +128,25 @@ impl PropertyKey {
 
     pub fn from_value(cx: Context, value_handle: Handle<Value>) -> EvalResult<PropertyKey> {
         let value = *value_handle;
-        if is_integral_number(value) {
+        if value.is_smi() {
+            if let Ok(array_index) = u32::try_from(value.as_smi()) {
+                return Ok(PropertyKey::array_index_unchecked(array_index));
+            }
+        } else if value.is_string() {
+            let string_value = value_handle.as_string();
+            return Ok(PropertyKey::string(cx, string_value)?);
+        } else if value.is_symbol() {
+            return Ok(*PropertyKey::symbol(value_handle.as_symbol()));
+        } else if is_integral_double(value) {
             let number = value.as_double();
             if (0.0..u32::MAX_AS_F64).contains(&number) {
                 return Ok(PropertyKey::array_index(cx, number as u32)?);
             }
         }
 
-        if value.is_symbol() {
-            Ok(*PropertyKey::symbol(value_handle.as_symbol()))
-        } else {
-            let string_value = to_string(cx, value_handle)?;
-            Ok(PropertyKey::string(cx, string_value)?)
-        }
+        // All other values (including non-array-index numbers) are converted to string keys
+        let string_value = to_string(cx, value_handle)?;
+        Ok(PropertyKey::string(cx, string_value)?)
     }
 
     /// Create a property key from a string that is known to already be interned (and therefore

--- a/src/js/runtime/type_utilities.rs
+++ b/src/js/runtime/type_utilities.rs
@@ -633,9 +633,12 @@ pub fn is_constructor_object_value(value: Handle<ObjectValue>) -> bool {
 }
 
 pub fn is_integral_number(value: Value) -> bool {
-    if value.is_smi() {
-        return true;
-    } else if !value.is_double() || value.is_nan() || value.is_infinity() {
+    value.is_smi() || is_integral_double(value)
+}
+
+#[inline]
+pub fn is_integral_double(value: Value) -> bool {
+    if !value.is_double() || value.is_nan() || value.is_infinity() {
         return false;
     }
 


### PR DESCRIPTION
## Summary

`PropertyKey::from_value` did not have a fast path for smis, instead converting them to doubles and running through the more expensive "check if integral -> convert to double -> compare to array index range" path. At least that's what we intended but the reality was worse - we accidentally used `as_double` for the conversion instead of `as_number`. This resulted in the incorrect doubles, which could never be in the allowed range, forcing us to take the extremely slow "convert to string" path instead.

Avoid all this by adding a smi fast path which can use a simpler range check. Also refactor `PropertyKey::from_value` to favor smis, then strings, then symbols, then integral doubles, then falling back to converting to strings.

+42% on Octane splay benchmarks which frequently hit this path, resulting in +4.2% overall to Octane score.

## Tests

- CI