### PR TITLE
[runtime] Only allocate shadowed scope slot name once

### DIFF
--- a/src/js/runtime/arguments_object.rs
+++ b/src/js/runtime/arguments_object.rs
@@ -1,6 +1,5 @@
 use crate::{
     extend_object, must,
-    parser::scope_tree::SHADOWED_SCOPE_SLOT_NAME,
     runtime::{
         Context, EvalResult, HeapPtr, Value,
         accessor::Accessor,
@@ -10,7 +9,6 @@ use crate::{
         bytecode::function::ClosureObject,
         common_shapes::CommonShape,
         gc::{Handle, HeapItem, HeapVisitor},
-        interned_strings::InternedStrings,
         intrinsics::intrinsics::Intrinsic,
         object_value::{ObjectValue, VirtualObject},
         ordinary_object::{
@@ -102,8 +100,6 @@ impl MappedArgumentsObject {
         scope: Handle<Scope>,
         num_parameters: usize,
     ) -> EvalResult<Handle<MappedArgumentsObject>> {
-        let shadowed_name = InternedStrings::alloc_static_wtf8_str(cx, &SHADOWED_SCOPE_SLOT_NAME)?;
-
         let mut object = ObjectBuilder::<MappedArgumentsObject>::new(cx)
             .common_shape(CommonShape::MappedArguments)?
             .build()?;
@@ -122,7 +118,7 @@ impl MappedArgumentsObject {
             !scope
                 .scope_names_ptr()
                 .get_slot_name(i)
-                .ptr_eq(&*shadowed_name)
+                .ptr_eq(&cx.names.shadowed_binding.as_string().as_flat())
         })?;
 
         let length_value = cx.number(arguments.len());

--- a/src/js/runtime/builtin_names.rs
+++ b/src/js/runtime/builtin_names.rs
@@ -64,6 +64,7 @@ builtin_names!(
     (negative_zero, "-0"),
     (negative_infinity_literal, "-Infinity"),
     (default_name, "*default*"),
+    (shadowed_binding, "%shadowed"),
     (__define_getter__, "__defineGetter__"),
     (__define_setter__, "__defineSetter__"),
     (__lookup_getter__, "__lookupGetter__"),


### PR DESCRIPTION
## Summary

We were unnecessarily allocating the shadowed scope slot name for every mapped arguments object. Totally unnecessary, we should be storing this as a builtin name on the Context instead.

+2.4% on Octane overall from this change.

| Benchmark | `6005bc574` (base) | `e4dd60f4b` |
| :--- | ---: | ---: |
| Richards | 2,658 | 2,669 (+0.4%) |
| DeltaBlue | 2,616 | 2,649 (+1.3%) |
| Crypto | 3,432 | 3,508 (+2.2%) |
| RayTrace | 3,489 | 4,160 (+19.2%) |
| EarleyBoyer | 5,575 | 5,894 (+5.7%) |
| RegExp | 3,969 | 4,000 (+0.8%) |
| Splay | 7,359 | 7,269 (-1.2%) |
| SplayLatency | 13,717 | 15,146 (+10.4%) |
| NavierStokes | 4,066 | 4,098 (+0.8%) |
| PdfJS | 7,872 | 8,036 (+2.1%) |
| Mandreel | 3,161 | 3,097 (-2.0%) |
| MandreelLatency | 22,763 | 22,763 (+0.0%) |
| Gameboy | 5,405 | 5,378 (-0.5%) |
| CodeLoad | 48,239 | 48,416 (+0.4%) |
| Box2D | 9,629 | 9,850 (+2.3%) |
| zlib | 5,843 | 5,826 (-0.3%) |
| Typescript | 24,682 | 24,615 (-0.3%) |
| **Total (octane)** | **6,806** | **6,972 (+2.4%)** |

## Tests

- CI